### PR TITLE
[OneDNN] Zufang/add per channel for w8a16

### DIFF
--- a/csrc/xpu/onednn/fp8_gemm_w8a16.h
+++ b/csrc/xpu/onednn/fp8_gemm_w8a16.h
@@ -8,7 +8,6 @@
 
 namespace oneDNN {
 
-using trans_type_t = at::native::onednn::trans_type_t;
 using GpuStreamManager = at::native::onednn::GpuStreamManager;
 using GpuEngineManager = at::native::onednn::GpuEngineManager;
 

--- a/tests/register_ops.py
+++ b/tests/register_ops.py
@@ -192,8 +192,8 @@ def fp8_gemm(input: torch.Tensor, weight: torch.Tensor,
 
 def fp8_gemm_w8a16(input: torch.Tensor, weight: torch.Tensor,
                    scale_wei: Optional[torch.Tensor],
-                   scale_act: Optional[torch.Tensor]):
-    return torch.ops._xpu_C.fp8_gemm_w8a16(input, weight, scale_wei, scale_act)
+                   bias: Optional[torch.Tensor]):
+    return torch.ops._xpu_C.fp8_gemm_w8a16(input, weight, scale_wei, bias)
 
 
 # moe


### PR DESCRIPTION
Add implementation and ut for per channel quant fp8 weight in wf8a16 gemm in case we need it. 

In vllm now, if user set the quantization method as fp8 and the model is not fp8, the weight will be quant per tensor.
But in case we need it for origin fp8 models, which means some weights of origin fp8 models may be in per channel quant.

