### PR TITLE
Add cache ops

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,6 +146,7 @@ endif()
 
 if(VLLM_GPU_LANG STREQUAL "SYCL")
   set(VLLM_EXT_SRC
+    "csrc/xpu/cache.cpp"
     "csrc/xpu/layernorm.cpp"
     "csrc/xpu/torch_bindings.cpp"
   )

--- a/benchmark/benchmark_reshape_and_cache.py
+++ b/benchmark/benchmark_reshape_and_cache.py
@@ -54,10 +54,11 @@ def run_benchmark(
                                 dtype=torch.long,
                                 device=device)
 
+    num_layers = 1  # for simplicity, we use a single layer
     key_caches, value_caches = create_kv_caches_with_random(
         num_blocks,
         block_size,
-        1,  # num_layers
+        num_layers,
         num_heads,
         head_size,
         kv_cache_dtype,
@@ -151,22 +152,25 @@ if __name__ == "__main__":
         "--head-size",
         type=int,
         choices=[64, 80, 96, 112, 120, 128, 192, 256],
-        default=256,
+        default=128,
     )
-    parser.add_argument("--block-size", type=int, choices=[16, 32], default=32)
+    parser.add_argument("--block-size",
+                        type=int,
+                        choices=[16, 32, 64],
+                        default=64)
     parser.add_argument("--num-blocks", type=int, default=1024)
 
     parser.add_argument(
         "--dtype",
         type=str,
-        choices=["half", "bfloat16", "float"],
+        choices=["half", "bfloat16"],
         default="half",
     )
 
     parser.add_argument(
         "--kv-cache-dtype",
         type=str,
-        choices=["auto", "fp8"],
+        choices=["auto", "fp8", "fp8_e4m3", "fp8_e5m2"],
         default="auto",
     )
 

--- a/benchmark/benchmark_reshape_and_cache.py
+++ b/benchmark/benchmark_reshape_and_cache.py
@@ -10,7 +10,7 @@ from tabulate import tabulate
 from tests import register_ops as ops
 from tests.utils import (
     STR_DTYPE_TO_TORCH_DTYPE,
-    create_kv_caches_with_random_flash,
+    create_kv_caches_with_random,
 )
 
 
