### PR TITLE
add ipex  and model config for rmsmorm op

### DIFF
--- a/benchmark/benchmark_rmsnorm.py
+++ b/benchmark/benchmark_rmsnorm.py
@@ -9,14 +9,12 @@ import triton
 from torch import nn
 
 from tests import register_ops as vllm_ops
-from tests import utils
+from tests.utils import check_ipex_availability, get_model_config
 
-try:
+HAS_IPEX = check_ipex_availability()
+
+if HAS_IPEX:
     import intel_extension_for_pytorch as ipex
-    HAS_IPEX = True
-except ImportError:
-    HAS_IPEX = False
-    print("Warning: IPEX not available, skipping IPEX benchmarks")
 
 
 class HuggingFaceRMSNorm(nn.Module):
@@ -340,7 +338,7 @@ def parse_args():
     args = parser.parse_args()
 
     if args.model_name:
-        model_config = utils.get_model_config(args.model_name, args.tp_size)
+        model_config = get_model_config(args.model_name, args.tp_size)
 
         if args.hidden_size == 4096:
             args.hidden_size = model_config["hidden_size"]

--- a/benchmark/benchmark_rmsnorm.py
+++ b/benchmark/benchmark_rmsnorm.py
@@ -197,7 +197,7 @@ def calculate_diff(batch_size, seq_len, hidden_size, use_residual=True):
         print("❌ Implementations differ")
 
 
-def get_benchmark(use_residual,):
+def get_benchmark(use_residual, dtype):
 
     @triton.testing.perf_report(
         triton.testing.Benchmark(
@@ -213,7 +213,7 @@ def get_benchmark(use_residual,):
             args={},
         ))
     def benchmark(head_num, batch_size, seq_len, provider):
-        dtype = torch.bfloat16
+        #dtype = torch.bfloat16
         hidden_size = head_num * 128  # assuming head_dim = 128
 
         x = torch.randn(batch_size,
@@ -301,7 +301,7 @@ def parse_args():
     parser.add_argument(
         "--dtype",
         type=str,
-        default=None,
+        default=torch.bfloat16,
         help="Data type from model config",
     )
     parser.add_argument(
@@ -403,6 +403,6 @@ if __name__ == "__main__":
     )
 
     # Get the benchmark function with proper use_residual setting
-    benchmark = get_benchmark(args.use_residual)
+    benchmark = get_benchmark(args.use_residual,args.dtype)
     # Run performance benchmark
     benchmark.run(print_data=True, save_path=args.save_path)

--- a/benchmark/benchmark_rmsnorm.py
+++ b/benchmark/benchmark_rmsnorm.py
@@ -315,14 +315,12 @@ def parse_args():
         default=None,
         help="Model name to load configuration from",
     )
-    parser.add_argument(
-        "--head-num-range",
-        type=int,
-        nargs='+',
-        default=[12, 32, 40, 48, 64, 96, 128],
-        help=
-        "Range of attention head numbers to test/use. Default: 12 32 40 48 64 96 128"
-    )
+    parser.add_argument("--head-num-range",
+                        type=int,
+                        nargs='+',
+                        default=[12, 32, 40, 48, 64, 96, 128],
+                        help=("Range of attention head numbers to test/use. "
+                              "Default: 12 32 40 48 64 96 128"))
     parser.add_argument(
         "--tp-size",
         type=int,
@@ -381,7 +379,7 @@ if __name__ == "__main__":
 
     args = parse_args()
 
-    print(f"Final configuration:")
+    print("Final configuration:")
     print(f"  Batch size: {args.batch_size}")
     print(f"  Sequence length: {args.seq_len}")
     print(f"  Hidden size: {args.hidden_size}")

--- a/benchmark/benchmark_rmsnorm.py
+++ b/benchmark/benchmark_rmsnorm.py
@@ -215,7 +215,6 @@ def get_benchmark(use_residual, dtype):
             args={},
         ))
     def benchmark(head_num, batch_size, seq_len, provider):
