### PR TITLE
use torch-xpu 2.8 link

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ wheel
 # torch dependency
 --extra-index-url=https://download.pytorch.org/whl/xpu
 torch==2.8.0+xpu
-pytorch-trion-xpu
+pytorch-triton-xpu
 # may need oneapi packages
 
 # tests


### PR DESCRIPTION
previously we use torch 2.8 nightly wheel, now that 2.8 released, change dependency to release version.