### PR TITLE
[1/2] More optimized & refactored MoEGEMM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -171,7 +171,7 @@ if(VLLM_GPU_LANG STREQUAL "SYCL")
   set(CUTLASS_ENABLE_HEADERS_ONLY "ON" CACHE BOOL "Enable only the header library")
 
   # Set CUTLASS_REVISION. Used for FetchContent. Also fixes some bogus messages when building.
-  set(CUTLASS_REVISION "9baca2cff3a28590fcd03e55515e2d91ff2cbc8b" CACHE STRING "CUTLASS revision to use")
+  set(CUTLASS_REVISION "2eeb05da5b801b34114b6b394dcef836fc9a7cc9" CACHE STRING "CUTLASS revision to use")
 
   # Use the specified CUTLASS source directory for compilation if VLLM_CUTLASS_SRC_DIR is provided
   FetchContent_Declare(

--- a/csrc/xpu/cutlass_kernels/grouped_gemm.hpp
+++ b/csrc/xpu/cutlass_kernels/grouped_gemm.hpp
@@ -14,21 +14,18 @@ namespace gpu::cutlass_kernel {
 
 namespace grouped_gemm {
 void kernel_functor(sycl::queue& stream, void* ptr_A, void* ptr_B, void* ptr_D,
-                    void* ptr_alpha, void* ptr_beta, void* offset, int64_t N,
-                    int64_t K, int64_t groups);
+                    void* offset, int32_t N, int32_t K, int32_t groups);
 }
 
 /* gemm2(group_A, w2, output, offset) */
 
 at::Tensor grouped_gemm_func(at::Tensor& ptr_A, at::Tensor& ptr_B,
-                             at::Tensor& ptr_D, at::Tensor& ptr_alpha,
-                             at::Tensor& ptr_beta, at::Tensor& offset,
+                             at::Tensor& ptr_D, at::Tensor& tokens_per_expert,
                              int64_t N, int64_t K, int64_t groups) {
   auto& dpcpp_queue = vllm::xpu::vllmGetQueue();
   grouped_gemm::kernel_functor(dpcpp_queue, ptr_A.data_ptr(), ptr_B.data_ptr(),
-                               ptr_D.data_ptr(), ptr_alpha.data_ptr(),
-                               ptr_beta.data_ptr(), offset.data_ptr(), N, K,
-                               groups);
+                               ptr_D.data_ptr(), tokens_per_expert.data_ptr(), (int32_t)N, (int32_t)K,
+                               (int32_t)groups);
   return ptr_D;
 }
 

--- a/csrc/xpu/cutlass_kernels/grouped_gemm_kernel.cpp
+++ b/csrc/xpu/cutlass_kernels/grouped_gemm_kernel.cpp
@@ -32,41 +32,8 @@
 /*! \file
     \brief CUTLASS Intel BMG Group Gemm
 
-    This file is almost a complete copy of 04_bmg_grouped_gemm,
-    except that it's used for FP8 (E5M2 & E4M3) datatype inputs.
-
-    This example demonstrates fusing multiple GEMM operations into one kernel.
-
-    Note that the scalar arguments to e.g. the standard 00_bmg_gemm example,
-   have been replaced with vector equivalents, as each individual GEMM has its
-   own inputs and outputs, which needn't be contiguous in memory. For example,
-   where 00_bmg_gemm receives an `ElementA *` defining Matrix A, grouped gemm
-   receives a `ElementA **`, i.e. a pointer to pointers, each pointing to a
-   distinct Matrix A. Likewise, each individual GEMM operation may have its own
-   alpha and beta factors for linear combination. This example demonstrates two
-   approaches: the user can provide `options.alpha` and `options.beta`, in which
-   case they will apply to all GEMMs; otherwise, random values are generated per
-   GEMM.
-
-    Group GEMM scheduling (cutlass::gemm::GroupScheduler) is more complex than
-   standard GEMM, because each GEMM may have a unique size, only known at
-   runtime. Thus, the scheduler will distribute an a priori unknown number of
-   tiles to each work-group. See
-    include/cutlass/gemm/kernel/xe_gemm_array_cooperative.hpp for
-   implementation.
-
-    Note that for simplicity, this example sets every GEMM in the group to the
-   same shape.
-
-    Verification for this example is a conventional GEMM kernel, executed
-   iteratively per group.
-
-    To build & run this example (from your build dir):
-
-      $ ninja 09_bmg_grouped_gemm_fp8
-      $ ./examples/sycl/09_bmg_grouped_gemm_fp8/09_bmg_grouped_gemm_fp8
-
-    Call with `--help` for information about available options.
+    This file is based off on the default cutlass group gemm example in the
+   cutlass-sycl repo, but it uses custom kernels.
 
     Note: the code may spill registers once compiled which will result in
    sub-optimal performance. This is because of an issue inside Intel Graphics
@@ -75,16 +42,14 @@
    variable: $ export IGC_VectorAliasBBThreshold=10000
 */
 
