### PR TITLE
Add activation: gelu_fast/gelu_new/gelu_quick

### DIFF
--- a/csrc/xpu/activation.cpp
+++ b/csrc/xpu/activation.cpp
@@ -31,7 +31,7 @@ inline T gelu_new_kernel(const T& x) {
 template <typename T>
 inline T gelu_quick_kernel(const T& x) {
   // x * sigmoid(1.702 * x)
-  return (T)(((float)x) / (1.0f + sycl::native::exp(-1.702f * (float)x)));
+  return (T)(((float)x) / (1.0f + (T)sycl::exp(-1.702f * (float)x)));
 }
 
 template <typename scalar_t, scalar_t (*ACT_FN)(const scalar_t&),

--- a/csrc/xpu/activation.cpp
+++ b/csrc/xpu/activation.cpp
@@ -24,9 +24,17 @@ template <typename T>
 inline T gelu_new_kernel(const T& x) {
   // 0.5 * x * (1.0 + tanh(0.7978845608 * (x + 0.044715 * x * x * x)))
   const float x3 = (float)(x * x * x);
-  // sycl::tanh does not pass accuracy tests for bfloat16
-  const T t = (T)tanhf((T)(0.79788456f * (float)(x + (T)(0.044715f * x3))));
+  const T t = (T)sycl::tanh((T)(0.79788456f * (float)(x + (T)(0.044715f * x3))));
   return ((T)0.5) * x * (((T)1.0) + t);
+}
+
+using sycl_bf16 = sycl::ext::oneapi::bfloat16;
+template <>
+inline sycl_bf16 gelu_new_kernel<sycl_bf16>(const sycl_bf16& x) {
+  const float x3 = (float)(x * x * x);
+  // sycl::tanh does not pass accuracy tests for bfloat16
+  const sycl_bf16 t = (sycl_bf16)tanhf((sycl_bf16)(0.79788456f * (float)(x + (sycl_bf16)(0.044715f * x3))));
+  return ((sycl_bf16)0.5) * x * (((sycl_bf16)1.0) + t);
 }
 
 template <typename T>

--- a/csrc/xpu/activation.cpp
+++ b/csrc/xpu/activation.cpp
@@ -42,10 +42,10 @@ inline scalar_t compute(const scalar_t& x, const scalar_t& y) {
 
 template <typename scalar_t, scalar_t (*ACT_FN)(const scalar_t&)>
 class act_kernel {
-public:
+ public:
   act_kernel(scalar_t* __restrict__ out,          // [..., d]
-              const scalar_t* __restrict__ input,  // [..., d]
-              const int d)
+             const scalar_t* __restrict__ input,  // [..., d]
+             const int d)
       : out_(out), input_(input), d_(d) {}
 
   void operator() [[intel::reqd_sub_group_size(32)]] (
@@ -57,6 +57,7 @@ public:
       out_[token_idx * d_ + idx] = ACT_FN(x);
     }
   }
+
  private:
   scalar_t* __restrict__ out_;          // [..., d]
   const scalar_t* __restrict__ input_;  // [..., d]
@@ -120,41 +121,39 @@ void silu_and_mul(torch::Tensor& out,    // [..., d]
   int64_t num_tokens = input.numel() / input.size(-1);                         \
   sycl::range<3> grid(1, 1, num_tokens);                                       \
   sycl::range<3> block(1, 1, std::min(d, 1024));                               \
-  if (num_tokens == 0) {                                                        \
-    return;                                                                     \
-  }                                                                             \
-  auto out_ptr = out.data_ptr<scalar_t>();                                      \
-  auto input_ptr = input.data_ptr<scalar_t>();                                  \
-  at::DeviceGuard device_guard(input.device());                                 \
-  auto& queue = vllm::xpu::vllmGetQueue();                                      \
-  queue.submit([&](sycl::handler& cgh) {                                        \
-    cgh.parallel_for(                                                           \
-      sycl::nd_range<3>(grid * block, block),                                   \
-      vllm::act_kernel<sycl_t, KERNEL>(                                         \
-        (sycl_t*)out_ptr, (sycl_t*)input_ptr, d));                              \
+  if (num_tokens == 0) {                                                       \
+    return;                                                                    \
+  }                                                                            \
+  auto out_ptr = out.data_ptr<scalar_t>();                                     \
+  auto input_ptr = input.data_ptr<scalar_t>();                                 \
+  at::DeviceGuard device_guard(input.device());                                \
+  auto& queue = vllm::xpu::vllmGetQueue();                                     \
+  queue.submit([&](sycl::handler& cgh) {                                       \
+    cgh.parallel_for(sycl::nd_range<3>(grid * block, block),                   \
+                     vllm::act_kernel<sycl_t, KERNEL>((sycl_t*)out_ptr,        \
+                                                      (sycl_t*)input_ptr, d)); \
   });
-
 
 void gelu_new(torch::Tensor& out,    // [..., d]
               torch::Tensor& input)  // [..., d]
 {
-  VLLM_DISPATCH_FLOATING_TYPES(
-      input.scalar_type(), "gelu_new",
-      [&] { LAUNCH_ACTIVATION_KERNEL(vllm::gelu_new_kernel); });
+  VLLM_DISPATCH_FLOATING_TYPES(input.scalar_type(), "gelu_new", [&] {
+    LAUNCH_ACTIVATION_KERNEL(vllm::gelu_new_kernel);
+  });
 }
 
 void gelu_fast(torch::Tensor& out,    // [..., d]
                torch::Tensor& input)  // [..., d]
 {
-  VLLM_DISPATCH_FLOATING_TYPES(
-      input.scalar_type(), "gelu_fast",
-      [&] { LAUNCH_ACTIVATION_KERNEL(vllm::gelu_fast_kernel); });
+  VLLM_DISPATCH_FLOATING_TYPES(input.scalar_type(), "gelu_fast", [&] {
+    LAUNCH_ACTIVATION_KERNEL(vllm::gelu_fast_kernel);
+  });
 }
 
 void gelu_quick(torch::Tensor& out,    // [..., d]
                 torch::Tensor& input)  // [..., d]
 {
-  VLLM_DISPATCH_FLOATING_TYPES(
-      input.scalar_type(), "gelu_quick",
-      [&] { LAUNCH_ACTIVATION_KERNEL(vllm::gelu_quick_kernel); });
+  VLLM_DISPATCH_FLOATING_TYPES(input.scalar_type(), "gelu_quick", [&] {
+    LAUNCH_ACTIVATION_KERNEL(vllm::gelu_quick_kernel);
+  });
 }

--- a/csrc/xpu/activation.cpp
+++ b/csrc/xpu/activation.cpp
@@ -24,7 +24,7 @@ template <typename T>
 inline T gelu_new_kernel(const T& x) {
   // 0.5 * x * (1.0 + tanh(0.7978845608 * (x + 0.044715 * x * x * x)))
   const float x3 = (float)(x * x * x);
-  const T t = (T)sycl::tanh((T)(0.79788456f * (float)(x + (T)(0.044715f * x3))));
+  const T t = (T)sycl::tanh(0.7978845608f * (float)(x + (T)(0.044715f * x3)));
   return ((T)0.5) * x * (((T)1.0) + t);
 }
 

--- a/csrc/xpu/activation.cpp
+++ b/csrc/xpu/activation.cpp
@@ -24,7 +24,8 @@ template <typename T>
 inline T gelu_new_kernel(const T& x) {
   // 0.5 * x * (1.0 + tanh(0.7978845608 * (x + 0.044715 * x * x * x)))
   const float x3 = (float)(x * x * x);
-  const T t = (T)sycl::tanh((T)(0.79788456f * (float)(x + (T)(0.044715f * x3))));
+  const T t =
+      (T)sycl::tanh((T)(0.79788456f * (float)(x + (T)(0.044715f * x3))));
   return ((T)0.5) * x * (((T)1.0) + t);
 }
 
@@ -33,7 +34,8 @@ template <>
 inline sycl_bf16 gelu_new_kernel<sycl_bf16>(const sycl_bf16& x) {
   const float x3 = (float)(x * x * x);
   // sycl::tanh does not pass accuracy tests for bfloat16
-  const sycl_bf16 t = (sycl_bf16)tanhf((sycl_bf16)(0.79788456f * (float)(x + (sycl_bf16)(0.044715f * x3))));
+  const sycl_bf16 t = (sycl_bf16)tanhf(
+      (sycl_bf16)(0.79788456f * (float)(x + (sycl_bf16)(0.044715f * x3))));
   return ((sycl_bf16)0.5) * x * (((sycl_bf16)1.0) + t);
 }
 

--- a/csrc/xpu/activation.cpp
+++ b/csrc/xpu/activation.cpp
@@ -24,6 +24,7 @@ template <typename T>
 inline T gelu_new_kernel(const T& x) {
   // 0.5 * x * (1.0 + tanh(0.7978845608 * (x + 0.044715 * x * x * x)))
   const float x3 = (float)(x * x * x);
+  // sycl::tanh does not pass accuracy tests for bfloat16
   const T t = (T)tanhf((T)(0.79788456f * (float)(x + (T)(0.044715f * x3))));
   return ((T)0.5) * x * (((T)1.0) + t);
 }

--- a/csrc/xpu/activation.cpp
+++ b/csrc/xpu/activation.cpp
@@ -1,5 +1,5 @@
 #include <sycl/sycl.hpp>
-
+#include <cmath>
 #include <algorithm>
 #include "utils.h"
 #include "dispatch_utils.h"
@@ -24,14 +24,14 @@ template <typename T>
 inline T gelu_new_kernel(const T& x) {
   // 0.5 * x * (1.0 + tanh(0.7978845608 * (x + 0.044715 * x * x * x)))
   const float x3 = (float)(x * x * x);
-  const T t = (T)sycl::tanh(0.7978845608f * (float)(x + (T)(0.044715f * x3)));
+  const T t = (T)tanhf((T)(0.79788456f * (float)(x + (T)(0.044715f * x3))));
   return ((T)0.5) * x * (((T)1.0) + t);
 }
 
 template <typename T>
 inline T gelu_quick_kernel(const T& x) {
   // x * sigmoid(1.702 * x)
-  return (T)(((float)x) / (1.0f + sycl::exp(-1.702f * (float)x)));
+  return (T)(((float)x) / (1.0f + sycl::native::exp(-1.702f * (float)x)));
 }
 
 template <typename scalar_t, scalar_t (*ACT_FN)(const scalar_t&),

--- a/csrc/xpu/activation.cpp
+++ b/csrc/xpu/activation.cpp
@@ -29,14 +29,14 @@ inline T gelu_new_kernel(const T& x) {
   return ((T)0.5) * x * (((T)1.0) + t);
 }
 
-using sycl_bf16 = sycl::ext::oneapi::bfloat16;
+using sycl_bf16_t = sycl::ext::oneapi::bfloat16;
 template <>
-inline sycl_bf16 gelu_new_kernel<sycl_bf16>(const sycl_bf16& x) {
+inline sycl_bf16_t gelu_new_kernel<sycl_bf16_t>(const sycl_bf16_t& x) {
   const float x3 = (float)(x * x * x);
   // sycl::tanh does not pass accuracy tests for bfloat16
-  const sycl_bf16 t = (sycl_bf16)tanhf(
-      (sycl_bf16)(0.79788456f * (float)(x + (sycl_bf16)(0.044715f * x3))));
-  return ((sycl_bf16)0.5) * x * (((sycl_bf16)1.0) + t);
+  const sycl_bf16_t t = (sycl_bf16_t)tanhf(
+      (sycl_bf16_t)(0.79788456f * (float)(x + (sycl_bf16_t)(0.044715f * x3))));
+  return ((sycl_bf16_t)0.5) * x * (((sycl_bf16_t)1.0) + t);
 }
 
 template <typename T>

--- a/csrc/xpu/activation.cpp
+++ b/csrc/xpu/activation.cpp
@@ -14,29 +14,18 @@ inline T silu_kernel(const T& x) {
 
 template <typename T>
 inline T gelu_fast_kernel(const T& x) {
-  // 0.5 * x * (1.0 + tanh(x * 0.7978845608 * (1.0 + 0.044715 * x * x)))
-  const float g = (float)(x * 0.7978845608f * (1.0f + 0.044715f * x * x));
-  const T t = sycl::tanh(g);
-  return (0.5f) * x * (1.0f + t);
+  const float f = (float)x;
+  const T t =
+      (T)tanhf(((T)(f * 0.79788456f)) * (((T)1.0) + (T)(0.044715f * f) * x));
+  return ((T)0.5) * x * (((T)1.0) + t);
 }
 
 template <typename T>
 inline T gelu_new_kernel(const T& x) {
   // 0.5 * x * (1.0 + tanh(0.7978845608 * (x + 0.044715 * x * x * x)))
   const float x3 = (float)(x * x * x);
-  const T t =
-      (T)sycl::tanh((T)(0.79788456f * (float)(x + (T)(0.044715f * x3))));
+  const T t = (T)tanhf((T)(0.79788456f * (float)(x + (T)(0.044715f * x3))));
   return ((T)0.5) * x * (((T)1.0) + t);
-}
-
-using sycl_bf16_t = sycl::ext::oneapi::bfloat16;
-template <>
-inline sycl_bf16_t gelu_new_kernel<sycl_bf16_t>(const sycl_bf16_t& x) {
-  const float x3 = (float)(x * x * x);
-  // sycl::tanh does not pass accuracy tests for bfloat16
-  const sycl_bf16_t t = (sycl_bf16_t)tanhf(
-      (sycl_bf16_t)(0.79788456f * (float)(x + (sycl_bf16_t)(0.044715f * x3))));
-  return ((sycl_bf16_t)0.5) * x * (((sycl_bf16_t)1.0) + t);
 }
 
 template <typename T>

--- a/csrc/xpu/activation.cpp
+++ b/csrc/xpu/activation.cpp
@@ -14,8 +14,10 @@ inline T silu_kernel(const T& x) {
 
 template <typename T>
 inline T gelu_fast_kernel(const T& x) {
-  // 0.5 * x * (1.0 + tanh(0.7978845608 * (x + 0.044715 * x * x)))
-  return (T)(0.5f * x * (1.0f + sycl::tanh(0.7978845608f * (x + 0.044715f * x * x))));
+  // 0.5 * x * (1.0 + tanh(x * 0.7978845608 * (1.0 + 0.044715 * x * x)))
+  const float g = (float)(x * 0.7978845608f * (1.0f + 0.044715f * x * x));
+  const T t = sycl::tanh(g);
+  return (0.5f) * x * (1.0f + t);
 }
 
 template <typename scalar_t, scalar_t (*ACT_FN)(const scalar_t&),

--- a/csrc/xpu/ops.h
+++ b/csrc/xpu/ops.h
@@ -14,6 +14,8 @@ void gelu_fast(torch::Tensor& out, torch::Tensor& input);
 
 void gelu_new(torch::Tensor& out, torch::Tensor& input);
 
+void gelu_quick(torch::Tensor& out, torch::Tensor& input);
+
 void rotary_embedding(torch::Tensor& positions, torch::Tensor& query,
                       std::optional<torch::Tensor> key, int64_t head_size,
                       torch::Tensor& cos_sin_cache, bool is_neox);

--- a/csrc/xpu/ops.h
+++ b/csrc/xpu/ops.h
@@ -10,6 +10,8 @@ void fused_add_rms_norm(torch::Tensor& input, torch::Tensor& residual,
 
 void silu_and_mul(torch::Tensor& out, torch::Tensor& input);
 
+void gelu_fast(torch::Tensor& out, torch::Tensor& input);
+
 void rotary_embedding(torch::Tensor& positions, torch::Tensor& query,
                       std::optional<torch::Tensor> key, int64_t head_size,
                       torch::Tensor& cos_sin_cache, bool is_neox);

--- a/csrc/xpu/ops.h
+++ b/csrc/xpu/ops.h
@@ -12,6 +12,8 @@ void silu_and_mul(torch::Tensor& out, torch::Tensor& input);
 
 void gelu_fast(torch::Tensor& out, torch::Tensor& input);
 
+void gelu_new(torch::Tensor& out, torch::Tensor& input);
+
 void rotary_embedding(torch::Tensor& positions, torch::Tensor& query,
                       std::optional<torch::Tensor> key, int64_t head_size,
                       torch::Tensor& cos_sin_cache, bool is_neox);

--- a/csrc/xpu/torch_bindings.cpp
+++ b/csrc/xpu/torch_bindings.cpp
@@ -36,6 +36,9 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
   ops.def("silu_and_mul(Tensor! out, Tensor! input) -> ()");
   ops.impl("silu_and_mul", torch::kXPU, &silu_and_mul);
 
+  ops.def("gelu_fast(Tensor! out, Tensor! input) -> ()");
+  ops.impl("gelu_fast", torch::kXPU, &gelu_fast);
+
   // pos_embedding
   ops.def(
       "rotary_embedding(Tensor positions, Tensor! query,"

--- a/csrc/xpu/torch_bindings.cpp
+++ b/csrc/xpu/torch_bindings.cpp
@@ -42,6 +42,9 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
   ops.def("gelu_new(Tensor! out, Tensor! input) -> ()");
   ops.impl("gelu_new", torch::kXPU, &gelu_new);
 
+  ops.def("gelu_quick(Tensor! out, Tensor! input) -> ()");
+  ops.impl("gelu_quick", torch::kXPU, &gelu_quick);
+
   // pos_embedding
   ops.def(
       "rotary_embedding(Tensor positions, Tensor! query,"

--- a/csrc/xpu/torch_bindings.cpp
+++ b/csrc/xpu/torch_bindings.cpp
@@ -39,6 +39,9 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
   ops.def("gelu_fast(Tensor! out, Tensor! input) -> ()");
   ops.impl("gelu_fast", torch::kXPU, &gelu_fast);
 
+  ops.def("gelu_new(Tensor! out, Tensor! input) -> ()");
+  ops.impl("gelu_new", torch::kXPU, &gelu_new);
+
   // pos_embedding
   ops.def(
       "rotary_embedding(Tensor positions, Tensor! query,"

--- a/tests/allclose_default.py
+++ b/tests/allclose_default.py
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import torch
+
+# Reference default values of atol and rtol are from
+# https://github.com/pytorch/pytorch/blob/6d96beb6bec24d73ee3f080bac54d2104068f675/test/test_transformers.py#L67
+default_atol = {torch.float16: 1e-3, torch.bfloat16: 1e-3, torch.float: 1e-5}
+default_rtol = {
+    torch.float16: 1e-3,
+    torch.bfloat16: 1.6e-2,
+    torch.float: 1.3e-6
+}
+
+
+def get_default_atol(output) -> float:
+    return default_atol[output.dtype]
+
+
+def get_default_rtol(output) -> float:
+    return default_rtol[output.dtype]

--- a/tests/ops/activation_op.py
+++ b/tests/ops/activation_op.py
@@ -63,3 +63,18 @@ class NewGELU(CustomOp):
         out = torch.empty_like(x)
         self.op(out, x)
         return out
+
+class QuickGELU(CustomOp):
+
+    def __init__(self):
+        super().__init__()
+        self.op = torch.ops._C.gelu_new
+
+    def forward_native(self, x: torch.Tensor) -> torch.Tensor:
+        """PyTorch-native implementation equivalent to forward()."""
+        return x * torch.sigmoid(1.702 * x)
+
+    def forward_xpu(self, x: torch.Tensor) -> torch.Tensor:
+        out = torch.empty_like(x)
+        self.op(out, x)
+        return out

--- a/tests/ops/activation_op.py
+++ b/tests/ops/activation_op.py
@@ -31,3 +31,19 @@ class SiluAndMul(CustomOp):
         out = torch.empty(output_shape, dtype=x.dtype, device=x.device)
         self.op(out, x)
         return out
+
+class FastGELU(CustomOp):
+
+    def __init__(self):
+        super().__init__()
+        self.op = torch.ops._C.gelu_fast
+
+    def forward_native(self, x: torch.Tensor) -> torch.Tensor:
+        """PyTorch-native implementation equivalent to forward()."""
+        return 0.5 * x * (1.0 + torch.tanh(x * 0.7978845608 *
+                                           (1.0 + 0.044715 * x * x)))
+
+    def forward_xpu(self, x: torch.Tensor) -> torch.Tensor:
+        out = torch.empty_like(x)
+        self.op(out, x)
+        return out

--- a/tests/ops/activation_op.py
+++ b/tests/ops/activation_op.py
@@ -47,3 +47,21 @@ class FastGELU(CustomOp):
         out = torch.empty_like(x)
         self.op(out, x)
         return out
+
+class NewGELU(CustomOp):
+
+    def __init__(self):
+        super().__init__()
+        self.op = torch.ops._C.gelu_new
+
+    def forward_native(self, x: torch.Tensor) -> torch.Tensor:
+        """PyTorch-native implementation equivalent to forward()."""
+        import math
+        c = math.sqrt(2.0 / math.pi)
+        return 0.5 * x * (1.0 + torch.tanh(c *
+                                           (x + 0.044715 * torch.pow(x, 3.0))))
+
+    def forward_xpu(self, x: torch.Tensor) -> torch.Tensor:
+        out = torch.empty_like(x)
+        self.op(out, x)
+        return out

--- a/tests/ops/activation_op.py
+++ b/tests/ops/activation_op.py
@@ -68,7 +68,7 @@ class QuickGELU(CustomOp):
 
     def __init__(self):
         super().__init__()
-        self.op = torch.ops._C.gelu_new
+        self.op = torch.ops._C.gelu_quick
 
     def forward_native(self, x: torch.Tensor) -> torch.Tensor:
         """PyTorch-native implementation equivalent to forward()."""

--- a/tests/ops/activation_op.py
+++ b/tests/ops/activation_op.py
@@ -56,9 +56,7 @@ class NewGELU(CustomOp):
 
     def forward_native(self, x: torch.Tensor) -> torch.Tensor:
         """PyTorch-native implementation equivalent to forward()."""
-        import math
-        c = math.sqrt(2.0 / math.pi)
-        return 0.5 * x * (1.0 + torch.tanh(c *
+        return 0.5 * x * (1.0 + torch.tanh(0.7978845608 *
                                            (x + 0.044715 * torch.pow(x, 3.0))))
 
     def forward_xpu(self, x: torch.Tensor) -> torch.Tensor:

--- a/tests/ops/activation_op.py
+++ b/tests/ops/activation_op.py
@@ -32,6 +32,7 @@ class SiluAndMul(CustomOp):
         self.op(out, x)
         return out
 
+
 class FastGELU(CustomOp):
 
     def __init__(self):
@@ -48,6 +49,7 @@ class FastGELU(CustomOp):
         self.op(out, x)
         return out
 
+
 class NewGELU(CustomOp):
 
     def __init__(self):
@@ -63,6 +65,7 @@ class NewGELU(CustomOp):
         out = torch.empty_like(x)
         self.op(out, x)
         return out
+
 
 class QuickGELU(CustomOp):
 

--- a/tests/register_ops.py
+++ b/tests/register_ops.py
@@ -29,6 +29,9 @@ def gelu_fast(out: torch.Tensor, input: torch.Tensor) -> None:
 def gelu_new(out: torch.Tensor, input: torch.Tensor) -> None:
     torch.ops._C.gelu_new(out, input)
 
+def gelu_quick(out: torch.Tensor, input: torch.Tensor) -> None:
+    torch.ops._C.gelu_quick(out, input)
+
 def rotary_embedding(
     positions: torch.Tensor,
     query: torch.Tensor,

--- a/tests/register_ops.py
+++ b/tests/register_ops.py
@@ -23,14 +23,18 @@ def fused_add_rms_norm(input: torch.Tensor, residual: torch.Tensor,
 def silu_and_mul(out: torch.Tensor, input: torch.Tensor) -> None:
     torch.ops._C.silu_and_mul(out, input)
 
+
 def gelu_fast(out: torch.Tensor, input: torch.Tensor) -> None:
     torch.ops._C.gelu_fast(out, input)
+
 
 def gelu_new(out: torch.Tensor, input: torch.Tensor) -> None:
     torch.ops._C.gelu_new(out, input)
 
+
 def gelu_quick(out: torch.Tensor, input: torch.Tensor) -> None:
     torch.ops._C.gelu_quick(out, input)
+
 
 def rotary_embedding(
     positions: torch.Tensor,

--- a/tests/register_ops.py
+++ b/tests/register_ops.py
@@ -23,6 +23,8 @@ def fused_add_rms_norm(input: torch.Tensor, residual: torch.Tensor,
 def silu_and_mul(out: torch.Tensor, input: torch.Tensor) -> None:
     torch.ops._C.silu_and_mul(out, input)
 
+def gelu_fast(out: torch.Tensor, input: torch.Tensor) -> None:
+    torch.ops._C.gelu_fast(out, input)
 
 def rotary_embedding(
     positions: torch.Tensor,

--- a/tests/register_ops.py
+++ b/tests/register_ops.py
@@ -26,6 +26,9 @@ def silu_and_mul(out: torch.Tensor, input: torch.Tensor) -> None:
 def gelu_fast(out: torch.Tensor, input: torch.Tensor) -> None:
     torch.ops._C.gelu_fast(out, input)
 
+def gelu_new(out: torch.Tensor, input: torch.Tensor) -> None:
+    torch.ops._C.gelu_new(out, input)
+
 def rotary_embedding(
     positions: torch.Tensor,
     query: torch.Tensor,

--- a/tests/test_activation.py
+++ b/tests/test_activation.py
@@ -2,7 +2,7 @@
 import pytest
 import torch
 
-from tests.ops.activation_op import SiluAndMul, FastGELU, NewGELU
+from tests.ops.activation_op import SiluAndMul, FastGELU, NewGELU, QuickGELU
 from tests.utils import opcheck, seed_everything
 
 DTYPES = [torch.half, torch.bfloat16, torch.float]
@@ -46,8 +46,8 @@ def test_act_and_mul(
     opcheck(fn, (out, x))
 
 @pytest.mark.parametrize("activation", [(FastGELU, torch.ops._C.gelu_fast),
-                                        (NewGELU, torch.ops._C.gelu_new),])
-                                        # (QuickGELU, torch.ops._C.gelu_quick)])
+                                        (NewGELU, torch.ops._C.gelu_new),
+                                        (QuickGELU, torch.ops._C.gelu_quick)])
 @pytest.mark.parametrize("num_tokens", NUM_TOKENS)
 @pytest.mark.parametrize("d", D)
 @pytest.mark.parametrize("dtype", DTYPES)

--- a/tests/test_activation.py
+++ b/tests/test_activation.py
@@ -2,7 +2,7 @@
 import pytest
 import torch
 
-from tests.ops.activation_op import SiluAndMul, FastGELU
+from tests.ops.activation_op import SiluAndMul, FastGELU, NewGELU
 from tests.utils import opcheck, seed_everything
 
 DTYPES = [torch.half, torch.bfloat16, torch.float]
@@ -45,9 +45,8 @@ def test_act_and_mul(
     out = torch.empty(output_shape, dtype=x.dtype, device=x.device)
     opcheck(fn, (out, x))
 
-@pytest.mark.parametrize("activation", [(FastGELU, torch.ops._C.gelu_fast),])
-                                        
-                                        # (NewGELU, torch.ops._C.gelu_new),
+@pytest.mark.parametrize("activation", [(FastGELU, torch.ops._C.gelu_fast),
+                                        (NewGELU, torch.ops._C.gelu_new),])
                                         # (QuickGELU, torch.ops._C.gelu_quick)])
 @pytest.mark.parametrize("num_tokens", NUM_TOKENS)
 @pytest.mark.parametrize("d", D)

--- a/tests/test_activation.py
+++ b/tests/test_activation.py
@@ -2,8 +2,8 @@
 import pytest
 import torch
 
-from tests.ops.activation_op import SiluAndMul, FastGELU, NewGELU, QuickGELU
 from tests.allclose_default import get_default_atol, get_default_rtol
+from tests.ops.activation_op import FastGELU, NewGELU, QuickGELU, SiluAndMul
 from tests.utils import opcheck, seed_everything
 
 DTYPES = [torch.half, torch.bfloat16, torch.float]
@@ -45,6 +45,7 @@ def test_act_and_mul(
     output_shape = (x.shape[:-1] + (d, ))
     out = torch.empty(output_shape, dtype=x.dtype, device=x.device)
     opcheck(fn, (out, x))
+
 
 @pytest.mark.parametrize("activation", [(FastGELU, torch.ops._C.gelu_fast),
                                         (NewGELU, torch.ops._C.gelu_new),

--- a/tests/test_activation.py
+++ b/tests/test_activation.py
@@ -2,7 +2,7 @@
 import pytest
 import torch
 
-from tests.ops.activation_op import SiluAndMul
+from tests.ops.activation_op import SiluAndMul, FastGELU
 from tests.utils import opcheck, seed_everything
 
 DTYPES = [torch.half, torch.bfloat16, torch.float]
@@ -43,4 +43,34 @@ def test_act_and_mul(
     d = x.shape[-1] // 2
     output_shape = (x.shape[:-1] + (d, ))
     out = torch.empty(output_shape, dtype=x.dtype, device=x.device)
+    opcheck(fn, (out, x))
+
+@pytest.mark.parametrize("activation", [(FastGELU, torch.ops._C.gelu_fast),])
+                                        
+                                        # (NewGELU, torch.ops._C.gelu_new),
+                                        # (QuickGELU, torch.ops._C.gelu_quick)])
+@pytest.mark.parametrize("num_tokens", NUM_TOKENS)
+@pytest.mark.parametrize("d", D)
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("seed", SEEDS)
+@pytest.mark.parametrize("device", XPU_DEVICES)
+@torch.inference_mode()
+def test_activation(
+    activation: type[torch.nn.Module],
+    num_tokens: int,
+    d: int,
+    dtype: torch.dtype,
+    seed: int,
+    device: str,
+) -> None:
+    seed_everything(seed)
+    torch.set_default_device(device)
+    x = torch.randn(num_tokens, d, dtype=dtype)
+    layer = activation[0]()
+    fn = activation[1]
+    out = layer(x)
+    ref_out = layer.forward_native(x)
+    torch.testing.assert_close(out, ref_out, atol=1e-3, rtol=1e-3)
+
+    out = torch.empty_like(x)
     opcheck(fn, (out, x))

--- a/tests/test_activation.py
+++ b/tests/test_activation.py
@@ -3,6 +3,7 @@ import pytest
 import torch
 
 from tests.ops.activation_op import SiluAndMul, FastGELU, NewGELU, QuickGELU
+from tests.allclose_default import get_default_atol, get_default_rtol
 from tests.utils import opcheck, seed_everything
 
 DTYPES = [torch.half, torch.bfloat16, torch.float]
@@ -69,7 +70,10 @@ def test_activation(
     fn = activation[1]
     out = layer(x)
     ref_out = layer.forward_native(x)
-    torch.testing.assert_close(out, ref_out, atol=1e-3, rtol=1e-3)
+    torch.testing.assert_close(out,
+                               ref_out,
+                               atol=get_default_atol(out),
+                               rtol=get_default_rtol(out))
 
     out = torch.empty_like(x)
     opcheck(fn, (out, x))


### PR DESCRIPTION
reference:
- https://github.com/vllm-project/vllm/blob/main/tests/kernels/core/test_activation.py
- https://github.com/vllm-project/vllm/blob/main/csrc/activation_kernels.cu

Currently known issues:
- `gelu_new_kernel` fails the accuracy test when using `sycl::tanh`, currently using `cmath's tanhf` instead.