### PR TITLE
Fix lora accuracy and oom issues

### DIFF
--- a/.github/workflows/ut.yaml
+++ b/.github/workflows/ut.yaml
@@ -63,6 +63,8 @@ jobs:
           xpu-kernel-ci-image \
           /bin/bash -c '
           ZE_AFFINITY_MASK=0,1 pytest -v -s /workspace/vllm-xpu-kernels/tests/ --ignore=/workspace/vllm-xpu-kernels/tests/test_lora_ops.py --ignore=/workspace/vllm-xpu-kernels/tests/test_fp8_quant.py
+          # fixme: Running lora UT separately to avoid OOM when running together with other tests.
+          ZE_AFFINITY_MASK=0,1 pytest -v -s /workspace/vllm-xpu-kernels/tests/test_lora_ops.py
           '
       - name: Remove container
         if: ${{ always() }} 

--- a/benchmark/benchmark_lora.py
+++ b/benchmark/benchmark_lora.py
@@ -18,7 +18,7 @@ from torch.utils.benchmark import Measurement as TMeasurement
 from utils import ArgPool, Bench, CudaGraphBenchParams
 from weight_shapes import WEIGHT_SHAPES
 
-from tests.lora.lora_ops import bgmv_expand, bgmv_expand_slice, bgmv_shrink
+from tests.lora.xpu_ops import bgmv_expand, bgmv_expand_slice, bgmv_shrink
 
 DEFAULT_MODELS = list(WEIGHT_SHAPES.keys())
 DEFAULT_TP_SIZES = [1]

