### PR TITLE
[FusedMoE] support TP by stream align with device

### DIFF
--- a/csrc/xpu/cutlass_kernels/grouped_gemm.hpp
+++ b/csrc/xpu/cutlass_kernels/grouped_gemm.hpp
@@ -24,7 +24,8 @@ at::Tensor grouped_gemm_func(at::Tensor& ptr_A, at::Tensor& ptr_B,
                              at::Tensor& ptr_D, at::Tensor& ptr_alpha,
                              at::Tensor& ptr_beta, at::Tensor& offset,
                              int64_t N, int64_t K, int64_t groups) {
-  auto& dpcpp_queue = vllm::xpu::vllmGetQueue();
+  auto& dpcpp_queue =
+      at::xpu::getCurrentXPUStream(ptr_A.device().index()).queue();
   grouped_gemm::kernel_functor(dpcpp_queue, ptr_A.data_ptr(), ptr_B.data_ptr(),
                                ptr_D.data_ptr(), ptr_alpha.data_ptr(),
                                ptr_beta.data_ptr(), offset.data_ptr(), N, K,

--- a/csrc/xpu/cutlass_kernels/grouped_gemm_kernel.cpp
+++ b/csrc/xpu/cutlass_kernels/grouped_gemm_kernel.cpp
@@ -390,6 +390,8 @@ void kernel_functor(sycl::queue& stream, void* ptr_A, void* ptr_B, void* ptr_D,
   //
   // Run examples
   //
+  syclcompat::set_default_queue(stream);
+
   auto offset_ptr = reinterpret_cast<int64_t*>(offset);
   Options options(offset_ptr, N, K, groups);
   // The KernelHardwareInfo struct holds the number of EUs on the GPU with a


### PR DESCRIPTION
at::DeviceGuard cannot help cutlass kernel allocate on right device. So set stream align with device index.
