### PR TITLE
add xpu op grouped topk

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -216,6 +216,7 @@ define_gpu_extension_target(
 
 set(VLLM_MOE_EXT_SRC
   "csrc/moe/torch_bindings.cpp"
+  "csrc/moe/grouped_topk.cpp"
   "csrc/moe/moe_align_sum_kernels.cpp")
 
 message(STATUS "Enabling moe extension.")

--- a/benchmark/benchmark_grouped_topk.py
+++ b/benchmark/benchmark_grouped_topk.py
@@ -73,7 +73,7 @@ n_expert_range = [16, 64, 128]
 topk_range = [2, 4]
 topk_group_range = [4, 8]
 scoring_func_range = ["sigmoid", "softmax"]
-dtype_range = [torch.float16]
+dtype_range = [torch.float16, torch.bfloat16, torch.float32]
 configs = list(
     itertools.product(
         n_token_range,

--- a/benchmark/benchmark_grouped_topk.py
+++ b/benchmark/benchmark_grouped_topk.py
@@ -69,18 +69,16 @@ def grouped_topk_compile(
 
 
 n_token_range = [1, 64, 256]
-n_expert_range = [64, 128, 256]
+n_expert_range = [16, 64, 128]
 topk_range = [2, 4]
-renormalize_range = [True, False]
 topk_group_range = [4, 8]
 scoring_func_range = ["sigmoid", "softmax"]
-dtype_range = [torch.float16, torch.bfloat16]
+dtype_range = [torch.float16]
 configs = list(
     itertools.product(
         n_token_range,
         n_expert_range,
         topk_range,
-        renormalize_range,
         topk_group_range,
         scoring_func_range,
         dtype_range,
@@ -92,8 +90,8 @@ def get_benchmark():
     @triton.testing.perf_report(
         triton.testing.Benchmark(
             x_names=[
-                "n_token", "n_expert", "topk", "renormalize", "topk_group",
-                "scoring_func", "dtype"
+                "n_token", "n_expert", "topk", "topk_group", "scoring_func",
+                "dtype"
             ],
             x_vals=[tuple(_) for _ in configs],
             line_arg="provider",
@@ -109,7 +107,6 @@ def get_benchmark():
         n_token: int,
         n_expert: int,
         topk: int,
-        renormalize: bool,
         topk_group: int,
         scoring_func: str,
         dtype: torch.dtype,
@@ -118,6 +115,7 @@ def get_benchmark():
         n_hidden = 1024
         routed_scaling_factor = 1.0
         num_expert_group = 8
+        renormalize = True
         hidden_states = torch.randn((n_token, n_hidden),
                                     dtype=dtype,
                                     device="xpu")

--- a/benchmark/benchmark_grouped_topk.py
+++ b/benchmark/benchmark_grouped_topk.py
@@ -1,0 +1,196 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import itertools
+from argparse import ArgumentParser
+from typing import Optional
+
+import torch
+import triton
+
+from tests.ops.grouped_topk_op import grouped_topk, fused_grouped_topk
+
+
+@torch.compile
+def grouped_topk_compile(
+    hidden_states: torch.Tensor,
+    gating_output: torch.Tensor,
+    topk: int,
+    renormalize: bool,
+    num_expert_group: int = 0,
+    topk_group: int = 0,
+    scoring_func: str = "softmax",
+    routed_scaling_factor: float = 1.0,
+    e_score_correction_bias: Optional[torch.Tensor] = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+
+    assert hidden_states.size(0) == gating_output.size(0), (
+        "Number of tokens mismatch")
+    if scoring_func == "softmax":
+        scores = torch.softmax(gating_output, dim=-1)
+    elif scoring_func == "sigmoid":
+        scores = gating_output.sigmoid()
+    else:
+        raise ValueError(f"Unsupported scoring function: {scoring_func}")
+    num_token = scores.size(0)
+    if e_score_correction_bias is not None:
+        # Store original scores before applying correction bias. We use biased
+        # scores for expert selection but original scores for routing weights
+        original_scores = scores
+        scores = scores + e_score_correction_bias.unsqueeze(0)
+        group_scores = (scores.view(num_token, num_expert_group,
+                                    -1).topk(2, dim=-1)[0].sum(dim=-1))
+    else:
+        group_scores = scores.view(num_token, num_expert_group,
+                                   -1).max(dim=-1).values  # [n, n_group]
+    group_idx = torch.topk(group_scores, k=topk_group, dim=-1,
+                           sorted=False)[1]  # [n, top_k_group]
+    group_mask = torch.zeros_like(group_scores)  # [n, n_group]
+    group_mask.scatter_(1, group_idx, 1)  # [n, n_group]
+    score_mask = group_mask.unsqueeze(-1).expand(
+        num_token, num_expert_group,
+        scores.size(-1) // num_expert_group).reshape(num_token, -1)  # [n, e]
+    tmp_scores = scores.masked_fill(~score_mask.bool(),
+                                    float("-inf"))  # [n, e]
+    if e_score_correction_bias is not None:
+        topk_ids = torch.topk(tmp_scores, k=topk, dim=-1, sorted=False)[1]
+        # Use original unbiased scores for the routing weights
+        topk_weights = original_scores.gather(1, topk_ids)
+    else:
+        topk_weights, topk_ids = torch.topk(tmp_scores,
+                                            k=topk,
+                                            dim=-1,
+                                            sorted=False)
+    if renormalize:
+        topk_weights = topk_weights / topk_weights.sum(dim=-1, keepdim=True)
+
+    topk_weights = topk_weights * routed_scaling_factor
+    return topk_weights.to(torch.float32), topk_ids.to(torch.int32)
+
+
+n_token_range = [1, 64, 256]
+n_expert_range = [64, 128, 256]
+topk_range = [2, 4]
+renormalize_range = [True, False]
+topk_group_range = [4, 8]
+scoring_func_range = ["sigmoid", "softmax"]
+dtype_range = [torch.float16, torch.bfloat16]
+configs = list(
+    itertools.product(
+        n_token_range,
+        n_expert_range,
+        topk_range,
+        renormalize_range,
+        topk_group_range,
+        scoring_func_range,
+        dtype_range,
+    ))
+
+
+def get_benchmark():
+
+    @triton.testing.perf_report(
+        triton.testing.Benchmark(
+            x_names=[
+                "n_token", "n_expert", "topk", "renormalize",
+                "topk_group", "scoring_func", "dtype"
+            ],
+            x_vals=[tuple(_) for _ in configs],
+            line_arg="provider",
+            line_vals=["vllm", "native", "compile"],
+            line_names=["vllm", "native", "compile"],
+            styles=[("blue", "-"), ("green", "-"), ("orange", "-"),
+                    ("red", "-")],
+            ylabel="us",
+            plot_name="grouped_topk-perf",
+            args={},
+        ))
+    def benchmark(
+        n_token: int,
+        n_expert: int,
+        topk: int,
+        renormalize: bool,
+        topk_group: int,
+        scoring_func: str,
+        dtype: torch.dtype,
+        provider: str = "vllm",
+    ):
+        n_hidden = 1024
+        routed_scaling_factor = 1.0
+        num_expert_group = 8
+        hidden_states = torch.randn((n_token, n_hidden),
+                                dtype=dtype,
+                                device="xpu")
+        gating_output = torch.randn((n_token, n_expert),
+                                    dtype=dtype,
+                                    device="xpu")
+        e_score_correction_bias = torch.randn((n_expert, ),
+                                            dtype=torch.float32,
+                                            device="xpu")
+
+        quantiles = [0.5, 0.2, 0.8]
+
+        if provider == "vllm":
+            ms, min_ms, max_ms = triton.testing.do_bench(
+                lambda: fused_grouped_topk(
+                    hidden_states=hidden_states,
+                    gating_output=gating_output,
+                    topk=topk,
+                    renormalize=renormalize,
+                    num_expert_group=num_expert_group,
+                    topk_group=topk_group,
+                    scoring_func=scoring_func,
+                    routed_scaling_factor=routed_scaling_factor,
+                    e_score_correction_bias=e_score_correction_bias
+                ),
+                quantiles=quantiles,
+            )
+        elif provider == "native":
+            ms, min_ms, max_ms = triton.testing.do_bench(
+                lambda: grouped_topk(
+                    hidden_states=hidden_states,
+                    gating_output=gating_output,
+                    topk=topk,
+                    renormalize=renormalize,
+                    num_expert_group=num_expert_group,
+                    topk_group=topk_group,
+                    scoring_func=scoring_func,
+                    routed_scaling_factor=routed_scaling_factor,
+                    e_score_correction_bias=e_score_correction_bias
+                ),
+                quantiles=quantiles,
+            )
+        else:
+            ms, min_ms, max_ms = triton.testing.do_bench(
+                lambda: grouped_topk_compile(
+                    hidden_states=hidden_states,
+                    gating_output=gating_output,
+                    topk=topk,
+                    renormalize=renormalize,
+                    num_expert_group=num_expert_group,
+                    topk_group=topk_group,
+                    scoring_func=scoring_func,
+                    routed_scaling_factor=routed_scaling_factor,
+                    e_score_correction_bias=e_score_correction_bias
+                ),
+                quantiles=quantiles,
+            )
+
+        return 1000 * ms, 1000 * max_ms, 1000 * min_ms
+
+    return benchmark
+
+
+if __name__ == "__main__":
+    parser = ArgumentParser(description="Benchmark the grouped topk kernel.")
+    parser.add_argument(
+        "--save-path",
+        type=str,
+        default="./configs/grouped_topk/",
+        help="Path to save grouped_topk benchmark results",
+    )
+
+    args = parser.parse_args()
+
+    benchmark = get_benchmark()
+    benchmark.run(print_data=True, save_path=args.save_path)

--- a/benchmark/benchmark_grouped_topk.py
+++ b/benchmark/benchmark_grouped_topk.py
@@ -8,7 +8,7 @@ from typing import Optional
 import torch
 import triton
 
-from tests.ops.grouped_topk_op import grouped_topk, fused_grouped_topk
+from tests.ops.grouped_topk_op import fused_grouped_topk, grouped_topk
 
 
 @torch.compile
@@ -92,8 +92,8 @@ def get_benchmark():
     @triton.testing.perf_report(
         triton.testing.Benchmark(
             x_names=[
-                "n_token", "n_expert", "topk", "renormalize",
-                "topk_group", "scoring_func", "dtype"
+                "n_token", "n_expert", "topk", "renormalize", "topk_group",
+                "scoring_func", "dtype"
             ],
             x_vals=[tuple(_) for _ in configs],
             line_arg="provider",
@@ -119,14 +119,14 @@ def get_benchmark():
         routed_scaling_factor = 1.0
         num_expert_group = 8
         hidden_states = torch.randn((n_token, n_hidden),
-                                dtype=dtype,
-                                device="xpu")
+                                    dtype=dtype,
+                                    device="xpu")
         gating_output = torch.randn((n_token, n_expert),
                                     dtype=dtype,
                                     device="xpu")
         e_score_correction_bias = torch.randn((n_expert, ),
-                                            dtype=torch.float32,
-                                            device="xpu")
+                                              dtype=torch.float32,
+                                              device="xpu")
 
         quantiles = [0.5, 0.2, 0.8]
 
@@ -141,8 +141,7 @@ def get_benchmark():
                     topk_group=topk_group,
                     scoring_func=scoring_func,
                     routed_scaling_factor=routed_scaling_factor,
-                    e_score_correction_bias=e_score_correction_bias
-                ),
+                    e_score_correction_bias=e_score_correction_bias),
                 quantiles=quantiles,
             )
         elif provider == "native":
@@ -156,8 +155,7 @@ def get_benchmark():
                     topk_group=topk_group,
                     scoring_func=scoring_func,
                     routed_scaling_factor=routed_scaling_factor,
-                    e_score_correction_bias=e_score_correction_bias
-                ),
+                    e_score_correction_bias=e_score_correction_bias),
                 quantiles=quantiles,
             )
         else:
@@ -171,8 +169,7 @@ def get_benchmark():
                     topk_group=topk_group,
                     scoring_func=scoring_func,
                     routed_scaling_factor=routed_scaling_factor,
-                    e_score_correction_bias=e_score_correction_bias
-                ),
+                    e_score_correction_bias=e_score_correction_bias),
                 quantiles=quantiles,
             )
 

--- a/csrc/moe/grouped_topk.cpp
+++ b/csrc/moe/grouped_topk.cpp
@@ -1,0 +1,751 @@
+#include <sycl/sycl.hpp>
+#include <torch/all.h>
+
+#include "../utils.h"
+#include "../dispatch_utils.h"
+
+namespace vllm {
+namespace moe {
+
+constexpr int32_t WARP_SIZE = 32;
+constexpr int32_t BLOCK_SIZE = 512;
+constexpr int32_t NUM_WARPS_PER_BLOCK = BLOCK_SIZE / WARP_SIZE;
+
+namespace warp_topk {
+
+template <int size, typename T>
+constexpr T round_up_to_multiple_of(T len) {
+  if (len == 0) {
+    return 0;
+  }
+  return ((len - 1) / size + 1) * size;
+}
+
+template <typename T>
+constexpr bool isPowerOf2(T v) {
+  return (v && !(v & (v - 1)));
+}
+
+template <bool greater, typename T>
+[[intel::device_indirectly_callable]] inline __attribute__((always_inline)) bool
+is_better_than(T val, T baseline) {
+  return (val > baseline && greater) || (val < baseline && !greater);
+}
+
+template <bool greater, typename T, typename idxT>
+[[intel::device_indirectly_callable]] inline __attribute__((always_inline)) bool
+is_better_than(T val, T baseline, idxT index, idxT baseline_index) {
+  bool res = (val > baseline && greater) || (val < baseline && !greater);
+  if (val == baseline) {
+    res = (index < baseline_index && greater) ||
+          (index < baseline_index && !greater);
+  }
+  return res;
+}
+
+template <typename T, typename idxT>
+int calc_smem_size_for_block_wide(int num_of_warp, int64_t k) {
+  uint64_t cache_topk = (sizeof(T) + sizeof(idxT)) * num_of_warp * k;
+  uint64_t n = std::max<int>(num_of_warp / 2 * k, num_of_warp * WARP_SIZE);
+  return std::max(cache_topk,
+             round_up_to_multiple_of<256>(n * sizeof(T)) + n * sizeof(idxT));
+}
+
+template <int size, bool ascending, bool reverse, typename T, typename idxT,
+          bool is_stable>
+struct BitonicMerge {
+  // input should be a bitonic sequence, and sort it to be a monotonic sequence
+  [[intel::device_indirectly_callable]] static void merge(T* __restrict__ val_arr,
+                               idxT* __restrict__ idx_arr, sycl::sub_group const & sg, const int local_id) {
+    static_assert(isPowerOf2(size));
+    static_assert(size >= 2 * WARP_SIZE);
+    constexpr int arr_len = size / WARP_SIZE;
+
+    constexpr int stride = arr_len / 2;
+    for (int i = 0; i < stride; ++i) {
+      int const other_i = i + stride;
+      T& val = val_arr[i];
+      T& other_val = val_arr[other_i];
+      bool is_better;
+      if constexpr (is_stable) {
+        is_better = is_better_than<ascending>(val, other_val, idx_arr[i],
+                                              idx_arr[other_i]);
+      } else {
+        is_better = is_better_than<ascending>(val, other_val);
+      }
+
+      if (is_better) {
+        T tmp = val;
+        val = other_val;
+        other_val = tmp;
+
+        idxT tmp2 = idx_arr[i];
+        idx_arr[i] = idx_arr[other_i];
+        idx_arr[other_i] = tmp2;
+      }
+    }
+
+    BitonicMerge<size / 2, ascending, reverse, T, idxT, is_stable>::merge(
+        val_arr, idx_arr, sg, local_id);
+    BitonicMerge<size / 2, ascending, reverse, T, idxT, is_stable>::merge(
+        val_arr + arr_len / 2, idx_arr + arr_len / 2, sg, local_id);
+  }
+};
+
+template <int size, bool ascending, typename T, typename idxT, bool is_stable>
+struct BitonicSort {
+  [[intel::device_indirectly_callable]] static void sort(T* __restrict__ val_arr,
+                              idxT* __restrict__ idx_arr, sycl::sub_group const & sg, const int local_id) {
+    static_assert(isPowerOf2(size));
+    static_assert(size >= 2 * WARP_SIZE);
+    constexpr int arr_len = size / WARP_SIZE;
+
+    BitonicSort<size / 2, true, T, idxT, is_stable>::sort(val_arr, idx_arr, sg, local_id);
+    BitonicSort<size / 2, false, T, idxT, is_stable>::sort(
+        val_arr + arr_len / 2, idx_arr + arr_len / 2, sg, local_id);
+    BitonicMerge<size, ascending, ascending, T, idxT, is_stable>::merge(
+        val_arr, idx_arr, sg, local_id);
+  }
+};
+
+template <bool ascending, typename T, typename idxT, bool is_stable>
+struct BitonicSort<32, ascending, T, idxT, is_stable> {
+  [[intel::device_indirectly_callable]] static void sort(T* __restrict__ val_arr,
+                              idxT* __restrict__ idx_arr, sycl::sub_group const & sg, const int local_id) {
+    int const lane = local_id % WARP_SIZE;
+
+    // ascending doesn't matter before merging since all we need is a bitonic
+    // sequence
+    for (int stage = 0; stage < 4; ++stage) {
+      for (int stride = (1 << stage); stride > 0; stride /= 2) {
+        bool reverse = (lane >> stage) & 2;
+        bool is_second = lane & stride;
+
+        T other = sycl::permute_group_by_xor(sg, *val_arr, stride);
+        idxT other_idx = sycl::permute_group_by_xor(sg, *idx_arr, stride);
+
+        bool is_better;
+        if constexpr (is_stable) {
+          if constexpr (ascending) {
+            is_better = ((*val_arr > other) ||
+                         ((*val_arr == other) && (*idx_arr < other_idx))) !=
+                        (reverse != is_second);
+          } else {
+            is_better = ((*val_arr > other) ||
+                         ((*val_arr == other) && (*idx_arr > other_idx))) !=
+                        (reverse != is_second);
+          }
+        } else {
+          is_better = (*val_arr != other &&
+                       (*val_arr > other) != (reverse != is_second));
+        }
+        if (is_better) {
+          *val_arr = other;
+          *idx_arr = other_idx;
+        }
+      }
+    }
+
+    BitonicMerge<32, ascending, ascending, T, idxT, is_stable>::merge(val_arr,
+                                                                      idx_arr, sg, local_id);
+  }
+};
+
+template <bool ascending, bool reverse, typename T, typename idxT,
+          bool is_stable>
+struct BitonicMerge<32, ascending, reverse, T, idxT, is_stable> {
+  [[intel::device_indirectly_callable]] static void merge(T* __restrict__ val_arr,
+                               idxT* __restrict__ idx_arr, sycl::sub_group const & sg ,const int local_id) {
+    int const lane = local_id % WARP_SIZE;
+    for (int stride = WARP_SIZE / 2; stride > 0; stride /= 2) {
+      bool is_second = lane & stride;
+      T& val = *val_arr;
+      T other = sycl::permute_group_by_xor(sg, val, stride);
+      idxT& idx = *idx_arr;
+      idxT other_idx = sycl::permute_group_by_xor(sg, idx, stride);
+
+      bool is_better;
+      if constexpr (is_stable) {
+        if constexpr (ascending) {
+          is_better = ((*val_arr > other) ||
+                       ((*val_arr == other) && (*idx_arr < other_idx))) ==
+                      (reverse != is_second);  // for min
+        } else {
+          is_better = ((*val_arr > other) ||
+                       ((*val_arr == other) && (*idx_arr > other_idx))) ==
+                      (reverse != is_second);  // for max
+        }
+      } else {
+        is_better =
+            (val != other && ((val > other) == (ascending != is_second)));
+      }
+
+      if (is_better) {
+        val = other;
+        idx = other_idx;
+      }
+    }
+  }
+};
+
+template <int capacity, bool greater, typename T, typename idxT, bool is_stable>
+class WarpSort {
+ public:
+ [[intel::device_indirectly_callable]] WarpSort(idxT k, T dummy, const int local_id)
+      : lane_(local_id % WARP_SIZE), k_(k), dummy_(dummy) {
+    static_assert(capacity >= WARP_SIZE && isPowerOf2(capacity));
+
+    for (int i = 0; i < max_arr_len_; ++i) {
+      val_arr_[i] = dummy_;
+      idx_arr_[i] = 0;
+    }
+  }
+
+  [[intel::device_indirectly_callable]] void dump(T* __restrict__ out, idxT* __restrict__ out_idx) const {
+    for (int i = 0; i < max_arr_len_; ++i) {
+      idxT out_i = i * WARP_SIZE + lane_;
+      if (out_i < k_) {
+        out[out_i] = val_arr_[i];
+        out_idx[out_i] = idx_arr_[i];
+      }
+    }
+  }
+
+  [[intel::device_indirectly_callable]] void dumpIdx(idxT* __restrict__ out_idx) const {
+    for (int i = 0; i < max_arr_len_; ++i) {
+      idxT out_i = i * WARP_SIZE + lane_;
+      if (out_i < k_) {
+        out_idx[out_i] = idx_arr_[i];
+      }
+    }
+  }
+
+ protected:
+  static constexpr int max_arr_len_ = capacity / WARP_SIZE;
+
+  T val_arr_[max_arr_len_];
+  idxT idx_arr_[max_arr_len_];
+
+  int const lane_;
+  idxT const k_;
+  T const dummy_;
+
+};  // end class WarpSort
+
+template <int capacity, bool greater, typename T, typename idxT, bool is_stable>
+class WarpSelect : public WarpSort<capacity, greater, T, idxT, is_stable> {
+ public:
+  [[intel::device_indirectly_callable]] WarpSelect(
+    idxT k,
+    T dummy,
+    char* smem_buf,  // slm_buf
+    const int local_id,
+    const int local_range
+  )
+      : WarpSort<capacity, greater, T, idxT, is_stable>(k, dummy, local_id),
+        k_th_(dummy),
+        k_th_lane_((k - 1) % WARP_SIZE) {
+
+    int const num_of_warp = local_range / WARP_SIZE;
+    int const warp_id = local_id / WARP_SIZE;
+    val_smem_ = reinterpret_cast<T*>(smem_buf);
+    val_smem_ += warp_id * WARP_SIZE;
+    idx_smem_ = reinterpret_cast<idxT*>(
+        smem_buf +
+        round_up_to_multiple_of<256>(num_of_warp * sizeof(T) * WARP_SIZE));
+    idx_smem_ += warp_id * WARP_SIZE;
+  }
+
+  [[intel::device_indirectly_callable]] void add(T const* in, idxT start, idxT end, sycl::sub_group const & sg, const int local_id) {
+    idxT const end_for_fullwarp =
+        round_up_to_multiple_of<WARP_SIZE>(end - start) + start;
+    for (idxT i = start + lane_; i < end_for_fullwarp; i += WARP_SIZE) {
+      T val = (i < end) ? in[i] : dummy_;
+      add(val, i, sg, local_id);
+    }
+  }
+
+  [[intel::device_indirectly_callable]] void add(T val, idxT idx, sycl::sub_group const & sg, const int local_id) {
+    bool do_add;
+    if constexpr (is_stable) {
+      do_add = is_better_than<greater>(val, k_th_, idx, k_th_idx_);
+    } else {
+      do_add = is_better_than<greater>(val, k_th_);
+    }
+
+    auto mask = sycl::ext::oneapi::group_ballot(sg, do_add);
+    if (mask == 0) {
+      return;
+    }
+
+    int pos = smem_buf_len_ + (mask & ((0x1u << lane_) - 1)).count();
+    if (do_add && pos < WARP_SIZE) {
+      val_smem_[pos] = val;
+      idx_smem_[pos] = idx;
+      do_add = false;
+    }
+    smem_buf_len_ += mask.count();
+    if (smem_buf_len_ >= WARP_SIZE) {
+      merge_buf_(val_smem_[lane_], idx_smem_[lane_], sg, local_id);
+      smem_buf_len_ -= WARP_SIZE;
+    }
+    if (do_add) {
+      pos -= WARP_SIZE;
+      val_smem_[pos] = val;
+      idx_smem_[pos] = idx;
+    }
+  }
+
+  [[intel::device_indirectly_callable]] void done(sycl::sub_group const & sg, const int local_id) {
+    if (smem_buf_len_) {
+      T val = (lane_ < smem_buf_len_) ? val_smem_[lane_] : dummy_;
+      idxT idx = (lane_ < smem_buf_len_) ? idx_smem_[lane_] : 0;
+      merge_buf_(val, idx, sg, local_id);
+    }
+  }
+
+ private:
+  [[intel::device_indirectly_callable]] void set_k_th_(sycl::sub_group const & sg) {
+    k_th_ = sycl::select_from_group(sg, val_arr_[max_arr_len_ - 1], k_th_lane_);
+    if constexpr (is_stable) {
+      k_th_idx_ =
+          sycl::select_from_group(sg, idx_arr_[max_arr_len_ - 1], k_th_lane_);
+    }
+  }
+
+  [[intel::device_indirectly_callable]] void merge_buf_(T val, idxT idx, sycl::sub_group const & sg, const int local_id) {
+    BitonicSort<WARP_SIZE, greater, T, idxT, is_stable>::sort(&val, &idx, sg, local_id);
+
+    T& old = val_arr_[max_arr_len_ - 1];
+
+    bool is_better;
+    if constexpr (is_stable) {
+      is_better =
+          is_better_than<greater>(val, old, idx, idx_arr_[max_arr_len_ - 1]);
+    } else {
+      is_better = is_better_than<greater>(val, old);
+    }
+
+    if (is_better) {
+      old = val;
+      idx_arr_[max_arr_len_ - 1] = idx;
+    }
+
+    BitonicMerge<capacity, greater, !greater, T, idxT, is_stable>::merge(
+        val_arr_, idx_arr_, sg, local_id);
+
+    set_k_th_(sg);
+  }
+
+  using WarpSort<capacity, greater, T, idxT, is_stable>::max_arr_len_;
+  using WarpSort<capacity, greater, T, idxT, is_stable>::val_arr_;
+  using WarpSort<capacity, greater, T, idxT, is_stable>::idx_arr_;
+  using WarpSort<capacity, greater, T, idxT, is_stable>::lane_;
+  using WarpSort<capacity, greater, T, idxT, is_stable>::k_;
+  using WarpSort<capacity, greater, T, idxT, is_stable>::dummy_;
+
+  T* val_smem_;
+  idxT* idx_smem_;
+  int smem_buf_len_ = 0;
+
+  T k_th_;
+  idxT k_th_idx_;
+  int const k_th_lane_;
+};  // end class WarpSelect
+}  // namespace warp_topk
+
+template <typename T_OUT, typename T_IN>
+[[intel::device_indirectly_callable]] inline T_OUT sycl_cast(T_IN val) {
+  return val;
+}
+
+template <>
+[[intel::device_indirectly_callable]] inline float sycl_cast<float, sycl::ext::oneapi::bfloat16>(sycl::ext::oneapi::bfloat16 val) {
+  return static_cast<float>(val);
+}
+
+template <typename T>
+[[intel::device_indirectly_callable]] inline void topk_with_k2(T* output, T const* input,
+                             sycl::sub_group const & sg,
+                             int32_t const lane_id,
+                             int const num_experts_per_group) {
+  // Get the top2 per thread
+  float largest = -INFINITY;
+  float second_largest = -INFINITY;
+
+  if (num_experts_per_group > WARP_SIZE) {
+    for (int i = lane_id; i < num_experts_per_group; i += WARP_SIZE) {
+      float value = input[i];
+      if (value > largest) {
+        second_largest = largest;
+        largest = value;
+      } else if (value > second_largest) {
+        second_largest = value;
+      }
+    }
+  } else {
+    for (int i = lane_id; i < num_experts_per_group; i += WARP_SIZE) {
+      largest = input[i];
+    }
+  }
+
+  float max1 = sycl::reduce_over_group(sg, largest, sycl::maximum<float>());
+
+  float max2 = max1;
+  bool equal_to_max1 = (max1 == largest);
+
+  int count_max1 = sycl::reduce_over_group(sg, equal_to_max1 ? 1 : 0, sycl::plus<>());
+
+  if (count_max1 == 1) {
+    largest = (largest == max1) ? second_largest : largest;
+    max2 = sycl::reduce_over_group(sg, largest, sycl::maximum<float>());
+  }
+
+  if (lane_id == 0) {
+    *output = max1 + max2;
+  }
+}
+
+template <typename T>
+class topk_with_k2_kernel{
+public:
+topk_with_k2_kernel(
+    T* output, T* input, int64_t const num_tokens, int64_t const num_cases,
+    int64_t const n_group, int64_t const num_experts_per_group)
+    : output(output),
+      input(input),
+      num_tokens(num_tokens),
+      num_cases(num_cases),
+      n_group(n_group),
+      num_experts_per_group(num_experts_per_group){}
+
+    void operator() [[sycl::reqd_sub_group_size(WARP_SIZE)]] (sycl::nd_item<1> item) const {
+        auto local_id = item.get_local_id(0);
+        auto group_id = item.get_group(0);
+        int32_t warp_id = local_id / WARP_SIZE;
+        int32_t lane_id = local_id % WARP_SIZE;
+
+        int32_t case_id = group_id * NUM_WARPS_PER_BLOCK + warp_id;
+        if (case_id < num_cases) {
+            auto current_input = input + case_id * num_experts_per_group;
+            auto current_output = output + case_id;
+            auto sg = item.get_sub_group();
+            topk_with_k2(current_output, current_input, sg, lane_id, num_experts_per_group);
+        }
+}
+
+private:
+  T* output;
+  T* input;
+  int64_t const num_tokens;
+  int64_t const num_cases;
+  int64_t const n_group;
+  int64_t const num_experts_per_group;
+};
+
+template <typename T, typename IdxT>
+class group_idx_and_topk_idx_kernel{
+public:
+group_idx_and_topk_idx_kernel(
+    sycl::local_accessor<char, 1>& slm,
+    T* scores, T const* group_scores, T* topk_values, IdxT* topk_indices,
+    T* scores_with_bias, int64_t const num_tokens, int64_t const n_group,
+    int64_t const topk_group, int64_t const topk, int64_t const num_experts,
+    int64_t const num_experts_per_group, bool renormalize,
+    double routed_scaling_factor)
+    : slm(slm), 
+      scores(scores),
+      group_scores(group_scores),
+      topk_values(topk_values),
+      topk_indices(topk_indices),
+      scores_with_bias(scores_with_bias),
+      num_tokens(num_tokens),
+      n_group(n_group),
+      topk_group(topk_group),
+      topk(topk),
+      num_experts(num_experts),
+      num_experts_per_group(num_experts_per_group),
+      renormalize(renormalize),
+      routed_scaling_factor(routed_scaling_factor){}
+
+void operator() [[sycl::reqd_sub_group_size(WARP_SIZE)]] (sycl::nd_item<1> item) const {
+    auto local_id = item.get_local_id(0);
+    auto group_id = item.get_group(0);
+    int32_t warp_id = local_id / WARP_SIZE;
+    int32_t lane_id = local_id % WARP_SIZE;
+    int32_t case_id =
+        group_id * NUM_WARPS_PER_BLOCK + warp_id;  // one per token
+    auto current_scores_with_bias = scores_with_bias + case_id * num_experts;
+    auto current_scores = scores + case_id * num_experts;
+    auto current_group_scores = group_scores + case_id * n_group;
+    auto current_topk_values = topk_values + case_id * topk;
+    auto current_topk_indices = topk_indices + case_id * topk;
+
+  int32_t align_num_experts_per_group =
+      warp_topk::round_up_to_multiple_of<WARP_SIZE>(num_experts_per_group);
+
+  auto sg = item.get_sub_group();
+
+  char* smem_buf = slm.template get_multi_ptr<sycl::access::decorated::no>().get();
+  int32_t* s_topk_idx = reinterpret_cast<int32_t*>(smem_buf);
+  T* s_topk_value =
+      reinterpret_cast<T*>(s_topk_idx + NUM_WARPS_PER_BLOCK * topk) +
+      warp_id * topk;
+  s_topk_idx += warp_id * topk;
+
+  T value = std::numeric_limits<T>::min();
+  T topk_group_value = std::numeric_limits<T>::min();
+  int32_t num_equalto_topkth_group;
+
+  if (case_id < num_tokens) {
+    // calculate group_idx
+    int32_t target_num_min = WARP_SIZE - n_group + topk_group;
+    if (lane_id < n_group &&
+        (std::isfinite(sycl_cast<float, T>(
+            current_group_scores[lane_id]))))  // The check is necessary to avoid
+                                       // abnormal input
+    {
+      value = current_group_scores[lane_id];
+    }
+
+    int count_equal_to_top_value = WARP_SIZE - n_group;
+    int pre_count_equal_to_top_value = 0;
+    // Use loop to find the largset top_group
+    while (count_equal_to_top_value < target_num_min) {
+      float value_f = sycl_cast<float, T>(value);
+      float topk_group_value_f = sycl::reduce_over_group(sg, value_f, sycl::maximum<float>());
+      topk_group_value = sycl_cast<T, float>(topk_group_value_f);
+      if (value_f == topk_group_value_f) {
+        value = std::numeric_limits<T>::min();
+      }
+      // topk_group_value = sycl::reduce_over_group(sg, value, sycl::maximum<T>());
+      // if (value == topk_group_value) {
+      //   value = std::numeric_limits<T>::min();
+      // }
+      pre_count_equal_to_top_value = count_equal_to_top_value;
+      count_equal_to_top_value = sycl::reduce_over_group(
+          sg, (value == std::numeric_limits<T>::min()) ? 1 : 0, sycl::plus<>()
+      );
+    }
+    num_equalto_topkth_group = target_num_min - pre_count_equal_to_top_value;
+  }
+
+  item.barrier(sycl::access::fence_space::local_space);
+
+  warp_topk::WarpSelect</*capability*/ WARP_SIZE, /*greater*/ true, T, int32_t,
+                        /* is_stable */ true>
+      queue((int32_t)topk, -INFINITY, smem_buf, local_id, item.get_local_range(0));
+
+  int count_equalto_topkth_group = 0;
+  bool if_proceed_next_topk =
+      (topk_group_value != std::numeric_limits<T>::min());
+  if (case_id < num_tokens && if_proceed_next_topk) {
+    for (int i_group = 0; i_group < n_group; i_group++) {
+      if ((current_group_scores[i_group] > topk_group_value) ||
+          ((current_group_scores[i_group] == topk_group_value) &&
+           (count_equalto_topkth_group < num_equalto_topkth_group))) {
+        int32_t offset = i_group * num_experts_per_group;
+        for (int32_t i = lane_id; i < align_num_experts_per_group;
+             i += WARP_SIZE) {
+          T candidates =
+              (i < num_experts_per_group) && std::isfinite(sycl_cast<float, T>(
+                                                 current_scores_with_bias[offset + i]))
+                  ? current_scores_with_bias[offset + i]
+                  : std::numeric_limits<T>::min();
+          queue.add(candidates, offset + i, sg, local_id);
+        }
+        if (current_group_scores[i_group] == topk_group_value) {
+          count_equalto_topkth_group++;
+        }
+      }
+    }
+    queue.done(sg, local_id);
+  }
+  // after done(), smem is used for merging results among warps
+  item.barrier(sycl::access::fence_space::local_space);
+  if(case_id < num_tokens && if_proceed_next_topk){
+    // Get the topk_idx
+    queue.dumpIdx(s_topk_idx);;
+  }
+
+  // Load the valid score value
+  // Calculate the summation
+  float topk_sum = 1e-20;
+  if (case_id < num_tokens && if_proceed_next_topk) {
+    for (int i = lane_id;
+         i < warp_topk::round_up_to_multiple_of<WARP_SIZE>(topk);
+         i += WARP_SIZE) {
+      T value =
+          i < topk
+              ? current_scores[s_topk_idx[i]]
+              : sycl_cast<T, float>(0.0f);  // Load the valid value of expert
+      if (i < topk) {
+        s_topk_value[i] = value;
+      }
+      topk_sum += sycl::reduce_over_group(sg, sycl_cast<float, T>(value), sycl::plus<>());
+    }
+  }
+
+  item.barrier(sycl::access::fence_space::local_space);
+
+  if (case_id < num_tokens) {
+    if (if_proceed_next_topk) {
+      for (int i = lane_id; i < topk; i += WARP_SIZE) {
+        float value;
+        if (renormalize) {
+          value = sycl_cast<float, T>(s_topk_value[i]) / topk_sum *
+                  routed_scaling_factor;
+        } else {
+          value = sycl_cast<float, T>(s_topk_value[i]) * routed_scaling_factor;
+        }
+        current_topk_indices[i] = s_topk_idx[i];
+        current_topk_values[i] = sycl_cast<T, float>(value);
+      }
+    } else {
+      for (int i = lane_id; i < topk; i += WARP_SIZE) {
+        current_topk_indices[i] = i;
+        current_topk_values[i] = sycl_cast<T, float>(1.0f / topk);
+      }
+    }
+    // Note: when if_proceed_next_topk==false, choose the first 8 experts as the
+    // default result.
+  }
+}
+
+private:
+  sycl::local_accessor<char, 1> slm;
+  T* scores;
+  T const* group_scores;
+  T* topk_values;
+  IdxT* topk_indices;
+  T* scores_with_bias;
+  int64_t const num_tokens;
+  int64_t const n_group;
+  int64_t const topk_group;
+  int64_t const topk;
+  int64_t const num_experts;
+  int64_t const num_experts_per_group;
+  bool renormalize;
+  double routed_scaling_factor;
+};
+
+template <typename T, typename IdxT>
+void invokeNoAuxTc(T* scores, T* group_scores, T* topk_values,
+                   IdxT* topk_indices, T* scores_with_bias,
+                   int64_t const num_tokens, int64_t const num_experts,
+                   int64_t const n_group, int64_t const topk_group,
+                   int64_t const topk, bool const renormalize,
+                   double const routed_scaling_factor, bool enable_pdl,
+                   sycl::queue& queue) {
+    int64_t num_cases = num_tokens * n_group;
+    int64_t topk_with_k2_num_blocks = (num_cases - 1) / NUM_WARPS_PER_BLOCK + 1;
+    sycl::range<1> grid(topk_with_k2_num_blocks);
+    sycl::range<1> block(BLOCK_SIZE);
+    queue.submit([&](sycl::handler& cgh) {
+        cgh.parallel_for(
+            sycl::nd_range<1>(grid * block, block),
+            topk_with_k2_kernel<T>(
+                group_scores, scores_with_bias, num_tokens, num_cases, n_group,
+                num_experts / n_group));
+    });
+
+  int64_t topk_with_k_group_num_blocks =
+      (num_tokens - 1) / NUM_WARPS_PER_BLOCK + 1;
+  size_t dynamic_smem_in_bytes =
+      warp_topk::calc_smem_size_for_block_wide<T, int32_t>(NUM_WARPS_PER_BLOCK,
+                                                           topk);
+    sycl::range<1> grid2(topk_with_k_group_num_blocks);
+    sycl::range<1> block2(BLOCK_SIZE);
+    queue.submit([&](sycl::handler& cgh) {
+        sycl::local_accessor<char, 1> slm(sycl::range<1>(dynamic_smem_in_bytes), cgh);
+        cgh.parallel_for(
+            sycl::nd_range<1>(grid * block, block),
+            group_idx_and_topk_idx_kernel<T, IdxT>(
+                slm,
+                scores, group_scores, topk_values, topk_indices, scores_with_bias,
+                num_tokens, n_group, topk_group, topk, num_experts,
+                num_experts / n_group, renormalize, routed_scaling_factor));
+    });
+}
+
+#define INSTANTIATE_NOAUX_TC(T, IdxT)                                       \
+  template void invokeNoAuxTc<T, IdxT>(                                     \
+      T * scores, T * group_scores, T * topk_values, IdxT * topk_indices,   \
+      T * scores_with_bias, int64_t const num_tokens,                       \
+      int64_t const num_experts, int64_t const n_group,                     \
+      int64_t const topk_group, int64_t const topk, bool const renormalize, \
+      double const routed_scaling_factor, bool enable_pdl,                  \
+      sycl::queue& queue);
+
+INSTANTIATE_NOAUX_TC(float, int32_t);
+INSTANTIATE_NOAUX_TC(sycl::half, int32_t);
+INSTANTIATE_NOAUX_TC(sycl::ext::oneapi::bfloat16, int32_t);
+}  // end namespace moe
+}  // namespace vllm
+
+std::tuple<torch::Tensor, torch::Tensor> grouped_topk(
+    torch::Tensor const& scores, torch::Tensor const& scores_with_bias,
+    int64_t n_group, int64_t topk_group, int64_t topk, bool renormalize,
+    double routed_scaling_factor) {
+  auto data_type = scores_with_bias.scalar_type();
+  auto input_size = scores_with_bias.sizes();
+  int64_t num_tokens = input_size[0];
+  int64_t num_experts = input_size[1];
+  TORCH_CHECK(input_size.size() == 2, "scores_with_bias must be a 2D Tensor");
+  TORCH_CHECK(num_experts % n_group == 0,
+              "num_experts should be divisible by n_group");
+  TORCH_CHECK(n_group <= 32,
+              "n_group should be smaller than or equal to 32 for now");
+  TORCH_CHECK(topk <= 32, "topk should be smaller than or equal to 32 for now");
+
+  torch::Tensor group_scores = torch::empty(
+      {num_tokens, n_group}, torch::dtype(data_type).device(torch::kXPU));
+  torch::Tensor topk_values = torch::empty(
+      {num_tokens, topk}, torch::dtype(data_type).device(torch::kXPU));
+  torch::Tensor topk_indices = torch::empty(
+      {num_tokens, topk}, torch::dtype(torch::kInt32).device(torch::kXPU));
+
+  auto& queue = vllm::xpu::vllmGetQueue();
+
+  switch (data_type) {
+    case torch::kFloat16:
+      // Handle Float16
+      vllm::moe::invokeNoAuxTc<sycl::half, int32_t>(
+          reinterpret_cast<sycl::half*>(scores.mutable_data_ptr()),
+          reinterpret_cast<sycl::half*>(group_scores.mutable_data_ptr()),
+          reinterpret_cast<sycl::half*>(topk_values.mutable_data_ptr()),
+          reinterpret_cast<int32_t*>(topk_indices.mutable_data_ptr()),
+          reinterpret_cast<sycl::half*>(scores_with_bias.data_ptr()), num_tokens,
+          num_experts, n_group, topk_group, topk, renormalize,
+          routed_scaling_factor, false, queue);
+      break;
+    case torch::kFloat32:
+      // Handle Float32
+      vllm::moe::invokeNoAuxTc<float, int32_t>(
+          reinterpret_cast<float*>(scores.mutable_data_ptr()),
+          reinterpret_cast<float*>(group_scores.mutable_data_ptr()),
+          reinterpret_cast<float*>(topk_values.mutable_data_ptr()),
+          reinterpret_cast<int32_t*>(topk_indices.mutable_data_ptr()),
+          reinterpret_cast<float*>(scores_with_bias.data_ptr()), num_tokens,
+          num_experts, n_group, topk_group, topk, renormalize,
+          routed_scaling_factor, false, queue);
+      break;
+    case torch::kBFloat16:
+      // Handle BFloat16
+      vllm::moe::invokeNoAuxTc<sycl::ext::oneapi::bfloat16, int32_t>(
+          reinterpret_cast<sycl::ext::oneapi::bfloat16*>(scores.mutable_data_ptr()),
+          reinterpret_cast<sycl::ext::oneapi::bfloat16*>(group_scores.mutable_data_ptr()),
+          reinterpret_cast<sycl::ext::oneapi::bfloat16*>(topk_values.mutable_data_ptr()),
+          reinterpret_cast<int32_t*>(topk_indices.mutable_data_ptr()),
+          reinterpret_cast<sycl::ext::oneapi::bfloat16*>(scores_with_bias.data_ptr()),
+          num_tokens, num_experts, n_group, topk_group, topk, renormalize,
+          routed_scaling_factor, false, queue);
+      break;
+    default:
+      // Handle other data types
+      throw std::invalid_argument(
+          "Invalid dtype, only supports float16, float32, and bfloat16");
+      break;
+  }
+  return {topk_values, topk_indices};
+}

--- a/csrc/moe/grouped_topk.cpp
+++ b/csrc/moe/grouped_topk.cpp
@@ -541,8 +541,7 @@ class group_idx_and_topk_idx_kernel {
         }
         pre_count_equal_to_top_value = count_equal_to_top_value;
         count_equal_to_top_value = sycl::reduce_over_group(
-            sg, (value == kNegInfinity) ? 1 : 0,
-            sycl::plus<>());
+            sg, (value == kNegInfinity) ? 1 : 0, sycl::plus<>());
       }
       num_equalto_topkth_group = target_num_min - pre_count_equal_to_top_value;
     }
