### PR TITLE
[FusedMoE] input reorder kernel support low precision inputs with scales

### DIFF
--- a/csrc/moe/fused_moe_prologue.hpp
+++ b/csrc/moe/fused_moe_prologue.hpp
@@ -554,7 +554,10 @@ void threeStepBuildExpertMapsSortFirstToken(
       stream);
 }
 
-template <class InputActivationsType, class ExpandedActivationsType, class ActivationsScaleType>
+template <
+    class InputActivationsType,
+    class ExpandedActivationsType,
+    class ActivationsScaleType>
 class ExpandInputRowsKernel {
  public:
   ExpandInputRowsKernel(
@@ -615,20 +618,24 @@ class ExpandInputRowsKernel {
            elem_index += stride) {
         dest_row_ptr[elem_index] = source_row_ptr[elem_index];
       }
-      
+
       if constexpr (!std::is_same_v<ActivationsScaleType, NoScale>) {
-        auto const* source_row_ptr_scale = unpermuted_input_scales + source_row * int(hidden_size / block_k); 
-        auto* dest_row_ptr_scale = permuted_input_scales + permuted_row * int(hidden_size / block_k);
-        for(int elem_index = start_offset; elem_index < num_elems_in_col / block_k; elem_index += stride){
+        auto const* source_row_ptr_scale =
+            unpermuted_input_scales + source_row * int(hidden_size / block_k);
+        auto* dest_row_ptr_scale =
+            permuted_input_scales + permuted_row * int(hidden_size / block_k);
+        for (int elem_index = start_offset;
+             elem_index < num_elems_in_col / block_k;
+             elem_index += stride) {
           dest_row_ptr_scale[elem_index] = source_row_ptr_scale[elem_index];
         }
       }
-      
 
       if (permuted_token_scales && item.get_local_id(2) == 0) {
         int64_t const source_k_idx = source_row * k + source_k_rank;
         permuted_token_scales[permuted_row] =
-            unpermuted_token_scales ? unpermuted_token_scales[source_k_idx] : 1.0f;
+            unpermuted_token_scales ? unpermuted_token_scales[source_k_idx]
+                                    : 1.0f;
       }
     }
   }
@@ -651,7 +658,10 @@ class ExpandInputRowsKernel {
   InputActivationsType const* prequant_scales;
 };
 
-template <class InputActivationsType, class ExpandedActivationsType, class ActivationsScaleType>
+template <
+    class InputActivationsType,
+    class ExpandedActivationsType,
+    class ActivationsScaleType>
 void expandInputRowsKernelLauncher(
     InputActivationsType const* unpermuted_input,
     ExpandedActivationsType* permuted_input,
@@ -678,7 +688,10 @@ void expandInputRowsKernelLauncher(
   stream.submit([&](sycl::handler& cgh) {
     cgh.parallel_for(
         sycl::nd_range<3>(grid * block, block),
-        ExpandInputRowsKernel<InputActivationsType, ExpandedActivationsType, ActivationsScaleType >(
+        ExpandInputRowsKernel<
+            InputActivationsType,
+            ExpandedActivationsType,
+            ActivationsScaleType>(
             unpermuted_input,
             permuted_input,
             unpermuted_input_scales,

--- a/csrc/moe/torch_bindings.cpp
+++ b/csrc/moe/torch_bindings.cpp
@@ -73,9 +73,11 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, m) {
       "expert_first_token_offset, int num_experts) -> ()");
   m.impl("moe_gather", torch::kXPU, &moe_gather);
   m.def(
-      "fused_moe_prologue(Tensor input, Tensor? input_scales, Tensor token_selected_experts, "
+      "fused_moe_prologue(Tensor input, Tensor? input_scales, Tensor "
+      "token_selected_experts, "
       "Tensor "
-      "token_final_scales, Tensor workspace, int hidden_size, int inter_size, int block_k, "
+      "token_final_scales, Tensor workspace, int hidden_size, int inter_size, "
+      "int block_k, "
       "int ep_rank, int ep_size,"
       "int num_experts_on_rank) -> "
       "()");

--- a/mll_build.sh
+++ b/mll_build.sh
@@ -1,2 +1,0 @@
-clear
-VLLM_TARGET_DEVICE=xpu python3 setup.py develop

--- a/vllm_xpu_kernels/fused_moe_interface.py
+++ b/vllm_xpu_kernels/fused_moe_interface.py
@@ -128,15 +128,15 @@ def xpu_fused_moe(hidden_states,
     '''
     hidden_states: [num_rows, hidden_size]
     w13: [num_experts, 2*inter_size, hidden_size]
-    w13_scales: 
-        None for bf16/fp16 
-        or [num_experts] for fp8 
+    w13_scales:
+        None for bf16/fp16
+        or [num_experts] for fp8
         or [num_experts, 2*inter_size, hidden_size // group_size] for 4bits
     w13_bias: [num_experts, 2*inter_size] or None
     w2: [num_experts, hidden_size, inter_size]
     w2_scales:
-        None for bf16/fp16 
-        or [num_experts] for fp8 
+        None for bf16/fp16
+        or [num_experts] for fp8
         or [num_experts, hidden_size, inter_size // group_size] for 4bits
     w2_bias: [num_experts, hidden_size] or None
     topk_weights: [num_rows, topk]
@@ -227,11 +227,13 @@ def xpu_fused_moe(hidden_states,
         topk_ids = topk_ids.to(torch.int64)
     torch.ops._moe_C.fused_moe_prologue(
         input=hidden_states,
+        input_scales=None,
         token_selected_experts=topk_ids,
         token_final_scales=topk_weights,
         workspace=workspace,
         hidden_size=hidden_size,
         inter_size=inter_size,
+        block_k=1,
         ep_rank=ep_rank,
         ep_size=ep_size,
         num_experts_on_rank=num_experts_per_node)


### PR DESCRIPTION
supports inputs with type bf16/fp16, mxfp8/mxfp4 with e8m0 scales, fp8 with 1x128 block scales.