@@ -48,7 +48,7 @@ def run_benchmark(
     slot_mapping_lst = random.sample(range(num_slots), num_tokens)
     slot_mapping = torch.tensor(slot_mapping_lst, dtype=torch.long, device=device)
 
-    key_caches, value_caches = create_kv_caches_with_random_flash(
+    key_caches, value_caches = create_kv_caches_with_random(
         num_blocks,
         block_size,
         1,  # num_layers
@@ -69,7 +69,7 @@ def run_benchmark(
         torch.xpu.synchronize()
         start = time.perf_counter()
         for _ in range(n_iters):
-            ops.reshape_and_cache_flash(
+            ops.reshape_and_cache(
                 key,
                 value,
                 key_cache,
@@ -143,21 +143,21 @@ if __name__ == "__main__":
     import argparse
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("--num-heads", type=int, default=128)
+    parser.add_argument("--num-heads", type=int, default=8)
     parser.add_argument(
         "--head-size",
         type=int,
         choices=[64, 80, 96, 112, 120, 128, 192, 256],
-        default=64,
+        default=256,
     )
-    parser.add_argument("--block-size", type=int, choices=[16, 32], default=16)
-    parser.add_argument("--num-blocks", type=int, default=512)
+    parser.add_argument("--block-size", type=int, choices=[16, 32], default=32)
+    parser.add_argument("--num-blocks", type=int, default=1024)
 
     parser.add_argument(
         "--dtype",
         type=str,
         choices=["half", "bfloat16", "float"],
-        default="bfloat16",
+        default="half",
     )
 
     parser.add_argument(

--- a/benchmark/benchmark_reshape_and_cache.py
+++ b/benchmark/benchmark_reshape_and_cache.py
@@ -7,11 +7,9 @@ import time
 
 import torch
 from tabulate import tabulate
+
 from tests import register_ops as ops
-from tests.utils import (
-    STR_DTYPE_TO_TORCH_DTYPE,
-    create_kv_caches_with_random,
-)
+from tests.utils import STR_DTYPE_TO_TORCH_DTYPE, create_kv_caches_with_random
 
 
 @torch.inference_mode()
@@ -29,7 +27,8 @@ def run_benchmark(
     """Return latency (seconds) for given num_tokens."""
 
     if kv_cache_dtype == "fp8" and head_size % 16:
-        raise ValueError("fp8 kv-cache requires head_size to be a multiple of 16.")
+        raise ValueError(
+            "fp8 kv-cache requires head_size to be a multiple of 16.")
 
     seed = 42
     random.seed(seed)
@@ -37,16 +36,23 @@ def run_benchmark(
     torch.set_default_device(device)
 
     # create random key / value tensors [T, H, D].
-    key = torch.randn(num_tokens, num_heads, head_size, dtype=dtype, device=device)
+    key = torch.randn(num_tokens,
+                      num_heads,
+                      head_size,
+                      dtype=dtype,
+                      device=device)
     value = torch.randn_like(key)
 
     # prepare the slot mapping.
     # each token is assigned a unique slot in the KV-cache.
     num_slots = block_size * num_blocks
     if num_tokens > num_slots:
-        raise ValueError("num_tokens cannot exceed the total number of cache slots")
+        raise ValueError(
+            "num_tokens cannot exceed the total number of cache slots")
     slot_mapping_lst = random.sample(range(num_slots), num_tokens)
-    slot_mapping = torch.tensor(slot_mapping_lst, dtype=torch.long, device=device)
+    slot_mapping = torch.tensor(slot_mapping_lst,
+                                dtype=torch.long,
+                                device=device)
 
     key_caches, value_caches = create_kv_caches_with_random(
         num_blocks,
@@ -110,18 +116,16 @@ def main(args):
             num_iters=args.iters,
             device="xpu",
         )
-        rows.append(
-            [
-                n_tok,
-                args.num_heads,
-                args.head_size,
-                args.block_size,
-                args.num_blocks,
-                args.dtype,
-                args.kv_cache_dtype,
-                f"{lat * 1e6:.3f}",
-            ]
-        )
+        rows.append([
+            n_tok,
+            args.num_heads,
+            args.head_size,
+            args.block_size,
+            args.num_blocks,
+            args.dtype,
+            args.kv_cache_dtype,
+            f"{lat * 1e6:.3f}",
+        ])
     print(
         tabulate(
             rows,
@@ -135,8 +139,7 @@ def main(args):
                 "kv_cache_dtype",
                 "latency (us)",
             ],
-        )
-    )
+        ))
 
 
 if __name__ == "__main__":

--- a/benchmark/benchmark_reshape_and_cache_flash.py
+++ b/benchmark/benchmark_reshape_and_cache_flash.py
@@ -55,10 +55,11 @@ def run_benchmark(
                                 dtype=torch.long,
                                 device=device)
 
+    num_layers = 1  # for simplicity, we use a single layer
     key_caches, value_caches = create_kv_caches_with_random_flash(
         num_blocks,
         block_size,
-        1,  # num_layers
+        num_layers,
         num_heads,
         head_size,
         kv_cache_dtype,
@@ -147,27 +148,30 @@ if __name__ == "__main__":
     import argparse
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("--num-heads", type=int, default=128)
+    parser.add_argument("--num-heads", type=int, default=8)
     parser.add_argument(
         "--head-size",
         type=int,
         choices=[64, 80, 96, 112, 120, 128, 192, 256],
-        default=64,
+        default=128,
     )
-    parser.add_argument("--block-size", type=int, choices=[16, 32], default=16)
+    parser.add_argument("--block-size",
+                        type=int,
+                        choices=[16, 32, 64],
+                        default=64)
     parser.add_argument("--num-blocks", type=int, default=512)
 
     parser.add_argument(
         "--dtype",
         type=str,
-        choices=["half", "bfloat16", "float"],
-        default="bfloat16",
+        choices=["half", "bfloat16"],
+        default="half",
     )
 
     parser.add_argument(
         "--kv-cache-dtype",
         type=str,
-        choices=["auto", "fp8"],
+        choices=["auto", "fp8", "fp8_e4m3", "fp8_e5m2"],
         default="auto",
     )
 

--- a/benchmark/benchmark_reshape_and_cache_flash.py
+++ b/benchmark/benchmark_reshape_and_cache_flash.py
@@ -7,11 +7,10 @@ import time
 
 import torch
 from tabulate import tabulate
+
 from tests import register_ops as ops
-from tests.utils import (
-    STR_DTYPE_TO_TORCH_DTYPE,
-    create_kv_caches_with_random_flash,
-)
+from tests.utils import (STR_DTYPE_TO_TORCH_DTYPE,
+                         create_kv_caches_with_random_flash)
 
 
 @torch.inference_mode()
@@ -29,7 +28,8 @@ def run_benchmark(
     """Return latency (seconds) for given num_tokens."""
 
     if kv_cache_dtype == "fp8" and head_size % 16:
-        raise ValueError("fp8 kv-cache requires head_size to be a multiple of 16.")
+        raise ValueError(
+            "fp8 kv-cache requires head_size to be a multiple of 16.")
 
     seed = 42
     random.seed(seed)
@@ -37,16 +37,23 @@ def run_benchmark(
     torch.set_default_device(device)
 
     # create random key / value tensors [T, H, D].
-    key = torch.randn(num_tokens, num_heads, head_size, dtype=dtype, device=device)
+    key = torch.randn(num_tokens,
+                      num_heads,
+                      head_size,
+                      dtype=dtype,
+                      device=device)
     value = torch.randn_like(key)
 
     # prepare the slot mapping.
     # each token is assigned a unique slot in the KV-cache.
     num_slots = block_size * num_blocks
     if num_tokens > num_slots:
-        raise ValueError("num_tokens cannot exceed the total number of cache slots")
+        raise ValueError(
+            "num_tokens cannot exceed the total number of cache slots")
     slot_mapping_lst = random.sample(range(num_slots), num_tokens)
-    slot_mapping = torch.tensor(slot_mapping_lst, dtype=torch.long, device=device)
+    slot_mapping = torch.tensor(slot_mapping_lst,
+                                dtype=torch.long,
+                                device=device)
 
     key_caches, value_caches = create_kv_caches_with_random_flash(
         num_blocks,
@@ -110,18 +117,16 @@ def main(args):
             num_iters=args.iters,
             device="xpu",
         )
-        rows.append(
-            [
-                n_tok,
-                args.num_heads,
-                args.head_size,
-                args.block_size,
-                args.num_blocks,
-                args.dtype,
-                args.kv_cache_dtype,
-                f"{lat * 1e6:.3f}",
-            ]
-        )
+        rows.append([
+            n_tok,
+            args.num_heads,
+            args.head_size,
+            args.block_size,
+            args.num_blocks,
+            args.dtype,
+            args.kv_cache_dtype,
+            f"{lat * 1e6:.3f}",
+        ])
     print(
         tabulate(
             rows,
@@ -135,8 +140,7 @@ def main(args):
                 "kv_cache_dtype",
                 "latency (us)",
             ],
-        )
-    )
+        ))
 
 
 if __name__ == "__main__":

--- a/benchmark/benchmark_reshape_and_cache_flash.py
+++ b/benchmark/benchmark_reshape_and_cache_flash.py
@@ -1,0 +1,152 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from __future__ import annotations
+
+import random
+import time
+
+import torch
+from tabulate import tabulate
+from tests import register_ops as ops
+from tests.utils import (
+    STR_DTYPE_TO_TORCH_DTYPE,
+    create_kv_caches_with_random_flash,
+)
+
+@torch.inference_mode()
+def run_benchmark(
+    num_tokens: int,
+    num_heads: int,
+    head_size: int,
+    block_size: int,
+    num_blocks: int,
+    dtype: torch.dtype,
+    kv_cache_dtype: str,
+    kv_cache_layout: str,
+    num_iters: int,
+    device: str = "xpu",
+) -> float:
+    """Return latency (seconds) for given num_tokens."""
+
+    if kv_cache_dtype == "fp8" and head_size % 16:
+        raise ValueError("fp8 kv-cache requires head_size to be a multiple of 16.")
+
+    seed = 42
+    random.seed(seed)
+    torch.manual_seed(seed)
+    torch.set_default_device(device)
+
+    # create random key / value tensors [T, H, D].
+    key = torch.randn(num_tokens, num_heads, head_size, dtype=dtype, device=device)
+    value = torch.randn_like(key)
+
+    # prepare the slot mapping.
+    # each token is assigned a unique slot in the KV-cache.
+    num_slots = block_size * num_blocks
+    if num_tokens > num_slots:
+        raise ValueError("num_tokens cannot exceed the total number of cache slots")
+    slot_mapping_lst = random.sample(range(num_slots), num_tokens)
+    slot_mapping = torch.tensor(slot_mapping_lst, dtype=torch.long, device=device)
+
+    key_caches, value_caches = create_kv_caches_with_random_flash(
+        num_blocks,
+        block_size,
+        1,  # num_layers
+        num_heads,
+        head_size,
+        kv_cache_dtype,
+        dtype,
+        device=device,
+        cache_layout=kv_cache_layout,
+    )
+    key_cache, value_cache = key_caches[0], value_caches[0]
+
+    # compute per-kernel scaling factors for fp8 conversion (if used).
+    k_scale = (key.amax() / 64.0).to(torch.float32)
+    v_scale = (value.amax() / 64.0).to(torch.float32)
+
+    def run_xpu_benchmark(n_iters: int) -> float:
+        nonlocal key, value, key_cache, value_cache, slot_mapping
+        torch.xpu.synchronize()
+        start = time.perf_counter()
+        for _ in range(n_iters):
+            ops.reshape_and_cache_flash(
+                key,
+                value,
+                key_cache,
+                value_cache,
+                slot_mapping,
+                kv_cache_dtype,
+                k_scale,
+                v_scale,
+            )
+        torch.xpu.synchronize()
+        end = time.perf_counter()
+        return (end - start) / n_iters
+
+    # warm-up
+    run_xpu_benchmark(3)
+
+    lat = run_xpu_benchmark(num_iters)
+
+    # free tensors to mitigate OOM when sweeping
+    del key, value, key_cache, value_cache, slot_mapping
+    torch.xpu.empty_cache()
+
+    return lat
+
+
+def main(args):
+    rows = []
+    for layout in ["NHD", "HND"]:
+        for exp in range(1, 12):
+            n_tok = 2**exp
+            lat = run_benchmark(
+                num_tokens=n_tok,
+                num_heads=args.num_heads,
+                head_size=args.head_size,
+                block_size=args.block_size,
+                num_blocks=args.num_blocks,
+                dtype=STR_DTYPE_TO_TORCH_DTYPE[args.dtype],
+                kv_cache_dtype=args.kv_cache_dtype,
+                kv_cache_layout=layout,
+                num_iters=args.iters,
+                device="xpu",
+            )
+            rows.append([n_tok, layout, f"{lat * 1e6:.3f}"])
+
+    print(tabulate(rows, headers=["num_tokens", "layout", "latency (µs)"]))
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--num-heads", type=int, default=128)
+    parser.add_argument(
+        "--head-size",
+        type=int,
+        choices=[64, 80, 96, 112, 120, 128, 192, 256],
+        default=64,
+    )
+    parser.add_argument("--block-size", type=int, choices=[16, 32], default=16)
+    parser.add_argument("--num-blocks", type=int, default=128)
+
+    parser.add_argument(
+        "--dtype",
+        type=str,
+        choices=["half", "bfloat16", "float"],
+        default="bfloat16",
+    )
+
+    parser.add_argument(
+        "--kv-cache-dtype",
+        type=str,
+        choices=["auto", "fp8", "fp8_e5m2"],
+        default="auto",
+    )
+
+    parser.add_argument("--iters", type=int, default=100)
+    args = parser.parse_args()
+
+    main(args)

--- a/csrc/xpu/cache.cpp
+++ b/csrc/xpu/cache.cpp
@@ -4,26 +4,106 @@
 #include <iostream>
 #include <string>
 
-#include "utils.h"
 #include "dispatch_utils.h"
+#include "quantization/fp8/quant_utils.hpp"
+#include "utils.h"
 
 namespace vllm {
 
-enum class Fp8KVCacheDataType {
-  kAuto = 0,
-  kFp8E4M3 = 1,
-  kFp8E5M2 = 2,
-};
+template <typename scalar_t, typename cache_t, Fp8KVCacheDataType kv_dt>
+void reshape_and_cache_kernel(
+    const scalar_t* __restrict__ key,    // [num_tokens, num_heads, head_size]
+    const scalar_t* __restrict__ value,  // [num_tokens, num_heads, head_size]
+    cache_t* __restrict__ key_cache,     // [num_blocks, num_heads, head_size/x,
+                                         // block_size, x]
+    cache_t* __restrict__ value_cache,   // [num_blocks, num_heads, head_size,
+                                         // block_size]
+    const int64_t* __restrict__ slot_mapping,  // [num_tokens]
+    const int key_stride, const int value_stride, const int num_heads,
+    const int head_size, const int block_size, const int x,
+    const float* k_scale, const float* v_scale, const sycl::nd_item<1>& item) {
+  int group_idx = item.get_group(0);
+  int local_idx = item.get_local_id(0);
+  int local_range = item.get_local_range(0);
+  int slot_idx = slot_mapping[group_idx];
+  if (slot_idx < 0) return;
+
+  const int block_idx = slot_idx / block_size;
+  const int block_offset = slot_idx % block_size;
+
+  const int n = num_heads * head_size;
+  for (int i = local_idx; i < n; i += local_range) {
+    const int src_key_idx = group_idx * key_stride + i;
+    const int src_value_idx = group_idx * value_stride + i;
+
+    const int head_idx = i / head_size;
+    const int head_offset = i % head_size;
+    const int x_idx = head_offset / x;
+    const int x_offset = head_offset % x;
+
+    const int tgt_key_idx =
+        block_idx * num_heads * (head_size / x) * block_size * x +
+        head_idx * (head_size / x) * block_size * x + x_idx * block_size * x +
+        block_offset * x + x_offset;
+    const int tgt_value_idx = block_idx * num_heads * head_size * block_size +
+                              head_idx * head_size * block_size +
+                              head_offset * block_size + block_offset;
+    scalar_t tgt_key = key[src_key_idx];
+    scalar_t tgt_value = value[src_value_idx];
+    if constexpr (kv_dt == Fp8KVCacheDataType::kFp8E5M2) {
+      key_cache[tgt_key_idx] =
+          static_cast<at::Float8_e5m2>(tgt_key * (*k_scale));
+      value_cache[tgt_value_idx] =
+          static_cast<at::Float8_e5m2>(tgt_value * (*v_scale));
+    } else if constexpr (kv_dt == Fp8KVCacheDataType::kFp8E4M3) {
+      key_cache[tgt_key_idx] =
+          static_cast<at::Float8_e4m3fn>(tgt_key * (*k_scale));
+      value_cache[tgt_value_idx] =
+          static_cast<at::Float8_e4m3fn>(tgt_value * (*v_scale));
+    } else {
+      key_cache[tgt_key_idx] = tgt_key;
+      value_cache[tgt_value_idx] = tgt_value;
+    }
+  }
+}
+
+template <typename scalar_t, typename cache_t, Fp8KVCacheDataType kv_dt>
+void call_reshape_and_cache(
+    const scalar_t* __restrict__ key, const scalar_t* __restrict__ value,
+    cache_t* __restrict__ key_cache, cache_t* __restrict__ value_cache,
+    const int64_t* __restrict__ slot_mapping, int num_tokens,
+    const int key_stride, const int value_stride, const int num_heads,
+    const int head_size, const int block_size, const int x,
+    const float* k_scale, const float* v_scale) {
+  auto& queue = vllm::xpu::vllmGetQueue();
+  int wg = std::min(1024, static_cast<int>(num_heads * head_size));
+
+  queue.submit([&](sycl::handler& cgh) {
+    cgh.parallel_for(
+        sycl::nd_range<1>(sycl::range<1>(num_tokens * wg), sycl::range<1>(wg)),
+        [=](sycl::nd_item<1> item) {
+          reshape_and_cache_kernel<scalar_t, cache_t, kv_dt>(
+              key, value, key_cache, value_cache, slot_mapping, key_stride,
+              value_stride, num_heads, head_size, block_size, x, k_scale,
+              v_scale, item);
+        });
+  });
+}
 
 template <typename scalar_t, typename cache_t, Fp8KVCacheDataType kv_dt>
 void reshape_and_cache_flash_kernel(
-    const scalar_t* __restrict__ key, const scalar_t* __restrict__ value,
-    cache_t* __restrict__ key_cache, cache_t* __restrict__ value_cache,
-    const int64_t* __restrict__ slot_mapping, const int64_t block_stride,
-    const int64_t page_stride, const int64_t head_stride,
-    const int64_t key_stride, const int64_t value_stride, const int num_heads,
-    const int head_size, const int block_size, const float* k_scale,
-    const float* v_scale, const sycl::nd_item<1>& item) {
+    const scalar_t* __restrict__ key,    // [num_tokens, num_heads, head_size]
+    const scalar_t* __restrict__ value,  // [num_tokens, num_heads, head_size]
+    cache_t* __restrict__ key_cache,     // [num_blocks, block_size, num_heads,
+                                         // head_size]
+    cache_t* __restrict__ value_cache,   // [num_blocks, block_size, num_heads,
+                                         // head_size]
+    const int64_t* __restrict__ slot_mapping,  // [num_tokens]
+    const int64_t block_stride, const int64_t page_stride,
+    const int64_t head_stride, const int64_t key_stride,
+    const int64_t value_stride, const int num_heads, const int head_size,
+    const int block_size, const float* k_scale, const float* v_scale,
+    const sycl::nd_item<1>& item) {
   int64_t group_idx = item.get_group(0);
   int64_t local_idx = item.get_local_id(0);
   int local_range = item.get_local_range(0);
@@ -44,36 +124,27 @@ void reshape_and_cache_flash_kernel(
 
     scalar_t tgt_key = key[src_key_idx];
     scalar_t tgt_value = value[src_value_idx];
-    if constexpr (kv_dt == Fp8KVCacheDataType::kFp8E4M3) {
-      key_cache[dst_idx] = static_cast<at::Float8_e4m3fn>(tgt_key * (*k_scale));
-      value_cache[dst_idx] =
-          static_cast<at::Float8_e4m3fn>(tgt_value * (*v_scale));
-    } else if constexpr (kv_dt == Fp8KVCacheDataType::kFp8E5M2) {
-      key_cache[dst_idx] = static_cast<at::Float8_e5m2>(tgt_key * (*k_scale));
-      value_cache[dst_idx] =
-          static_cast<at::Float8_e5m2>(tgt_value * (*v_scale));
-    } else {
+    if constexpr (kv_dt == Fp8KVCacheDataType::kAuto) {
       key_cache[dst_idx] = tgt_key;
       value_cache[dst_idx] = tgt_value;
+    } else {
+      key_cache[dst_idx] =
+          fp8::scaled_convert<cache_t, scalar_t, kv_dt>(tgt_key, *k_scale);
+      value_cache[dst_idx] =
+          fp8::scaled_convert<cache_t, scalar_t, kv_dt>(tgt_value, *v_scale);
     }
   }
 }
 
 template <typename scalar_t, typename cache_t, Fp8KVCacheDataType kv_dt>
 void call_reshape_and_cache_flash(
-    const scalar_t* __restrict__ key,    // [num_tokens, num_heads, head_size]
-    const scalar_t* __restrict__ value,  // [num_tokens, num_heads, head_size]
-    cache_t* __restrict__ key_cache,     // [num_blocks, block_size, num_heads,
-                                         // head_size]
-    cache_t* __restrict__ value_cache,   // [num_blocks, block_size, num_heads,
-                                         // head_size]
-    const int64_t* __restrict__ slot_mapping,  // [num_tokens]
-    const int64_t block_stride, const int64_t page_stride,
-    const int64_t head_stride, const int64_t key_stride,
-    const int64_t value_stride, const int num_tokens, const int num_heads,
-    const int head_size, const int block_size, const float* k_scale,
-    const float* v_scale) {
-
+    const scalar_t* __restrict__ key, const scalar_t* __restrict__ value,
+    cache_t* __restrict__ key_cache, cache_t* __restrict__ value_cache,
+    const int64_t* __restrict__ slot_mapping, const int64_t block_stride,
+    const int64_t page_stride, const int64_t head_stride,
+    const int64_t key_stride, const int64_t value_stride, const int num_tokens,
+    const int num_heads, const int head_size, const int block_size,
+    const float* k_scale, const float* v_scale) {
   auto& queue = vllm::xpu::vllmGetQueue();
   int wg = std::min(1024, static_cast<int>(num_heads * head_size));
 
@@ -91,47 +162,39 @@ void call_reshape_and_cache_flash(
 
 }  // namespace vllm
 
-// The following macro is used to dispatch the conversion function based on
-// the data type of the key and value cache. The FN is a macro that calls a
-// function with template<typename scalar_t, typename cache_t,
-// Fp8KVCacheDataType kv_dt>.
-#define DISPATCH_BY_KV_CACHE_DTYPE(SRC_DTYPE, KV_DTYPE, FN)                    \
-  if (KV_DTYPE == "auto") {                                                    \
-    if (SRC_DTYPE == at::ScalarType::Float) {                                  \
-      FN(float, float, vllm::Fp8KVCacheDataType::kAuto);                       \
-    } else if (SRC_DTYPE == at::ScalarType::Half) {                            \
-      FN(at::Half, at::Half, vllm::Fp8KVCacheDataType::kAuto);                 \
-    } else if (SRC_DTYPE == at::ScalarType::BFloat16) {                        \
-      FN(at::BFloat16, at::BFloat16, vllm::Fp8KVCacheDataType::kAuto);         \
-    } else {                                                                   \
-      TORCH_CHECK(false, "Unsupported input type of kv cache: ", SRC_DTYPE);   \
-    }                                                                          \
-  } else {                                                                     \
-    if (KV_DTYPE == "fp8" || KV_DTYPE == "fp8_e4m3") {                         \
-      if (SRC_DTYPE == at::ScalarType::Float) {                                \
-        FN(float, at::Float8_e4m3fn, vllm::Fp8KVCacheDataType::kFp8E4M3);      \
-      } else if (SRC_DTYPE == at::ScalarType::Half) {                          \
-        FN(at::Half, at::Float8_e4m3fn, vllm::Fp8KVCacheDataType::kFp8E4M3);   \
-      } else if (SRC_DTYPE == at::ScalarType::BFloat16) {                      \
-        FN(at::BFloat16, at::Float8_e4m3fn,                                    \
-           vllm::Fp8KVCacheDataType::kFp8E4M3);                                \
-      } else {                                                                 \
-        TORCH_CHECK(false, "Unsupported input type of kv cache: ", SRC_DTYPE); \
-      }                                                                        \
-    } else if (KV_DTYPE == "fp8_e5m2") {                                       \
-      if (SRC_DTYPE == at::ScalarType::Float) {                                \
-        FN(float, at::Float8_e5m2, vllm::Fp8KVCacheDataType::kFp8E5M2);        \
-      } else if (SRC_DTYPE == at::ScalarType::Half) {                          \
-        FN(at::Half, at::Float8_e5m2, vllm::Fp8KVCacheDataType::kFp8E5M2);     \
-      } else if (SRC_DTYPE == at::ScalarType::BFloat16) {                      \
-        FN(at::BFloat16, at::Float8_e5m2, vllm::Fp8KVCacheDataType::kFp8E5M2); \
-      } else {                                                                 \
-        TORCH_CHECK(false, "Unsupported input type of kv cache: ", SRC_DTYPE); \
-      }                                                                        \
-    } else {                                                                   \
-      TORCH_CHECK(false, "Unsupported data type of kv cache: ", KV_DTYPE);     \
-    }                                                                          \
-  }
+// KV_T is the stored data type of kv-cache.
+// CACHE_T is the data type of key and value tensors.
+// KV_DTYPE is the real data type of kv-cache.
+#define CALL_RESHAPE_AND_CACHE(KV_T, CACHE_T, KV_DTYPE)                      \
+  VLLM_DISPATCH_FLOATING_TYPES(key.scalar_type(), "reshape_and_cache", [&] { \
+    vllm::call_reshape_and_cache<KV_T, CACHE_T, KV_DTYPE>(                   \
+        reinterpret_cast<KV_T*>(key.data_ptr()),                             \
+        reinterpret_cast<KV_T*>(value.data_ptr()),                           \
+        reinterpret_cast<CACHE_T*>(key_cache.data_ptr()),                    \
+        reinterpret_cast<CACHE_T*>(value_cache.data_ptr()),                  \
+        slot_mapping.data_ptr<int64_t>(), num_tokens, key_stride,            \
+        value_stride, num_heads, head_size, block_size, x,                   \
+        reinterpret_cast<const float*>(k_scale.data_ptr()),                  \
+        reinterpret_cast<const float*>(v_scale.data_ptr()));                 \
+  });
+
+void reshape_and_cache(torch::Tensor& key, torch::Tensor& value,
+                       torch::Tensor& key_cache, torch::Tensor& value_cache,
+                       torch::Tensor& slot_mapping,
+                       const std::string& kv_cache_dtype,
+                       torch::Tensor& k_scale, torch::Tensor& v_scale) {
+  int num_tokens = slot_mapping.size(0);
+  int num_heads = key.size(1);
+  int head_size = key.size(2);
+  int block_size = key_cache.size(3);
+  int x = key_cache.size(4);
+
+  int key_stride = key.stride(0);
+  int value_stride = value.stride(0);
+
+  DISPATCH_BY_KV_CACHE_DTYPE(key.scalar_type(), kv_cache_dtype,
+                             CALL_RESHAPE_AND_CACHE);
+}
 
 // KV_T is the stored data type of kv-cache.
 // CACHE_T is the data type of key and value tensors.

--- a/csrc/xpu/cache.cpp
+++ b/csrc/xpu/cache.cpp
@@ -1,0 +1,174 @@
+#include <sycl/sycl.hpp>
+
+#include <algorithm>
+#include <iostream>
+#include <string>
+
+#include "utils.h"
+#include "dispatch_utils.h"
+
+namespace vllm {
+
+enum class Fp8KVCacheDataType {
+  kAuto = 0,
+  kFp8E4M3 = 1,
+  kFp8E5M2 = 2,
+};
+
+template <typename scalar_t, typename cache_t, Fp8KVCacheDataType kv_dt>
+void reshape_and_cache_flash_kernel(
+    const scalar_t* __restrict__ key, const scalar_t* __restrict__ value,
+    cache_t* __restrict__ key_cache, cache_t* __restrict__ value_cache,
+    const int64_t* __restrict__ slot_mapping, const int64_t block_stride,
+    const int64_t page_stride, const int64_t head_stride,
+    const int64_t key_stride, const int64_t value_stride, const int num_heads,
+    const int head_size, const int block_size, const float* k_scale,
+    const float* v_scale, const sycl::nd_item<1>& item) {
+  int64_t group_idx = item.get_group(0);
+  int64_t local_idx = item.get_local_id(0);
+  int local_range = item.get_local_range(0);
+  int64_t slot_idx = slot_mapping[group_idx];
+  if (slot_idx < 0) return;
+
+  const int64_t block_idx = slot_idx / block_size;
+  const int64_t block_offset = slot_idx % block_size;
+  const int n = num_heads * head_size;
+  for (int i = local_idx; i < n; i += local_range) {
+    const int64_t src_key_idx = group_idx * key_stride + i;
+    const int64_t src_value_idx = group_idx * value_stride + i;
+    const int head_idx = i / head_size;
+    const int head_offset = i % head_size;
+    const int64_t dst_idx = block_idx * block_stride +
+                            block_offset * page_stride +
+                            head_idx * head_stride + head_offset;
+
+    scalar_t tgt_key = key[src_key_idx];
+    scalar_t tgt_value = value[src_value_idx];
+    if constexpr (kv_dt == Fp8KVCacheDataType::kFp8E4M3) {
+      key_cache[dst_idx] = static_cast<at::Float8_e4m3fn>(tgt_key * (*k_scale));
+      value_cache[dst_idx] =
+          static_cast<at::Float8_e4m3fn>(tgt_value * (*v_scale));
+    } else if constexpr (kv_dt == Fp8KVCacheDataType::kFp8E5M2) {
+      key_cache[dst_idx] = static_cast<at::Float8_e5m2>(tgt_key * (*k_scale));
+      value_cache[dst_idx] =
+          static_cast<at::Float8_e5m2>(tgt_value * (*v_scale));
+    } else {
+      key_cache[dst_idx] = tgt_key;
+      value_cache[dst_idx] = tgt_value;
+    }
+  }
+}
+
+template <typename scalar_t, typename cache_t, Fp8KVCacheDataType kv_dt>
+void call_reshape_and_cache_flash(
+    const scalar_t* __restrict__ key,    // [num_tokens, num_heads, head_size]
+    const scalar_t* __restrict__ value,  // [num_tokens, num_heads, head_size]
+    cache_t* __restrict__ key_cache,     // [num_blocks, block_size, num_heads,
+                                         // head_size]
+    cache_t* __restrict__ value_cache,   // [num_blocks, block_size, num_heads,
+                                         // head_size]
+    const int64_t* __restrict__ slot_mapping,  // [num_tokens]
+    const int64_t block_stride, const int64_t page_stride,
+    const int64_t head_stride, const int64_t key_stride,
+    const int64_t value_stride, const int num_tokens, const int num_heads,
+    const int head_size, const int block_size, const float* k_scale,
+    const float* v_scale) {
+
+  auto& queue = vllm::xpu::vllmGetQueue();
+  int wg = std::min(1024, static_cast<int>(num_heads * head_size));
+
+  queue.submit([&](sycl::handler& cgh) {
+    cgh.parallel_for(
+        sycl::nd_range<1>(sycl::range<1>(num_tokens * wg), sycl::range<1>(wg)),
+        [=](sycl::nd_item<1> item) {
+          reshape_and_cache_flash_kernel<scalar_t, cache_t, kv_dt>(
+              key, value, key_cache, value_cache, slot_mapping, block_stride,
+              page_stride, head_stride, key_stride, value_stride, num_heads,
+              head_size, block_size, k_scale, v_scale, item);
+        });
+  });
+}
+
+}  // namespace vllm
+
+// The following macro is used to dispatch the conversion function based on
+// the data type of the key and value cache. The FN is a macro that calls a
+// function with template<typename scalar_t, typename cache_t,
+// Fp8KVCacheDataType kv_dt>.
+#define DISPATCH_BY_KV_CACHE_DTYPE(SRC_DTYPE, KV_DTYPE, FN)                    \
+  if (KV_DTYPE == "auto") {                                                    \
+    if (SRC_DTYPE == at::ScalarType::Float) {                                  \
+      FN(float, float, vllm::Fp8KVCacheDataType::kAuto);                       \
+    } else if (SRC_DTYPE == at::ScalarType::Half) {                            \
+      FN(at::Half, at::Half, vllm::Fp8KVCacheDataType::kAuto);                 \
+    } else if (SRC_DTYPE == at::ScalarType::BFloat16) {                        \
+      FN(at::BFloat16, at::BFloat16, vllm::Fp8KVCacheDataType::kAuto);         \
+    } else {                                                                   \
+      TORCH_CHECK(false, "Unsupported input type of kv cache: ", SRC_DTYPE);   \
+    }                                                                          \
+  } else {                                                                     \
+    if (KV_DTYPE == "fp8" || KV_DTYPE == "fp8_e4m3") {                         \
+      if (SRC_DTYPE == at::ScalarType::Float) {                                \
+        FN(float, at::Float8_e4m3fn, vllm::Fp8KVCacheDataType::kFp8E4M3);      \
+      } else if (SRC_DTYPE == at::ScalarType::Half) {                          \
+        FN(at::Half, at::Float8_e4m3fn, vllm::Fp8KVCacheDataType::kFp8E4M3);   \
+      } else if (SRC_DTYPE == at::ScalarType::BFloat16) {                      \
+        FN(at::BFloat16, at::Float8_e4m3fn,                                    \
+           vllm::Fp8KVCacheDataType::kFp8E4M3);                                \
+      } else {                                                                 \
+        TORCH_CHECK(false, "Unsupported input type of kv cache: ", SRC_DTYPE); \
+      }                                                                        \
+    } else if (KV_DTYPE == "fp8_e5m2") {                                       \
+      if (SRC_DTYPE == at::ScalarType::Float) {                                \
+        FN(float, at::Float8_e5m2, vllm::Fp8KVCacheDataType::kFp8E5M2);        \
+      } else if (SRC_DTYPE == at::ScalarType::Half) {                          \
+        FN(at::Half, at::Float8_e5m2, vllm::Fp8KVCacheDataType::kFp8E5M2);     \
+      } else if (SRC_DTYPE == at::ScalarType::BFloat16) {                      \
+        FN(at::BFloat16, at::Float8_e5m2, vllm::Fp8KVCacheDataType::kFp8E5M2); \
+      } else {                                                                 \
+        TORCH_CHECK(false, "Unsupported input type of kv cache: ", SRC_DTYPE); \
+      }                                                                        \
+    } else {                                                                   \
+      TORCH_CHECK(false, "Unsupported data type of kv cache: ", KV_DTYPE);     \
+    }                                                                          \
+  }
+
+// KV_T is the stored data type of kv-cache.
+// CACHE_T is the data type of key and value tensors.
+// KV_DTYPE is the real data type of kv-cache.
+#define CALL_RESHAPE_AND_CACHE_FLASH(KV_T, CACHE_T, KV_DTYPE)             \
+  VLLM_DISPATCH_FLOATING_TYPES(                                           \
+      key.scalar_type(), "reshape_and_cache_flash", [&] {                 \
+        vllm::call_reshape_and_cache_flash<KV_T, CACHE_T, KV_DTYPE>(      \
+            reinterpret_cast<KV_T*>(key.data_ptr()),                      \
+            reinterpret_cast<KV_T*>(value.data_ptr()),                    \
+            reinterpret_cast<CACHE_T*>(key_cache.data_ptr()),             \
+            reinterpret_cast<CACHE_T*>(value_cache.data_ptr()),           \
+            slot_mapping.data_ptr<int64_t>(), block_stride, page_stride,  \
+            head_stride, key_stride, value_stride, num_tokens, num_heads, \
+            head_size, block_size,                                        \
+            reinterpret_cast<const float*>(k_scale.data_ptr()),           \
+            reinterpret_cast<const float*>(v_scale.data_ptr()));          \
+      });
+
+void reshape_and_cache_flash(torch::Tensor& key, torch::Tensor& value,
+                             torch::Tensor& key_cache,
+                             torch::Tensor& value_cache,
+                             torch::Tensor& slot_mapping,
+                             const std::string& kv_cache_dtype,
+                             torch::Tensor& k_scale, torch::Tensor& v_scale) {
+  int num_tokens = slot_mapping.size(0);
+  int num_heads = key.size(1);
+  int head_size = key.size(2);
+  int block_size = key_cache.size(1);
+
+  int64_t key_stride = key.stride(0);
+  int64_t value_stride = value.stride(0);
+  int64_t block_stride = key_cache.stride(0);
+  int64_t page_stride = key_cache.stride(1);
+  int64_t head_stride = key_cache.stride(2);
+  TORCH_CHECK(key_cache.stride(0) == value_cache.stride(0));
+
+  DISPATCH_BY_KV_CACHE_DTYPE(key.scalar_type(), kv_cache_dtype,
+                             CALL_RESHAPE_AND_CACHE_FLASH);
+}

--- a/csrc/xpu/ops.h
+++ b/csrc/xpu/ops.h
@@ -7,3 +7,10 @@ void rms_norm(torch::Tensor& out, torch::Tensor& input, torch::Tensor& weight,
 
 void fused_add_rms_norm(torch::Tensor& input, torch::Tensor& residual,
                         torch::Tensor& weight, double epsilon);
+
+void reshape_and_cache_flash(torch::Tensor& key, torch::Tensor& value,
+                             torch::Tensor& key_cache,
+                             torch::Tensor& value_cache,
+                             torch::Tensor& slot_mapping,
+                             const std::string& kv_cache_dtype,
+                             torch::Tensor& k_scale, torch::Tensor& v_scale);

--- a/csrc/xpu/ops.h
+++ b/csrc/xpu/ops.h
@@ -8,6 +8,12 @@ void rms_norm(torch::Tensor& out, torch::Tensor& input, torch::Tensor& weight,
 void fused_add_rms_norm(torch::Tensor& input, torch::Tensor& residual,
                         torch::Tensor& weight, double epsilon);
 
+void reshape_and_cache(torch::Tensor& key, torch::Tensor& value,
+                       torch::Tensor& key_cache, torch::Tensor& value_cache,
+                       torch::Tensor& slot_mapping,
+                       const std::string& kv_cache_dtype,
+                       torch::Tensor& k_scale, torch::Tensor& v_scale);
+
 void reshape_and_cache_flash(torch::Tensor& key, torch::Tensor& value,
                              torch::Tensor& key_cache,
                              torch::Tensor& value_cache,

--- a/csrc/xpu/quantization/fp8/quant_utils.hpp
+++ b/csrc/xpu/quantization/fp8/quant_utils.hpp
@@ -1,0 +1,68 @@
+#include <ATen/ScalarType.h>
+
+namespace vllm {
+
+enum class Fp8KVCacheDataType {
+  kAuto = 0,
+  kFp8E4M3 = 1,
+  kFp8E5M2 = 2,
+};
+
+namespace fp8 {
+
+template <typename Tout, typename Tin, Fp8KVCacheDataType kv_dt>
+__inline__ Tout scaled_convert(const Tin& x, const float scale) {
+  if constexpr (kv_dt == Fp8KVCacheDataType::kFp8E4M3) {
+    return static_cast<at::Float8_e4m3fn>(x * scale);
+  } else if constexpr (kv_dt == Fp8KVCacheDataType::kFp8E5M2) {
+    return static_cast<at::Float8_e5m2>(x * scale);
+  }
+
+  assert(false);
+  return {};  // Squash missing return statement warning
+}
+
+}  // namespace fp8
+}  // namespace vllm
+
+// The following macro is used to dispatch the conversion function based on
+// the data type of the key and value cache. The FN is a macro that calls a
+// function with template<typename scalar_t, typename cache_t,
+// Fp8KVCacheDataType kv_dt>.
+#define DISPATCH_BY_KV_CACHE_DTYPE(SRC_DTYPE, KV_DTYPE, FN)                    \
+  if (KV_DTYPE == "auto") {                                                    \
+    if (SRC_DTYPE == at::ScalarType::Float) {                                  \
+      FN(float, float, vllm::Fp8KVCacheDataType::kAuto);                       \
+    } else if (SRC_DTYPE == at::ScalarType::Half) {                            \
+      FN(at::Half, at::Half, vllm::Fp8KVCacheDataType::kAuto);                 \
+    } else if (SRC_DTYPE == at::ScalarType::BFloat16) {                        \
+      FN(at::BFloat16, at::BFloat16, vllm::Fp8KVCacheDataType::kAuto);         \
+    } else {                                                                   \
+      TORCH_CHECK(false, "Unsupported input type of kv cache: ", SRC_DTYPE);   \
+    }                                                                          \
+  } else {                                                                     \
+    if (KV_DTYPE == "fp8" || KV_DTYPE == "fp8_e4m3") {                         \
+      if (SRC_DTYPE == at::ScalarType::Float) {                                \
+        FN(float, at::Float8_e4m3fn, vllm::Fp8KVCacheDataType::kFp8E4M3);      \
+      } else if (SRC_DTYPE == at::ScalarType::Half) {                          \
+        FN(at::Half, at::Float8_e4m3fn, vllm::Fp8KVCacheDataType::kFp8E4M3);   \
+      } else if (SRC_DTYPE == at::ScalarType::BFloat16) {                      \
+        FN(at::BFloat16, at::Float8_e4m3fn,                                    \
+           vllm::Fp8KVCacheDataType::kFp8E4M3);                                \
+      } else {                                                                 \
+        TORCH_CHECK(false, "Unsupported input type of kv cache: ", SRC_DTYPE); \
+      }                                                                        \
+    } else if (KV_DTYPE == "fp8_e5m2") {                                       \
+      if (SRC_DTYPE == at::ScalarType::Float) {                                \
+        FN(float, at::Float8_e5m2, vllm::Fp8KVCacheDataType::kFp8E5M2);        \
+      } else if (SRC_DTYPE == at::ScalarType::Half) {                          \
+        FN(at::Half, at::Float8_e5m2, vllm::Fp8KVCacheDataType::kFp8E5M2);     \
+      } else if (SRC_DTYPE == at::ScalarType::BFloat16) {                      \
+        FN(at::BFloat16, at::Float8_e5m2, vllm::Fp8KVCacheDataType::kFp8E5M2); \
+      } else {                                                                 \
+        TORCH_CHECK(false, "Unsupported input type of kv cache: ", SRC_DTYPE); \
+      }                                                                        \
+    } else {                                                                   \
+      TORCH_CHECK(false, "Unsupported data type of kv cache: ", KV_DTYPE);     \
+    }                                                                          \
+  }

--- a/csrc/xpu/quantization/fp8/quant_utils.hpp
+++ b/csrc/xpu/quantization/fp8/quant_utils.hpp
@@ -13,9 +13,9 @@ namespace fp8 {
 template <typename Tout, typename Tin, Fp8KVCacheDataType kv_dt>
 __inline__ Tout scaled_convert(const Tin& x, const float scale) {
   if constexpr (kv_dt == Fp8KVCacheDataType::kFp8E4M3) {
-    return static_cast<at::Float8_e4m3fn>(x * scale);
+    return static_cast<at::Float8_e4m3fn>(x / scale);
   } else if constexpr (kv_dt == Fp8KVCacheDataType::kFp8E5M2) {
-    return static_cast<at::Float8_e5m2>(x * scale);
+    return static_cast<at::Float8_e5m2>(x / scale);
   }
 
   assert(false);

--- a/csrc/xpu/torch_bindings.cpp
+++ b/csrc/xpu/torch_bindings.cpp
@@ -33,4 +33,17 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
   ops.impl("fused_add_rms_norm", torch::kXPU, &fused_add_rms_norm);
 }
 
+TORCH_LIBRARY_EXPAND(CONCAT(TORCH_EXTENSION_NAME, _cache_ops), cache_ops) {
+  // Reshape the key and value tensors and cache them.
+  cache_ops.def(
+      "reshape_and_cache_flash(Tensor key, Tensor value,"
+      "                        Tensor! key_cache,"
+      "                        Tensor! value_cache,"
+      "                        Tensor slot_mapping,"
+      "                        str kv_cache_dtype,"
+      "                        Tensor k_scale, Tensor v_scale) -> ()");
+  cache_ops.impl("reshape_and_cache_flash", torch::kXPU,
+                 &reshape_and_cache_flash);
+}
+
 REGISTER_EXTENSION(TORCH_EXTENSION_NAME)

--- a/csrc/xpu/torch_bindings.cpp
+++ b/csrc/xpu/torch_bindings.cpp
@@ -36,6 +36,15 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
 TORCH_LIBRARY_EXPAND(CONCAT(TORCH_EXTENSION_NAME, _cache_ops), cache_ops) {
   // Reshape the key and value tensors and cache them.
   cache_ops.def(
+      "reshape_and_cache(Tensor key, Tensor value,"
+      "                  Tensor! key_cache, Tensor! value_cache,"
+      "                  Tensor slot_mapping,"
+      "                  str kv_cache_dtype,"
+      "                  Tensor k_scale, Tensor v_scale) -> ()");
+  cache_ops.impl("reshape_and_cache", torch::kXPU, &reshape_and_cache);
+
+  // Reshape the key and value tensors and cache them.
+  cache_ops.def(
       "reshape_and_cache_flash(Tensor key, Tensor value,"
       "                        Tensor! key_cache,"
       "                        Tensor! value_cache,"

--- a/tests/ops/cache_op.py
+++ b/tests/ops/cache_op.py
@@ -1,1 +1,3 @@
-from tests.register_ops import reshape_and_cache, reshape_and_cache_flash
+# SPDX-License-Identifier: Apache-2.0
+from tests.register_ops import reshape_and_cache  # noqa: F401
+from tests.register_ops import reshape_and_cache_flash  # noqa: F401

--- a/tests/ops/cache_op.py
+++ b/tests/ops/cache_op.py
@@ -1,1 +1,1 @@
-from tests.register_ops import reshape_and_cache_flash
+from tests.register_ops import reshape_and_cache, reshape_and_cache_flash

--- a/tests/ops/cache_op.py
+++ b/tests/ops/cache_op.py
@@ -1,0 +1,1 @@
+from tests.register_ops import reshape_and_cache_flash

--- a/tests/register_ops.py
+++ b/tests/register_ops.py
@@ -20,6 +20,28 @@ def fused_add_rms_norm(input: torch.Tensor, residual: torch.Tensor,
     torch.ops._C.fused_add_rms_norm(input, residual, weight, epsilon)
 
 
+def reshape_and_cache(
+    key: torch.Tensor,
+    value: torch.Tensor,
+    key_cache: torch.Tensor,
+    value_cache: torch.Tensor,
+    slot_mapping: torch.Tensor,
+    kv_cache_dtype: str,
+    k_scale: torch.Tensor,
+    v_scale: torch.Tensor,
+) -> None:
+    torch.ops._C_cache_ops.reshape_and_cache(
+        key,
+        value,
+        key_cache,
+        value_cache,
+        slot_mapping,
+        kv_cache_dtype,
+        k_scale,
+        v_scale,
+    )
+
+
 def reshape_and_cache_flash(
     key: torch.Tensor,
     value: torch.Tensor,

--- a/tests/register_ops.py
+++ b/tests/register_ops.py
@@ -18,3 +18,25 @@ def rms_norm(out: torch.Tensor, input: torch.Tensor, weight: torch.Tensor,
 def fused_add_rms_norm(input: torch.Tensor, residual: torch.Tensor,
                        weight: torch.Tensor, epsilon: float) -> None:
     torch.ops._C.fused_add_rms_norm(input, residual, weight, epsilon)
+
+
+def reshape_and_cache_flash(
+    key: torch.Tensor,
+    value: torch.Tensor,
+    key_cache: torch.Tensor,
+    value_cache: torch.Tensor,
+    slot_mapping: torch.Tensor,
+    kv_cache_dtype: str,
+    k_scale: torch.Tensor,
+    v_scale: torch.Tensor,
+) -> None:
+    torch.ops._C_cache_ops.reshape_and_cache_flash(
+        key,
+        value,
+        key_cache,
+        value_cache,
+        slot_mapping,
+        kv_cache_dtype,
+        k_scale,
+        v_scale,
+    )

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -5,9 +5,10 @@ import random
 import pytest
 import torch
 
-from tests.ops.cache_op import reshape_and_cache_flash
+from tests.ops.cache_op import reshape_and_cache, reshape_and_cache_flash
 from tests.utils import (
     opcheck,
+    create_kv_caches_with_random,
     create_kv_caches_with_random_flash,
 )
 
@@ -18,8 +19,112 @@ NUM_LAYERS = [1]
 HEAD_SIZES = [64, 80, 120, 256]
 BLOCK_SIZES = [8, 16, 32]
 NUM_BLOCKS = [1024]  # don't make it too large. e.g. [36000] will OOM
-DEVICES = [f"xpu:{i}" for i in range(1 if torch.xpu.device_count() == 1 else 2)]
+SEEDS = [0]
+DEVICES = [f"xpu:{0}"]
 KV_CACHE_DTYPE = ["auto"]
+
+
+@pytest.mark.parametrize("num_tokens", NUM_TOKENS)
+@pytest.mark.parametrize("num_heads", NUM_HEADS)
+@pytest.mark.parametrize("head_size", HEAD_SIZES)
+@pytest.mark.parametrize("block_size", BLOCK_SIZES)
+@pytest.mark.parametrize("num_blocks", NUM_BLOCKS)
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("seed", SEEDS)
+@pytest.mark.parametrize("device", DEVICES)
+@pytest.mark.parametrize("kv_cache_dtype", KV_CACHE_DTYPE)
+@torch.inference_mode()
+def test_reshape_and_cache(
+    num_tokens: int,
+    num_heads: int,
+    head_size: int,
+    block_size: int,
+    num_blocks: int,
+    dtype: torch.dtype,
+    device: str,
+    seed: int,
+    kv_cache_dtype: str,
+) -> None:
+    if kv_cache_dtype == "fp8" and head_size % 16:
+        pytest.skip()
+
+    torch.set_default_device(device)
+    # Create a random slot mapping.
+    num_slots = block_size * num_blocks
+    slot_mapping_lst = random.sample(range(num_slots), num_tokens)
+    slot_mapping = torch.tensor(slot_mapping_lst, dtype=torch.long)
+
+    qkv = torch.randn(num_tokens, 3, num_heads, head_size, dtype=dtype)
+    _, key, value = qkv.unbind(dim=1)
+
+    # Create the KV caches.
+    key_caches, value_caches = create_kv_caches_with_random(
+        num_blocks,
+        block_size,
+        1,
+        num_heads,
+        head_size,
+        kv_cache_dtype,
+        dtype,
+        seed=seed,
+        device=device,
+    )
+    key_cache, value_cache = key_caches[0], value_caches[0]
+
+    # Using default kv_scale
+    k_scale = (key.amax() / 64.0).to(torch.float32)
+    v_scale = (value.amax() / 64.0).to(torch.float32)
+
+    def permute_and_compact(x):
+        return x.contiguous()
+
+    key_cache_compact = permute_and_compact(key_cache)
+    value_cache_compact = permute_and_compact(value_cache)
+
+    cloned_key_cache = key_cache_compact.clone()
+    cloned_value_cache = value_cache_compact.clone()
+
+    # Call the reshape_and_cache kernel.
+    opcheck(
+        torch.ops._C_cache_ops.reshape_and_cache,
+        (
+            key,
+            value,
+            key_cache,
+            value_cache,
+            slot_mapping,
+            kv_cache_dtype,
+            k_scale,
+            v_scale,
+        ),
+        cond=(head_size == HEAD_SIZES[0]),
+    )
+    reshape_and_cache(
+        key,
+        value,
+        key_cache,
+        value_cache,
+        slot_mapping,
+        kv_cache_dtype,
+        k_scale,
+        v_scale,
+    )
+    key_cache_compact = permute_and_compact(key_cache)
+    value_cache_compact = permute_and_compact(value_cache)
+
+    reshaped_key = key.reshape(num_tokens, *key_cache[0, :, :, 0, :].shape)
+    block_indices = torch.div(slot_mapping, block_size, rounding_mode="floor")
+    block_indices_lst = block_indices.cpu().tolist()
+    block_offsets = slot_mapping % block_size
+    block_offsets_lst = block_offsets.cpu().tolist()
+    for i in range(num_tokens):
+        block_idx = block_indices_lst[i]
+        block_offset = block_offsets_lst[i]
+        cloned_key_cache[block_idx, :, :, block_offset, :] = reshaped_key[i]
+        cloned_value_cache[block_idx, :, :, block_offset] = value[i]
+
+    torch.testing.assert_close(key_cache_compact, cloned_key_cache)
+    torch.testing.assert_close(value_cache_compact, cloned_value_cache)
 
 
 @pytest.mark.parametrize("num_tokens", NUM_TOKENS)
@@ -29,6 +134,7 @@ KV_CACHE_DTYPE = ["auto"]
 @pytest.mark.parametrize("block_size", BLOCK_SIZES)
 @pytest.mark.parametrize("num_blocks", NUM_BLOCKS)
 @pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("seed", SEEDS)
 @pytest.mark.parametrize("device", DEVICES)
 @pytest.mark.parametrize("kv_cache_dtype", KV_CACHE_DTYPE)
 @torch.inference_mode()
@@ -40,6 +146,7 @@ def test_reshape_and_cache_flash(
     block_size: int,
     num_blocks: int,
     dtype: torch.dtype,
+    seed: int,
     device: str,
     kv_cache_dtype: str,
 ) -> None:
@@ -61,6 +168,7 @@ def test_reshape_and_cache_flash(
         head_size,
         kv_cache_dtype,
         dtype,
+        seed=seed,
         device=device,
     )
     key_cache, value_cache = key_caches[0], value_caches[0]

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -4,12 +4,10 @@ import random
 
 import pytest
 import torch
-from typing import Optional, Union
 
 from tests.ops.cache_op import reshape_and_cache_flash
 from tests.utils import (
     opcheck,
-    STR_DTYPE_TO_TORCH_DTYPE,
     create_kv_caches_with_random_flash,
 )
 
@@ -17,41 +15,11 @@ DTYPES = [torch.half, torch.bfloat16]
 NUM_TOKENS = [42]  # Arbitrary values for testing
 NUM_HEADS = [8]  # Arbitrary values for testing
 NUM_LAYERS = [1]
-HEAD_SIZES = [64]
-# HEAD_SIZES = [64, 80, 120, 256]
-BLOCK_SIZES = [8]
-# BLOCK_SIZES = [8, 16, 32]
-CACHE_LAYOUTS = ["NHD"]
-# CACHE_LAYOUTS = ["NHD", "HND"]
-
-# Parameters for MLA tests.
-KV_LORA_RANKS = [512]
-QK_ROPE_HEAD_DIMS = [64]
-NUM_TOKENS_MLA = [42]
-BLOCK_SIZES_MLA = [16]
-NUM_BLOCKS_MLA = [8]
-
-# Arbitrary values for testing
-# don't make it too large. e.g. [1024, 36000] will OOM
-NUM_BLOCKS = [1024]
-# NUM_BLOCKS = [1024, 10000]
-
-NUM_MAPPINGS = [256]  # Arbitrary values for testing
-SEEDS = [0]
-CUDA_DEVICES = [f"xpu:{i}" for i in range(1 if torch.xpu.device_count() == 1 else 2)]
-
-# We assume fp8 is always enabled for testing.
+HEAD_SIZES = [64, 80, 120, 256]
+BLOCK_SIZES = [8, 16, 32]
+NUM_BLOCKS = [1024]  # don't make it too large. e.g. [36000] will OOM
+DEVICES = [f"xpu:{i}" for i in range(1 if torch.xpu.device_count() == 1 else 2)]
 KV_CACHE_DTYPE = ["auto"]
-# KV_CACHE_DTYPE = ["auto", "fp8", "fp8_e4m3", "fp8_e5m2"]
-
-# STR_DTYPE_TO_TORCH_DTYPE = {
-#     "half": torch.half,
-#     "bfloat16": torch.bfloat16,
-#     "fp8": torch.float8_e4m3fn,
-#     "fp8_e4m3": torch.float8_e4m3fn,
-#     "fp8_e5m2": torch.float8_e5m2,
-#     "int8": torch.int8,
-# }
 
 
 @pytest.mark.parametrize("num_tokens", NUM_TOKENS)
@@ -61,10 +29,8 @@ KV_CACHE_DTYPE = ["auto"]
 @pytest.mark.parametrize("block_size", BLOCK_SIZES)
 @pytest.mark.parametrize("num_blocks", NUM_BLOCKS)
 @pytest.mark.parametrize("dtype", DTYPES)
-@pytest.mark.parametrize("seed", SEEDS)
-@pytest.mark.parametrize("device", CUDA_DEVICES)
+@pytest.mark.parametrize("device", DEVICES)
 @pytest.mark.parametrize("kv_cache_dtype", KV_CACHE_DTYPE)
-@pytest.mark.parametrize("kv_cache_layout", CACHE_LAYOUTS)
 @torch.inference_mode()
 def test_reshape_and_cache_flash(
     num_tokens: int,
@@ -74,10 +40,8 @@ def test_reshape_and_cache_flash(
     block_size: int,
     num_blocks: int,
     dtype: torch.dtype,
-    seed: int,
     device: str,
     kv_cache_dtype: str,
-    kv_cache_layout: str,
 ) -> None:
     torch.set_default_device(device)
 
@@ -98,7 +62,6 @@ def test_reshape_and_cache_flash(
         kv_cache_dtype,
         dtype,
         device=device,
-        cache_layout=kv_cache_layout,
     )
     key_cache, value_cache = key_caches[0], value_caches[0]
 
@@ -106,28 +69,18 @@ def test_reshape_and_cache_flash(
     v_scale = (value.amax() / 64.0).to(torch.float32)
 
     def permute_and_compact(x):
-        y = x if kv_cache_layout == "NHD" else x.permute(0, 2, 1, 3)
-        return y.contiguous()
+        return x.contiguous()
 
     key_cache_compact = permute_and_compact(key_cache)
     value_cache_compact = permute_and_compact(value_cache)
 
     # Clone the KV caches.
-    if kv_cache_dtype == "fp8":
-        cloned_key_cache = torch.empty_like(key_cache_compact, dtype=torch.float16)
-        ops.convert_fp8(
-            cloned_key_cache, key_cache_compact, k_scale.item(), kv_cache_dtype
-        )
-        cloned_value_cache = torch.empty_like(value_cache_compact, dtype=torch.float16)
-        ops.convert_fp8(
-            cloned_value_cache, value_cache_compact, v_scale.item(), kv_cache_dtype
-        )
-    else:
-        cloned_key_cache = key_cache_compact.clone()
-        cloned_value_cache = value_cache_compact.clone()
+    cloned_key_cache = key_cache_compact.clone()
+    cloned_value_cache = value_cache_compact.clone()
+
     # Call the reshape_and_cache kernel.
     opcheck(
-        reshape_and_cache_flash,
+        torch.ops._C_cache_ops.reshape_and_cache_flash,
         (
             key,
             value,
@@ -138,7 +91,6 @@ def test_reshape_and_cache_flash(
             k_scale,
             v_scale,
         ),
-        cond=(head_size == HEAD_SIZES[0]),
     )
     reshape_and_cache_flash(
         key,
@@ -153,19 +105,6 @@ def test_reshape_and_cache_flash(
     key_cache_compact = permute_and_compact(key_cache)
     value_cache_compact = permute_and_compact(value_cache)
 
-    if kv_cache_dtype == "fp8":
-        result_key_cache = torch.empty_like(key_cache_compact, dtype=torch.float16)
-        ops.convert_fp8(
-            result_key_cache, key_cache_compact, k_scale.item(), kv_dtype=kv_cache_dtype
-        )
-        result_value_cache = torch.empty_like(value_cache_compact, dtype=torch.float16)
-        ops.convert_fp8(
-            result_value_cache,
-            value_cache_compact,
-            v_scale.item(),
-            kv_dtype=kv_cache_dtype,
-        )
-
     # Run the reference implementation.
     block_indicies = torch.div(slot_mapping, block_size, rounding_mode="floor")
     block_indicies_lst = block_indicies.cpu().tolist()
@@ -174,20 +113,8 @@ def test_reshape_and_cache_flash(
     for i in range(num_tokens):
         block_idx = block_indicies_lst[i]
         block_offset = block_offsets_lst[i]
-        if kv_cache_layout == "NHD":
-            cloned_key_cache[block_idx, block_offset, :, :] = key[i]
-            cloned_value_cache[block_idx, block_offset, :, :] = value[i]
-        else:
-            cloned_key_cache[block_idx, :, block_offset, :] = key[i]
-            cloned_value_cache[block_idx, :, block_offset, :] = value[i]
+        cloned_key_cache[block_idx, block_offset, :, :] = key[i]
+        cloned_value_cache[block_idx, block_offset, :, :] = value[i]
 
-    if kv_cache_dtype == "fp8":
-        torch.testing.assert_close(
-            result_key_cache, cloned_key_cache, atol=0.001, rtol=0.1
-        )
-        torch.testing.assert_close(
-            result_value_cache, cloned_value_cache, atol=0.001, rtol=0.1
-        )
-    else:
-        torch.testing.assert_close(key_cache_compact, cloned_key_cache)
-        torch.testing.assert_close(value_cache_compact, cloned_value_cache)
+    torch.testing.assert_close(key_cache_compact, cloned_key_cache)
+    torch.testing.assert_close(value_cache_compact, cloned_value_cache)

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -6,11 +6,8 @@ import pytest
 import torch
 
 from tests.ops.cache_op import reshape_and_cache, reshape_and_cache_flash
-from tests.utils import (
-    opcheck,
-    create_kv_caches_with_random,
-    create_kv_caches_with_random_flash,
-)
+from tests.utils import (create_kv_caches_with_random,
+                         create_kv_caches_with_random_flash, opcheck)
 
 DTYPES = [torch.half, torch.bfloat16]
 NUM_TOKENS = [42]  # Arbitrary values for testing
@@ -20,7 +17,9 @@ HEAD_SIZES = [64, 80, 120, 256]
 BLOCK_SIZES = [8, 16, 32]
 NUM_BLOCKS = [1024]  # don't make it too large. e.g. [36000] will OOM
 SEEDS = [0]
-DEVICES = [f"xpu:{i}" for i in range(1 if torch.xpu.device_count() == 1 else 2)]
+DEVICES = [
+    f"xpu:{i}" for i in range(1 if torch.xpu.device_count() == 1 else 2)
+]
 KV_CACHE_DTYPE = ["auto"]
 
 
@@ -159,8 +158,15 @@ def test_reshape_and_cache_flash(
     # Create a random slot mapping.
     num_slots = block_size * num_blocks
     slot_mapping_lst = random.sample(range(num_slots), num_tokens)
-    slot_mapping = torch.tensor(slot_mapping_lst, dtype=torch.long, device=device)
-    qkv = torch.randn(num_tokens, 3, num_heads, head_size, dtype=dtype, device=device)
+    slot_mapping = torch.tensor(slot_mapping_lst,
+                                dtype=torch.long,
+                                device=device)
+    qkv = torch.randn(num_tokens,
+                      3,
+                      num_heads,
+                      head_size,
+                      dtype=dtype,
+                      device=device)
     _, key, value = qkv.unbind(dim=1)
 
     # Create the KV caches.

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -20,7 +20,7 @@ HEAD_SIZES = [64, 80, 120, 256]
 BLOCK_SIZES = [8, 16, 32]
 NUM_BLOCKS = [1024]  # don't make it too large. e.g. [36000] will OOM
 SEEDS = [0]
-DEVICES = [f"xpu:{0}"]
+DEVICES = [f"xpu:{i}" for i in range(1 if torch.xpu.device_count() == 1 else 2)]
 KV_CACHE_DTYPE = ["auto"]
 
 
@@ -48,7 +48,9 @@ def test_reshape_and_cache(
     if kv_cache_dtype == "fp8" and head_size % 16:
         pytest.skip()
 
-    torch.set_default_device(device)
+    # Note: torch.set_default_device("xpu:1") not works.
+    torch.set_default_device("xpu")
+    torch.xpu.set_device(device)
     # Create a random slot mapping.
     num_slots = block_size * num_blocks
     slot_mapping_lst = random.sample(range(num_slots), num_tokens)
@@ -150,7 +152,9 @@ def test_reshape_and_cache_flash(
     device: str,
     kv_cache_dtype: str,
 ) -> None:
-    torch.set_default_device(device)
+    # Note: torch.set_default_device("xpu:1") not works.
+    torch.set_default_device("xpu")
+    torch.xpu.set_device(device)
 
     # Create a random slot mapping.
     num_slots = block_size * num_blocks

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,193 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import random
+
+import pytest
+import torch
+from typing import Optional, Union
+
+from tests.ops.cache_op import reshape_and_cache_flash
+from tests.utils import (
+    opcheck,
+    STR_DTYPE_TO_TORCH_DTYPE,
+    create_kv_caches_with_random_flash,
+)
+
+DTYPES = [torch.half, torch.bfloat16]
+NUM_TOKENS = [42]  # Arbitrary values for testing
+NUM_HEADS = [8]  # Arbitrary values for testing
+NUM_LAYERS = [1]
+HEAD_SIZES = [64]
+# HEAD_SIZES = [64, 80, 120, 256]
+BLOCK_SIZES = [8]
+# BLOCK_SIZES = [8, 16, 32]
+CACHE_LAYOUTS = ["NHD"]
+# CACHE_LAYOUTS = ["NHD", "HND"]
+
+# Parameters for MLA tests.
+KV_LORA_RANKS = [512]
+QK_ROPE_HEAD_DIMS = [64]
+NUM_TOKENS_MLA = [42]
+BLOCK_SIZES_MLA = [16]
+NUM_BLOCKS_MLA = [8]
+
+# Arbitrary values for testing
+# don't make it too large. e.g. [1024, 36000] will OOM
+NUM_BLOCKS = [1024]
+# NUM_BLOCKS = [1024, 10000]
+
+NUM_MAPPINGS = [256]  # Arbitrary values for testing
+SEEDS = [0]
+CUDA_DEVICES = [f"xpu:{i}" for i in range(1 if torch.xpu.device_count() == 1 else 2)]
+
+# We assume fp8 is always enabled for testing.
+KV_CACHE_DTYPE = ["auto"]
+# KV_CACHE_DTYPE = ["auto", "fp8", "fp8_e4m3", "fp8_e5m2"]
+
+# STR_DTYPE_TO_TORCH_DTYPE = {
+#     "half": torch.half,
+#     "bfloat16": torch.bfloat16,
+#     "fp8": torch.float8_e4m3fn,
+#     "fp8_e4m3": torch.float8_e4m3fn,
+#     "fp8_e5m2": torch.float8_e5m2,
+#     "int8": torch.int8,
+# }
+
+
+@pytest.mark.parametrize("num_tokens", NUM_TOKENS)
+@pytest.mark.parametrize("num_heads", NUM_HEADS)
+@pytest.mark.parametrize("num_layers", NUM_LAYERS)
+@pytest.mark.parametrize("head_size", HEAD_SIZES)
+@pytest.mark.parametrize("block_size", BLOCK_SIZES)
+@pytest.mark.parametrize("num_blocks", NUM_BLOCKS)
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("seed", SEEDS)
+@pytest.mark.parametrize("device", CUDA_DEVICES)
+@pytest.mark.parametrize("kv_cache_dtype", KV_CACHE_DTYPE)
+@pytest.mark.parametrize("kv_cache_layout", CACHE_LAYOUTS)
+@torch.inference_mode()
+def test_reshape_and_cache_flash(
+    num_tokens: int,
+    num_heads: int,
+    num_layers: int,
+    head_size: int,
+    block_size: int,
+    num_blocks: int,
+    dtype: torch.dtype,
+    seed: int,
+    device: str,
+    kv_cache_dtype: str,
+    kv_cache_layout: str,
+) -> None:
+    torch.set_default_device(device)
+
+    # Create a random slot mapping.
+    num_slots = block_size * num_blocks
+    slot_mapping_lst = random.sample(range(num_slots), num_tokens)
+    slot_mapping = torch.tensor(slot_mapping_lst, dtype=torch.long, device=device)
+    qkv = torch.randn(num_tokens, 3, num_heads, head_size, dtype=dtype, device=device)
+    _, key, value = qkv.unbind(dim=1)
+
+    # Create the KV caches.
+    key_caches, value_caches = create_kv_caches_with_random_flash(
+        num_blocks,
+        block_size,
+        1,  # num_layers
+        num_heads,
+        head_size,
+        kv_cache_dtype,
+        dtype,
+        device=device,
+        cache_layout=kv_cache_layout,
+    )
+    key_cache, value_cache = key_caches[0], value_caches[0]
+
+    k_scale = (key.amax() / 64.0).to(torch.float32)
+    v_scale = (value.amax() / 64.0).to(torch.float32)
+
+    def permute_and_compact(x):
+        y = x if kv_cache_layout == "NHD" else x.permute(0, 2, 1, 3)
+        return y.contiguous()
+
+    key_cache_compact = permute_and_compact(key_cache)
+    value_cache_compact = permute_and_compact(value_cache)
+
+    # Clone the KV caches.
+    if kv_cache_dtype == "fp8":
+        cloned_key_cache = torch.empty_like(key_cache_compact, dtype=torch.float16)
+        ops.convert_fp8(
+            cloned_key_cache, key_cache_compact, k_scale.item(), kv_cache_dtype
+        )
+        cloned_value_cache = torch.empty_like(value_cache_compact, dtype=torch.float16)
+        ops.convert_fp8(
+            cloned_value_cache, value_cache_compact, v_scale.item(), kv_cache_dtype
+        )
+    else:
+        cloned_key_cache = key_cache_compact.clone()
+        cloned_value_cache = value_cache_compact.clone()
+    # Call the reshape_and_cache kernel.
+    opcheck(
+        reshape_and_cache_flash,
+        (
+            key,
+            value,
+            key_cache,
+            value_cache,
+            slot_mapping,
+            kv_cache_dtype,
+            k_scale,
+            v_scale,
+        ),
+        cond=(head_size == HEAD_SIZES[0]),
+    )
+    reshape_and_cache_flash(
+        key,
+        value,
+        key_cache,
+        value_cache,
+        slot_mapping,
+        kv_cache_dtype,
+        k_scale,
+        v_scale,
+    )
+    key_cache_compact = permute_and_compact(key_cache)
+    value_cache_compact = permute_and_compact(value_cache)
+
+    if kv_cache_dtype == "fp8":
+        result_key_cache = torch.empty_like(key_cache_compact, dtype=torch.float16)
+        ops.convert_fp8(
+            result_key_cache, key_cache_compact, k_scale.item(), kv_dtype=kv_cache_dtype
+        )
+        result_value_cache = torch.empty_like(value_cache_compact, dtype=torch.float16)
+        ops.convert_fp8(
+            result_value_cache,
+            value_cache_compact,
+            v_scale.item(),
+            kv_dtype=kv_cache_dtype,
+        )
+
+    # Run the reference implementation.
+    block_indicies = torch.div(slot_mapping, block_size, rounding_mode="floor")
+    block_indicies_lst = block_indicies.cpu().tolist()
+    block_offsets = slot_mapping % block_size
+    block_offsets_lst = block_offsets.cpu().tolist()
+    for i in range(num_tokens):
+        block_idx = block_indicies_lst[i]
+        block_offset = block_offsets_lst[i]
+        if kv_cache_layout == "NHD":
+            cloned_key_cache[block_idx, block_offset, :, :] = key[i]
+            cloned_value_cache[block_idx, block_offset, :, :] = value[i]
+        else:
+            cloned_key_cache[block_idx, :, block_offset, :] = key[i]
+            cloned_value_cache[block_idx, :, block_offset, :] = value[i]
+
+    if kv_cache_dtype == "fp8":
+        torch.testing.assert_close(
+            result_key_cache, cloned_key_cache, atol=0.001, rtol=0.1
+        )
+        torch.testing.assert_close(
+            result_value_cache, cloned_value_cache, atol=0.001, rtol=0.1
+        )
+    else:
+        torch.testing.assert_close(key_cache_compact, cloned_key_cache)
+        torch.testing.assert_close(value_cache_compact, cloned_value_cache)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -3,6 +3,8 @@ import unittest
 from collections.abc import Sequence
 from typing import Any, Optional, Union
 
+import numpy as np
+import random
 import torch
 from torch._prims_common import TensorLikeType
 
@@ -69,3 +71,86 @@ STR_DTYPE_TO_TORCH_DTYPE = {
     "int8": torch.int8,
     "fp8_inc": torch.float8_e4m3fn,
 }
+
+def _generate_random_fp8(
+    cache_dtype: Optional[Union[str, torch.dtype]],
+    tensor: torch.Tensor,
+    low: float,
+    high: float,
+) -> None:
+    if cache_dtype == "fp8" or cache_dtype == "fp8_e4m3":
+        dst_dtype = torch.float8_e4m3fn
+    elif cache_dtype == "fp8_e5m2":
+        dst_dtype = torch.float8_e5m2
+    else:
+        assert False
+    tensor_tmp = torch.empty_like(tensor, dtype=torch.float16)
+    tensor_tmp.uniform_(low, high)
+    tensor = tensor_tmp.to(dst_dtype)
+    del tensor_tmp
+
+def get_kv_cache_torch_dtype(
+        cache_dtype: Optional[Union[str, torch.dtype]],
+        model_dtype: Optional[Union[str, torch.dtype]] = None) -> torch.dtype:
+    if isinstance(cache_dtype, str):
+        if cache_dtype == "auto":
+            if isinstance(model_dtype,
+                          str) and model_dtype in STR_DTYPE_TO_TORCH_DTYPE:
+                torch_dtype = STR_DTYPE_TO_TORCH_DTYPE[model_dtype]
+            elif isinstance(model_dtype, torch.dtype):
+                torch_dtype = model_dtype
+            else:
+                raise ValueError(f"Invalid model dtype: {model_dtype}")
+        elif cache_dtype in STR_DTYPE_TO_TORCH_DTYPE:
+            torch_dtype = STR_DTYPE_TO_TORCH_DTYPE[cache_dtype]
+        else:
+            raise ValueError(f"Invalid kv cache dtype: {cache_dtype}")
+    elif isinstance(cache_dtype, torch.dtype):
+        torch_dtype = cache_dtype
+    else:
+        raise ValueError(f"Invalid kv cache dtype: {cache_dtype}")
+    return torch_dtype
+
+def create_kv_caches_with_random_flash(
+    num_blocks: int,
+    block_size: int,
+    num_layers: int,
+    num_heads: int,
+    head_size: int,
+    cache_dtype: Optional[Union[str, torch.dtype]],
+    model_dtype: Optional[Union[str, torch.dtype]] = None,
+    seed: Optional[int] = None,
+    device: Optional[str] = "xpu",
+    cache_layout: Optional[str] = "NHD",
+) -> tuple[list[torch.Tensor], list[torch.Tensor]]:
+    if not seed is None:
+        random.seed(seed)
+        np.random.seed(seed)
+        torch.manual_seed(seed)
+    torch_dtype = get_kv_cache_torch_dtype(cache_dtype, model_dtype)
+    generic_kv_cache_shape = (num_blocks, 2, block_size, num_heads, head_size)
+    assert cache_layout in ("NHD", "HND")
+    stride_order = (0, 1, 2, 3, 4) if cache_layout == "NHD" else (0, 1, 3, 2,
+                                                                  4)
+
+    kv_cache_allocation_shape = tuple(generic_kv_cache_shape[i]
+                                      for i in stride_order)
+    scale = head_size**-0.5
+
+    key_caches: list[torch.Tensor] = []
+    value_caches: list[torch.Tensor] = []
+
+    for _ in range(num_layers):
+        key_value_cache = torch.empty(size=kv_cache_allocation_shape,
+                                      dtype=torch_dtype,
+                                      device=device).permute(*stride_order)
+        if cache_dtype in ["auto", "half", "bfloat16", "float"]:
+            key_value_cache.uniform_(-scale, scale)
+        elif cache_dtype in ["fp8", "fp8_e4m3", "fp8_e5m2"]:
+            _generate_random_fp8(cache_dtype, key_value_cache, -scale, scale)
+        else:
+            raise ValueError(
+                f"Does not support key cache of type {cache_dtype}")
+        key_caches.append(key_value_cache[:, 0])
+        value_caches.append(key_value_cache[:, 1])
+    return key_caches, value_caches

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -27,38 +27,40 @@ def fp8_allclose(
     """
     Reference implementation of torch.allclose
     """
-    torch._refs._check_close_args(name="torch.allclose",
-                                  a=a,
-                                  b=b,
-                                  rtol=rtol,
-                                  atol=atol)
+    torch._refs._check_close_args(name="torch.allclose", a=a, b=b, rtol=rtol, atol=atol)
 
     return bool(
         torch.all(
-            torch.isclose(a.double(),
-                          b.double(),
-                          rtol=rtol,
-                          atol=atol,
-                          equal_nan=equal_nan)).item())
+            torch.isclose(
+                a.double(), b.double(), rtol=rtol, atol=atol, equal_nan=equal_nan
+            )
+        ).item()
+    )
 
 
 # A special version of op check that has a restricted default set of test_utils
 # and a patched version of allclose that supports fp8 types.
-def opcheck(op: Union[torch._ops.OpOverload, torch._ops.OpOverloadPacket,
-                      torch._library.custom_ops.CustomOpDef],
-            args: tuple[Any, ...],
-            kwargs: Optional[dict[str, Any]] = None,
-            *,
-            test_utils: Union[str, Sequence[str]] = ALL_OPCHECK_TEST_UTILS,
-            raise_exception: bool = True,
-            cond: bool = True) -> dict[str, str]:
-    with unittest.mock.patch('torch.allclose', new=fp8_allclose):
-        return torch.library.opcheck(
-            op,
-            args,
-            kwargs,
-            test_utils=test_utils,
-            raise_exception=raise_exception) if cond else {}
+def opcheck(
+    op: Union[
+        torch._ops.OpOverload,
+        torch._ops.OpOverloadPacket,
+        torch._library.custom_ops.CustomOpDef,
+    ],
+    args: tuple[Any, ...],
+    kwargs: Optional[dict[str, Any]] = None,
+    *,
+    test_utils: Union[str, Sequence[str]] = ALL_OPCHECK_TEST_UTILS,
+    raise_exception: bool = True,
+    cond: bool = True,
+) -> dict[str, str]:
+    with unittest.mock.patch("torch.allclose", new=fp8_allclose):
+        return (
+            torch.library.opcheck(
+                op, args, kwargs, test_utils=test_utils, raise_exception=raise_exception
+            )
+            if cond
+            else {}
+        )
 
 
 STR_DTYPE_TO_TORCH_DTYPE = {
@@ -72,30 +74,25 @@ STR_DTYPE_TO_TORCH_DTYPE = {
     "fp8_inc": torch.float8_e4m3fn,
 }
 
+
 def _generate_random_fp8(
-    cache_dtype: Optional[Union[str, torch.dtype]],
     tensor: torch.Tensor,
     low: float,
     high: float,
-) -> None:
-    if cache_dtype == "fp8" or cache_dtype == "fp8_e4m3":
-        dst_dtype = torch.float8_e4m3fn
-    elif cache_dtype == "fp8_e5m2":
-        dst_dtype = torch.float8_e5m2
-    else:
-        assert False
+) -> torch.Tensor:
+    # TODO(zufang): we don't have convert_fp8 kernel, only used in tests or benchmarks
     tensor_tmp = torch.empty_like(tensor, dtype=torch.float16)
     tensor_tmp.uniform_(low, high)
-    tensor = tensor_tmp.to(dst_dtype)
-    del tensor_tmp
+    return tensor_tmp.to(torch.float8_e4m3fn)
+
 
 def get_kv_cache_torch_dtype(
-        cache_dtype: Optional[Union[str, torch.dtype]],
-        model_dtype: Optional[Union[str, torch.dtype]] = None) -> torch.dtype:
+    cache_dtype: Optional[Union[str, torch.dtype]],
+    model_dtype: Optional[Union[str, torch.dtype]] = None,
+) -> torch.dtype:
     if isinstance(cache_dtype, str):
         if cache_dtype == "auto":
-            if isinstance(model_dtype,
-                          str) and model_dtype in STR_DTYPE_TO_TORCH_DTYPE:
+            if isinstance(model_dtype, str) and model_dtype in STR_DTYPE_TO_TORCH_DTYPE:
                 torch_dtype = STR_DTYPE_TO_TORCH_DTYPE[model_dtype]
             elif isinstance(model_dtype, torch.dtype):
                 torch_dtype = model_dtype
@@ -111,6 +108,7 @@ def get_kv_cache_torch_dtype(
         raise ValueError(f"Invalid kv cache dtype: {cache_dtype}")
     return torch_dtype
 
+
 def create_kv_caches_with_random_flash(
     num_blocks: int,
     block_size: int,
@@ -121,7 +119,6 @@ def create_kv_caches_with_random_flash(
     model_dtype: Optional[Union[str, torch.dtype]] = None,
     seed: Optional[int] = None,
     device: Optional[str] = "xpu",
-    cache_layout: Optional[str] = "NHD",
 ) -> tuple[list[torch.Tensor], list[torch.Tensor]]:
     if not seed is None:
         random.seed(seed)
@@ -129,28 +126,24 @@ def create_kv_caches_with_random_flash(
         torch.manual_seed(seed)
     torch_dtype = get_kv_cache_torch_dtype(cache_dtype, model_dtype)
     generic_kv_cache_shape = (num_blocks, 2, block_size, num_heads, head_size)
-    assert cache_layout in ("NHD", "HND")
-    stride_order = (0, 1, 2, 3, 4) if cache_layout == "NHD" else (0, 1, 3, 2,
-                                                                  4)
+    stride_order = (0, 1, 2, 3, 4)
 
-    kv_cache_allocation_shape = tuple(generic_kv_cache_shape[i]
-                                      for i in stride_order)
+    kv_cache_allocation_shape = tuple(generic_kv_cache_shape[i] for i in stride_order)
     scale = head_size**-0.5
 
     key_caches: list[torch.Tensor] = []
     value_caches: list[torch.Tensor] = []
 
     for _ in range(num_layers):
-        key_value_cache = torch.empty(size=kv_cache_allocation_shape,
-                                      dtype=torch_dtype,
-                                      device=device).permute(*stride_order)
+        key_value_cache = torch.empty(
+            size=kv_cache_allocation_shape, dtype=torch_dtype, device=device
+        ).permute(*stride_order)
         if cache_dtype in ["auto", "half", "bfloat16", "float"]:
             key_value_cache.uniform_(-scale, scale)
-        elif cache_dtype in ["fp8", "fp8_e4m3", "fp8_e5m2"]:
-            _generate_random_fp8(cache_dtype, key_value_cache, -scale, scale)
+        elif cache_dtype in ["fp8", "fp8_e4m3"]:
+            key_value_cache = _generate_random_fp8(key_value_cache, -scale, scale)
         else:
-            raise ValueError(
-                f"Does not support key cache of type {cache_dtype}")
+            raise ValueError(f"Does not support key cache of type {cache_dtype}")
         key_caches.append(key_value_cache[:, 0])
         value_caches.append(key_value_cache[:, 1])
     return key_caches, value_caches

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -109,6 +109,58 @@ def get_kv_cache_torch_dtype(
     return torch_dtype
 
 
+def create_kv_caches_with_random(
+    num_blocks: int,
+    block_size: int,
+    num_layers: int,
+    num_heads: int,
+    head_size: int,
+    cache_dtype: Optional[Union[str, torch.dtype]],
+    model_dtype: Optional[Union[str, torch.dtype]] = None,
+    seed: Optional[int] = None,
+    device: Optional[str] = "xpu",
+) -> tuple[list[torch.Tensor], list[torch.Tensor]]:
+    if cache_dtype == "fp8" and head_size % 16:
+        raise ValueError(
+            f"Does not support key cache of type fp8 with head_size {head_size}"
+        )
+    if seed is not None:
+        random.seed(seed)
+        np.random.seed(seed)
+        torch.manual_seed(seed)
+
+    torch_dtype = get_kv_cache_torch_dtype(cache_dtype, model_dtype)
+
+    scale = head_size**-0.5
+    x = 16 // torch.tensor([], dtype=torch_dtype).element_size()
+    key_cache_shape = (num_blocks, num_heads, head_size // x, block_size, x)
+    key_caches: list[torch.Tensor] = []
+    for _ in range(num_layers):
+        key_cache = torch.empty(size=key_cache_shape, dtype=torch_dtype, device=device)
+        if cache_dtype in ["auto", "half", "bfloat16", "float"]:
+            key_cache.uniform_(-scale, scale)
+        elif cache_dtype == "fp8":
+            _generate_random_fp8(key_cache, -scale, scale)
+        else:
+            raise ValueError(f"Does not support key cache of type {cache_dtype}")
+        key_caches.append(key_cache)
+
+    value_cache_shape = (num_blocks, num_heads, head_size, block_size)
+    value_caches: list[torch.Tensor] = []
+    for _ in range(num_layers):
+        value_cache = torch.empty(
+            size=value_cache_shape, dtype=torch_dtype, device=device
+        )
+        if cache_dtype in ["auto", "half", "bfloat16", "float"]:
+            value_cache.uniform_(-scale, scale)
+        elif cache_dtype == "fp8":
+            _generate_random_fp8(value_cache, -scale, scale)
+        else:
+            raise ValueError(f"Does not support value cache of type {cache_dtype}")
+        value_caches.append(value_cache)
+    return key_caches, value_caches
+
+
 def create_kv_caches_with_random_flash(
     num_blocks: int,
     block_size: int,

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -120,7 +120,7 @@ def create_kv_caches_with_random_flash(
     seed: Optional[int] = None,
     device: Optional[str] = "xpu",
 ) -> tuple[list[torch.Tensor], list[torch.Tensor]]:
-    if not seed is None:
+    if seed is not None:
         random.seed(seed)
         np.random.seed(seed)
         torch.manual_seed(seed)


### PR DESCRIPTION
add reshape_and_cache and reshape_and_cache_flash

For reshape_and_cache_flash:
before vectorization:
fp8
<img width="1179" height="268" alt="image" src="https://github.com/user-attachments/assets/2a721f04-aef0-40e1-883a-185af686a3d7" />

After vectorization:
fp8
<img width="1154" height="262" alt="image" src="https://github.com/user-attachments/assets/2fa4b45c-07e8-4f24-a8e2-5975d888bd25" />


modify:  vllm/v1/attention/backends/ipex_attn.py
from vllm import _custom_ops as ops
ops.reshape_and_cache_flash(
                key[:num_actual_tokens],
                value[:num_actual_tokens],
                key_cache,
                value_cache,
                attn_metadata.slot_mapping,
                self.kv_cache_dtype,
                layer._k_scale,
                layer._v_scale,
)