--- a/csrc/xpu/lora/lora_expand.cpp
+++ b/csrc/xpu/lora/lora_expand.cpp
@@ -8,298 +8,306 @@
 #include "utils/dpcpp.h"
 
 namespace vllm::lora {
+namespace constants {
+constexpr uint32_t kSmallProblemThreshold = 8192;
+constexpr uint32_t kMediumProblemThreshold = 65536;
+constexpr uint32_t kLargeProblemThreshold = 1048576;  // 1M
+constexpr uint32_t kMaxWorkgroupsLimit = 8192;
+constexpr uint32_t kMaxElementsPerThread = 16;
+constexpr uint32_t kVectorAlignmentBytes = 16;
+constexpr uint32_t kDefaultWorkgroupSize = 256;
+constexpr uint32_t kSmallWorkgroupSize = 64;
+constexpr uint32_t kMediumWorkgroupSize = 128;
+}  // namespace constants
 /**
- * BGMV Expand Kernel with slice
+ * BGMV Expand Slice Kernel
  * ---------------------------------
- * Performs batched matrix–vector multiplication and writes the result
- * into a slice of the output tensor.
+ * Performs batched grouped matrix–vector multiplication with an expand
+ * operation, but only writes to a slice of the output tensor.
  *
  * Template parameters:
- *   - output_t           : Output tensor data type
- *   - input_t            : Input tensor data type
- *   - vec_size           : Number of elements processed per vectorized loop
- *   - subgroup_size      : Subgroup size in SYCL
- *   - use_aligned_vector : Whether to use aligned vector load/store
+ *   - output_t : Output tensor data type
+ *   - input_t  : Input tensor data type
+ *   - vec_size : Number of elements processed per vectorized loop
  *
  * Tensor dimensions:
- *   - inputs   : [batch_size, hidden_size]
- *   - weights  : [num_loras, hidden_size, hidden_size_out]  (LoRA B matrix)
+ *   - inputs   : [batch_size, rank]
+ *   - weights  : [num_loras, slice_size, rank]   (LoRA B matrix slice)
  *   - indices  : [batch_size]
- *   - outputs  : [batch_size, hidden_size_out]
+ *   - outputs  : [batch_size, hidden_size] (only slice is updated)
  *
  * Mathematical operation:
- *   For each sample b:
- *     outputs[b] = inputs[b] @ weights[indices[b]]
- *                  + (add_inputs ? inputs[b] : 0)
+ *   For each sample b and slice dimension s:
+ *     outputs[b, slice_offset + s] += Σ_r (inputs[b, r] * weights[indices[b],
+ * s, r])
  */
-template <
-    typename output_t,
-    typename input_t,
-    uint32_t vec_size,
-    uint32_t subgroup_size,
-    bool use_aligned_vector>
-class bgmv_expand_kernel {
-  using accscalar_t = vllm::xpu::acc_type<output_t>;
-  using input_vec_t = vllm::xpu::aligned_vec<input_t, vec_size>;
-  using weight_vec_t = vllm::xpu::aligned_vec<output_t, vec_size>;
-
+template <typename output_t, typename input_t, uint32_t vec_size>
+class bgmv_expand_slice_kernel {
  private:
   output_t* outputs_;
-  const input_t* __restrict__ inputs_;
-  const output_t* __restrict__ weights_;
-  const int64_t* __restrict__ indices_;
-  const uint32_t batch_size_;
-  const uint32_t rank_;
+  const input_t* inputs_;
+  const input_t* weights_;
+  const int64_t* indices_;
   const uint32_t hidden_;
-  const uint32_t output_hidden_;
+  const uint32_t rank_;
   const uint32_t slice_offset_;
-  const bool add_to_output_;
-  WorkgroupLocal<accscalar_t> slm_;
-  const uint32_t workitem_per_hidden_;
-  const uint32_t hidden_per_subgroup_;
-  const uint32_t subgroup_num_;
-  const uint32_t sg_per_wg_;
+  const uint32_t slice_size_;
+  const bool add_inputs_;
+  const uint32_t batch_size_;
 
  public:
+  using acc_t = vllm::xpu::acc_type<input_t>;
+  using vec_t = vllm::xpu::aligned_vec<input_t, vec_size>;
+
   /**
    * Constructor
-   * @param outputs Output tensor [batch_size, output_hidden]
+   * @param outputs Output tensor [batch_size, hidden_size]
    * @param inputs Input tensor [batch_size, rank]
-   * @param weights Weight tensor [num_loras, hidden, rank]
+   * @param weights LoRA weights [num_loras, slice_size, rank]
    * @param indices LoRA indices [batch_size]
-   * @param batch_size Batch size
-   * @param rank LoRA rank
    * @param hidden Hidden dimension
-   * @param output_hidden Output hidden dimension
-   * @param slice_offset Start offset in output tensor
-   * @param add_to_output Whether to accumulate to existing output
-   * @param slm Workgroup local memory accessor
-   * @param workitem_per_hidden Number of workitems per hidden element
-   * @param hidden_per_subgroup Number of hidden elements per subgroup
-   * @param subgroup_num Total number of subgroups
-   * @param sg_per_wg Number of subgroups per workgroup
+   * @param rank LoRA rank
+   * @param slice_offset Starting offset in output dimension
+   * @param slice_size Size of the slice to update
+   * @param add_inputs Whether to accumulate to existing output
    */
-  bgmv_expand_kernel(
-      output_t* __restrict__ outputs,
-      const input_t* __restrict__ inputs,
-      const output_t* __restrict__ weights,
-      const int64_t* __restrict__ indices,
-      const uint32_t batch_size,
-      const uint32_t rank,
+  bgmv_expand_slice_kernel(
+      output_t* outputs,
+      const input_t* inputs,
+      const input_t* weights,
+      const int64_t* indices,
       const uint32_t hidden,
-      const uint32_t output_hidden,
+      const uint32_t rank,
       const uint32_t slice_offset,
-      const bool add_to_output,
-      WorkgroupLocal<accscalar_t> slm,
-      const uint32_t workitem_per_hidden,
-      const uint32_t hidden_per_subgroup,
-      const uint32_t subgroup_num,
-      const uint32_t sg_per_wg)
+      const uint32_t slice_size,
+      const bool add_inputs,
+      const uint32_t batch_size)
       : outputs_(outputs),
         inputs_(inputs),
         weights_(weights),
         indices_(indices),
-        batch_size_(batch_size),
-        rank_(rank),
         hidden_(hidden),
-        output_hidden_(output_hidden),
+        rank_(rank),
         slice_offset_(slice_offset),
-        add_to_output_(add_to_output),
-        slm_(slm),
-        workitem_per_hidden_(workitem_per_hidden),
-        hidden_per_subgroup_(hidden_per_subgroup),
-        subgroup_num_(subgroup_num),
-        sg_per_wg_(sg_per_wg) {}
+        slice_size_(slice_size),
+        add_inputs_(add_inputs),
+        batch_size_(batch_size) {}
 
-  void operator() [[sycl::reqd_sub_group_size(subgroup_size)]] (
-      sycl::nd_item<1> item) const {
-    sycl::group<1> g = item.get_group();
-    sycl::sub_group sg = item.get_sub_group();
-    uint32_t group_id = g.get_group_linear_id();
-    uint32_t subgroup_id = sg.get_group_linear_id() + group_id * sg_per_wg_;
-    if (subgroup_id >= subgroup_num_) {
-      return;
-    }
+  void operator()(sycl::nd_item<1> item) const {
+    const uint32_t global_id = item.get_global_linear_id();
+    const uint32_t group_size = item.get_local_range(0);
+    const uint32_t group_id = item.get_group_linear_id();
 
-    const uint32_t item_id = g.get_local_linear_id();
-    const uint32_t line_id = sg.get_local_linear_id();
-    const uint32_t hidden_id_in_subgroup = line_id / workitem_per_hidden_;
-    const uint32_t vec_id = line_id % workitem_per_hidden_;
-    const uint32_t hidden_linear_id =
-        subgroup_id * hidden_per_subgroup_ + hidden_id_in_subgroup;
+    const uint32_t total_threads = group_size * item.get_group_range(0);
 
-    if (hidden_id_in_subgroup >= hidden_per_subgroup_ ||
-        hidden_linear_id >= batch_size_ * hidden_) {
-      return;
-    }
+    const uint32_t elements_per_thread =
+        (batch_size_ * slice_size_ + total_threads - 1) / total_threads;
 
-    const uint32_t batch_id = hidden_linear_id / hidden_;
-    const uint32_t hidden_id = hidden_linear_id % hidden_;
+    for (uint32_t i = 0; i < elements_per_thread; i++) {
+      const uint32_t element_idx = global_id + i * total_threads;
+      if (element_idx >= batch_size_ * slice_size_) break;
 
-    const int64_t lora_idx = indices_[batch_id];
-    if (lora_idx < 0) return;
+      const uint32_t batch_id = element_idx / slice_size_;
+      const uint32_t slice_id = element_idx % slice_size_;
 
-    const input_t* __restrict__ input_ptr =
-        inputs_ + static_cast<size_t>(batch_id) * rank_;
-    const output_t* __restrict__ weight_ptr =
-        weights_ +
-        (static_cast<size_t>(lora_idx) * hidden_ + hidden_id) * rank_;
+      const int64_t lora_idx = indices_[batch_id];
+      if (lora_idx < 0) continue;
 
-    accscalar_t local_result = 0;
+      const input_t* input_base = inputs_ + batch_id * rank_;
+      const input_t* weight_base =
+          weights_ + lora_idx * slice_size_ * rank_ + slice_id * rank_;
 
-    uint32_t offset = vec_id * vec_size;
-    while (offset < rank_) {
-      const input_t* __restrict__ input_base = input_ptr + offset;
-      const output_t* __restrict__ weight_base = weight_ptr + offset;
-      if constexpr (use_aligned_vector) {
-        const input_vec_t in_vec =
-            *reinterpret_cast<const input_vec_t*>(input_base);
-        const weight_vec_t wt_vec =
-            *reinterpret_cast<const weight_vec_t*>(weight_base);
-#pragma unroll(vec_size)
-        for (uint32_t i = 0; i < vec_size; ++i) {
-          local_result += static_cast<accscalar_t>(in_vec[i]) *
-                          static_cast<accscalar_t>(wt_vec[i]);
-        }
-      } else {
-#pragma unroll(vec_size)
-        for (uint32_t i = 0; i < vec_size; ++i) {
-          const uint32_t idx = offset + i;
-          if (idx >= rank_) break;
-          local_result += static_cast<accscalar_t>(input_base[i]) *
-                          static_cast<accscalar_t>(weight_base[i]);
-        }
-      }
-      offset += workitem_per_hidden_ * vec_size;
-    }
+      acc_t sum = 0;
 
-    const uint32_t slm_base = item_id - vec_id;
-    slm_[slm_base + vec_id] = local_result;
-    sycl::group_barrier(sg);
+      const uint32_t full_vectors = rank_ / vec_size;
+      for (uint32_t j = 0; j < full_vectors; j++) {
+        const vec_t input_vec =
+            *reinterpret_cast<const vec_t*>(input_base + j * vec_size);
+        const vec_t weight_vec =
+            *reinterpret_cast<const vec_t*>(weight_base + j * vec_size);
 
-    if (vec_id == 0) {
-      accscalar_t result = 0;
 #pragma unroll
-      for (uint32_t i = 0; i < workitem_per_hidden_; ++i) {
-        result += slm_[slm_base + i];
+        for (uint32_t k = 0; k < vec_size; k++) {
+          sum = sycl::mad(
+              static_cast<acc_t>(input_vec[k]),
+              static_cast<acc_t>(weight_vec[k]),
+              sum);
+        }
       }
-      const size_t out_off = static_cast<size_t>(batch_id) * output_hidden_ +
-                             slice_offset_ + hidden_id;
-      if (add_to_output_) {
-        outputs_[out_off] = static_cast<output_t>(
-            static_cast<accscalar_t>(outputs_[out_off]) + result);
-      } else {
-        outputs_[out_off] = static_cast<output_t>(result);
+
+      const uint32_t remaining = rank_ % vec_size;
+      for (uint32_t j = 0; j < remaining; j++) {
+        const uint32_t offset = full_vectors * vec_size + j;
+        sum += static_cast<acc_t>(input_base[offset]) *
+               static_cast<acc_t>(weight_base[offset]);
+      }
+
+      const uint32_t output_hidden_id = slice_offset_ + slice_id;
+      if (output_hidden_id < hidden_) {
+        const uint32_t output_idx = batch_id * hidden_ + output_hidden_id;
+        const output_t result = static_cast<output_t>(sum);
+
+        if (add_inputs_) {
+          outputs_[output_idx] += result;
+        } else {
+          outputs_[output_idx] = result;
+        }
       }
     }
   }
 };
+
 }  // namespace vllm::lora
 
+// Vector size dispatch function
+template <typename Fn>
+void dispatch_vec_size(int vec_size, Fn&& fn) {
+  switch (vec_size) {
+    case 8:
+      fn(std::integral_constant<int, 8>{});
+      break;
+    case 4:
+      [[likely]] fn(std::integral_constant<int, 4>{});
+      break;
+    case 2:
+      fn(std::integral_constant<int, 2>{});
+      break;
+    case 1:
+      [[unlikely]] fn(std::integral_constant<int, 1>{});
+      break;
+    default:
+      [[unlikely]] TORCH_CHECK(false, "Unsupported vector size: ", vec_size);
+  }
+}
+
 /**
- * Launch BGMV expand kernel for a sliced output
- * @param outputs Output tensor [batch_size, output_hidden]
- * @param inputs Input tensor [batch_size, rank]
- * @param weights Weight tensor [num_loras, hidden, rank]
- * @param indices LoRA indices [batch_size]
- * @param batch_size Batch size
- * @param rank LoRA rank
- * @param hidden Hidden dimension
- * @param output_hidden Output hidden dimension
- * @param slice_offset Start offset in output
- * @param add_to_output Whether to accumulate to output
+ * Compute optimal workgroup configuration
+ */
+std::pair<uint32_t, uint32_t>
+compute_workgroup(uint32_t total_elements, uint32_t max_workgroup_size) {
+  using namespace vllm::lora::constants;
+
+  uint32_t workgroup_size;
+  uint32_t num_workgroups;
+
+  // Choose workgroup size based on problem size
+  if (total_elements <= kSmallProblemThreshold) {
+    workgroup_size = kSmallWorkgroupSize;
+  } else if (total_elements <= kMediumProblemThreshold) {
+    workgroup_size = kMediumWorkgroupSize;
+  } else {
+    workgroup_size = kDefaultWorkgroupSize;
+  }
+
+  // Calculate number of workgroups
+  if (total_elements <= kLargeProblemThreshold) {
+    // Small to medium problems: one thread per element
+    num_workgroups = (total_elements + workgroup_size - 1) / workgroup_size;
+  } else {
+    // Large problems: use multiple elements per thread to limit workgroups
+    const uint32_t elements_per_thread = kMaxElementsPerThread;
+    num_workgroups =
+        (total_elements + elements_per_thread - 1) / elements_per_thread;
+    num_workgroups = std::min(num_workgroups, kMaxWorkgroupsLimit);
+  }
+
+  // Apply device constraints
+  workgroup_size = std::min(workgroup_size, max_workgroup_size);
+  num_workgroups = std::max(num_workgroups, 1u);
+
+  // Ensure workgroup size doesn't exceed total elements for small problems
+  if (total_elements < workgroup_size) {
+    workgroup_size = std::max(total_elements, 1u);
+    num_workgroups = 1;
+  }
+
+  return {workgroup_size, num_workgroups};
+}
+
+/**
+ * Launch BGMV expand slice kernel
+ *
+ * @param outputs  [batch_size, hidden_size] - Output tensor
+ * @param inputs   [batch_size, rank] - Input tensor
+ * @param weights  [num_loras, slice_size, rank] - LoRA weights slice
+ * @param indices  [batch_size] - LoRA index mapping
+ * @param batch_size - Batch size
+ * @param hidden     - Hidden dimension size
+ * @param rank       - LoRA rank
+ * @param slice_offset - Starting offset in output dimension
+ * @param slice_size   - Size of the slice to update
+ * @param add_inputs - Whether to accumulate to existing output
  */
 template <typename output_t, typename input_t>
-void launch_bgmv_expand_with_slice(
+void launch_bgmv_expand_slice(
     output_t* outputs,
-    const input_t* inputs,
-    const output_t* weights,
-    const int64_t* indices,
+    input_t* inputs,
+    input_t* weights,
+    int64_t* indices,
     const uint32_t batch_size,
-    const uint32_t rank,
     const uint32_t hidden,
-    const uint32_t output_hidden,
+    const uint32_t rank,
     const uint32_t slice_offset,
-    const bool add_to_output) {
-  if (batch_size == 0 || rank == 0 || hidden == 0) return;
+    const uint32_t slice_size,
+    const bool add_inputs) {
+  uint32_t vec_bytes = 16;
+  const auto input_align = reinterpret_cast<uintptr_t>(inputs);
+  const auto weight_align = reinterpret_cast<uintptr_t>(weights);
+  const uint32_t data_bytes = rank * sizeof(input_t);
 
-  constexpr uint32_t vec_size = 16 / sizeof(input_t);
-  constexpr uint32_t subgroup_size = 32;
-  const bool use_aligned_vector =
-      (rank % vec_size == 0 && reinterpret_cast<uintptr_t>(inputs) % 16 == 0 &&
-       reinterpret_cast<uintptr_t>(weights) % 16 == 0);
+  while (vec_bytes > sizeof(input_t) &&
+         (data_bytes % vec_bytes != 0 || input_align % vec_bytes != 0 ||
+          weight_align % vec_bytes != 0)) {
+    vec_bytes /= 2;
+  }
+  // Fallback to scalar operations
+  if (vec_bytes < sizeof(input_t)) {
+    vec_bytes = sizeof(input_t);
+  }
+  uint32_t vec_size = vec_bytes / sizeof(input_t);
 
-  // Use several workitems to write one element to output with [batch_size,
-  // hidden]. Use at most one subgroup to process one element.
-  const uint32_t workitem_per_hidden =
-      std::min<uint32_t>((rank + vec_size - 1) / vec_size, subgroup_size);
-
-  const uint32_t hidden_per_subgroup = subgroup_size / workitem_per_hidden;
-  const uint32_t subgroup_num =
-      (batch_size * hidden + hidden_per_subgroup - 1) / hidden_per_subgroup;
-
-  at::DeviceGuard device_guard(at::Device(at::kXPU, at::xpu::current_device()));
-  auto& q = vllm::xpu::vllmGetQueue();
+  at::Device curDevice = at::Device(at::kXPU, at::xpu::current_device());
+  at::DeviceGuard device_guard(curDevice);
+  auto& dpcpp_queue = vllm::xpu::vllmGetQueue();
   const auto dev_id = at::xpu::current_device();
   const uint32_t max_workgroup_size = vllm::xpu::getMaxWorkGroupSize(dev_id);
 
-  const uint32_t workgroup_size =
-      std::min<uint32_t>(max_workgroup_size, subgroup_num * subgroup_size);
-  const uint32_t sg_per_wg = workgroup_size / subgroup_size;
-  const uint32_t workgroup_num = (subgroup_num + sg_per_wg - 1) / sg_per_wg;
+  const uint32_t total_elements = batch_size * slice_size;
 
-  sycl::range<1> local_range{workgroup_size};
-  sycl::range<1> global_range{workgroup_num * workgroup_size};
-  q.submit([&](sycl::handler& cgh) {
-    WorkgroupLocal<vllm::xpu::acc_type<output_t>> slm(
-        sycl::range(workgroup_size), cgh);
-    if (use_aligned_vector) {
-      vllm::lora::
-          bgmv_expand_kernel<output_t, input_t, vec_size, subgroup_size, true>
-              kfn(outputs,
-                  inputs,
-                  weights,
-                  indices,
-                  batch_size,
-                  rank,
-                  hidden,
-                  output_hidden,
-                  slice_offset,
-                  add_to_output,
-                  slm,
-                  workitem_per_hidden,
-                  hidden_per_subgroup,
-                  subgroup_num,
-                  sg_per_wg);
+  // Compute workgroup configuration
+  auto [workgroup_size, num_workgroups] =
+      compute_workgroup(total_elements, max_workgroup_size);
+
+  const sycl::range<1> local_range{workgroup_size};
+  const sycl::range<1> global_range{num_workgroups * workgroup_size};
+
+  dpcpp_queue.submit([&](sycl::handler& cgh) {
+    dispatch_vec_size(vec_size, [&](auto vec_c) {
+      constexpr int V = vec_c.value;
+      vllm::lora::bgmv_expand_slice_kernel<output_t, input_t, V> kfn(
+          outputs,
+          inputs,
+          weights,
+          indices,
+          hidden,
+          rank,
+          slice_offset,
+          slice_size,
+          add_inputs,
+          batch_size);
       cgh.parallel_for(sycl::nd_range<1>(global_range, local_range), kfn);
-    } else {
-      vllm::lora::
-          bgmv_expand_kernel<output_t, input_t, vec_size, subgroup_size, false>
-              kfn(outputs,
-                  inputs,
-                  weights,
-                  indices,
-                  batch_size,
-                  rank,
-                  hidden,
-                  output_hidden,
-                  slice_offset,
-                  add_to_output,
-                  slm,
-                  workitem_per_hidden,
-                  hidden_per_subgroup,
-                  subgroup_num,
-                  sg_per_wg);
-      cgh.parallel_for(sycl::nd_range<1>(global_range, local_range), kfn);
-    }
+    });
   });
 }
 
-void validate_lora_b_tensors(
+void validate_lora_b_slice_tensors(
     const at::Tensor& inputs,
     const at::Tensor& lora_b_weights,
     const at::Tensor& output_tensor,
-    const at::Tensor& lora_indices_tensor) {
+    const at::Tensor& lora_indices_tensor,
+    const uint32_t slice_offset,
+    const uint32_t slice_size) {
+  // Device checks
   TORCH_CHECK(inputs.is_xpu(), "inputs must be on XPU");
   TORCH_CHECK(lora_b_weights.is_xpu(), "lora_b_weights must be on XPU");
   TORCH_CHECK(output_tensor.is_xpu(), "output_tensor must be on XPU");
@@ -318,41 +326,41 @@ void validate_lora_b_tensors(
 
   // Dtype checks
   TORCH_CHECK(
-      inputs.scalar_type() == at::kFloat ||
-          inputs.scalar_type() == at::kBFloat16 ||
-          inputs.scalar_type() == at::kHalf,
-      "inputs must be float16, bfloat16, or float32");
+      inputs.scalar_type() == lora_b_weights.scalar_type(),
+      "inputs dtype must match lora_b_weights dtype");
 
   TORCH_CHECK(
-      lora_b_weights.scalar_type() == at::kBFloat16 ||
-          lora_b_weights.scalar_type() == at::kHalf,
-      "lora_b_weights must be float16 or bfloat16");
+      inputs.scalar_type() == at::kHalf ||
+          inputs.scalar_type() == at::kBFloat16,
+      "inputs must be float16 or bfloat16");
 
   TORCH_CHECK(
-      output_tensor.scalar_type() == lora_b_weights.scalar_type(),
-      "output_tensor dtype must match lora_b_weights dtype");
+      output_tensor.scalar_type() == at::kHalf ||
+          output_tensor.scalar_type() == at::kBFloat16 ||
+          output_tensor.scalar_type() == at::kFloat,
+      "output_tensor must be float16, bfloat16, or float32");
 
   TORCH_CHECK(
       lora_indices_tensor.scalar_type() == at::kLong,
       "lora_indices_tensor must be int64");
 
   // Dimension checks
-  TORCH_CHECK(inputs.dim() == 2, "inputs must be 2D [batch_size, hidden_size]");
+  TORCH_CHECK(inputs.dim() == 2, "inputs must be 2D [batch_size, rank]");
   TORCH_CHECK(
-      output_tensor.dim() == 2, "output_tensor must be 2D [batch_size, rank]");
+      output_tensor.dim() == 2,
+      "output_tensor must be 2D [batch_size, hidden_size]");
   TORCH_CHECK(
       lora_indices_tensor.dim() == 1,
       "lora_indices_tensor must be 1D [batch_size]");
 
   at::Tensor lora_weights = lora_b_weights;
-  if (lora_b_weights.dim() == 4) {  // shape: (lora_num,1,hidden_size,rank)
+  if (lora_b_weights.dim() == 4) {  // shape: (lora_num,1,slice_size,rank)
     TORCH_CHECK(
         lora_b_weights.size(1) == 1, "lora_b_weights.size(1) must be 1");
-    lora_weights = lora_b_weights.squeeze(1);  // squeeze dim 1
   } else {
     TORCH_CHECK(
         lora_b_weights.dim() == 3,
-        "lora_b_weights must be 3D [lora_num, hidden_size, rank]");
+        "lora_b_weights must be 3D [lora_num, slice_size, rank]");
   }
 
   // Shape consistency checks
@@ -360,69 +368,134 @@ void validate_lora_b_tensors(
       inputs.size(1) == lora_weights.size(-1),
       "inputs.size(1) must match lora_b_weights.size(-1)");
   TORCH_CHECK(
+      lora_weights.size(-2) == slice_size,
+      "lora_b_weights.size(-2) must match slice_size");
+  TORCH_CHECK(
       inputs.size(0) == output_tensor.size(0),
       "inputs.size(0) must match output_tensor.size(0)");
   TORCH_CHECK(
       inputs.size(0) == lora_indices_tensor.size(0),
       "inputs.size(0) must match lora_indices_tensor.size(0)");
+
+  // Slice bounds check
+  TORCH_CHECK(
+      slice_offset + slice_size <= output_tensor.size(1),
+      "slice [",
+      slice_offset,
+      ":",
+      slice_offset + slice_size,
+      ") is out of bounds for output dimension ",
+      output_tensor.size(1));
 }
 
+/**
+ * BGMV expand slice operation main function
+ *
+ * @param outputs [batch_size, hidden_size] - Output tensor
+ * @param inputs  [batch_size, rank] - Input feature tensor
+ * @param weights [num_loras, slice_size, rank] - LoRA weight matrix B slice
+ * @param indices [batch_size] - LoRA index for each sample
+ * @param slice_offset - Starting offset in output dimension
+ * @param slice_size - Size of the slice to update
+ * @param add_inputs - Whether to accumulate to existing output
+ */
 void bgmv_expand_slice(
     torch::Tensor& outputs,
     const torch::Tensor& inputs,
     const torch::Tensor& weights,
     const torch::Tensor& indices,
     const int64_t slice_offset,
-    const bool add_to_output) {
-  validate_lora_b_tensors(inputs, weights, outputs, indices);
-  TORCH_CHECK(slice_offset >= 0, "slice_offset must be non-negative");
+    const int64_t slice_size,
+    bool add_inputs) {
+  // 1. Input validation
+  validate_lora_b_slice_tensors(
+      inputs, weights, outputs, indices, slice_offset, slice_size);
 
+  at::Tensor lora_weights = weights;
+  if (lora_weights.dim() == 4) {  // shape: (lora_num,1,slice_size,rank)
+    lora_weights = lora_weights.squeeze(1);  // squeeze dim 1
+  }
+
+  // 2. Get dimension information
   uint32_t batch_size = inputs.size(0);
   uint32_t rank = inputs.size(1);
-  uint32_t hidden = weights.size(1);
-  uint32_t output_hidden = outputs.size(1);
-  VLLM_DISPATCH_HALF_TYPES(inputs.scalar_type(), "bgmv_expand_slice", [&]() {
-    using input_t = scalar_t;
-    switch (outputs.scalar_type()) {
-      case at::ScalarType::Half:
-        launch_bgmv_expand_with_slice<at::Half, input_t>(
-            outputs.data_ptr<at::Half>(),
-            inputs.data_ptr<input_t>(),
-            weights.data_ptr<at::Half>(),
-            indices.data_ptr<int64_t>(),
-            batch_size,
-            rank,
-            hidden,
-            output_hidden,
-            slice_offset,
-            add_to_output);
-        break;
-      case at::ScalarType::BFloat16:
-        launch_bgmv_expand_with_slice<at::BFloat16, input_t>(
-            outputs.data_ptr<at::BFloat16>(),
-            inputs.data_ptr<input_t>(),
-            weights.data_ptr<at::BFloat16>(),
-            indices.data_ptr<int64_t>(),
-            batch_size,
-            rank,
-            hidden,
-            output_hidden,
-            slice_offset,
-            add_to_output);
-        break;
-      default:
-        TORCH_CHECK(false, "Unsupported output type: ", inputs.scalar_type());
-    }
-  });
-};
+  uint32_t hidden = outputs.size(1);
 
+  // 3. Dispatch based on INPUT type
+  VLLM_DISPATCH_FLOATING_TYPES(
+      inputs.scalar_type(), "bgmv_expand_slice", [&]() {
+        using input_t = scalar_t;
+        switch (outputs.scalar_type()) {
+          case at::ScalarType::Half:
+            launch_bgmv_expand_slice<at::Half, input_t>(
+                outputs.data_ptr<at::Half>(),
+                inputs.data_ptr<input_t>(),
+                lora_weights.data_ptr<input_t>(),
+                indices.data_ptr<int64_t>(),
+                batch_size,
+                hidden,
+                rank,
+                slice_offset,
+                slice_size,
+                add_inputs);
+            break;
+          case at::ScalarType::BFloat16:
+            launch_bgmv_expand_slice<at::BFloat16, input_t>(
+                outputs.data_ptr<at::BFloat16>(),
+                inputs.data_ptr<input_t>(),
+                lora_weights.data_ptr<input_t>(),
+                indices.data_ptr<int64_t>(),
+                batch_size,
+                hidden,
+                rank,
+                slice_offset,
+                slice_size,
+                add_inputs);
+            break;
+          case at::ScalarType::Float:
+            launch_bgmv_expand_slice<float, input_t>(
+                outputs.data_ptr<float>(),
+                inputs.data_ptr<input_t>(),
+                lora_weights.data_ptr<input_t>(),
+                indices.data_ptr<int64_t>(),
+                batch_size,
+                hidden,
+                rank,
+                slice_offset,
+                slice_size,
+                add_inputs);
+            break;
+          default:
+            TORCH_CHECK(
+                false, "Unsupported output type: ", outputs.scalar_type());
+            break;
+        }
+      });
+}
+
+/**
+ * BGMV expand operation main function
+ *
+ * @param outputs [batch_size, hidden_size] - Output tensor
+ * @param inputs  [batch_size, rank] - Input feature tensor
+ * @param weights [num_loras, hidden_size, rank] - LoRA weight matrix B
+ * @param indices [batch_size] - LoRA index for each sample
+ * @param add_inputs - Whether to accumulate to existing output
+ */
 void bgmv_expand(
     torch::Tensor& outputs,
     const torch::Tensor& inputs,
     const torch::Tensor& weights,
     const torch::Tensor& indices,
-    bool add_to_output) {
-  validate_lora_b_tensors(inputs, weights, outputs, indices);
+    bool add_inputs) {
+  uint32_t hidden = outputs.size(1);
+
   bgmv_expand_slice(
-      outputs, inputs, weights, indices, /*slice_offset=*/0, add_to_output);
-};
+      outputs,
+      inputs,
+      weights,
+      indices,
+      0,       // slice_offset = 0
+      hidden,  // slice_size
+      add_inputs);
+}

--- a/csrc/xpu/lora/lora_ops.h
+++ b/csrc/xpu/lora/lora_ops.h
@@ -63,7 +63,8 @@ void bgmv_expand_slice(
     const torch::Tensor& inputs,
     const torch::Tensor& weights,
     const torch::Tensor& indices,
-    int64_t slice_offset,
+    const int64_t slice_offset,
+    const int64_t slice_size,
     bool add_to_output);
 
 //------------------------------------------------------------------------------

--- a/csrc/xpu/torch_bindings.cpp
+++ b/csrc/xpu/torch_bindings.cpp
@@ -68,7 +68,8 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, xpu_ops) {
 
   xpu_ops.def(
       "bgmv_expand_slice(Tensor! outputs, Tensor inputs, Tensor weights, "
-      "Tensor indices, int slice_offset,bool add_to_output) -> ()");
+      "Tensor indices, int slice_offset, int slice_size, bool add_to_output) "
+      "-> ()");
   xpu_ops.impl("bgmv_expand_slice", torch::kXPU, &bgmv_expand_slice);
 
   xpu_ops.def(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 import os
 
+import pytest
+
 
 def pytest_generate_tests(metafunc):
     use_mini_pytest_profiler = os.getenv("XPU_KERNEL_PYTEST_PROFILER",
@@ -28,3 +30,16 @@ def pytest_generate_tests(metafunc):
                     new_markers.append(mark)
                 metafunc.definition.own_markers = new_markers
             metafunc.parametrize(param_name, values)
+
+
+@pytest.fixture
+def reset_default_device():
+    """
+    Some tests, such as `test_punica_ops.py`, explicitly set the
+    default device, which can affect subsequent tests. Adding this fixture
+    helps avoid this problem.
+    """
+    import torch
+    original_device = torch.get_default_device()
+    yield
+    torch.set_default_device(original_device)

--- a/tests/lora/torch_ops.py
+++ b/tests/lora/torch_ops.py
@@ -1,0 +1,136 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import torch
+
+
+def sgmv_expand(
+    inputs: torch.Tensor,
+    lora_b_weights: torch.Tensor,
+    output_tensor: torch.Tensor,
+    b_seq_start_loc: torch.Tensor,
+    seq_len_tensor: torch.Tensor,
+    lora_indices_tensor: torch.Tensor,
+    batches: int,
+    max_seq_length: int,
+    token_nums: int,
+    add_inputs: bool = False,
+):
+    exploded_indices = torch.repeat_interleave(lora_indices_tensor,
+                                               seq_len_tensor)
+
+    bgmv_expand(inputs, lora_b_weights, output_tensor, exploded_indices,
+                add_inputs)
+
+
+def bgmv_expand(
+    inputs: torch.Tensor,
+    lora_b_weights: torch.Tensor,
+    output_tensor: torch.Tensor,
+    lora_indices_tensor: torch.Tensor,
+    add_inputs: bool = True,
+):
+    selected_loras = lora_b_weights[lora_indices_tensor].to(
+        dtype=output_tensor.dtype)
+    if len(selected_loras.shape) == 4:
+        selected_loras = selected_loras.squeeze(dim=1)
+    inputs = inputs.to(dtype=output_tensor.dtype)
+    outputs = torch.einsum("bi, boi -> bo", inputs, selected_loras)
+
+    limit = output_tensor.shape[0]
+    if outputs.shape[0] == 1 and output_tensor.shape[0] != 1:
+        limit = 1
+
+    # LoRA adapter and model may add different amounts of padding to output
+    common_len = min(outputs.shape[1], output_tensor.shape[1])
+
+    if add_inputs:
+        output_tensor[:, :common_len] += outputs[:limit, :common_len]
+    else:
+        output_tensor[:, :common_len] = outputs[:limit, :common_len]
+
+
+def sgmv_shrink(
+    inputs: torch.Tensor,
+    lora_a_weights: torch.Tensor,
+    output_tensor: torch.Tensor,
+    b_seq_start_loc: torch.Tensor,
+    seq_len_tensor: torch.Tensor,
+    lora_indices_tensor: torch.Tensor,
+    batches: int,
+    max_seq_length: int,
+    token_nums: int,
+    scaling: float,
+):
+    exploded_indices = torch.repeat_interleave(lora_indices_tensor,
+                                               seq_len_tensor)
+
+    bgmv_shrink(inputs, lora_a_weights, output_tensor, exploded_indices,
+                scaling)
+
+
+def bgmv_shrink(
+    inputs: torch.Tensor,
+    lora_b_weights: torch.Tensor,
+    output_tensor: torch.Tensor,
+    lora_indices_tensor: torch.Tensor,
+    scaling: float = 1.0,
+):
+    selected_loras = lora_b_weights[lora_indices_tensor].to(
+        dtype=output_tensor.dtype)
+    if len(selected_loras.shape) == 4:
+        selected_loras = selected_loras.squeeze(dim=1)
+    inputs = inputs.to(dtype=output_tensor.dtype)
+    outputs = torch.einsum("bi, boi -> bo", inputs, selected_loras)
+
+    output_tensor[:, :outputs.shape[1]] = scaling * outputs[:]
+
+
+def sgmv_expand_slice(
+    inputs: torch.Tensor,
+    lora_b_weights: torch.Tensor,
+    output_tensor: torch.Tensor,
+    b_seq_start_loc: torch.Tensor,
+    seq_len_tensor: torch.Tensor,
+    lora_indices_tensor: torch.Tensor,
+    batches: int,
+    max_seq_length: int,
+    token_nums: int,
+    slice_offset: int,
+    slice_size: int,
+    add_inputs: bool = False,
+):
+    exploded_indices = torch.repeat_interleave(lora_indices_tensor,
+                                               seq_len_tensor)
+
+    bgmv_expand_slice(
+        inputs,
+        lora_b_weights,
+        output_tensor,
+        exploded_indices,
+        slice_offset,
+        slice_size,
+        add_inputs,
+    )
+
+
+def bgmv_expand_slice(
+    inputs: torch.Tensor,
+    lora_b_weights: torch.Tensor,
+    output_tensor: torch.Tensor,
+    lora_indices_tensor: torch.Tensor,
+    slice_offset: int,
+    slice_size: int,
+    add_inputs: bool = True,
+):
+    selected_loras = lora_b_weights[lora_indices_tensor].to(
+        dtype=output_tensor.dtype)
+    inputs = inputs.to(dtype=output_tensor.dtype)
+    if len(selected_loras.shape) == 4:
+        selected_loras = selected_loras.squeeze(dim=1)
+    outputs = torch.einsum("bi, boi -> bo", inputs, selected_loras)
+
+    if add_inputs:
+        output_tensor[:, slice_offset:slice_offset + slice_size] += outputs[:]
+    else:
+        output_tensor[:, slice_offset:slice_offset + slice_size] = outputs[:]

--- a/tests/lora/utils.py
+++ b/tests/lora/utils.py
@@ -183,3 +183,82 @@ def generate_data_for_expand_nslices(
         seq_len_tensor,
         indices,
     )
+
+
+def generate_data_for_nslices(
+    batches,
+    hidden_size,
+    lora_nums,
+    max_rank,
+    seq_length,
+    nslices,
+    dtype,
+    op_type,
+    device,
+) -> PunicaTensors:
+    seq_len_tensor = torch.randint(seq_length, seq_length + 1,
+                                   (batches, )).to(device)
+    b_seq_start_loc = torch.cumsum(
+        torch.tensor([0] + seq_len_tensor[:-1].tolist(), dtype=torch.long),
+        dim=0,
+    ).to(device)
+    total_tokens = seq_len_tensor.sum()
+
+    lora_weights_lst = []
+    if op_type == "shrink":
+        inputs_tensor = torch.rand((total_tokens, hidden_size),
+                                   dtype=dtype).to(device)
+
+        for _ in range(nslices):
+            if op_type == "shrink":
+                lora_weights_lst.append(
+                    torch.rand(
+                        (lora_nums, max_rank, hidden_size),  # col-major
+                        dtype=dtype,
+                    ).to(device))
+        # NOTE  shrink kernel using torch.float32 as output type
+        # shrink op need atomic_add, so output is initinized by 0
+        our_out_tensor = torch.zeros(
+            (nslices, total_tokens, max_rank),
+            dtype=torch.float32,
+        ).to(device)
+    else:
+        inputs_tensor = torch.rand(
+            (nslices, total_tokens, max_rank),
+            dtype=dtype,
+        ).to(device)
+        for _ in range(nslices):
+            lora_weights_lst.append(
+                torch.rand(
+                    (lora_nums, hidden_size, max_rank),  # col-major
+                    dtype=dtype,
+                ).to(device))
+        # expand op needs to complete y+=a@lora_b, so output is
+        # initinized randomly
+        our_out_tensor = torch.rand((total_tokens, hidden_size * nslices),
+                                    dtype=dtype).to(device)
+
+    # Ensure the same input.
+    ref_out_tensor = our_out_tensor.clone()
+    lora_indices_tensor = torch.randint(0,
+                                        lora_nums - 1 if lora_nums > 1 else 1,
+                                        (batches, ))
+    indices = torch.zeros((total_tokens), dtype=torch.long).to(device)
+    current_offset = 0
+    for b_id in range(batches):
+        lora_index = lora_indices_tensor[b_id]
+        indices[current_offset:current_offset +
+                seq_len_tensor[b_id]] = (lora_index.item())
+        current_offset += seq_len_tensor[b_id].item()
+
+    lora_indices_tensor = lora_indices_tensor.to(device)
+    return PunicaTensors(
+        inputs_tensor,
+        lora_weights_lst,
+        our_out_tensor,
+        ref_out_tensor,
+        b_seq_start_loc,
+        lora_indices_tensor,
+        seq_len_tensor,
+        indices,
+    )

--- a/tests/lora/xpu_ops.py
+++ b/tests/lora/xpu_ops.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 import torch
+
 import vllm_xpu_kernels._xpu_C  # noqa: F401
 
 
@@ -87,5 +88,6 @@ def bgmv_expand_slice(
         lora_b_weights,
         lora_indices_tensor,
         slice_offset,
+        slice_size,
         add_inputs,
     )

--- a/tests/test_lora_ops.py
+++ b/tests/test_lora_ops.py
@@ -1,166 +1,134 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from threading import Lock
 
 import pytest
 import torch
 
-from tests.lora.lora_ops import bgmv_expand, bgmv_expand_slice, bgmv_shrink
-from tests.lora.utils import (PunicaTensors, assert_close, generate_data,
-                              generate_data_for_expand_nslices)
+from tests.lora import torch_ops, xpu_ops
+from tests.lora.utils import (PunicaTensors, assert_close,
+                              generate_data_for_nslices)
+from tests.utils import seed_everything
+
+MINI_PYTEST_PARAMS = {
+    "test_kernels": {
+        "batches": [1],
+        "num_loras": [1],
+        "rank": [1],
+        "hidden_size": [2049],
+        "nslices": [1],
+        "dtype": [torch.float16],
+        "device": ["xpu:0"],
+        "seed": [0],
+        "op_type": ["shrink", "expand"],
+    },
+    "test_kernels_hidden_size": {
+        "batches": [4],
+        "num_loras": [4],
+        "rank": [32],
+        "hidden_size": [128],
+        "nslices": [1],
+        "dtype": [torch.float16],
+        "device": ["xpu:0"],
+        "seed": [0],
+        "op_type": ["shrink", "expand"],
+    },
+}
 
 
-def torch_bgmv_expand(
-    inputs: torch.Tensor,
-    lora_b_weights: torch.Tensor,
-    output_tensor: torch.Tensor,
-    lora_indices_tensor: torch.Tensor,
-    add_inputs: bool = True,
-):
-    selected_loras = lora_b_weights[lora_indices_tensor].to(
-        dtype=output_tensor.dtype)
-    if len(selected_loras.shape) == 4:
-        selected_loras = selected_loras.squeeze(dim=1)
-    inputs = inputs.to(dtype=output_tensor.dtype)
-    outputs = torch.einsum("bi, boi -> bo", inputs, selected_loras)
-
-    limit = output_tensor.shape[0]
-    if outputs.shape[0] == 1 and output_tensor.shape[0] != 1:
-        limit = 1
-
-    # LoRA adapter and model may add different amounts of padding to output
-    common_len = min(outputs.shape[1], output_tensor.shape[1])
-
-    if add_inputs:
-        output_tensor[:, :common_len] += outputs[:limit, :common_len]
-    else:
-        output_tensor[:, :common_len] = outputs[:limit, :common_len]
+@pytest.fixture(autouse=True)
+def reset_device(reset_default_device):
+    pass
 
 
-def torch_bgmv_shrink(
-    inputs: torch.Tensor,
-    lora_b_weights: torch.Tensor,
-    output_tensor: torch.Tensor,
-    lora_indices_tensor: torch.Tensor,
-    scaling: float = 1.0,
-):
-    selected_loras = lora_b_weights[lora_indices_tensor].to(
-        dtype=output_tensor.dtype)
-    if len(selected_loras.shape) == 4:
-        selected_loras = selected_loras.squeeze(dim=1)
-    inputs = inputs.to(dtype=output_tensor.dtype)
-    outputs = torch.einsum("bi, boi -> bo", inputs, selected_loras)
-
-    output_tensor[:, :outputs.shape[1]] = scaling * outputs[:]
-
-
-def torch_bgmv_expand_slice(
-    inputs: torch.Tensor,
-    lora_b_weights: torch.Tensor,
-    output_tensor: torch.Tensor,
-    lora_indices_tensor: torch.Tensor,
-    slice_offset: int,
-    slice_size: int,
-    add_inputs: bool = True,
-):
-    selected_loras = lora_b_weights[lora_indices_tensor].to(
-        dtype=output_tensor.dtype)
-    inputs = inputs.to(dtype=output_tensor.dtype)
-    if len(selected_loras.shape) == 4:
-        selected_loras = selected_loras.squeeze(dim=1)
-    outputs = torch.einsum("bi, boi -> bo", inputs, selected_loras)
-
-    if add_inputs:
-        output_tensor[:, slice_offset:slice_offset + slice_size] += outputs[:]
-    else:
-        output_tensor[:, slice_offset:slice_offset + slice_size] = outputs[:]
-
-
-def check_bgmv_shrink(
+# Utility shrink and expand operations used as reference implementations.
+def sgmv_shrink_for_nslices(
+    nslices: int,
+    inputs_tensor: torch.Tensor,
+    lora_weights_lst: list[torch.Tensor],
+    out_tensor: torch.Tensor,
+    b_seq_start_loc: torch.Tensor,
+    seq_len_tensor: torch.Tensor,
+    prompt_lora_mapping: torch.Tensor,
     batches: int,
-    num_loras: int,
-    rank: int,
-    hidden_size: int,
-    dtype: torch.dtype,
-    device: str,
+    max_seq_length: int,
+    num_tokens: int,
     scaling: float,
 ):
     """
-    Compare vllm.bgmv_shrink against a reference implementation.
+    Wrapper around torch_ops.sgmv_shrink that handles any nslices.
     """
-    seq_length = 1
-    data: PunicaTensors = generate_data(
-        batches,
-        hidden_size,
-        num_loras,
-        rank,
-        seq_length,
-        dtype,
-        "shrink",
-        device,
-    )
-
-    bgmv_shrink(
-        data.inputs_tensor,
-        data.lora_weights,
-        data.our_out_tensor,
-        data.token_lora_mapping,
-        scaling,
-    )
-
-    torch_bgmv_shrink(
-        data.inputs_tensor,
-        data.lora_weights,
-        data.ref_out_tensor,
-        data.token_lora_mapping,
-        scaling,
-    )
-
-    data.ref_out_tensor = data.ref_out_tensor.to(torch.float32)
-    assert_close(data.our_out_tensor, data.ref_out_tensor)
+    for index in range(nslices):
+        torch_ops.sgmv_shrink(
+            inputs_tensor,
+            lora_weights_lst[index],
+            out_tensor[index],
+            b_seq_start_loc,
+            seq_len_tensor,
+            prompt_lora_mapping,
+            batches,
+            max_seq_length,
+            num_tokens,
+            scaling,
+        )
 
 
-def check_bgmv_expand(
-    batches: int,
-    num_loras: int,
-    rank: int,
+def sgmv_expand_for_nslices(
+    nslices: int,
     hidden_size: int,
-    dtype: torch.dtype,
-    device: str,
+    inputs_tensor: torch.Tensor,
+    lora_weights_lst: list[torch.Tensor],
+    out_tensor: torch.Tensor,
+    b_seq_start_loc: torch.Tensor,
+    seq_len_tensor: torch.Tensor,
+    prompt_lora_mapping: torch.Tensor,
+    batches: int,
+    max_seq_length: int,
+    num_tokens: int,
     add_inputs: bool,
-):
+) -> None:
     """
-    Compare vllm.bgmv_expand against a reference implementation.
+    Wrapper around torch_ops.sgmv_expand that handles any nslices.
     """
-    seq_length = 1
-    data: PunicaTensors = generate_data(
-        batches,
-        hidden_size,
-        num_loras,
-        rank,
-        seq_length,
-        dtype,
-        "expand",
-        device,
-    )
+    if nslices == 1:
+        # Verify the torch's sgmv_expand op
+        torch_ops.sgmv_expand(
+            inputs_tensor[0],
+            lora_weights_lst[0],
+            out_tensor,
+            b_seq_start_loc,
+            seq_len_tensor,
+            prompt_lora_mapping,
+            batches,
+            max_seq_length,
+            num_tokens,
+            add_inputs=add_inputs,
+        )
+    else:
+        slice_offset = 0
+        for index in range(nslices):
+            lora_weights = lora_weights_lst[index]
+            torch_ops.sgmv_expand_slice(
+                inputs_tensor[index],
+                lora_weights,
+                out_tensor,
+                b_seq_start_loc,
+                seq_len_tensor,
+                prompt_lora_mapping,
+                batches,
+                max_seq_length,
+                num_tokens,
+                slice_offset,
+                hidden_size,
+                add_inputs=add_inputs,
+            )
+            slice_offset += hidden_size
 
-    bgmv_expand(
-        data.inputs_tensor,
-        data.lora_weights,
-        data.our_out_tensor,
-        data.token_lora_mapping,
-        add_inputs=add_inputs,
-    )
-    torch_bgmv_expand(
-        data.inputs_tensor,
-        data.lora_weights,
-        data.ref_out_tensor,
-        data.token_lora_mapping,
-        add_inputs=add_inputs,
-    )
-    assert_close(data.ref_out_tensor, data.our_out_tensor)
+
+_dict_lock = Lock()
 
 
-def check_bgmv_expand_slice(
+def check_lora_shrink_kernel(
     batches: int,
     num_loras: int,
     rank: int,
@@ -168,55 +136,247 @@ def check_bgmv_expand_slice(
     nslices: int,
     dtype: torch.dtype,
     device: str,
-    add_inputs: bool,
+    seq_length: int,
+    scaling: float,
 ):
     """
-    Compare vllm.bgmv_expand_slice against a reference implementation.
+    Compare outputs of torch_ops.sgmv_shrink and xpu_ops.lora_shrink
+    kernels.
     """
-    seq_length = 1
-    data: PunicaTensors = generate_data_for_expand_nslices(
+    data: PunicaTensors = generate_data_for_nslices(
         batches,
         hidden_size,
         num_loras,
         rank,
         seq_length,
-        dtype,
         nslices,
+        dtype,
+        "shrink",
+        device,
+    )
+    max_seq_length, token_nums = data.meta()
+
+    # Setup metadata information for SGMV and reference kernels
+    sgmv_meta_args = (
+        data.b_seq_start_loc,
+        data.seq_len_tensor,
+        data.prompt_lora_mapping,
+        batches,
+        max_seq_length,
+        token_nums,
+    )
+
+    ref_out_tensor = data.ref_out_tensor
+    out_tensor = data.our_out_tensor.clone()
+
+    # Preventing cache error pointer.
+    with _dict_lock:
+        for index in range(nslices):
+            xpu_ops.bgmv_shrink(
+                data.inputs_tensor,
+                data.lora_weights[index],
+                out_tensor[index],
+                data.token_lora_mapping,
+                scaling,
+            )
+    # Reference
+    sgmv_shrink_for_nslices(
+        nslices,
+        data.inputs_tensor,
+        data.lora_weights,
+        ref_out_tensor,
+        *sgmv_meta_args,
+        scaling,
+    )
+
+    assert_close(out_tensor, ref_out_tensor)
+
+
+def check_lora_expand_kernel(
+    batches: int,
+    num_loras: int,
+    rank: int,
+    hidden_size: int,
+    nslices: int,
+    dtype: torch.dtype,
+    device: str,
+    seq_length: int,
+    add_inputs: bool,
+):
+    """
+    Compare outputs of torch_ops.sgmv_expand and xpu_ops.lora_expand
+    kernels.
+    """
+    data: PunicaTensors = generate_data_for_nslices(
+        batches,
+        hidden_size,
+        num_loras,
+        rank,
+        seq_length,
+        nslices,
+        dtype,
+        "expand",
         device,
     )
 
-    slice_offset = 0
-    for index in range(nslices):
-        bgmv_expand_slice(
-            data.inputs_tensor,
-            data.lora_weights[index],
-            data.our_out_tensor,
-            data.token_lora_mapping,
-            slice_offset,
-            slice_size=hidden_size,
-            add_inputs=add_inputs,
-        )
-        torch_bgmv_expand_slice(
-            data.inputs_tensor,
-            data.lora_weights[index],
-            data.ref_out_tensor,
-            data.token_lora_mapping,
-            slice_offset,
-            slice_size=hidden_size,
-            add_inputs=add_inputs,
-        )
+    max_seq_length, token_nums = data.meta()
 
-        slice_offset += hidden_size
-    assert_close(data.ref_out_tensor, data.our_out_tensor)
+    # Setup metadata information for SGMV and reference kernels
+    sgmv_meta_args = (
+        data.b_seq_start_loc,
+        data.seq_len_tensor,
+        data.prompt_lora_mapping,
+        batches,
+        max_seq_length,
+        token_nums,
+    )
 
+    # Setup metadata information for the LoRA kernel.
+
+    # Setup output tensors
+    ref_out_tensor = data.ref_out_tensor
+    out_tensor = data.our_out_tensor.clone()
+
+    with _dict_lock:
+        # lora_expand kernel
+        slice_offset = 0
+        for index in range(nslices):
+            xpu_ops.bgmv_expand_slice(
+                data.inputs_tensor[index],
+                data.lora_weights[index],
+                out_tensor,
+                data.token_lora_mapping,
+                slice_offset,
+                slice_size=hidden_size,
+                add_inputs=add_inputs,
+            )
+            slice_offset += hidden_size
+
+    # Reference
+    sgmv_expand_for_nslices(
+        nslices,
+        hidden_size,
+        data.inputs_tensor,
+        data.lora_weights,
+        ref_out_tensor,
+        *sgmv_meta_args,
+        add_inputs=add_inputs,
+    )
+
+    assert_close(out_tensor, ref_out_tensor)
+
+
+# Tests
+# We test the punica kernels along 2 verticals mainly.
+# 1. Variations in hidden_dim size
+# 2. Variations in all other parameters like (batch_size, max_rank, num_loras
+#  etc.)
+
+# We have collected the hidden_sizes included in the LoRA models
+# currently supported by vLLM. It tests whether the corresponding Triton
+# kernel can run normally when tensor parallelism is set to
+# [1, 2, 4, 8, 16, 32, 64].
+HIDDEN_SIZES = [
+    128,
+    256,
+    512,
+    896,
+    1024,
+    1152,
+    1216,
+    1280,
+    1536,
+    1664,
+    2048,
+    2240,
+    2304,
+    2368,
+    2432,
+    2560,
+    2752,
+    3072,
+    3328,
+    3456,
+    3584,
+    3712,
+    4096,
+    4480,
+    4608,
+    4736,
+    4864,
+    5120,
+    5504,
+    5632,
+    5888,
+    6144,
+    6400,
+    6848,
+    6912,
+    7168,
+    7424,
+    8192,
+    8960,
+    9216,
+    9472,
+    10240,
+    11008,
+    11264,
+    13824,
+    14336,
+    14784,
+    14848,
+    15360,
+    18944,
+    22016,
+    22528,
+    24576,
+    27392,
+    27648,
+    29568,
+    29696,
+    32000,
+    32256,
+    32512,
+    32768,
+    33024,
+    36864,
+    43264,
+    49152,
+    49408,
+    60544,
+    60672,
+    64000,
+    64256,
+    102400,
+    102656,
+    128000,
+    128256,
+]
+# The size of TP
+divisibility = [1, 2, 8, 16, 64]
+
+all_hidden_size = []
+for div in divisibility:
+    for hidden_size in HIDDEN_SIZES:
+        all_hidden_size.append(hidden_size // div)
+
+HIDDEN_SIZES = list(set(all_hidden_size))
+
+# Test params that focuses on hidden_size variation.
+hs_test_params = {
+    "hidden_sizes": HIDDEN_SIZES,
+    "batches": [4],
+    "num_loras": [4],
+    "max_ranks": [32],
+}
 
 # General tests params that tests for variations in all dimensions
 # except hidden_size.
 test_params = {
     "hidden_sizes": [2049],
-    "batches": [4],
-    "num_loras": [4],
-    "max_ranks": [32],
+    "batches": [1, 4, 16, 32],
+    "num_loras": [1, 8, 32, 128],
+    "max_ranks": [1, 4, 8, 16, 32, 64, 128, 256],
 }
 
 DTYPES = [torch.float16, torch.bfloat16]
@@ -228,51 +388,12 @@ SEED = [0]
 @pytest.mark.parametrize("num_loras", test_params["num_loras"])
 @pytest.mark.parametrize("rank", test_params["max_ranks"])
 @pytest.mark.parametrize("hidden_size", test_params["hidden_sizes"])
+@pytest.mark.parametrize("nslices", [1, 2, 3])
 @pytest.mark.parametrize("dtype", DTYPES)
 @pytest.mark.parametrize("device", DEVICES)
 @pytest.mark.parametrize("seed", SEED)
 @pytest.mark.parametrize("op_type", ["shrink", "expand"])
-def test_bgmv(
-    batches: int,
-    num_loras: int,
-    rank: int,
-    hidden_size: int,
-    dtype: torch.dtype,
-    device: str,
-    seed: int,
-    op_type: str,
-):
-    if op_type == "shrink":
-        check_bgmv_shrink(
-            batches=batches,
-            num_loras=num_loras,
-            rank=rank,
-            hidden_size=hidden_size,
-            dtype=dtype,
-            device=device,
-            scaling=0.5,
-        )
-    else:
-        check_bgmv_expand(
-            batches=batches,
-            num_loras=num_loras,
-            rank=rank,
-            hidden_size=hidden_size,
-            dtype=dtype,
-            device=device,
-            add_inputs=True,
-        )
-
-
-@pytest.mark.parametrize("batches", test_params["batches"])
-@pytest.mark.parametrize("num_loras", test_params["num_loras"])
-@pytest.mark.parametrize("rank", test_params["max_ranks"])
-@pytest.mark.parametrize("hidden_size", test_params["hidden_sizes"])
-@pytest.mark.parametrize("nslices", [2, 3])
-@pytest.mark.parametrize("dtype", DTYPES)
-@pytest.mark.parametrize("device", DEVICES)
-@pytest.mark.parametrize("seed", SEED)
-def test_bgmv_expand_nslices(
+def test_kernels(
     batches: int,
     num_loras: int,
     rank: int,
@@ -281,14 +402,89 @@ def test_bgmv_expand_nslices(
     dtype: torch.dtype,
     device: str,
     seed: int,
+    op_type: str,
 ):
-    check_bgmv_expand_slice(
-        batches=batches,
-        num_loras=num_loras,
-        rank=rank,
-        hidden_size=hidden_size,
-        nslices=nslices,
-        dtype=dtype,
-        device=device,
-        add_inputs=True,
-    )
+    """
+    Tests LoRA kernels.
+    """
+    torch.set_default_device(device)
+    torch.xpu.set_device(device)
+    seed_everything(seed)
+
+    if op_type == "shrink":
+        check_lora_shrink_kernel(
+            batches=batches,
+            num_loras=num_loras,
+            rank=rank,
+            hidden_size=hidden_size,
+            nslices=nslices,
+            dtype=dtype,
+            device=device,
+            seq_length=128,
+            scaling=0.5,
+        )
+    else:
+        check_lora_expand_kernel(
+            batches=batches,
+            num_loras=num_loras,
+            rank=rank,
+            hidden_size=hidden_size,
+            nslices=nslices,
+            dtype=dtype,
+            device=device,
+            seq_length=128,
+            add_inputs=True,
+        )
+
+
+@pytest.mark.parametrize("batches", hs_test_params["batches"])
+@pytest.mark.parametrize("num_loras", hs_test_params["num_loras"])
+@pytest.mark.parametrize("rank", hs_test_params["max_ranks"])
+@pytest.mark.parametrize("hidden_size", hs_test_params["hidden_sizes"])
+@pytest.mark.parametrize("nslices", [1, 2, 3])
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("device", DEVICES)
+@pytest.mark.parametrize("seed", SEED)
+@pytest.mark.parametrize("op_type", ["shrink", "expand"])
+def test_kernels_hidden_size(
+    batches: int,
+    num_loras: int,
+    rank: int,
+    hidden_size: int,
+    nslices: int,
+    dtype: torch.dtype,
+    device: str,
+    seed: int,
+    op_type: str,
+):
+    """
+    Tests SGMV and LoRA kernels.
+    """
+    torch.set_default_device(device)
+    torch.xpu.set_device(device)
+    seed_everything(seed)
+
+    if op_type == "shrink":
+        check_lora_shrink_kernel(
+            batches=batches,
+            num_loras=num_loras,
+            rank=rank,
+            hidden_size=hidden_size,
+            nslices=nslices,
+            dtype=dtype,
+            device=device,
+            seq_length=128,
+            scaling=0.5,
+        )
+    else:
+        check_lora_expand_kernel(
+            batches=batches,
+            num_loras=num_loras,
+            rank=rank,
+            hidden_size=hidden_size,
+            nslices=nslices,
+            dtype=dtype,
+            device=device,
+            seq_length=128,
+            add_inputs=True,
+        )


### PR DESCRIPTION
# Essential Elements of an Effective PR Description Checklist

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.

PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS ABOVE HAVE BEEN CONSIDERED.

## Purpose

- Fix the OOM issue by adjusting the group allocation logic for the LoRA expand operation, allowing multiple Items per group.
- Fix the ACC issue by using slice instead of the default hidden size.

## Test Plan
pytest tests/test_lora_ops.py
## Test Result
tests/test_lora_ops.py::test_kernels_hidden_size[expand-0-xpu:0-dtype1-3-1000-32-4-4] PASSED
tests/test_lora_ops.py::test_kernels_hidden_size[expand-0-xpu:0-dtype1-3-7424-32-4-4] PASSED
tests/test_lora_ops.py::test_kernels_hidden_size[expand-0-xpu:0-dtype1-3-1004-32-4-4] PASSED
tests/test_lora_ops.py::test_kernels_hidden_size[expand-0-xpu:0-dtype1-3-2032-32-4-4] PASSED
tests/test_lora_ops.py::test_kernels_hidden_size[expand-0-xpu:0-dtype1-3-32256-32-4-4] PASSED
tests/test_lora_ops.py::test_kernels_hidden_size[expand-0-xpu:0-dtype1-3-500-32-4-4] PASSED
tests/test_lora_ops.py::test_kernels_hidden_size[expand-0-xpu:0-dtype1-3-504-32-4-4] PASSED
tests/test_lora_ops.py::test_kernels_hidden_size[expand-0-xpu:0-dtype1-3-508-32-4-4] PASSED

========================================= 4272 passed in 146.52s (0:02:26) =========================================
## (Optional) Documentation Update

**BEFORE SUBMITTING, PLEASE READ <https://docs.vllm.ai/en/latest/contributing>** (anything written below this line will be removed by GitHub Actions)
