### PR TITLE
[LayerNorm] remove condition

### DIFF
--- a/csrc/layernorm.cpp
+++ b/csrc/layernorm.cpp
@@ -205,10 +205,7 @@ void rms_norm(
     torch::Tensor& weight,
     double epsilon) {
   TORCH_CHECK(out.is_contiguous());
-  if (input.stride(-1) != 1) {
-    input = input.contiguous();
-  }
-  TORCH_CHECK(input.stride(-1) == 1);
+  input = input.contiguous();
   TORCH_CHECK(weight.is_contiguous());
   VLLM_DISPATCH_FLOATING_TYPES(
       input.scalar_type(), "call_rms_norm_kernel", [&] {


### PR DESCRIPTION
input is 3 dim in the latest vllm code, the before condition is not helful to make sure the input is contiguous.