### PR TITLE
Skip UVA tests for the mini pytest profiler.

### DIFF
--- a/tests/test_uva.py
+++ b/tests/test_uva.py
@@ -1,16 +1,22 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import os
+
 import pytest
 import torch
 
 import vllm_xpu_kernels._C  # noqa: F401
 
-CUDA_DEVICES = [
-    f"xpu:{i}" for i in range(1 if torch.cuda.device_count() == 1 else 2)
+XPU_DEVICES = [
+    f"xpu:{i}" for i in range(1 if torch.xpu.device_count() == 1 else 2)
 ]
 
+SKIP_TEST_FOR_MINI_SCOPE = os.getenv("XPU_KERNEL_PYTEST_PROFILER") == "MINI"
 
-@pytest.mark.parametrize("device", CUDA_DEVICES)
+
+@pytest.mark.parametrize("device", XPU_DEVICES)
+@pytest.mark.skipif(SKIP_TEST_FOR_MINI_SCOPE,
+                    reason="Skip UVA tests for the mini pytest profiler.")
 def test_cpu_write(device):
     torch.set_default_device(device)
     cpu_tensor = torch.zeros(10,
@@ -18,24 +24,26 @@ def test_cpu_write(device):
                              device="cpu",
                              pin_memory=True,
                              dtype=torch.int32)
-    cuda_view = torch.ops._C.get_xpu_view_from_cpu_tensor(cpu_tensor)
-    assert cuda_view.device.type == "xpu"
+    xpu_view = torch.ops._C.get_xpu_view_from_cpu_tensor(cpu_tensor)
+    assert xpu_view.device.type == "xpu"
 
-    assert cuda_view[0, 0] == 0
-    assert cuda_view[2, 3] == 0
-    assert cuda_view[4, 5] == 0
+    assert xpu_view[0, 0] == 0
+    assert xpu_view[2, 3] == 0
+    assert xpu_view[4, 5] == 0
 
     cpu_tensor[0, 0] = 1
     cpu_tensor[2, 3] = 2
     cpu_tensor[4, 5] = -1
 
-    cuda_view.mul_(2)
-    assert cuda_view[0, 0] == 2
-    assert cuda_view[2, 3] == 4
-    assert cuda_view[4, 5] == -2
+    xpu_view.mul_(2)
+    assert xpu_view[0, 0] == 2
+    assert xpu_view[2, 3] == 4
+    assert xpu_view[4, 5] == -2
 
 
-@pytest.mark.parametrize("device", CUDA_DEVICES)
+@pytest.mark.parametrize("device", XPU_DEVICES)
+@pytest.mark.skipif(SKIP_TEST_FOR_MINI_SCOPE,
+                    reason="Skip UVA tests for the mini pytest profiler.")
 def test_gpu_write(device):
     torch.set_default_device(device)
     cpu_tensor = torch.zeros(10,
@@ -43,17 +51,17 @@ def test_gpu_write(device):
                              device="cpu",
                              pin_memory=True,
                              dtype=torch.int32)
-    cuda_view = torch.ops._C.get_xpu_view_from_cpu_tensor(cpu_tensor)
-    assert cuda_view.device.type == "xpu"
+    xpu_view = torch.ops._C.get_xpu_view_from_cpu_tensor(cpu_tensor)
+    assert xpu_view.device.type == "xpu"
 
-    assert cuda_view[0, 0] == 0
-    assert cuda_view[2, 3] == 0
-    assert cuda_view[4, 5] == 0
+    assert xpu_view[0, 0] == 0
+    assert xpu_view[2, 3] == 0
+    assert xpu_view[4, 5] == 0
 
-    cuda_view[0, 0] = 1
-    cuda_view[2, 3] = 2
-    cuda_view[4, 5] = -1
-    cuda_view.mul_(2)
+    xpu_view[0, 0] = 1
+    xpu_view[2, 3] = 2
+    xpu_view[4, 5] = -1
+    xpu_view.mul_(2)
 
     assert cpu_tensor[0, 0] == 2
     assert cpu_tensor[2, 3] == 4


### PR DESCRIPTION
## Purpose
Skip UVA tests for the mini pytest profiler.

## Test Plan
export XPU_KERNEL_PYTEST_PROFILER=MINI

pytest tests/test_uva.py
## Test Result
collected 4 items                                                                                                                                 

tests/test_uva.py::test_cpu_write[xpu:0] SKIPPED (Skip UVA tests for the mini pytest profiler.)
tests/test_uva.py::test_cpu_write[xpu:1] SKIPPED (Skip UVA tests for the mini pytest profiler.)
tests/test_uva.py::test_gpu_write[xpu:0] SKIPPED (Skip UVA tests for the mini pytest profiler.)
tests/test_uva.py::test_gpu_write[xpu:1] SKIPPED (Skip UVA tests for the mini pytest profiler.)

=============================================================== 4 skipped in 1.02s ================================================================
## (Optional) Documentation Update

**BEFORE SUBMITTING, PLEASE READ <https://docs.vllm.ai/en/latest/contributing>** (anything written below this line will be removed by GitHub Actions)
