### PR TITLE
【GPTQ】add stride setting

### DIFF
--- a/vllm_xpu_kernels/quantization/_quantize_convert.py
+++ b/vllm_xpu_kernels/quantization/_quantize_convert.py
@@ -218,6 +218,7 @@ def transpose_onednn_woq_format(layer: torch.nn.Module,
             qzeros = torch.Tensor([8]).to(torch.int8).to("xpu")
         else:
             qzeros = layer.qzeros + 0x11111111
+        layer.qzeros.as_strided_(qzeros.shape, qzeros.stride())
         layer.qzeros.copy_(qzeros)
 
 


### PR DESCRIPTION
Fix gptq sym model accuracy issue.
When the model is GPTQ symmetrically quantized, the layer’s zero points should be set as:
 _qzeros = torch_.Tensor([8]).to(torch.int8).to("xpu")
, while directly copying the original layer’s zero points will retain their original shape, which can lead to accuracy issues when using oneDNN INT4 GEMM.