### PR TITLE
change grouped gemm kernel fp8 scales to float

### DIFF
--- a/csrc/xpu/grouped_gemm/xe_2/grouped_gemm_xe2_interface.hpp
+++ b/csrc/xpu/grouped_gemm/xe_2/grouped_gemm_xe2_interface.hpp
@@ -306,20 +306,21 @@ at::Tensor cutlass_grouped_gemm_xe2_impl(
     TORCH_CHECK(
         ptr_scales->size(0) == num_experts,
         "ptr_scales.size(0) of fp8 must match num_experts");
+    TORCH_CHECK(ptr_scales->dtype() == at::kFloat, "ptr_scales must be float");
 
-#define W8A16LauncherCallER(policy)                                            \
-  if (B_dtype == at::kFloat8_e4m3fn && A_dtype == at::kHalf) {                 \
-    using scalar_t = half_t;                                                   \
-    MoEGEMMLauncherCallER('R', 'R', policy, scalar_t, float_e4m3_t, scalar_t); \
-  } else if (B_dtype == at::kFloat8_e5m2 && A_dtype == at::kHalf) {            \
-    using scalar_t = half_t;                                                   \
-    MoEGEMMLauncherCallER('R', 'R', policy, scalar_t, float_e5m2_t, scalar_t); \
-  } else if (B_dtype == at::kFloat8_e4m3fn && A_dtype == at::kBFloat16) {      \
-    using scalar_t = bfloat16_t;                                               \
-    MoEGEMMLauncherCallER('R', 'R', policy, scalar_t, float_e4m3_t, scalar_t); \
-  } else if (B_dtype == at::kFloat8_e5m2 && A_dtype == at::kBFloat16) {        \
-    using scalar_t = bfloat16_t;                                               \
-    MoEGEMMLauncherCallER('R', 'R', policy, scalar_t, float_e5m2_t, scalar_t); \
+#define W8A16LauncherCallER(policy)                                         \
+  if (B_dtype == at::kFloat8_e4m3fn && A_dtype == at::kHalf) {              \
+    using scalar_t = half_t;                                                \
+    MoEGEMMLauncherCallER('R', 'R', policy, scalar_t, float_e4m3_t, float); \
+  } else if (B_dtype == at::kFloat8_e5m2 && A_dtype == at::kHalf) {         \
+    using scalar_t = half_t;                                                \
+    MoEGEMMLauncherCallER('R', 'R', policy, scalar_t, float_e5m2_t, float); \
+  } else if (B_dtype == at::kFloat8_e4m3fn && A_dtype == at::kBFloat16) {   \
+    using scalar_t = bfloat16_t;                                            \
+    MoEGEMMLauncherCallER('R', 'R', policy, scalar_t, float_e4m3_t, float); \
+  } else if (B_dtype == at::kFloat8_e5m2 && A_dtype == at::kBFloat16) {     \
+    using scalar_t = bfloat16_t;                                            \
+    MoEGEMMLauncherCallER('R', 'R', policy, scalar_t, float_e5m2_t, float); \
   }
 
     if (A_avg_M <= 32) {

--- a/tests/fused_moe/test_fused_moe.py
+++ b/tests/fused_moe/test_fused_moe.py
@@ -179,9 +179,9 @@ def test_fused_moe(m, n, k, e, topk, dtype, w_dtype, has_bias):
 
         # scale
         random_exponents = torch.randint(-3, 4, (num_experts, ), device=DEVICE)
-        w13_scales = torch.pow(2.0, random_exponents.float()).to(dtype)
+        w13_scales = torch.pow(2.0, random_exponents.float())
         random_exponents = torch.randint(-3, 4, (num_experts, ), device=DEVICE)
-        w2_scales = torch.pow(2.0, random_exponents.float()).to(dtype)
+        w2_scales = torch.pow(2.0, random_exponents.float())
 
         for i in range(num_experts):
             w13_fp8[i], _ = scaled_fp8_quant(w13[i],

--- a/tests/fused_moe/test_grouped_gemm.py
+++ b/tests/fused_moe/test_grouped_gemm.py
@@ -166,7 +166,7 @@ def test_xe_grouped_gemm_fp8(m, n, k, e, topk, dtype, fp8_dtype, has_bias):
     input_B = torch.randn((num_experts, k, n), dtype=dtype, device=DEVICE)
     # scale
     random_exponents = torch.randint(-3, 4, (num_experts, ), device=DEVICE)
-    scale_B = torch.pow(2.0, random_exponents.float()).to(dtype)
+    scale_B = torch.pow(2.0, random_exponents.float())
     if has_bias:
         bias = torch.randn((num_experts, n), dtype=dtype, device=DEVICE) * 100
     else:
@@ -182,7 +182,8 @@ def test_xe_grouped_gemm_fp8(m, n, k, e, topk, dtype, fp8_dtype, has_bias):
                                              fp8_dtype=fp8_dtype)
     input_B_dequatize = torch.empty_like(input_B, dtype=dtype)
     for i in range(num_experts):
-        input_B_dequatize[i] = input_B_fp8[i].to(dtype) * scale_B[i]
+        input_B_dequatize[i] = (input_B_fp8[i].to(torch.float32) *
+                                scale_B[i]).to(dtype)
 
     # output offset
     num_rows_per_expert = torch.zeros(num_experts,


### PR DESCRIPTION
Vllm default scales data type is float.
Wrong output:
<img width="638" height="415" alt="image" src="https://github.com/user-attachments/assets/1b2484fd-f68e-4cc6-afbd-a361259b5028" />
After fix:
<img width="575" height="155" alt="image" src="https://github.com/user-attachments/assets/2434d48f-6581-44fe-851d-27ef9124b343" />
fp8 model e2e result:
<img width="1384" height="301" alt="image" src="https://github.com/user-attachments/assets/c3bfe62a-e084-47e8-af98-7b04ce92f031" />