-        #dtype = torch.bfloat16
         hidden_size = head_num * 128  # assuming head_dim = 128
 
         x = torch.randn(batch_size,

--- a/benchmark/benchmark_rmsnorm.py
+++ b/benchmark/benchmark_rmsnorm.py
@@ -9,6 +9,15 @@ import triton
 from torch import nn
 
 from tests import register_ops as vllm_ops
+from tests import utils
+
+
+try:
+    import intel_extension_for_pytorch as ipex
+    HAS_IPEX = True
+except ImportError:
+    HAS_IPEX = False
+    print("Warning: IPEX not available, skipping IPEX benchmarks")
 
 
 class HuggingFaceRMSNorm(nn.Module):
@@ -112,6 +121,36 @@ def rmsnorm_vllm(
     return output
 
 
+def rmsnorm_ipex(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    residual: Optional[torch.Tensor] = None,
+    eps: float = 1e-6,
+):
+    """IPEX implementation using ipex.llm.functional.rms_norm"""
+    if not HAS_IPEX:
+        raise RuntimeError("IPEX is not available")
+    
+    orig_shape = x.shape
+    x = x.view(-1, x.shape[-1])
+    
+    if residual is not None:
+        residual = residual.view(-1, residual.shape[-1])
+        if hasattr(ipex.llm.functional, 'fused_add_rms_norm'):
+            output, residual_out = ipex.llm.functional.fused_add_rms_norm(
+                x, residual, weight, eps)
+            output = (output.view(orig_shape), residual_out.view(orig_shape))
+        else:
+            x = x + residual
+            output = ipex.llm.functional.rms_norm(x, weight, eps)
+            output = (output.view(orig_shape), x.view(orig_shape))
+    else:
+        output = ipex.llm.functional.rms_norm(x, weight, eps)
+        output = output.view(orig_shape)
+    
+    return output
+
+
 def calculate_diff(batch_size, seq_len, hidden_size, use_residual=True):
     dtype = torch.bfloat16
     x = torch.randn(batch_size,
@@ -136,35 +175,38 @@ def calculate_diff(batch_size, seq_len, hidden_size, use_residual=True):
     print(f"Naive output={output_naive}")
     print(f"vLLM output={output_vllm}")
 
+    if HAS_IPEX:
+        try:
+            output_ipex = rmsnorm_ipex(
+                x.clone(), weight,
+                residual.clone() if residual is not None else None)
+            if use_residual:
+                output_ipex = output_ipex[0]
+            print(f"IPEX output={output_ipex}")
+            
+            if torch.allclose(output_naive, output_ipex, atol=1e-2, rtol=1e-2):
+                print("✅ IPEX implementation matches naive")
+            else:
+                print("❌ IPEX implementation differs from naive")
+        except Exception as e:
+            print(f"❌ IPEX implementation failed: {e}")
+
     if torch.allclose(output_naive, output_vllm, atol=1e-2, rtol=1e-2):
         print("✅ All implementations match")
     else:
         print("❌ Implementations differ")
 
 
-batch_size_range = [2**i for i in range(0, 7, 2)]
-seq_length_range = [2**i for i in range(6, 10, 1)]
-head_num_range = [
-    32,  #Llama
-    40,  #Qwen 14B/32B
-    48,
-    64,  #Llama 2 70B
-    128,  # Deepseek R1
-]
-configs = list(
-    itertools.product(head_num_range, batch_size_range, seq_length_range))
-
-
-def get_benchmark(use_residual):
+def get_benchmark(use_residual,):
 
     @triton.testing.perf_report(
         triton.testing.Benchmark(
             x_names=["head_num", "batch_size", "seq_len"],
             x_vals=[tuple(_) for _ in configs],
             line_arg="provider",
-            line_vals=["huggingface", "vllm", "t.compile"],
-            line_names=["HuggingFace", "vLLM", "t.compile"],
-            styles=[("blue", "-"), ("green", "-"), ("orange", "-")],
+            line_vals=["huggingface", "vllm", "t.compile", "ipex"] if HAS_IPEX else ["huggingface", "vllm", "t.compile"],
+            line_names=["HuggingFace", "vLLM", "t.compile", "IPEX"] if HAS_IPEX else ["HuggingFace", "vLLM", "t.compile"],
+            styles=[("blue", "-"), ("green", "-"), ("orange", "-"), ("red", "-")] if HAS_IPEX else [("blue", "-"), ("green", "-"), ("orange", "-")],
             ylabel="us",
             plot_name=
             f"rmsnorm-perf-{'with' if use_residual else 'without'}-residual",
@@ -202,6 +244,15 @@ def get_benchmark(use_residual):
                 ),
                 quantiles=quantiles,
             )
+        elif provider == "ipex" and HAS_IPEX:
+            ms, min_ms, max_ms = triton.testing.do_bench(
+                lambda: rmsnorm_ipex(
+                    x.clone(),
+                    weight,
+                    residual.clone() if residual is not None else None,
+                ),
+                quantiles=quantiles,
+            )
         else:
             ms, min_ms, max_ms = triton.testing.do_bench(
                 lambda: rmsnorm_vllm(
@@ -215,10 +266,7 @@ def get_benchmark(use_residual):
 
     return benchmark
 
-
-if __name__ == "__main__":
-    import argparse
-
+def parse_args():
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--batch-size",
@@ -238,6 +286,43 @@ if __name__ == "__main__":
         default=4096,
         help="Hidden size (2nd dimension) of the sequence",
     )
+    parser.add_argument(
+        "--intermediate-size",
+        type=int,
+        default=None,  
+        help="Intermediate size for FFN layers",
+    )
+    parser.add_argument(
+        "--num-groups",
+        type=int,
+        default=None,  
+        help="Number of expert groups for MoE models",
+    )
+    parser.add_argument(
+        "--dtype",
+        type=str,
+        default=None,
+        help="Data type from model config",
+    )
+    parser.add_argument(
+        "--model-name",
+        type=str,
+        default=None,
+        help="Model name to load configuration from",
+    )
+    parser.add_argument(
+        "--head-num-range",
+        type=int,
+        nargs='+', 
+        default=[12, 32, 40, 48, 64, 96, 128],  
+        help="Range of attention head numbers to test/use. Default: 12 32 40 48 64 96 128"
+    )
+    parser.add_argument(
+        "--tp-size",
+        type=int,
+        default=1,
+        help="Tensor parallelism size",
+    )
     parser.add_argument("--use-residual",
                         action="store_true",
                         help="Whether to use residual connection")
@@ -249,6 +334,65 @@ if __name__ == "__main__":
     )
 
     args = parser.parse_args()
+    
+    if args.model_name:
+        model_config = utils.get_model_config(args.model_name, args.tp_size)
+        
+        if args.hidden_size == 4096:  
+            args.hidden_size = model_config["hidden_size"]
+        
+        if args.intermediate_size is None:
+            args.intermediate_size = model_config["intermediate_size"]
+        
+        if args.num_groups is None:
+            args.num_groups = model_config["num_groups"]
+        
+        if args.dtype is None:
+            args.dtype = model_config["dtype"]
+        
+        if args.head_num_range == [12, 32, 40, 48, 64, 96, 128]:
+            model_heads = model_config.get("num_attention_heads", 32)
+            if model_heads not in args.head_num_range:
+                args.head_num_range.append(model_heads)
+                args.head_num_range.sort() 
+                print(f"Added model's head number {model_heads} to head_num_range")
+            
+        print(f"Using model configuration from: {args.model_name}")
+        print(f"Updated hidden_size: {args.hidden_size}")
+        print(f"Updated intermediate_size: {args.intermediate_size}")
+        print(f"Updated num_groups: {args.num_groups}")
+        print(f"Updated head_num_range: {args.head_num_range}")
+        print(f"Updated dtype: {args.dtype}")
+    
+    return args
+
+
+if __name__ == "__main__":
+    
+    import argparse
+
+    args = parse_args()
+    
+    print(f"Final configuration:")
+    print(f"  Batch size: {args.batch_size}")
+    print(f"  Sequence length: {args.seq_len}")
+    print(f"  Hidden size: {args.hidden_size}")
+    print(f"  Intermediate size: {args.intermediate_size}")
+    print(f"  Number of groups: {args.num_groups}")
+    print(f"  Data type: {args.dtype}")
+    print(f"  Use residual: {args.use_residual}")
+
+    batch_size_range = [2**i for i in range(0, 7, 2)]
+    seq_length_range = [2**i for i in range(6, 10, 1)]
+    head_num_range = args.head_num_range
+    configs = list(
+    itertools.product(head_num_range, batch_size_range, seq_length_range))
+
+    if HAS_IPEX:
+        print("✅ IPEX is available")
+        print(f"IPEX version: {ipex.__version__}")
+    else:
+        print("⚠️  IPEX is not available, skipping IPEX benchmarks")
 
     # Run correctness test
     calculate_diff(

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,4 @@ pytest
 # dependencies
 matplotlib # in benchmark, introduced by triton
 pandas # in benchmark, introduced by triton
+transformers # for model config

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -336,3 +336,18 @@ def get_model_config(model_name: str, tp_size: int = 1):
             print(f"  {key}: {value}")
 
     return shape_configs
+
+
+def check_ipex_availability():
+    """
+    Check if Intel Extension for PyTorch (IPEX) is available.
+    
+    Returns:
+        bool: True if IPEX is available, False otherwise
+    """
+    import importlib.util
+    if importlib.util.find_spec("intel_extension_for_pytorch") is not None:
+        return True
+    else:
+        print("Warning: IPEX not available, skipping IPEX benchmarks")
+        return False

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -222,11 +222,12 @@ def create_kv_caches_with_random_flash(
         value_caches.append(key_value_cache[:, 1])
     return key_caches, value_caches
 
+
 def get_model_config(model_name: str, tp_size: int = 1):
     from transformers import AutoConfig
-    config = AutoConfig.from_pretrained(model_name, trust_remote_code=True)    
+    config = AutoConfig.from_pretrained(model_name, trust_remote_code=True)
     model_arch = config.architectures[0] if config.architectures else "Unknown"
-    
+
     if model_arch == "DbrxForCausalLM":
         original_num_groups = config.ffn_config.moe_num_experts
         original_intermediate_size = config.ffn_config.ffn_hidden_size
@@ -244,7 +245,8 @@ def get_model_config(model_name: str, tp_size: int = 1):
         original_intermediate_size = config.intermediate_size
     else:
         original_num_groups = getattr(config, 'num_local_experts', 1)
-        original_intermediate_size = getattr(config, 'intermediate_size', config.hidden_size * 4)
+        original_intermediate_size = getattr(config, 'intermediate_size',
+                                             config.hidden_size * 4)
 
     effective_hidden_size = config.hidden_size
     effective_intermediate_size = original_intermediate_size
@@ -259,53 +261,78 @@ def get_model_config(model_name: str, tp_size: int = 1):
     moe_config = {}
     if original_num_groups > 1:
         moe_config = {
-            "moe_top_k": getattr(config, 'num_experts_per_tok', getattr(config, 'top_k', 2)),
-            "moe_min_capacity": getattr(config, 'moe_min_capacity', 4),
-            "moe_capacity_factor": getattr(config, 'moe_capacity_factor', 1.0),
-            "moe_aux_loss_coef": getattr(config, 'moe_aux_loss_coef', 0.01),
+            "moe_top_k":
+            getattr(config, 'num_experts_per_tok', getattr(config, 'top_k',
+                                                           2)),
+            "moe_min_capacity":
+            getattr(config, 'moe_min_capacity', 4),
+            "moe_capacity_factor":
+            getattr(config, 'moe_capacity_factor', 1.0),
+            "moe_aux_loss_coef":
+            getattr(config, 'moe_aux_loss_coef', 0.01),
         }
 
     shape_configs = {
-        "num_groups": effective_num_groups,
-        "hidden_size": effective_hidden_size,
-        "intermediate_size": effective_intermediate_size,
-        "dtype": config.torch_dtype,
-        "model_arch": model_arch,
-        
-        "vocab_size": getattr(config, 'vocab_size', 32000),
-        "num_layers": getattr(config, 'num_hidden_layers', getattr(config, 'n_layer', 32)),
-        "num_attention_heads": getattr(config, 'num_attention_heads', getattr(config, 'n_head', 32)),
-        "num_key_value_heads": getattr(config, 'num_key_value_heads', getattr(config, 'num_attention_heads', 32)),
-        "head_dim": getattr(config, 'head_dim', config.hidden_size // getattr(config, 'num_attention_heads', 32)),
-        "hidden_act": getattr(config, 'hidden_act', 'silu'),
-        
-        "max_position_embeddings": getattr(config, 'max_position_embeddings', 2048),
-        "rope_theta": getattr(config, 'rope_theta', 10000.0),
-        "rope_scaling": getattr(config, 'rope_scaling', None),
-        
-        "rms_norm_eps": getattr(config, 'rms_norm_eps', 1e-6),
-        "layer_norm_eps": getattr(config, 'layer_norm_eps', 1e-5),
-        
-        "attention_dropout": getattr(config, 'attention_dropout', 0.0),
-        "hidden_dropout": getattr(config, 'hidden_dropout', 0.0),
-        
-        "moe_config": moe_config,
-        "is_moe": original_num_groups > 1,
-        
+        "num_groups":
+        effective_num_groups,
+        "hidden_size":
+        effective_hidden_size,
+        "intermediate_size":
+        effective_intermediate_size,
+        "dtype":
+        config.torch_dtype,
+        "model_arch":
+        model_arch,
+        "vocab_size":
+        getattr(config, 'vocab_size', 32000),
+        "num_layers":
+        getattr(config, 'num_hidden_layers', getattr(config, 'n_layer', 32)),
+        "num_attention_heads":
+        getattr(config, 'num_attention_heads', getattr(config, 'n_head', 32)),
+        "num_key_value_heads":
+        getattr(config, 'num_key_value_heads',
+                getattr(config, 'num_attention_heads', 32)),
+        "head_dim":
+        getattr(
+            config, 'head_dim',
+            config.hidden_size // getattr(config, 'num_attention_heads', 32)),
+        "hidden_act":
+        getattr(config, 'hidden_act', 'silu'),
+        "max_position_embeddings":
+        getattr(config, 'max_position_embeddings', 2048),
+        "rope_theta":
+        getattr(config, 'rope_theta', 10000.0),
+        "rope_scaling":
+        getattr(config, 'rope_scaling', None),
+        "rms_norm_eps":
+        getattr(config, 'rms_norm_eps', 1e-6),
+        "layer_norm_eps":
+        getattr(config, 'layer_norm_eps', 1e-5),
+        "attention_dropout":
+        getattr(config, 'attention_dropout', 0.0),
+        "hidden_dropout":
+        getattr(config, 'hidden_dropout', 0.0),
+        "moe_config":
+        moe_config,
+        "is_moe":
+        original_num_groups > 1,
         "original_config": {
             "hidden_size": config.hidden_size,
             "intermediate_size": original_intermediate_size,
             "num_groups": original_num_groups,
         },
-        "tp_size": tp_size,
-        
-        "model_type": getattr(config, 'model_type', 'unknown'),
-        "torch_dtype": str(config.torch_dtype) if hasattr(config, 'torch_dtype') else 'float32',
+        "tp_size":
+        tp_size,
+        "model_type":
+        getattr(config, 'model_type', 'unknown'),
+        "torch_dtype":
+        str(config.torch_dtype)
+        if hasattr(config, 'torch_dtype') else 'float32',
     }
-    
+
     print(f"Full model config with TP={tp_size}:")
     for key, value in shape_configs.items():
-        if key != "original_config":  
+        if key != "original_config":
             print(f"  {key}: {value}")
-    
+
     return shape_configs

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -221,3 +221,91 @@ def create_kv_caches_with_random_flash(
         key_caches.append(key_value_cache[:, 0])
         value_caches.append(key_value_cache[:, 1])
     return key_caches, value_caches
+
+def get_model_config(model_name: str, tp_size: int = 1):
+    from transformers import AutoConfig
+    config = AutoConfig.from_pretrained(model_name, trust_remote_code=True)    
+    model_arch = config.architectures[0] if config.architectures else "Unknown"
+    
+    if model_arch == "DbrxForCausalLM":
+        original_num_groups = config.ffn_config.moe_num_experts
+        original_intermediate_size = config.ffn_config.ffn_hidden_size
+    elif model_arch == "JambaForCausalLM":
+        original_num_groups = config.num_experts
+        original_intermediate_size = config.intermediate_size
+    elif model_arch in ["Qwen2MoeForCausalLM", "Qwen3MoeForCausalLM"]:
+        original_num_groups = config.num_experts
+        original_intermediate_size = config.moe_intermediate_size
+    elif model_arch in ["DeepseekV2ForCausalLM", "DeepseekV3ForCausalLM"]:
+        original_num_groups = config.n_routed_experts
+        original_intermediate_size = config.moe_intermediate_size
+    elif model_arch == "LlamaForCausalLM":
+        original_num_groups = 1
+        original_intermediate_size = config.intermediate_size
+    else:
+        original_num_groups = getattr(config, 'num_local_experts', 1)
+        original_intermediate_size = getattr(config, 'intermediate_size', config.hidden_size * 4)
+
+    effective_hidden_size = config.hidden_size
+    effective_intermediate_size = original_intermediate_size
+    effective_num_groups = original_num_groups
+
+    if tp_size > 1:
+        effective_hidden_size = config.hidden_size
+        effective_intermediate_size = original_intermediate_size // tp_size
+        if original_num_groups > 1:
+            effective_num_groups = original_num_groups
+
+    moe_config = {}
+    if original_num_groups > 1:
+        moe_config = {
+            "moe_top_k": getattr(config, 'num_experts_per_tok', getattr(config, 'top_k', 2)),
+            "moe_min_capacity": getattr(config, 'moe_min_capacity', 4),
+            "moe_capacity_factor": getattr(config, 'moe_capacity_factor', 1.0),
+            "moe_aux_loss_coef": getattr(config, 'moe_aux_loss_coef', 0.01),
+        }
+
+    shape_configs = {
+        "num_groups": effective_num_groups,
+        "hidden_size": effective_hidden_size,
+        "intermediate_size": effective_intermediate_size,
+        "dtype": config.torch_dtype,
+        "model_arch": model_arch,
+        
+        "vocab_size": getattr(config, 'vocab_size', 32000),
+        "num_layers": getattr(config, 'num_hidden_layers', getattr(config, 'n_layer', 32)),
+        "num_attention_heads": getattr(config, 'num_attention_heads', getattr(config, 'n_head', 32)),
+        "num_key_value_heads": getattr(config, 'num_key_value_heads', getattr(config, 'num_attention_heads', 32)),
+        "head_dim": getattr(config, 'head_dim', config.hidden_size // getattr(config, 'num_attention_heads', 32)),
+        "hidden_act": getattr(config, 'hidden_act', 'silu'),
+        
+        "max_position_embeddings": getattr(config, 'max_position_embeddings', 2048),
+        "rope_theta": getattr(config, 'rope_theta', 10000.0),
+        "rope_scaling": getattr(config, 'rope_scaling', None),
+        
+        "rms_norm_eps": getattr(config, 'rms_norm_eps', 1e-6),
+        "layer_norm_eps": getattr(config, 'layer_norm_eps', 1e-5),
+        
+        "attention_dropout": getattr(config, 'attention_dropout', 0.0),
+        "hidden_dropout": getattr(config, 'hidden_dropout', 0.0),
+        
+        "moe_config": moe_config,
+        "is_moe": original_num_groups > 1,
+        
+        "original_config": {
+            "hidden_size": config.hidden_size,
+            "intermediate_size": original_intermediate_size,
+            "num_groups": original_num_groups,
+        },
+        "tp_size": tp_size,
+        
+        "model_type": getattr(config, 'model_type', 'unknown'),
+        "torch_dtype": str(config.torch_dtype) if hasattr(config, 'torch_dtype') else 'float32',
+    }
+    
+    print(f"Full model config with TP={tp_size}:")
+    for key, value in shape_configs.items():
+        if key != "original_config":  
+            print(f"  {key}: {value}")
+    
+    return shape_configs


### PR DESCRIPTION
## Purpose
Enable ipex benchmarks and add parameter with model name 

## Test Plan

## Test Result
test cmd without model:
python benchmark/benchmark_rmsnorm.py
BMG Result: PASS 
<html xmlns:v="urn:schemas-microsoft-com:vml"
xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:x="urn:schemas-microsoft-com:office:excel"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=Excel.Sheet>
<meta name=Generator content="Microsoft Excel 15">
<link id=Main-File rel=Main-File
href="file:///C:/Users/wenjunli/AppData/Local/Temp/msohtmlclip1/01/clip.htm">
<link rel=File-List
href="file:///C:/Users/wenjunli/AppData/Local/Temp/msohtmlclip1/01/clip_filelist.xml">
<style>
<!--table
	{mso-displayed-decimal-separator:"\.";
	mso-displayed-thousand-separator:"\,";}
@page
	{margin:.75in .7in .75in .7in;
	mso-header-margin:.3in;
	mso-footer-margin:.3in;}
tr
	{mso-height-source:auto;}
col
	{mso-width-source:auto;}
br
	{mso-data-placement:same-cell;}
td
	{padding-top:1px;
	padding-right:1px;
	padding-left:1px;
	mso-ignore:padding;
	color:black;
	font-size:11.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:"Aptos Narrow", sans-serif;
	mso-font-charset:0;
	mso-number-format:General;
	text-align:general;
	vertical-align:bottom;
	border:none;
	mso-background-source:auto;
	mso-pattern:auto;
	mso-protection:locked visible;
	white-space:nowrap;
	mso-rotate:0;}
.xl63
	{border:.5pt solid windowtext;}
.xl64
	{font-weight:700;
	border:.5pt solid windowtext;}
-->
</style>
</head>

<body link="#467886" vlink="#96607D">


  | head_num | batch_size | seq_len | HuggingFace | vLLM | t.compile | IPEX
-- | -- | -- | -- | -- | -- | -- | --
0 | 12 | 1 | 64 | 164.736 | 14.612 | 12.376 | 32.084
1 | 12 | 1 | 128 | 503.828 | 18.096 | 14.248 | 20.54
2 | 12 | 1 | 256 | 565.136 | 23.4 | 573.404 | 75.608
3 | 12 | 1 | 512 | 523.692 | 34.476 | 98.436 | 361.66
4 | 12 | 4 | 64 | 1008.228 | 23.608 | 16.588 | 282.048
5 | 12 | 4 | 128 | 912.808 | 34.58 | 143.702 | 35.62
6 | 12 | 4 | 256 | 479.492 | 56.004 | 164.112 | 43.576
7 | 12 | 4 | 512 | 590.122 | 100.1 | 131.716 | 72.644
8 | 12 | 16 | 64 | 491.348 | 55.848 | 115.18 | 41.964
9 | 12 | 16 | 128 | 510.302 | 100.1 | 95.316 | 72.592
10 | 12 | 16 | 256 | 728.104 | 229.684 | 120.302 | 218.114
11 | 12 | 16 | 512 | 1422.616 | 479.648 | 286.442 | 440.076
12 | 12 | 64 | 64 | 1298.83 | 431.444 | 877.188 | 479.362
13 | 12 | 64 | 128 | 1419.704 | 478.556 | 664.82 | 453.544
14 | 12 | 64 | 256 | 2778.88 | 968.552 | 513.188 | 877.084
15 | 12 | 64 | 512 | 5506.41 | 1948.96 | 1037.92 | 1737.164
16 | 32 | 1 | 64 | 1127.048 | 369.044 | 601.016 | 512.46
17 | 32 | 1 | 128 | 1098.162 | 137.15 | 662.948 | 573.014
18 | 32 | 1 | 256 | 1201.746 | 402.298 | 791.778 | 730.964
19 | 32 | 1 | 512 | 1066.26 | 413.868 | 675.22 | 471.64
20 | 32 | 4 | 64 | 1448.2 | 444.86 | 581.412 | 516.62
21 | 32 | 4 | 128 | 1351.896 | 433.42 | 601.198 | 712.244
22 | 32 | 4 | 256 | 1510.704 | 451.204 | 1085.214 | 127.66
23 | 32 | 4 | 512 | 1196.52 | 410.436 | 614.328 | 455.338
24 | 32 | 16 | 64 | 1195.064 | 101.634 | 709.618 | 517.972
25 | 32 | 16 | 128 | 1176.89 | 500.656 | 655.928 | 449.93
26 | 32 | 16 | 256 | 1850.914 | 477.022 | 403.624 | 621.92
27 | 32 | 16 | 512 | 3667.3 | 955.604 | 816.92 | 1205.984
28 | 32 | 64 | 64 | 1851.902 | 475.28 | 401.96 | 624.052
29 | 32 | 64 | 128 | 3666.962 | 955.448 | 815.776 | 1205.178
30 | 32 | 64 | 256 | 7288.476 | 1916.772 | 1632.644 | 2397.876
31 | 32 | 64 | 512 | 14523.834 | 3841.24 | 3239.73 | 4719.884
32 | 40 | 1 | 64 | 632.996 | 311.012 | 548.834 | 572.494
33 | 40 | 1 | 128 | 1010.23 | 387.738 | 684.788 | 537.628
34 | 40 | 1 | 256 | 1583.166 | 372.372 | 601.874 | 575.536
35 | 40 | 1 | 512 | 1488.448 | 438.308 | 1043.848 | 300.508
36 | 40 | 4 | 64 | 1098.084 | 396.5 | 641.134 | 609.804
37 | 40 | 4 | 128 | 1255.696 | 489.736 | 853.528 | 529.204
38 | 40 | 4 | 256 | 1245.27 | 415.168 | 824.096 | 549.9
39 | 40 | 4 | 512 | 1176.37 | 560.04 | 822.146 | 990.652
40 | 40 | 16 | 64 | 1565.408 | 413.4 | 697.892 | 520.572
41 | 40 | 16 | 128 | 1184.352 | 345.02 | 716.794 | 806.26
42 | 40 | 16 | 256 | 2308.228 | 579.592 | 591.994 | 784.862
43 | 40 | 16 | 512 | 4582.708 | 1161.108 | 1069.692 | 1512.836
44 | 40 | 64 | 64 | 2308.54 | 579.54 | 724.204 | 786.734
45 | 40 | 64 | 128 | 4580.732 | 1161.186 | 1067.898 | 1512.42
46 | 40 | 64 | 256 | 9099.454 | 2326.532 | 2124.096 | 3009.864
47 | 40 | 64 | 512 | 18155.904 | 4659.356 | 4249.648 | 5917.314
48 | 48 | 1 | 64 | 1123.46 | 368.576 | 550.108 | 567.424
49 | 48 | 1 | 128 | 1298.57 | 430.976 | 852.592 | 420.628
50 | 48 | 1 | 256 | 1238.666 | 486.668 | 606.71 | 475.904
51 | 48 | 1 | 512 | 1365.78 | 430.456 | 844.246 | 509.964
52 | 48 | 4 | 64 | 1195.376 | 392.08 | 931.892 | 567.008
53 | 48 | 4 | 128 | 1061.476 | 425.048 | 613.73 | 495.508
54 | 48 | 4 | 256 | 1143.584 | 337.272 | 629.928 | 400.036
55 | 48 | 4 | 512 | 1479.972 | 339.3 | 914.056 | 548.08
56 | 48 | 16 | 64 | 1352.676 | 340.626 | 613.418 | 541.19
57 | 48 | 16 | 128 | 1479.608 | 429.052 | 628.836 | 633.88
58 | 48 | 16 | 256 | 2848.716 | 694.044 | 662.116 | 994.422
59 | 48 | 16 | 512 | 5576.74 | 1388.608 | 1229.332 | 1847.04
60 | 48 | 64 | 64 | 2850.12 | 693.706 | 676.78 | 991.458
61 | 48 | 64 | 128 | 5575.492 | 1387.776 | 1228.032 | 1847.378
62 | 48 | 64 | 256 | 11014.588 | 2796.794 | 2461.368 | 3595.592
63 | 48 | 64 | 512 | 21860.332 | 5592.86 | 4926.688 | 7121.036
64 | 64 | 1 | 64 | 1051.83 | 405.73 | 717.496 | 566.176
65 | 64 | 1 | 128 | 1227.148 | 390.78 | 668.226 | 543.92
66 | 64 | 1 | 256 | 1346.592 | 441.688 | 612.352 | 424.008
67 | 64 | 1 | 512 | 1302.392 | 422.006 | 873.002 | 459.732
68 | 64 | 4 | 64 | 1243.736 | 418.574 | 605.8 | 495.3
69 | 64 | 4 | 128 | 1210.742 | 416.676 | 659.334 | 560.092
70 | 64 | 4 | 256 | 1161.966 | 418.288 | 659.36 | 776.178
71 | 64 | 4 | 512 | 2016.976 | 443.482 | 640.38 | 468.104
72 | 64 | 16 | 64 | 1127.282 | 451.464 | 771.472 | 535.652
73 | 64 | 16 | 128 | 1858.74 | 443.3 | 714.272 | 465.192
74 | 64 | 16 | 256 | 3673.02 | 889.772 | 818.532 | 1285.882
75 | 64 | 16 | 512 | 7296.068 | 1781.364 | 1631.032 | 2502.136
76 | 64 | 64 | 64 | 3674.008 | 890.162 | 815.256 | 1291.16
77 | 64 | 64 | 128 | 7294.82 | 1781.26 | 1629.108 | 2502.812
78 | 64 | 64 | 256 | 14524.094 | 3556.644 | 3239.08 | 4835.636
79 | 64 | 64 | 512 | 28977.52 | 7125.82 | 6505.2 | 9660.456
80 | 96 | 1 | 64 | 1209.156 | 391.144 | 627.068 | 262.912
81 | 96 | 1 | 128 | 1268.8 | 452.114 | 650 | 564.538
82 | 96 | 1 | 256 | 1122.732 | 322.764 | 812.916 | 587.444
83 | 96 | 1 | 512 | 1193.66 | 340.288 | 589.836 | 439.296
84 | 96 | 4 | 64 | 1238.848 | 383.396 | 880.724 | 576.784
85 | 96 | 4 | 128 | 1334.944 | 441.792 | 802.932 | 484.952
86 | 96 | 4 | 256 | 1428.908 | 424.892 | 818.168 | 704.314
87 | 96 | 4 | 512 | 2861.066 | 659.412 | 642.148 | 803.192
88 | 96 | 16 | 64 | 1428.856 | 419.692 | 1024.166 | 490.49
89 | 96 | 16 | 128 | 2851.732 | 659.438 | 897.78 | 802.048
90 | 96 | 16 | 256 | 5622.188 | 1314.586 | 1226.888 | 2017.808
91 | 96 | 16 | 512 | 11072.412 | 2629.926 | 2449.876 | 3975.192
92 | 96 | 64 | 64 | 5606.562 | 1315.418 | 1226.524 | 2012.348
93 | 96 | 64 | 128 | 11068.07 | 2630.524 | 2447.12 | 3976.232
94 | 96 | 64 | 256 | 21912.046 | 5282.316 | 4902.144 | 7883.304
95 | 96 | 64 | 512 | 43553.354 | 10479.04 | 9730.188 | 14523.78
96 | 128 | 1 | 64 | 221.208 | 35.516 | 153.556 | 47.866
97 | 128 | 1 | 128 | 1233.856 | 385.684 | 699.66 | 729.404
98 | 128 | 1 | 256 | 1120.08 | 373.152 | 668.928 | 693.394
99 | 128 | 1 | 512 | 1196.52 | 420.966 | 788.944 | 568.932
100 | 128 | 4 | 64 | 1499.108 | 407.68 | 608.036 | 485.94
101 | 128 | 4 | 128 | 1015.768 | 334.412 | 809.588 | 608.608
102 | 128 | 4 | 256 | 1855.62 | 429.156 | 952.744 | 449.774
103 | 128 | 4 | 512 | 3674.684 | 864.5 | 831.012 | 989.04
104 | 128 | 16 | 64 | 1853.54 | 428.74 | 606.762 | 570.934
105 | 128 | 16 | 128 | 3674.424 | 864.604 | 831.402 | 988.416
106 | 128 | 16 | 256 | 7303.504 | 1729.416 | 1648.504 | 2722.434
107 | 128 | 16 | 512 | 14564.862 | 3444.324 | 3273.452 | 5274.88
108 | 128 | 64 | 64 | 7305.896 | 1729.728 | 1648.374 | 2721.212
109 | 128 | 64 | 128 | 14562.678 | 3443.076 | 3274.752 | 5274.724
110 | 128 | 64 | 256 | 29050.996 | 6903.572 | 6565.052 | 10549.76
111 | 128 | 64 | 512 | 58052.228 | 13780.42 | 13085.38 | 20934.37



</body>

</html>

test cmd with model:
python benchmark/benchmark_rmsnorm.py  --model-name "deepseek-ai/DeepSeek-R1-Distill-Qwen-14B"
BMG Result: PASS 

## (Optional) Documentation Update

**BEFORE SUBMITTING, PLEASE READ <https://docs.vllm.ai/en/latest/contributing>** (anything written below this line will be removed by GitHub Actions)