-#pragma once
-
-// #include "cutlass/epilogue/collective/default_epilogue.hpp"
-// #include "cutlass/epilogue/collective/xe_array_epilogue.hpp"
-// #include "cutlass/epilogue/fusion/xe_callbacks.hpp"
-// #include "cutlass/epilogue/collective/collective_builder.hpp"
+#include "cutlass/epilogue/collective/default_epilogue.hpp"
+#include "cutlass/epilogue/collective/xe_array_epilogue.hpp"
+#include "cutlass/epilogue/fusion/xe_callbacks.hpp"
+#include "cutlass/epilogue/collective/collective_builder.hpp"
 #include "cutlass/gemm/group_array_problem_shape.hpp"
-// #include "cutlass/gemm/device/gemm_universal.h"
-// #include "cutlass/gemm/device/gemm_universal_adapter.h"
-// #include "cutlass/gemm/collective/collective_mma.hpp"
+#include "cutlass/gemm/device/gemm_universal.h"
+#include "cutlass/gemm/device/gemm_universal_adapter.h"
+#include "cutlass/gemm/collective/collective_mma.hpp"
 #include "cutlass/util/GPU_Clock.hpp"
 
 #include <cute/tensor.hpp>
@@ -99,14 +64,6 @@
 #include <cfloat>
 
 #include "cutlass/gemm/collective/collective_mma_decl.hpp"
-#include "./collective/gemm/gemm_universal.h"
-#include "./collective/gemm/gemm_universal_adapter.h"
-#include "./collective/gemm/xe_array_mma.hpp"
-#include "./collective/gemm/xe_array_epilogue.hpp"
-#include "./collective/gemm/xe_builder.hpp"
-#include "./collective/gemm/xe_callbacks.hpp"
-// #include "./collective/gemm/xe_gemm_array_cooperative.hpp"
-// #include "./collective/gemm/gemm_universal_adapter.hpp"
 
 using namespace cute;
 using ProblemShape =
@@ -115,10 +72,10 @@ using ProblemShape =
 
 using ElementAccumulator = float;      // <- data type of accumulator
 using ElementComputeEpilogue = float;  // <- data type of epilogue operations
-using ElementA = bfloat16_t;  // <- data type of elements in input matrix A
-using ElementB = bfloat16_t;  // <- data type of elements in input matrix B
+using ElementA = bfloat16_t;  // <- data type of elements in input tensor A
+using ElementB = bfloat16_t;  // <- data type of elements in input tensor B
 using ElementOutput =
-    bfloat16_t;  // <- data type of elements in output matrix D
+    bfloat16_t;  // <- data type of elements in output tensor D
 bool debug = false;
 bool collect_gflops = false;
 ///////////////////////////////////////////////////////////////////////////////////////////////////