@@ -556,8 +555,7 @@ class group_idx_and_topk_idx_kernel {
               item.get_local_range(0));
 
     int count_equalto_topkth_group = 0;
-    bool if_proceed_next_topk =
-        (topk_group_value != kNegInfinity);
+    bool if_proceed_next_topk = (topk_group_value != kNegInfinity);
     if (case_id < num_tokens && if_proceed_next_topk) {
       for (int i_group = 0; i_group < n_group; i_group++) {
         if ((current_group_scores[i_group] > topk_group_value) ||

--- a/csrc/moe/grouped_topk.cpp
+++ b/csrc/moe/grouped_topk.cpp
@@ -47,16 +47,17 @@ template <typename T, typename idxT>
 int calc_smem_size_for_block_wide(int num_of_warp, int64_t k) {
   uint64_t cache_topk = (sizeof(T) + sizeof(idxT)) * num_of_warp * k;
   uint64_t n = std::max<int>(num_of_warp / 2 * k, num_of_warp * WARP_SIZE);
-  return std::max(cache_topk,
-             round_up_to_multiple_of<256>(n * sizeof(T)) + n * sizeof(idxT));
+  return std::max(cache_topk, round_up_to_multiple_of<256>(n * sizeof(T)) +
+                                  n * sizeof(idxT));
 }
 
 template <int size, bool ascending, bool reverse, typename T, typename idxT,
           bool is_stable>
 struct BitonicMerge {
   // input should be a bitonic sequence, and sort it to be a monotonic sequence
-  [[intel::device_indirectly_callable]] static void merge(T* __restrict__ val_arr,
-                               idxT* __restrict__ idx_arr, sycl::sub_group const & sg, const int local_id) {
+  [[intel::device_indirectly_callable]] static void merge(
+      T* __restrict__ val_arr, idxT* __restrict__ idx_arr,
+      sycl::sub_group const& sg, const int local_id) {
     static_assert(isPowerOf2(size));
     static_assert(size >= 2 * WARP_SIZE);
     constexpr int arr_len = size / WARP_SIZE;
@@ -94,13 +95,15 @@ struct BitonicMerge {
 
 template <int size, bool ascending, typename T, typename idxT, bool is_stable>
 struct BitonicSort {
-  [[intel::device_indirectly_callable]] static void sort(T* __restrict__ val_arr,
-                              idxT* __restrict__ idx_arr, sycl::sub_group const & sg, const int local_id) {
+  [[intel::device_indirectly_callable]] static void sort(
+      T* __restrict__ val_arr, idxT* __restrict__ idx_arr,
+      sycl::sub_group const& sg, const int local_id) {
     static_assert(isPowerOf2(size));
     static_assert(size >= 2 * WARP_SIZE);
     constexpr int arr_len = size / WARP_SIZE;
 
-    BitonicSort<size / 2, true, T, idxT, is_stable>::sort(val_arr, idx_arr, sg, local_id);
+    BitonicSort<size / 2, true, T, idxT, is_stable>::sort(val_arr, idx_arr, sg,
+                                                          local_id);
     BitonicSort<size / 2, false, T, idxT, is_stable>::sort(
         val_arr + arr_len / 2, idx_arr + arr_len / 2, sg, local_id);
     BitonicMerge<size, ascending, ascending, T, idxT, is_stable>::merge(
@@ -110,8 +113,9 @@ struct BitonicSort {
 
 template <bool ascending, typename T, typename idxT, bool is_stable>
 struct BitonicSort<32, ascending, T, idxT, is_stable> {
-  [[intel::device_indirectly_callable]] static void sort(T* __restrict__ val_arr,
-                              idxT* __restrict__ idx_arr, sycl::sub_group const & sg, const int local_id) {
+  [[intel::device_indirectly_callable]] static void sort(
+      T* __restrict__ val_arr, idxT* __restrict__ idx_arr,
+      sycl::sub_group const& sg, const int local_id) {
     int const lane = local_id % WARP_SIZE;
 
     // ascending doesn't matter before merging since all we need is a bitonic
@@ -146,16 +150,17 @@ struct BitonicSort<32, ascending, T, idxT, is_stable> {
       }
     }
 
-    BitonicMerge<32, ascending, ascending, T, idxT, is_stable>::merge(val_arr,
-                                                                      idx_arr, sg, local_id);
+    BitonicMerge<32, ascending, ascending, T, idxT, is_stable>::merge(
+        val_arr, idx_arr, sg, local_id);
   }
 };
 
 template <bool ascending, bool reverse, typename T, typename idxT,
           bool is_stable>
 struct BitonicMerge<32, ascending, reverse, T, idxT, is_stable> {
-  [[intel::device_indirectly_callable]] static void merge(T* __restrict__ val_arr,
-                               idxT* __restrict__ idx_arr, sycl::sub_group const & sg ,const int local_id) {
+  [[intel::device_indirectly_callable]] static void merge(
+      T* __restrict__ val_arr, idxT* __restrict__ idx_arr,
+      sycl::sub_group const& sg, const int local_id) {
     int const lane = local_id % WARP_SIZE;
     for (int stride = WARP_SIZE / 2; stride > 0; stride /= 2) {
       bool is_second = lane & stride;
@@ -191,7 +196,8 @@ struct BitonicMerge<32, ascending, reverse, T, idxT, is_stable> {
 template <int capacity, bool greater, typename T, typename idxT, bool is_stable>
 class WarpSort {
  public:
- [[intel::device_indirectly_callable]] WarpSort(idxT k, T dummy, const int local_id)
+  [[intel::device_indirectly_callable]] WarpSort(idxT k, T dummy,
+                                                 const int local_id)
       : lane_(local_id % WARP_SIZE), k_(k), dummy_(dummy) {
     static_assert(capacity >= WARP_SIZE && isPowerOf2(capacity));
 
@@ -201,7 +207,8 @@ class WarpSort {
     }
   }
 
-  [[intel::device_indirectly_callable]] void dump(T* __restrict__ out, idxT* __restrict__ out_idx) const {
+  [[intel::device_indirectly_callable]] void dump(
+      T* __restrict__ out, idxT* __restrict__ out_idx) const {
     for (int i = 0; i < max_arr_len_; ++i) {
       idxT out_i = i * WARP_SIZE + lane_;
       if (out_i < k_) {
@@ -211,7 +218,8 @@ class WarpSort {
     }
   }
 
-  [[intel::device_indirectly_callable]] void dumpIdx(idxT* __restrict__ out_idx) const {
+  [[intel::device_indirectly_callable]] void dumpIdx(
+      idxT* __restrict__ out_idx) const {
     for (int i = 0; i < max_arr_len_; ++i) {
       idxT out_i = i * WARP_SIZE + lane_;
       if (out_i < k_) {
@@ -235,17 +243,13 @@ class WarpSort {
 template <int capacity, bool greater, typename T, typename idxT, bool is_stable>
 class WarpSelect : public WarpSort<capacity, greater, T, idxT, is_stable> {
  public:
-  [[intel::device_indirectly_callable]] WarpSelect(
-    idxT k,
-    T dummy,
-    char* smem_buf,  // slm_buf
-    const int local_id,
-    const int local_range
-  )
+  [[intel::device_indirectly_callable]] WarpSelect(idxT k, T dummy,
+                                                   char* smem_buf,  // slm_buf
+                                                   const int local_id,
+                                                   const int local_range)
       : WarpSort<capacity, greater, T, idxT, is_stable>(k, dummy, local_id),
         k_th_(dummy),
         k_th_lane_((k - 1) % WARP_SIZE) {
-
     int const num_of_warp = local_range / WARP_SIZE;
     int const warp_id = local_id / WARP_SIZE;
     val_smem_ = reinterpret_cast<T*>(smem_buf);
@@ -256,7 +260,10 @@ class WarpSelect : public WarpSort<capacity, greater, T, idxT, is_stable> {
     idx_smem_ += warp_id * WARP_SIZE;
   }
 
-  [[intel::device_indirectly_callable]] void add(T const* in, idxT start, idxT end, sycl::sub_group const & sg, const int local_id) {
+  [[intel::device_indirectly_callable]] void add(T const* in, idxT start,
+                                                 idxT end,
+                                                 sycl::sub_group const& sg,
+                                                 const int local_id) {
     idxT const end_for_fullwarp =
         round_up_to_multiple_of<WARP_SIZE>(end - start) + start;
     for (idxT i = start + lane_; i < end_for_fullwarp; i += WARP_SIZE) {
@@ -265,7 +272,9 @@ class WarpSelect : public WarpSort<capacity, greater, T, idxT, is_stable> {
     }
   }
 
-  [[intel::device_indirectly_callable]] void add(T val, idxT idx, sycl::sub_group const & sg, const int local_id) {
+  [[intel::device_indirectly_callable]] void add(T val, idxT idx,
+                                                 sycl::sub_group const& sg,
+                                                 const int local_id) {
     bool do_add;
     if constexpr (is_stable) {
       do_add = is_better_than<greater>(val, k_th_, idx, k_th_idx_);
@@ -296,7 +305,8 @@ class WarpSelect : public WarpSort<capacity, greater, T, idxT, is_stable> {
     }
   }
 
-  [[intel::device_indirectly_callable]] void done(sycl::sub_group const & sg, const int local_id) {
+  [[intel::device_indirectly_callable]] void done(sycl::sub_group const& sg,
+                                                  const int local_id) {
     if (smem_buf_len_) {
       T val = (lane_ < smem_buf_len_) ? val_smem_[lane_] : dummy_;
       idxT idx = (lane_ < smem_buf_len_) ? idx_smem_[lane_] : 0;
@@ -305,7 +315,8 @@ class WarpSelect : public WarpSort<capacity, greater, T, idxT, is_stable> {
   }
 
  private:
-  [[intel::device_indirectly_callable]] void set_k_th_(sycl::sub_group const & sg) {
+  [[intel::device_indirectly_callable]] void set_k_th_(
+      sycl::sub_group const& sg) {
     k_th_ = sycl::select_from_group(sg, val_arr_[max_arr_len_ - 1], k_th_lane_);
     if constexpr (is_stable) {
       k_th_idx_ =
@@ -313,8 +324,10 @@ class WarpSelect : public WarpSort<capacity, greater, T, idxT, is_stable> {
     }
   }
 
-  [[intel::device_indirectly_callable]] void merge_buf_(T val, idxT idx, sycl::sub_group const & sg, const int local_id) {
-    BitonicSort<WARP_SIZE, greater, T, idxT, is_stable>::sort(&val, &idx, sg, local_id);
+  [[intel::device_indirectly_callable]] void merge_buf_(
+      T val, idxT idx, sycl::sub_group const& sg, const int local_id) {
+    BitonicSort<WARP_SIZE, greater, T, idxT, is_stable>::sort(&val, &idx, sg,
+                                                              local_id);
 
     T& old = val_arr_[max_arr_len_ - 1];
 
@@ -360,15 +373,15 @@ template <typename T_OUT, typename T_IN>
 }
 
 template <>
-[[intel::device_indirectly_callable]] inline float sycl_cast<float, sycl::ext::oneapi::bfloat16>(sycl::ext::oneapi::bfloat16 val) {
+[[intel::device_indirectly_callable]] inline float
+sycl_cast<float, sycl::ext::oneapi::bfloat16>(sycl::ext::oneapi::bfloat16 val) {
   return static_cast<float>(val);
 }
 
 template <typename T>
-[[intel::device_indirectly_callable]] inline void topk_with_k2(T* output, T const* input,
-                             sycl::sub_group const & sg,
-                             int32_t const lane_id,
-                             int const num_experts_per_group) {
+[[intel::device_indirectly_callable]] inline void topk_with_k2(
+    T* output, T const* input, sycl::sub_group const& sg, int32_t const lane_id,
+    int const num_experts_per_group) {
   // Get the top2 per thread
   float largest = -INFINITY;
   float second_largest = -INFINITY;
@@ -394,7 +407,8 @@ template <typename T>
   float max2 = max1;
   bool equal_to_max1 = (max1 == largest);
 
-  int count_max1 = sycl::reduce_over_group(sg, equal_to_max1 ? 1 : 0, sycl::plus<>());
+  int count_max1 =
+      sycl::reduce_over_group(sg, equal_to_max1 ? 1 : 0, sycl::plus<>());
 
   if (count_max1 == 1) {
     largest = (largest == max1) ? second_largest : largest;
@@ -407,34 +421,36 @@ template <typename T>
 }
 
 template <typename T>
-class topk_with_k2_kernel{
-public:
-topk_with_k2_kernel(
-    T* output, T* input, int64_t const num_tokens, int64_t const num_cases,
-    int64_t const n_group, int64_t const num_experts_per_group)
-    : output(output),
-      input(input),
-      num_tokens(num_tokens),
-      num_cases(num_cases),
-      n_group(n_group),
-      num_experts_per_group(num_experts_per_group){}
+class topk_with_k2_kernel {
+ public:
+  topk_with_k2_kernel(T* output, T* input, int64_t const num_tokens,
+                      int64_t const num_cases, int64_t const n_group,
+                      int64_t const num_experts_per_group)
+      : output(output),
+        input(input),
+        num_tokens(num_tokens),
+        num_cases(num_cases),
+        n_group(n_group),
+        num_experts_per_group(num_experts_per_group) {}
 
-    void operator() [[sycl::reqd_sub_group_size(WARP_SIZE)]] (sycl::nd_item<1> item) const {
-        auto local_id = item.get_local_id(0);
-        auto group_id = item.get_group(0);
-        int32_t warp_id = local_id / WARP_SIZE;
-        int32_t lane_id = local_id % WARP_SIZE;
+  void operator()
+      [[sycl::reqd_sub_group_size(WARP_SIZE)]] (sycl::nd_item<1> item) const {
+    auto local_id = item.get_local_id(0);
+    auto group_id = item.get_group(0);
+    int32_t warp_id = local_id / WARP_SIZE;
+    int32_t lane_id = local_id % WARP_SIZE;
 
-        int32_t case_id = group_id * NUM_WARPS_PER_BLOCK + warp_id;
-        if (case_id < num_cases) {
-            auto current_input = input + case_id * num_experts_per_group;
-            auto current_output = output + case_id;
-            auto sg = item.get_sub_group();
-            topk_with_k2(current_output, current_input, sg, lane_id, num_experts_per_group);
-        }
-}
+    int32_t case_id = group_id * NUM_WARPS_PER_BLOCK + warp_id;
+    if (case_id < num_cases) {
+      auto current_input = input + case_id * num_experts_per_group;
+      auto current_output = output + case_id;
+      auto sg = item.get_sub_group();
+      topk_with_k2(current_output, current_input, sg, lane_id,
+                   num_experts_per_group);
+    }
+  }
 
-private:
+ private:
   T* output;
   T* input;
   int64_t const num_tokens;
@@ -444,31 +460,33 @@ private:
 };
 
 template <typename T, typename IdxT>
-class group_idx_and_topk_idx_kernel{
-public:
-group_idx_and_topk_idx_kernel(
-    sycl::local_accessor<char, 1>& slm,
-    T* scores, T const* group_scores, T* topk_values, IdxT* topk_indices,
-    T* scores_with_bias, int64_t const num_tokens, int64_t const n_group,
-    int64_t const topk_group, int64_t const topk, int64_t const num_experts,
-    int64_t const num_experts_per_group, bool renormalize,
-    double routed_scaling_factor)
-    : slm(slm), 
-      scores(scores),
-      group_scores(group_scores),
-      topk_values(topk_values),
-      topk_indices(topk_indices),
-      scores_with_bias(scores_with_bias),
-      num_tokens(num_tokens),
-      n_group(n_group),
-      topk_group(topk_group),
-      topk(topk),
-      num_experts(num_experts),
-      num_experts_per_group(num_experts_per_group),
-      renormalize(renormalize),
-      routed_scaling_factor(routed_scaling_factor){}
+class group_idx_and_topk_idx_kernel {
+ public:
+  group_idx_and_topk_idx_kernel(sycl::local_accessor<char, 1>& slm, T* scores,
+                                T const* group_scores, T* topk_values,
+                                IdxT* topk_indices, T* scores_with_bias,
+                                int64_t const num_tokens, int64_t const n_group,
+                                int64_t const topk_group, int64_t const topk,
+                                int64_t const num_experts,
+                                int64_t const num_experts_per_group,
+                                bool renormalize, double routed_scaling_factor)
+      : slm(slm),
+        scores(scores),
+        group_scores(group_scores),
+        topk_values(topk_values),
+        topk_indices(topk_indices),
+        scores_with_bias(scores_with_bias),
+        num_tokens(num_tokens),
+        n_group(n_group),
+        topk_group(topk_group),
+        topk(topk),
+        num_experts(num_experts),
+        num_experts_per_group(num_experts_per_group),
+        renormalize(renormalize),
+        routed_scaling_factor(routed_scaling_factor) {}
 
-void operator() [[sycl::reqd_sub_group_size(WARP_SIZE)]] (sycl::nd_item<1> item) const {
+  void operator()
+      [[sycl::reqd_sub_group_size(WARP_SIZE)]] (sycl::nd_item<1> item) const {
     auto local_id = item.get_local_id(0);
     auto group_id = item.get_group(0);
     int32_t warp_id = local_id / WARP_SIZE;
@@ -481,138 +499,145 @@ void operator() [[sycl::reqd_sub_group_size(WARP_SIZE)]] (sycl::nd_item<1> item)
     auto current_topk_values = topk_values + case_id * topk;
     auto current_topk_indices = topk_indices + case_id * topk;
 
-  int32_t align_num_experts_per_group =
-      warp_topk::round_up_to_multiple_of<WARP_SIZE>(num_experts_per_group);
+    int32_t align_num_experts_per_group =
+        warp_topk::round_up_to_multiple_of<WARP_SIZE>(num_experts_per_group);
 
-  auto sg = item.get_sub_group();
+    auto sg = item.get_sub_group();
 
-  char* smem_buf = slm.template get_multi_ptr<sycl::access::decorated::no>().get();
-  int32_t* s_topk_idx = reinterpret_cast<int32_t*>(smem_buf);
-  T* s_topk_value =
-      reinterpret_cast<T*>(s_topk_idx + NUM_WARPS_PER_BLOCK * topk) +
-      warp_id * topk;
-  s_topk_idx += warp_id * topk;
+    char* smem_buf =
+        slm.template get_multi_ptr<sycl::access::decorated::no>().get();
+    int32_t* s_topk_idx = reinterpret_cast<int32_t*>(smem_buf);
+    T* s_topk_value =
+        reinterpret_cast<T*>(s_topk_idx + NUM_WARPS_PER_BLOCK * topk) +
+        warp_id * topk;
+    s_topk_idx += warp_id * topk;
 
-  T value = std::numeric_limits<T>::min();
-  T topk_group_value = std::numeric_limits<T>::min();
-  int32_t num_equalto_topkth_group;
+    T value = std::numeric_limits<T>::min();
+    T topk_group_value = std::numeric_limits<T>::min();
+    int32_t num_equalto_topkth_group;
 
-  if (case_id < num_tokens) {
-    // calculate group_idx
-    int32_t target_num_min = WARP_SIZE - n_group + topk_group;
-    if (lane_id < n_group &&
-        (std::isfinite(sycl_cast<float, T>(
-            current_group_scores[lane_id]))))  // The check is necessary to avoid
-                                       // abnormal input
-    {
-      value = current_group_scores[lane_id];
-    }
-
-    int count_equal_to_top_value = WARP_SIZE - n_group;
-    int pre_count_equal_to_top_value = 0;
-    // Use loop to find the largset top_group
-    while (count_equal_to_top_value < target_num_min) {
-      float value_f = sycl_cast<float, T>(value);
-      float topk_group_value_f = sycl::reduce_over_group(sg, value_f, sycl::maximum<float>());
-      topk_group_value = sycl_cast<T, float>(topk_group_value_f);
-      if (value_f == topk_group_value_f) {
-        value = std::numeric_limits<T>::min();
+    if (case_id < num_tokens) {
+      // calculate group_idx
+      int32_t target_num_min = WARP_SIZE - n_group + topk_group;
+      if (lane_id < n_group &&
+          (std::isfinite(sycl_cast<float, T>(
+              current_group_scores[lane_id]))))  // The check is necessary to
+                                                 // avoid abnormal input
+      {
+        value = current_group_scores[lane_id];
       }
-      // topk_group_value = sycl::reduce_over_group(sg, value, sycl::maximum<T>());
-      // if (value == topk_group_value) {
-      //   value = std::numeric_limits<T>::min();
-      // }
-      pre_count_equal_to_top_value = count_equal_to_top_value;
-      count_equal_to_top_value = sycl::reduce_over_group(
-          sg, (value == std::numeric_limits<T>::min()) ? 1 : 0, sycl::plus<>()
-      );
-    }
-    num_equalto_topkth_group = target_num_min - pre_count_equal_to_top_value;
-  }
 
-  item.barrier(sycl::access::fence_space::local_space);
-
-  warp_topk::WarpSelect</*capability*/ WARP_SIZE, /*greater*/ true, T, int32_t,
-                        /* is_stable */ true>
-      queue((int32_t)topk, -INFINITY, smem_buf, local_id, item.get_local_range(0));
-
-  int count_equalto_topkth_group = 0;
-  bool if_proceed_next_topk =
-      (topk_group_value != std::numeric_limits<T>::min());
-  if (case_id < num_tokens && if_proceed_next_topk) {
-    for (int i_group = 0; i_group < n_group; i_group++) {
-      if ((current_group_scores[i_group] > topk_group_value) ||
-          ((current_group_scores[i_group] == topk_group_value) &&
-           (count_equalto_topkth_group < num_equalto_topkth_group))) {
-        int32_t offset = i_group * num_experts_per_group;
-        for (int32_t i = lane_id; i < align_num_experts_per_group;
-             i += WARP_SIZE) {
-          T candidates =
-              (i < num_experts_per_group) && std::isfinite(sycl_cast<float, T>(
-                                                 current_scores_with_bias[offset + i]))
-                  ? current_scores_with_bias[offset + i]
-                  : std::numeric_limits<T>::min();
-          queue.add(candidates, offset + i, sg, local_id);
+      int count_equal_to_top_value = WARP_SIZE - n_group;
+      int pre_count_equal_to_top_value = 0;
+      // Use loop to find the largset top_group
+      while (count_equal_to_top_value < target_num_min) {
+        float value_f = sycl_cast<float, T>(value);
+        float topk_group_value_f =
+            sycl::reduce_over_group(sg, value_f, sycl::maximum<float>());
+        topk_group_value = sycl_cast<T, float>(topk_group_value_f);
+        if (value_f == topk_group_value_f) {
+          value = std::numeric_limits<T>::min();
         }
-        if (current_group_scores[i_group] == topk_group_value) {
-          count_equalto_topkth_group++;
+        // topk_group_value = sycl::reduce_over_group(sg, value,
+        // sycl::maximum<T>()); if (value == topk_group_value) {
+        //   value = std::numeric_limits<T>::min();
+        // }
+        pre_count_equal_to_top_value = count_equal_to_top_value;
+        count_equal_to_top_value = sycl::reduce_over_group(
+            sg, (value == std::numeric_limits<T>::min()) ? 1 : 0,
+            sycl::plus<>());
+      }
+      num_equalto_topkth_group = target_num_min - pre_count_equal_to_top_value;
+    }
+
+    item.barrier(sycl::access::fence_space::local_space);
+
+    warp_topk::WarpSelect</*capability*/ WARP_SIZE, /*greater*/ true, T,
+                          int32_t,
+                          /* is_stable */ true>
+        queue((int32_t)topk, -INFINITY, smem_buf, local_id,
+              item.get_local_range(0));
+
+    int count_equalto_topkth_group = 0;
+    bool if_proceed_next_topk =
+        (topk_group_value != std::numeric_limits<T>::min());
+    if (case_id < num_tokens && if_proceed_next_topk) {
+      for (int i_group = 0; i_group < n_group; i_group++) {
+        if ((current_group_scores[i_group] > topk_group_value) ||
+            ((current_group_scores[i_group] == topk_group_value) &&
+             (count_equalto_topkth_group < num_equalto_topkth_group))) {
+          int32_t offset = i_group * num_experts_per_group;
+          for (int32_t i = lane_id; i < align_num_experts_per_group;
+               i += WARP_SIZE) {
+            T candidates = (i < num_experts_per_group) &&
+                                   std::isfinite(sycl_cast<float, T>(
+                                       current_scores_with_bias[offset + i]))
+                               ? current_scores_with_bias[offset + i]
+                               : std::numeric_limits<T>::min();
+            queue.add(candidates, offset + i, sg, local_id);
+          }
+          if (current_group_scores[i_group] == topk_group_value) {
+            count_equalto_topkth_group++;
+          }
         }
       }
+      queue.done(sg, local_id);
     }
-    queue.done(sg, local_id);
-  }
-  // after done(), smem is used for merging results among warps
-  item.barrier(sycl::access::fence_space::local_space);
-  if(case_id < num_tokens && if_proceed_next_topk){
-    // Get the topk_idx
-    queue.dumpIdx(s_topk_idx);;
-  }
-
-  // Load the valid score value
-  // Calculate the summation
-  float topk_sum = 1e-20;
-  if (case_id < num_tokens && if_proceed_next_topk) {
-    for (int i = lane_id;
-         i < warp_topk::round_up_to_multiple_of<WARP_SIZE>(topk);
-         i += WARP_SIZE) {
-      T value =
-          i < topk
-              ? current_scores[s_topk_idx[i]]
-              : sycl_cast<T, float>(0.0f);  // Load the valid value of expert
-      if (i < topk) {
-        s_topk_value[i] = value;
-      }
-      topk_sum += sycl::reduce_over_group(sg, sycl_cast<float, T>(value), sycl::plus<>());
+    // after done(), smem is used for merging results among warps
+    item.barrier(sycl::access::fence_space::local_space);
+    if (case_id < num_tokens && if_proceed_next_topk) {
+      // Get the topk_idx
+      queue.dumpIdx(s_topk_idx);
+      ;
     }
-  }
 
-  item.barrier(sycl::access::fence_space::local_space);
-
-  if (case_id < num_tokens) {
-    if (if_proceed_next_topk) {
-      for (int i = lane_id; i < topk; i += WARP_SIZE) {
-        float value;
-        if (renormalize) {
-          value = sycl_cast<float, T>(s_topk_value[i]) / topk_sum *
-                  routed_scaling_factor;
-        } else {
-          value = sycl_cast<float, T>(s_topk_value[i]) * routed_scaling_factor;
+    // Load the valid score value
+    // Calculate the summation
+    float topk_sum = 1e-20;
+    if (case_id < num_tokens && if_proceed_next_topk) {
+      for (int i = lane_id;
+           i < warp_topk::round_up_to_multiple_of<WARP_SIZE>(topk);
+           i += WARP_SIZE) {
+        T value =
+            i < topk
+                ? current_scores[s_topk_idx[i]]
+                : sycl_cast<T, float>(0.0f);  // Load the valid value of expert
+        if (i < topk) {
+          s_topk_value[i] = value;
         }
-        current_topk_indices[i] = s_topk_idx[i];
-        current_topk_values[i] = sycl_cast<T, float>(value);
-      }
-    } else {
-      for (int i = lane_id; i < topk; i += WARP_SIZE) {
-        current_topk_indices[i] = i;
-        current_topk_values[i] = sycl_cast<T, float>(1.0f / topk);
+        topk_sum += sycl::reduce_over_group(sg, sycl_cast<float, T>(value),
+                                            sycl::plus<>());
       }
     }
-    // Note: when if_proceed_next_topk==false, choose the first 8 experts as the
-    // default result.
-  }
-}
 
-private:
+    item.barrier(sycl::access::fence_space::local_space);
+
+    if (case_id < num_tokens) {
+      if (if_proceed_next_topk) {
+        for (int i = lane_id; i < topk; i += WARP_SIZE) {
+          float value;
+          if (renormalize) {
+            value = sycl_cast<float, T>(s_topk_value[i]) / topk_sum *
+                    routed_scaling_factor;
+          } else {
+            value =
+                sycl_cast<float, T>(s_topk_value[i]) * routed_scaling_factor;
+          }
+          current_topk_indices[i] = s_topk_idx[i];
+          current_topk_values[i] = sycl_cast<T, float>(value);
+        }
+      } else {
+        for (int i = lane_id; i < topk; i += WARP_SIZE) {
+          current_topk_indices[i] = i;
+          current_topk_values[i] = sycl_cast<T, float>(1.0f / topk);
+        }
+      }
+      // Note: when if_proceed_next_topk==false, choose the first 8 experts as
+      // the default result.
+    }
+  }
+
+ private:
   sycl::local_accessor<char, 1> slm;
   T* scores;
   T const* group_scores;
@@ -637,35 +662,34 @@ void invokeNoAuxTc(T* scores, T* group_scores, T* topk_values,
                    int64_t const topk, bool const renormalize,
                    double const routed_scaling_factor, bool enable_pdl,
                    sycl::queue& queue) {
-    int64_t num_cases = num_tokens * n_group;
-    int64_t topk_with_k2_num_blocks = (num_cases - 1) / NUM_WARPS_PER_BLOCK + 1;
-    sycl::range<1> grid(topk_with_k2_num_blocks);
-    sycl::range<1> block(BLOCK_SIZE);
-    queue.submit([&](sycl::handler& cgh) {
-        cgh.parallel_for(
-            sycl::nd_range<1>(grid * block, block),
-            topk_with_k2_kernel<T>(
-                group_scores, scores_with_bias, num_tokens, num_cases, n_group,
-                num_experts / n_group));
-    });
+  int64_t num_cases = num_tokens * n_group;
+  int64_t topk_with_k2_num_blocks = (num_cases - 1) / NUM_WARPS_PER_BLOCK + 1;
+  sycl::range<1> grid(topk_with_k2_num_blocks);
+  sycl::range<1> block(BLOCK_SIZE);
+  queue.submit([&](sycl::handler& cgh) {
+    cgh.parallel_for(
+        sycl::nd_range<1>(grid * block, block),
+        topk_with_k2_kernel<T>(group_scores, scores_with_bias, num_tokens,
+                               num_cases, n_group, num_experts / n_group));
+  });
 
   int64_t topk_with_k_group_num_blocks =
       (num_tokens - 1) / NUM_WARPS_PER_BLOCK + 1;
   size_t dynamic_smem_in_bytes =
       warp_topk::calc_smem_size_for_block_wide<T, int32_t>(NUM_WARPS_PER_BLOCK,
                                                            topk);
-    sycl::range<1> grid2(topk_with_k_group_num_blocks);
-    sycl::range<1> block2(BLOCK_SIZE);
-    queue.submit([&](sycl::handler& cgh) {
-        sycl::local_accessor<char, 1> slm(sycl::range<1>(dynamic_smem_in_bytes), cgh);
-        cgh.parallel_for(
-            sycl::nd_range<1>(grid * block, block),
-            group_idx_and_topk_idx_kernel<T, IdxT>(
-                slm,
-                scores, group_scores, topk_values, topk_indices, scores_with_bias,
-                num_tokens, n_group, topk_group, topk, num_experts,
-                num_experts / n_group, renormalize, routed_scaling_factor));
-    });
+  sycl::range<1> grid2(topk_with_k_group_num_blocks);
+  sycl::range<1> block2(BLOCK_SIZE);
+  queue.submit([&](sycl::handler& cgh) {
+    sycl::local_accessor<char, 1> slm(sycl::range<1>(dynamic_smem_in_bytes),
+                                      cgh);
+    cgh.parallel_for(sycl::nd_range<1>(grid * block, block),
+                     group_idx_and_topk_idx_kernel<T, IdxT>(
+                         slm, scores, group_scores, topk_values, topk_indices,
+                         scores_with_bias, num_tokens, n_group, topk_group,
+                         topk, num_experts, num_experts / n_group, renormalize,
+                         routed_scaling_factor));
+  });
 }
 
 #define INSTANTIATE_NOAUX_TC(T, IdxT)                                       \
@@ -715,8 +739,8 @@ std::tuple<torch::Tensor, torch::Tensor> grouped_topk(
           reinterpret_cast<sycl::half*>(group_scores.mutable_data_ptr()),
           reinterpret_cast<sycl::half*>(topk_values.mutable_data_ptr()),
           reinterpret_cast<int32_t*>(topk_indices.mutable_data_ptr()),
-          reinterpret_cast<sycl::half*>(scores_with_bias.data_ptr()), num_tokens,
-          num_experts, n_group, topk_group, topk, renormalize,
+          reinterpret_cast<sycl::half*>(scores_with_bias.data_ptr()),
+          num_tokens, num_experts, n_group, topk_group, topk, renormalize,
           routed_scaling_factor, false, queue);
       break;
     case torch::kFloat32:
@@ -733,11 +757,15 @@ std::tuple<torch::Tensor, torch::Tensor> grouped_topk(
     case torch::kBFloat16:
       // Handle BFloat16
       vllm::moe::invokeNoAuxTc<sycl::ext::oneapi::bfloat16, int32_t>(
-          reinterpret_cast<sycl::ext::oneapi::bfloat16*>(scores.mutable_data_ptr()),
-          reinterpret_cast<sycl::ext::oneapi::bfloat16*>(group_scores.mutable_data_ptr()),
-          reinterpret_cast<sycl::ext::oneapi::bfloat16*>(topk_values.mutable_data_ptr()),
+          reinterpret_cast<sycl::ext::oneapi::bfloat16*>(
+              scores.mutable_data_ptr()),
+          reinterpret_cast<sycl::ext::oneapi::bfloat16*>(
+              group_scores.mutable_data_ptr()),
+          reinterpret_cast<sycl::ext::oneapi::bfloat16*>(
+              topk_values.mutable_data_ptr()),
           reinterpret_cast<int32_t*>(topk_indices.mutable_data_ptr()),
-          reinterpret_cast<sycl::ext::oneapi::bfloat16*>(scores_with_bias.data_ptr()),
+          reinterpret_cast<sycl::ext::oneapi::bfloat16*>(
+              scores_with_bias.data_ptr()),
           num_tokens, num_experts, n_group, topk_group, topk, renormalize,
           routed_scaling_factor, false, queue);
       break;

--- a/csrc/moe/moe_ops.h
+++ b/csrc/moe/moe_ops.h
@@ -3,3 +3,8 @@
 #include <torch/all.h>
 
 void moe_sum(torch::Tensor& input, torch::Tensor& output);
+
+std::tuple<torch::Tensor, torch::Tensor> grouped_topk(
+    torch::Tensor const& scores, torch::Tensor const& scores_with_bias,
+    int64_t n_group, int64_t topk_group, int64_t topk, bool renormalize,
+    double routed_scaling_factor);

--- a/csrc/moe/torch_bindings.cpp
+++ b/csrc/moe/torch_bindings.cpp
@@ -6,6 +6,13 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, m) {
   // from all selected experts.
   m.def("moe_sum(Tensor input, Tensor! output) -> ()");
   m.impl("moe_sum", torch::kXPU, &moe_sum);
+
+  // Apply grouped topk routing to select experts.
+  m.def(
+      "grouped_topk(Tensor scores, Tensor scores_with_bias, int n_group, int "
+      "topk_group, int topk, bool renormalize, float "
+      "routed_scaling_factor) -> (Tensor, Tensor)");
+  m.impl("grouped_topk", torch::kXPU, &grouped_topk);
 }
 
 REGISTER_EXTENSION(TORCH_EXTENSION_NAME)

--- a/tests/ops/grouped_topk_op.py
+++ b/tests/ops/grouped_topk_op.py
@@ -4,7 +4,9 @@
 from typing import Optional
 
 import torch
+
 import tests.register_ops as ops
+
 
 def grouped_topk(
     hidden_states: torch.Tensor,

--- a/tests/ops/grouped_topk_op.py
+++ b/tests/ops/grouped_topk_op.py
@@ -1,0 +1,90 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from typing import Optional
+
+import torch
+import tests.register_ops as ops
+
+def grouped_topk(
+    hidden_states: torch.Tensor,
+    gating_output: torch.Tensor,
+    topk: int,
+    renormalize: bool,
+    num_expert_group: int = 0,
+    topk_group: int = 0,
+    scoring_func: str = "softmax",
+    routed_scaling_factor: float = 1.0,
+    e_score_correction_bias: Optional[torch.Tensor] = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+
+    assert hidden_states.size(0) == gating_output.size(0), (
+        "Number of tokens mismatch")
+    if scoring_func == "softmax":
+        scores = torch.softmax(gating_output, dim=-1)
+    elif scoring_func == "sigmoid":
+        scores = gating_output.sigmoid()
+    else:
+        raise ValueError(f"Unsupported scoring function: {scoring_func}")
+    num_token = scores.size(0)
+    if e_score_correction_bias is not None:
+        # Store original scores before applying correction bias. We use biased
+        # scores for expert selection but original scores for routing weights
+        original_scores = scores
+        scores = scores + e_score_correction_bias.unsqueeze(0)
+        group_scores = (scores.view(num_token, num_expert_group,
+                                    -1).topk(2, dim=-1)[0].sum(dim=-1))
+    else:
+        group_scores = scores.view(num_token, num_expert_group,
+                                   -1).max(dim=-1).values  # [n, n_group]
+    group_idx = torch.topk(group_scores, k=topk_group, dim=-1,
+                           sorted=False)[1]  # [n, top_k_group]
+    group_mask = torch.zeros_like(group_scores)  # [n, n_group]
+    group_mask.scatter_(1, group_idx, 1)  # [n, n_group]
+    score_mask = group_mask.unsqueeze(-1).expand(
+        num_token, num_expert_group,
+        scores.size(-1) // num_expert_group).reshape(num_token, -1)  # [n, e]
+    tmp_scores = scores.masked_fill(~score_mask.bool(),
+                                    float("-inf"))  # [n, e]
+    if e_score_correction_bias is not None:
+        topk_ids = torch.topk(tmp_scores, k=topk, dim=-1, sorted=False)[1]
+        # Use original unbiased scores for the routing weights
+        topk_weights = original_scores.gather(1, topk_ids)
+    else:
+        topk_weights, topk_ids = torch.topk(tmp_scores,
+                                            k=topk,
+                                            dim=-1,
+                                            sorted=False)
+    if renormalize:
+        topk_weights = topk_weights / topk_weights.sum(dim=-1, keepdim=True)
+
+    topk_weights = topk_weights * routed_scaling_factor
+    return topk_weights.to(torch.float32), topk_ids.to(torch.int32)
+
+
+def fused_grouped_topk(
+    hidden_states: torch.Tensor,
+    gating_output: torch.Tensor,
+    topk: int,
+    renormalize: bool,
+    e_score_correction_bias: torch.Tensor,
+    num_expert_group: int = 0,
+    topk_group: int = 0,
+    scoring_func: str = "softmax",
+    routed_scaling_factor: float = 1.0,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    assert hidden_states.size(0) == gating_output.size(0), (
+        "Number of tokens mismatch")
+
+    if scoring_func == "softmax":
+        scores = torch.softmax(gating_output, dim=-1)
+    elif scoring_func == "sigmoid":
+        scores = gating_output.sigmoid()
+    else:
+        raise ValueError(f"Unsupported scoring function: {scoring_func}")
+
+    scores_with_bias = scores + e_score_correction_bias.unsqueeze(0)
+    topk_values, topk_indices = ops.grouped_topk(
+        scores, scores_with_bias.to(scores.dtype), num_expert_group,
+        topk_group, topk, renormalize, routed_scaling_factor)
+    return topk_values.to(torch.float32), topk_indices.to(torch.int32)

--- a/tests/register_ops.py
+++ b/tests/register_ops.py
@@ -116,3 +116,11 @@ def dynamic_per_token_scaled_fp8_quant(
 # moe
 def moe_sum(input: torch.Tensor, output: torch.Tensor) -> None:
     torch.ops._moe_C.moe_sum(input, output)
+
+
+def grouped_topk(scores: torch.Tensor, scores_with_bias: torch.Tensor,
+                 num_expert_group: int, topk_group: int, topk: int,
+                 renormalize: bool, routed_scaling_factor: float):
+    return torch.ops._moe_C.grouped_topk(scores, scores_with_bias,
+                                         num_expert_group, topk_group, topk,
+                                         renormalize, routed_scaling_factor)

--- a/tests/test_grouped_topk.py
+++ b/tests/test_grouped_topk.py
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: Apache-2.0
+import pytest
+import torch
+
+from tests.ops.grouped_topk_op import grouped_topk, fused_grouped_topk
+from tests.utils import seed_everything
+
+@pytest.mark.parametrize("n_token", [1, 33, 64])
+@pytest.mark.parametrize("n_hidden", [1024, 2048])
+@pytest.mark.parametrize("n_expert", [16])
+@pytest.mark.parametrize("topk", [2])
+@pytest.mark.parametrize("renormalize", [True, False])
+@pytest.mark.parametrize("num_expert_group", [8])
+@pytest.mark.parametrize("topk_group", [2])
+@pytest.mark.parametrize("scoring_func", ["softmax", "sigmoid"])
+@pytest.mark.parametrize("routed_scaling_factor", [1.0, 2.5])
+@pytest.mark.parametrize("dtype",
+                         [torch.float16, torch.bfloat16, torch.float32])
+def test_grouped_topk(n_token: int,
+                      n_hidden: int, n_expert: int, topk: int,
+                      renormalize: bool, num_expert_group: int,
+                      topk_group: int, scoring_func: str,
+                      routed_scaling_factor: float, dtype: torch.dtype):
+    seed_everything(0)
+    hidden_states = torch.randn((n_token, n_hidden),
+                                dtype=dtype,
+                                device="xpu")
+    gating_output = torch.randn((n_token, n_expert),
+                                dtype=dtype,
+                                device="xpu")
+    e_score_correction_bias = torch.randn((n_expert, ),
+                                          dtype=torch.float32,
+                                          device="xpu")
+
+    baseline_topk_weights, baseline_topk_ids = grouped_topk(
+        hidden_states=hidden_states,
+        gating_output=gating_output,
+        topk=topk,
+        renormalize=renormalize,
+        num_expert_group=num_expert_group,
+        topk_group=topk_group,
+        scoring_func=scoring_func,
+        routed_scaling_factor=routed_scaling_factor,
+        e_score_correction_bias=e_score_correction_bias)
+
+    test_topk_weights, test_topk_ids = fused_grouped_topk(
+        hidden_states=hidden_states,
+        gating_output=gating_output,
+        topk=topk,
+        renormalize=renormalize,
+        num_expert_group=num_expert_group,
+        topk_group=topk_group,
+        scoring_func=scoring_func,
+        routed_scaling_factor=routed_scaling_factor,
+        e_score_correction_bias=e_score_correction_bias)
+
+    if renormalize:
+        torch.testing.assert_close(baseline_topk_weights,
+                                    test_topk_weights,
+                                    atol=2e-2,
+                                    rtol=0)
+
+    torch.testing.assert_close(baseline_topk_ids,
+                                test_topk_ids,
+                                atol=0,
+                                rtol=0)

--- a/tests/test_grouped_topk.py
+++ b/tests/test_grouped_topk.py
@@ -2,8 +2,9 @@
 import pytest
 import torch
 
-from tests.ops.grouped_topk_op import grouped_topk, fused_grouped_topk
+from tests.ops.grouped_topk_op import fused_grouped_topk, grouped_topk
 from tests.utils import seed_everything
+
 
 @pytest.mark.parametrize("n_token", [1, 33, 64])
 @pytest.mark.parametrize("n_hidden", [1024, 2048])
@@ -16,18 +17,13 @@ from tests.utils import seed_everything
 @pytest.mark.parametrize("routed_scaling_factor", [1.0, 2.5])
 @pytest.mark.parametrize("dtype",
                          [torch.float16, torch.bfloat16, torch.float32])
-def test_grouped_topk(n_token: int,
-                      n_hidden: int, n_expert: int, topk: int,
+def test_grouped_topk(n_token: int, n_hidden: int, n_expert: int, topk: int,
                       renormalize: bool, num_expert_group: int,
                       topk_group: int, scoring_func: str,
                       routed_scaling_factor: float, dtype: torch.dtype):
     seed_everything(0)
-    hidden_states = torch.randn((n_token, n_hidden),
-                                dtype=dtype,
-                                device="xpu")
-    gating_output = torch.randn((n_token, n_expert),
-                                dtype=dtype,
-                                device="xpu")
+    hidden_states = torch.randn((n_token, n_hidden), dtype=dtype, device="xpu")
+    gating_output = torch.randn((n_token, n_expert), dtype=dtype, device="xpu")
     e_score_correction_bias = torch.randn((n_expert, ),
                                           dtype=torch.float32,
                                           device="xpu")
@@ -56,11 +52,11 @@ def test_grouped_topk(n_token: int,
 
     if renormalize:
         torch.testing.assert_close(baseline_topk_weights,
-                                    test_topk_weights,
-                                    atol=2e-2,
-                                    rtol=0)
+                                   test_topk_weights,
+                                   atol=2e-2,
+                                   rtol=0)
 
     torch.testing.assert_close(baseline_topk_ids,
-                                test_topk_ids,
-                                atol=0,
-                                rtol=0)
+                               test_topk_ids,
+                               atol=0,
+                               rtol=0)


### PR DESCRIPTION
add xpu grouped topk kernel
Previous PR: https://github.com/vllm-project/vllm-xpu-kernels/pull/10
Now we decide to follow cuda implementation: https://github.com/vllm-project/vllm/pull/23274

Although the UT can pass on CUDA and XPU platform, the cuda kernel will hang if use below inputs in UT:
**[dtype0-1.0-softmax-8-8-True-2-16-1024-1] (PVC)**
**[dtype0-1.0-softmax-4-8-True-2-16-2048-256] (4070ti)**
I will debug the kernel or create an issue to request the author to fix it.

Bug fixed.
The PR to vllm to fix cuda kernel has been merged: https://github.com/vllm-project/vllm/pull/24146