@@ -126,75 +83,8 @@ bool collect_gflops = false;
 namespace gpu::cutlass_kernel {
 namespace grouped_gemm {
 
-struct Options {
-  bool error = false;
-  bool help = false;
-
-  float alpha, beta;
-  int iterations;
-  int m, n, k, groups;
-  std::vector<typename ProblemShape::UnderlyingProblemShape> problem_sizes_host;
-
-  int num_of_expert;
-
-  Options(int64_t* offset, int N, int K, int ne)
-      : num_of_expert(ne),
-        n(N),
-        k(K),
-        error(false),
-        help(false),
-        alpha(FLT_MAX),
-        beta(FLT_MAX),
-        iterations(100) {
-    if (debug) {
-      std::cout << "Options()" << std::endl;
-    }
-    int group_cnt = 0;
-    // std::cout << "****Options() num_of_expert  " << num_of_expert <<
-    // std::endl;
-    for (int i = 0; i < num_of_expert; ++i) {
-      // std::cout << "****Options() i  " << i << std::endl;
-      // std::cout << "****Options() offset[i]  " << offset[i] << std::endl;
-      if (offset[i] != 0) {
-        group_cnt++;
-      }
-    }
-    // std::cout << "****Options() group_cnt  " << group_cnt << std::endl;
-    problem_sizes_host.reserve(group_cnt);
-    for (int i = 0; i < num_of_expert; ++i) {
-      if (offset[i] != 0) {
-        problem_sizes_host.push_back({static_cast<int>(offset[i]), n, k});
-      }
-    }
-    groups = group_cnt;
-  }
-
-  /// Compute performance in GFLOP/s
-  double gflops(double runtime_s,
-                std::vector<typename ProblemShape::UnderlyingProblemShape>
-                    problem_sizes_host) const {
-    // Number of real-valued multiply-adds
-    uint64_t fmas = uint64_t();
-
-    for (auto const& problem : problem_sizes_host) {
-      fmas += static_cast<uint64_t>(get<0>(problem)) *
-              static_cast<uint64_t>(get<1>(problem)) *
-              static_cast<uint64_t>(get<2>(problem));
-    }
-    // Two flops per multiply-add
-    uint64_t flop = uint64_t(2) * uint64_t(fmas);
-    double gflop = double(flop) / double(1.0e9);
-    return gflop / runtime_s;
-  }
-};
-
 template <class Gemm>
 struct GroupedGemmRunner {
-  using StrideA = typename Gemm::GemmKernel::InternalStrideA;
-  using StrideB = typename Gemm::GemmKernel::InternalStrideB;
-  using StrideC = typename Gemm::GemmKernel::InternalStrideC;
-  using StrideD = typename Gemm::GemmKernel::InternalStrideD;
-
   using LayoutA = typename Gemm::LayoutA;
   using LayoutB = typename Gemm::LayoutB;
   using LayoutC = typename Gemm::LayoutC;
@@ -210,134 +100,90 @@ struct GroupedGemmRunner {
 
   using ProblemShapeType = typename Gemm::GemmKernel::ProblemShape;
 
-  std::vector<StrideA> stride_A_host;
-  std::vector<StrideB> stride_B_host;
-  std::vector<StrideC> stride_C_host;
-  std::vector<StrideD> stride_D_host;
+  // Compiler fails if std::vector<const ElementA *> ptr_A_host(1)
+  // is used, so using resize() as a workaround
+  std::vector<const ElementA*> ptr_A_host;
+  std::vector<const ElementB*> ptr_B_host;
+  std::vector<const ElementC*> ptr_C_host;
+  std::vector<ElementOutput*> ptr_D_host;
 
-  // Device-side allocations
-  cutlass::DeviceAllocation<typename ProblemShape::UnderlyingProblemShape>
-      problem_sizes;
+  // We need to pass pointers of pointers, so this allocation is unavoidable
+  // because the pointer to a GPU pointer obtained via & is obviously a CPU
+  // pointer.
+  cutlass::DeviceAllocation<const ElementA*> ptr_A_device;
+  cutlass::DeviceAllocation<const ElementB*> ptr_B_device;
+  cutlass::DeviceAllocation<const ElementC*> ptr_C_device;
+  cutlass::DeviceAllocation<ElementOutput*> ptr_D_device;
 
-  cutlass::DeviceAllocation<StrideA> stride_A;
-  cutlass::DeviceAllocation<StrideB> stride_B;
-  cutlass::DeviceAllocation<StrideC> stride_C;
-  cutlass::DeviceAllocation<StrideD> stride_D;
-
-  void release() {
-    problem_sizes.release();
-    // ptr_C.release();
-    stride_A.release();
-    stride_B.release();
-    stride_C.release();
-    stride_D.release();
-    // block_C.release();
-  }
-
-  /// Allocates device-side data
-  void allocate(const Options& options) {
-    if (debug) {
-      std::cout << "void allocate()" << std::endl;
-    }
-    for (int32_t i = 0; i < options.groups; ++i) {
-      auto problem = options.problem_sizes_host.at(i);
-      auto M = get<0>(problem);
-      auto N = get<1>(problem);
-      auto K = get<2>(problem);
-
-      stride_A_host.push_back(
-          cutlass::make_cute_packed_stride(StrideA{}, {M, K, 1}));
-      stride_B_host.push_back(
-          cutlass::make_cute_packed_stride(StrideB{}, {N, K, 1}));
-      stride_C_host.push_back(
-          cutlass::make_cute_packed_stride(StrideC{}, {M, N, 1}));
-      stride_D_host.push_back(
-          cutlass::make_cute_packed_stride(StrideD{}, {M, N, 1}));
-    }
-  }
-
-  void initialize(const Options& options) {
-    if (debug) {
-      std::cout << "void initialize()" << std::endl;
-    }
-    problem_sizes.reset(options.groups);
-    problem_sizes.copy_from_host(options.problem_sizes_host.data());
-
-    stride_A.reset(options.groups);
-    stride_A.copy_from_host(stride_A_host.data());
-
-    stride_B.reset(options.groups);
-    stride_B.copy_from_host(stride_B_host.data());
-
-    stride_C.reset(options.groups);
-    stride_C.copy_from_host(stride_C_host.data());
-
-    stride_D.reset(options.groups);
-    stride_D.copy_from_host(stride_D_host.data());
-  }
-
-  /// Populates a Gemm::Arguments structure from the given commandline options
-  typename Gemm::Arguments args_from_options(
-      const Options& options, const cutlass::KernelHardwareInfo& hw_info,
-      const ElementA** ptr_A, const ElementB** ptr_B, ElementOutput** ptr_D,
-      ElementAccumulator** ptr_alpha, ElementAccumulator** ptr_beta,
-      bool host_problem_shapes_available = true) {
+  /// Populates a Gemm::Arguments structure
+  typename Gemm::Arguments generate_gemm_args(
+      const cutlass::KernelHardwareInfo& hw_info, const ElementA* ptr_A,
+      const ElementB* ptr_B, ElementOutput* ptr_D,
+      const int32_t* num_rows_per_expert, const int32_t& N, const int32_t& K,
+      const int32_t& num_groups) {
+    ptr_A_host.resize(1);
+    ptr_B_host.resize(1);
+    ptr_C_host.resize(1);
+    ptr_D_host.resize(1);
+    ptr_A_device.reset(1);
+    ptr_B_device.reset(1);
+    ptr_C_device.reset(1);
+    ptr_D_device.reset(1);
+    ptr_A_host.at(0) = ptr_A;
+    ptr_B_host.at(0) = ptr_B;
+    ptr_C_host.at(0) = nullptr;
+    ptr_D_host.at(0) = ptr_D;
+    ptr_A_device.copy_from_host(ptr_A_host.data());
+    ptr_B_device.copy_from_host(ptr_B_host.data());
+    ptr_C_device.copy_from_host(ptr_C_host.data());
+    ptr_D_device.copy_from_host(ptr_D_host.data());
     typename Gemm::Arguments arguments;
-    decltype(arguments.epilogue.thread) fusion_args;
-
-    // If pointers to alpha/beta are provided, i.e., alpha/beta can differ
-    // between batches/groups.
-    fusion_args.alpha = 0;
+    decltype(arguments.fusion_args) fusion_args;
+    fusion_args.alpha = 1;
     fusion_args.beta = 0;
     fusion_args.alpha_ptr = nullptr;
     fusion_args.beta_ptr = nullptr;
-    fusion_args.alpha_ptr_array = ptr_alpha;
-    fusion_args.beta_ptr_array = ptr_beta;
+    fusion_args.alpha_ptr_array = nullptr;
+    fusion_args.beta_ptr_array = nullptr;
     // One alpha and beta per each group
+    // Doesn't matter, because we won't use it.
     fusion_args.dAlpha = {cute::_0{}, cute::_0{}, 1};
     fusion_args.dBeta = {cute::_0{}, cute::_0{}, 1};
     using RasterOrderOptions =
         typename cutlass::gemm::kernel::detail::PersistentTileSchedulerXeGroup<
             ProblemShape>::RasterOrderOptions;
 
-    // Per-GEMM problem shape info may only exist on the device.
-    if (host_problem_shapes_available) {
-      arguments = typename Gemm::Arguments{
-          cutlass::gemm::GemmUniversalMode::kGrouped,
-          {options.groups, problem_sizes.get(),
-           options.problem_sizes_host.data()},
-          {ptr_A, stride_A.get(), ptr_B, stride_B.get()},
-          {fusion_args, nullptr, stride_C.get(), ptr_D, stride_D.get()},
-          hw_info,
-          {1, RasterOrderOptions::AlongN}};
-    } else {
-      arguments = typename Gemm::Arguments{
-          cutlass::gemm::GemmUniversalMode::kGrouped,
-          {options.groups, problem_sizes.get(), nullptr},
-          {ptr_A, stride_A.get(), ptr_B, stride_B.get()},
-          {fusion_args, nullptr, stride_C.get(), ptr_D, stride_D.get()},
-          hw_info,
-          {1, RasterOrderOptions::AlongN}};
-    }
+    arguments =
+        typename Gemm::Arguments{cutlass::gemm::GemmUniversalMode::kGrouped,
+                                 ptr_A_device.get(),
+                                 ptr_B_device.get(),
+                                 ptr_C_device.get(),
+                                 ptr_D_device.get(),
+                                 fusion_args,
+                                 hw_info,
+                                 {1, RasterOrderOptions::AlongN},
+                                 num_rows_per_expert,
+                                 num_groups,
+                                 N,
+                                 K};
 
     return arguments;
   }
 
-  cutlass::Status run(const Options& options, sycl::queue& stream,
+  cutlass::Status run(sycl::queue& stream,
                       const cutlass::KernelHardwareInfo& hw_info,
-                      const ElementA** ptr_A, const ElementB** ptr_B,
-                      ElementOutput** ptr_D, ElementAccumulator** ptr_alpha,
-                      ElementAccumulator** ptr_beta) {
+                      const ElementA* ptr_A, const ElementB* ptr_B,
+                      ElementOutput* ptr_D, const int32_t* num_rows_per_expert,
+                      const int32_t& N, const int32_t& K,
+                      const int32_t& num_groups) {
     if (debug) {
       std::cout << "enter run" << std::endl;
     }
 
-    allocate(options);
-    initialize(options);
     Gemm gemm_op;
 
-    auto arguments = args_from_options(options, hw_info, ptr_A, ptr_B, ptr_D,
-                                       ptr_alpha, ptr_beta, true);
+    auto arguments = generate_gemm_args(hw_info, ptr_A, ptr_B, ptr_D,
+                                        num_rows_per_expert, N, K, num_groups);
 
     size_t workspace_size = Gemm::get_workspace_size(arguments);
     cutlass::device_memory::allocation<uint8_t> workspace(workspace_size);
@@ -350,54 +196,22 @@ struct GroupedGemmRunner {
       std::cout << "before run kernel" << std::endl;
     }
     // Run the GEMM
-
-    GPU_Clock timer;
-    timer.start();
-    CUTLASS_CHECK(gemm_op.run(stream));
-    if (collect_gflops) {
-      stream.wait();
-      float cute_time = timer.seconds() * 1000;
-      double cute_average_time = double(cute_time) / double(1);
-      std::cout << "  Avg runtimei : " << cute_average_time << " ms"
-                << std::endl;
-    }
-
-    if (collect_gflops) {
-      std::cout << "collect_gflops:" << collect_gflops << std::endl;
-      GPU_Clock timer;
-      timer.start();
-      for (int iter = 0; iter < 100; ++iter) {
-        CUTLASS_CHECK(gemm_op.run(stream));
-      }
-      stream.wait();
-      float cute_time = timer.seconds() * 1000;
-      double cute_average_time = double(cute_time) / double(options.iterations);
-      double gflops = options.gflops(cute_average_time / 1000.0,
-                                     options.problem_sizes_host);
-      std::cout << "  Avg runtime : " << cute_average_time << " ms"
-                << std::endl;
-      std::cout << "  GFLOPS      : " << gflops << std::endl;
-    }
-    stream.throw_asynchronous();
-    release();
+    CUTLASS_CHECK(gemm_op.run());
     return cutlass::Status::kSuccess;
   }
 };
 
 void kernel_functor(sycl::queue& stream, void* ptr_A, void* ptr_B, void* ptr_D,
-                    void* ptr_alpha, void* ptr_beta, void* offset, int64_t N,
-                    int64_t K, int64_t groups) {
-  //
-  // Run examples
-  //
-  auto offset_ptr = reinterpret_cast<int64_t*>(offset);
-  Options options(offset_ptr, N, K, groups);
+                    void* tokens_per_expert, int32_t N, int32_t K,
+                    int32_t groups) {
+  auto num_rows_per_expert = reinterpret_cast<int32_t*>(tokens_per_expert);
   // The KernelHardwareInfo struct holds the number of EUs on the GPU with a
   // given device ID. This information is used by the underlying kernel.
   cutlass::KernelHardwareInfo hw_info;
 
   // Change device_id to another value if you are running on a machine with
   // multiple GPUs and wish to use a GPU other than that with device ID 0.
+  // TODO: we should get device id with a vllm or torch API.
   hw_info.sm_count =
       cutlass::KernelHardwareInfo::query_device_multiprocessor_count(
           hw_info.device_id);
@@ -407,21 +221,16 @@ void kernel_functor(sycl::queue& stream, void* ptr_A, void* ptr_B, void* ptr_D,
   using ElementA = cutlass::bfloat16_t;
   using ElementB = cutlass::bfloat16_t;
   using ElementOutput = bfloat16_t;
-  using ElementScale = cutlass::bfloat16_t;
 
   using LayoutA = cutlass::layout::RowMajor;
-  using LayoutB = cutlass::layout::RowMajor;
+  using LayoutB = cutlass::layout::ColumnMajor;
   using LayoutC = cutlass::layout::RowMajor;
   using LayoutD = cutlass::layout::RowMajor;
 
   using TileShape = Shape<_256, _256, _32>;
-  using GmemTiledCopyA =
-      XE_2D_U16x32x32_LD_N;  // Note: This shape has to match the shape used for
-                             // the scaling factors
-  using GmemTiledCopyB =
-      XE_2D_U16x32x32_LD_V;  // Note: This shape has to match the shape used for
-                             // the scaling factors
-
+  using GmemTiledCopyA = XE_2D_U16x32x32_LD_N;
+  using GmemTiledCopyB = XE_2D_U16x16x16_LD_T;
+  // This TiledMMA is the default one in intel/cutlass-sycl examples
   using TiledMma =
       TiledMMA<MMA_Atom<XE_8x16x16_F32BF16BF16F32_TT>,
                Layout<Shape<_8, _4, _1>, Stride<_4, _1, _0>>,
@@ -430,10 +239,12 @@ void kernel_functor(sycl::queue& stream, void* ptr_A, void* ptr_B, void* ptr_D,
 
   constexpr int PipelineStages = 2;
   using GEMMDispatchPolicy =
-      cutlass::gemm::MainloopIntelXeXMX16Group<PipelineStages>;
+      cutlass::gemm::MainloopIntelXeXMX16Group<PipelineStages,
+                                               cutlass::gemm::KernelXeMoEGEMM>;
   using EpilogueDispatchPolicy = cutlass::epilogue::IntelXeXMX16Group;
-  using EpilogueOp =
-      cutlass::epilogue::fusion::LinearCombination<float_t, float_t>;
+  using EpilogueOp = cutlass::epilogue::fusion::LinearCombination<
+      float_t, float_t, float_t, float_t,
+      cutlass::FloatRoundStyle::round_to_nearest, false>;
 
   using CollectiveEpilogue =
       typename cutlass::epilogue::collective::CollectiveBuilder<
@@ -459,12 +270,11 @@ void kernel_functor(sycl::queue& stream, void* ptr_A, void* ptr_B, void* ptr_D,
   using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
 
   GroupedGemmRunner<Gemm> runner;
-  runner.run(options, stream, hw_info,
-             reinterpret_cast<const ElementA**>(ptr_A),
-             reinterpret_cast<const ElementB**>(ptr_B),
-             reinterpret_cast<ElementOutput**>(ptr_D),
-             reinterpret_cast<ElementAccumulator**>(ptr_alpha),
-             reinterpret_cast<ElementAccumulator**>(ptr_beta));
+  // Might wanna throw an exception here
+  runner.run(stream, hw_info, reinterpret_cast<const ElementA*>(ptr_A),
+             reinterpret_cast<const ElementB*>(ptr_B),
+             reinterpret_cast<ElementOutput*>(ptr_D), num_rows_per_expert, N, K,
+             groups);
 }
 
 }  // namespace grouped_gemm

--- a/csrc/xpu/ops.h
+++ b/csrc/xpu/ops.h
@@ -8,8 +8,7 @@ torch::Tensor fp8_gemm_w8a16(const torch::Tensor& A, const torch::Tensor& B,
                              const std::optional<torch::Tensor>& bias_);
 
 torch::Tensor cutlass_grouped_gemm(torch::Tensor ptr_A, torch::Tensor ptr_B,
-                                   torch::Tensor ptr_D, torch::Tensor ptr_alpha,
-                                   torch::Tensor ptr_beta, torch::Tensor offset,
+                                   torch::Tensor ptr_D, torch::Tensor tokens_per_expert,
                                    int64_t N, int64_t K, int64_t groups);
 
 std::tuple<at::Tensor, at::Tensor> deepseek_scaling_rope(

--- a/csrc/xpu/torch_bindings.cpp
+++ b/csrc/xpu/torch_bindings.cpp
@@ -15,8 +15,7 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, xpu_ops) {
   xpu_ops.impl("fp8_gemm_w8a16", torch::kXPU, &fp8_gemm_w8a16);
 
   xpu_ops.def(
-      "cutlass_grouped_gemm(Tensor ptr_A, Tensor ptr_B, Tensor ptr_D, Tensor "
-      "ptr_alpha, Tensor ptr_beta, Tensor offset, int N, int K, int groups) -> "
+      "cutlass_grouped_gemm(Tensor ptr_A, Tensor ptr_B, Tensor ptr_D, Tensor tokens_per_expert, int N, int K, int groups) -> "
       "Tensor");
   xpu_ops.impl("cutlass_grouped_gemm", torch::kXPU,
                gpu::cutlass_kernel::grouped_gemm_func);

--- a/vllm_xpu_kernels/fused_moe_interface.py
+++ b/vllm_xpu_kernels/fused_moe_interface.py
@@ -10,71 +10,18 @@ except ImportError as e:
     FUSEDMOE_AVAILABLE = False
 
 
-def prepare_gemm_args(n, k, offset, A, B, D, alpha, beta, e):
-
-    if not hasattr(prepare_gemm_args, "gemm_args"):
-        gemm_args = {}
-        device = A.device
-        ptr_A = torch.empty(e * 8, dtype=torch.uint8,
-                            device=device).contiguous()
-        ptr_B = torch.empty(e * 8, dtype=torch.uint8,
-                            device=device).contiguous()
-        ptr_D = torch.empty(e * 8, dtype=torch.uint8,
-                            device=device).contiguous()
-        ptr_alpha = torch.empty(e * 8, dtype=torch.uint8,
-                                device=device).contiguous()
-        ptr_beta = torch.empty(e * 8, dtype=torch.uint8,
-                               device=device).contiguous()
-        gemm_args["ptr_A"] = ptr_A
-        gemm_args["ptr_B"] = ptr_B
-        gemm_args["ptr_D"] = ptr_D
-        gemm_args["ptr_alpha"] = ptr_alpha
-        gemm_args["ptr_beta"] = ptr_beta
-        prepare_gemm_args.gemm_args = gemm_args
-
-    ptr_A = prepare_gemm_args.gemm_args["ptr_A"]
-    ptr_B = prepare_gemm_args.gemm_args["ptr_B"]
-    ptr_D = prepare_gemm_args.gemm_args["ptr_D"]
-    ptr_alpha = prepare_gemm_args.gemm_args["ptr_alpha"]
-    ptr_beta = prepare_gemm_args.gemm_args["ptr_beta"]
-    total_elements_A = 0
-    total_elements_D = 0
-
-    def process_data_ptr(tensor, offset, addr_tensor, dim, group):
-        if dim == 1:
-            addr = tensor[offset].data_ptr()
-        elif dim == 2:
-            addr = tensor[offset, :].data_ptr()
-        elif dim == 3:
-            addr = tensor[offset, :, :].data_ptr()
-        for i in range(8):  # 64bit -> 8 bytes
-            byte_val = (addr >> (i * 8)) & 0xFF
-            addr_tensor[8 * group + i] = byte_val
-
-    groups = 0
-    for expert_i, m in enumerate(offset):
-        if m != 0:
-            # problem_sizes.extend([m, n, k])
-            process_data_ptr(A, total_elements_A, ptr_A, 2, groups)
-            process_data_ptr(B, expert_i, ptr_B, 3, groups)
-            process_data_ptr(D, total_elements_D, ptr_D, 2, groups)
-            process_data_ptr(alpha, groups, ptr_alpha, 1, groups)
-            process_data_ptr(beta, groups, ptr_beta, 1, groups)
-            total_elements_A += m
-            total_elements_D += m
-            groups += 1
-
-    prepare_gemm_args.gemm_args["groups"] = e  # FIXME: groups
-    return prepare_gemm_args.gemm_args
+def prepare_gemm_args(n, k, A, B, D, e):
+    gemm_args = {}
+    gemm_args["ptr_A"] = A
+    gemm_args["ptr_B"] = B
+    gemm_args["ptr_D"] = D
+    gemm_args["groups"] = e  # FIXME: groups
+    return gemm_args
 
 
-def cutlass_grouped_gemm(input_A, input_B, output, offset, n, k, num_experts):
-    alpha = torch.ones(num_experts, dtype=torch.float32, device=input_A.device)
-    beta = torch.zeros(num_experts, dtype=torch.float32, device=input_A.device)
-    gemm_args = prepare_gemm_args(n, k, offset, input_A, input_B, output,
-                                  alpha, beta, num_experts)
-    offset = torch.tensor(offset, dtype=torch.int64, device="cpu")
-    torch.ops._xpu_C.cutlass_grouped_gemm(offset=offset, N=n, K=k, **gemm_args)
+def cutlass_grouped_gemm(input_A, input_B, output, tokens_per_expert, n, k, num_experts):
+    gemm_args = prepare_gemm_args(n, k, input_A, input_B, output, num_experts)
+    torch.ops._xpu_C.cutlass_grouped_gemm(tokens_per_expert=tokens_per_expert, N=n, K=k, **gemm_args)
 
 
 def cutlass_fused_moe(hidden_states, w13, w2, topk_weights, topk_ids,
@@ -100,12 +47,6 @@ def cutlass_fused_moe(hidden_states, w13, w2, topk_weights, topk_ids,
             (total_input_size, hidden_size),
             dtype=hidden_states.dtype,
             device=hidden_states.device)
-        moe_buffer["alpha"] = torch.ones(num_experts,
-                                         dtype=torch.float32,
-                                         device=hidden_states.device)
-        moe_buffer["beta"] = torch.zeros(num_experts,
-                                         dtype=torch.float32,
-                                         device=hidden_states.device)
 
         cutlass_fused_moe.moe_buffer = moe_buffer
 
@@ -116,37 +57,22 @@ def cutlass_fused_moe(hidden_states, w13, w2, topk_weights, topk_ids,
         "gemm1_output"][:total_input_size, :]
     gemm2_output = cutlass_fused_moe.moe_buffer[
         "gemm2_output"][:total_input_size, :]
-    alpha = cutlass_fused_moe.moe_buffer["alpha"]
-    beta = cutlass_fused_moe.moe_buffer["beta"]
+
 
     # map token to experts
     idxs = topk_ids.argsort()
-    counts = topk_ids.to(torch.long).bincount().cpu().numpy()
-    tokens_per_expert = counts.cumsum()
+    counts = topk_ids.to(torch.int).bincount()
+    tokens_per_expert = counts.cumsum().to(torch.int32)
     num_per_tok = n_experts_per_token
     token_idxs = idxs // num_per_tok
-    offset = []
-    for expert_id, end_idx in enumerate(tokens_per_expert):
-        start_idx = 0 if expert_id == 0 else tokens_per_expert[expert_id - 1]
-        offset.append(end_idx - start_idx)
-        if start_idx == end_idx:
-            continue
-        exp_token_idxs = token_idxs[start_idx:end_idx]
-        # expert_tokens = hidden_states[exp_token_idxs]
-        # grouped_input_A.append(expert_tokens)
-        input_A[start_idx:end_idx, :].copy_(hidden_states[exp_token_idxs])
-
-    while len(offset) < num_experts:
-        offset.append(0)
 
     ########### gemm1 ##################
-    input_B = w13.transpose(-1, -2).contiguous().transpose(-1, -2)
+    input_B = w13
     assert (list(input_A.shape)[0] == total_input_size)
-    gemm_args = prepare_gemm_args(2 * intermediate_size, hidden_size, offset,
-                                  input_A, input_B, gemm1_output, alpha, beta,
+    gemm_args = prepare_gemm_args(2 * intermediate_size, hidden_size,
+                                  input_A, input_B, gemm1_output,
                                   num_experts)
-    offset_t = torch.tensor(offset, dtype=torch.int64, device='cpu')
-    torch.ops._xpu_C.cutlass_grouped_gemm(offset=offset_t,
+    torch.ops._xpu_C.cutlass_grouped_gemm(tokens_per_expert=tokens_per_expert,
                                           N=2 * intermediate_size,
                                           K=hidden_size,
                                           **gemm_args)
@@ -157,11 +83,11 @@ def cutlass_fused_moe(hidden_states, w13, w2, topk_weights, topk_ids,
 
     ########### gemm2 ##################
     input_A = act_output.contiguous()
-    input_B = w2.transpose(-1, -2).contiguous().transpose(-1, -2)
-    gemm_args = prepare_gemm_args(hidden_size, intermediate_size, offset,
-                                  input_A, input_B, gemm2_output, alpha, beta,
+    input_B = w2
+    gemm_args = prepare_gemm_args(hidden_size, intermediate_size,
+                                  input_A, input_B, gemm2_output,
                                   num_experts)
-    torch.ops._xpu_C.cutlass_grouped_gemm(offset=offset_t,
+    torch.ops._xpu_C.cutlass_grouped_gemm(tokens_per_expert=tokens_per_expert,
                                           N=hidden_size,
                                           K=intermediate_size,
                                           **gemm_args)


### PR DESCRIPTION
## Problem

The Existing MoEGEMM implementation is using duplicated headers from cutlass-sycl to use cutlass Group GEMM (except for commenting out a line in a duplicated `xe_array_epilogue` pertaining to `C` matrix, but then that change destroys the generality of groupgemm).

### Performance issues with the MoEGEMM implementation:

1. `B` matrix was being transposed on CPU
2. There were lots of lists being transferred from Host to Device
3. The current implementation doesn't require transporting `num_tokens_per_expert` from GPU to CPU, so this implementation will be useful towards developing a fully fused implementation in the future.

### Integration issues:
1. It's quite messy because some unnecessary cutlass headers had to be duplicated.
2. Further cutlass headers will have to be duplicated, so this approach is not scalable


## Solution

Reference: https://github.com/intel/cutlass-sycl/pull/520 

1. Do not transpose B matrix
2. Only pass the base `A`, `B`, `C`, `D` matrix pointers to the GPU.
3. Prevent D2H & H2D transfers (except for passing a GPU pointer of pointer which points to a base matrix). 
4. Compute tensor offsets in cutlass kernels
5. Instead of copy-pasting cutlass headers, use a separate cutlass branch, and regularly merge main branch commits to it.
6. The interface looks pretty clean now, at least to me.


## Follow-up

1. Improve performance further
2. Consider renaming GroupGEMM in the API to MoEGEMM (perhaps in this PR)?

## Test Plan

UTs
 - [ ] Measure E2E performance
 - [ ] Measure kernel performance (can't be compared to the previous implementation directly since it pre-transposed B on CPU, and then used Rowwise B in the GEMM computation, whereas B is ColumnWise in this PR. 32X32 transpose copy atom has not been added in cutlass-sycl yet, and performance will become better once it's added).


cc @pengzhao-intel 