### PR TITLE
refine bf16 group gemm dispatch policy

### DIFF
--- a/csrc/xpu/grouped_gemm/xe_2/gemm_xe2_policy.hpp
+++ b/csrc/xpu/grouped_gemm/xe_2/gemm_xe2_policy.hpp
@@ -8,8 +8,8 @@ using namespace cute;
 
 class xe_gemm_policy_base {
  public:
-  using WGTile = Shape<_256, _256, _32>;
-  using SGLayout = Layout<Shape<_8, _4, _1>, Stride<_4, _1, _0>>;
+  using WGTile = Shape<_256, _128, _32>;
+  using SGLayout = Layout<Shape<_8, _2, _1>, Stride<_2, _1, _0>>;
 
   // Copy can be turned for better performance
   using GmemTiledCopyA = void;  // same as make_block_2d_copy_A

--- a/csrc/xpu/grouped_gemm/xe_2/grouped_gemm_xe2_interface.hpp
+++ b/csrc/xpu/grouped_gemm/xe_2/grouped_gemm_xe2_interface.hpp
@@ -346,8 +346,14 @@ at::Tensor cutlass_grouped_gemm_xe2_impl(
     MoEGEMMLauncherCallER('R', 'R', policy, scalar_t, scalar_t, scalar_t); \
   }
 
-    if (A_avg_M <= 4) {
+    if (A_avg_M <= 8) {
+      using policy = w16a16_policy_m_8;
+      W16A16LauncherCallER(policy);
+    } else if (A_avg_M <= 16) {
       using policy = w16a16_policy_m_16;
+      W16A16LauncherCallER(policy);
+    } else if (A_avg_M <= 32) {
+      using policy = w16a16_policy_m_32;
       W16A16LauncherCallER(policy);
     } else {
       using policy = w16a16_policy;


### PR DESCRIPTION
# Essential Elements of an Effective PR Description Checklist

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.

PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS ABOVE HAVE BEEN CONSIDERED.

## Purpose

To refine the dispatch policy of bf16 group gemm. Especially for the cases M and N are small.


## Test Plan

Script:

```python
# SPDX-License-Identifier: Apache-2.0
import torch

import random
import numpy as np

from vllm_xpu_kernels.fused_moe_interface import cutlass_grouped_gemm_xe2

DEVICE = "xpu"


def seed_everything(seed) -> None:
    random.seed(seed)
    np.random.seed(seed)
    torch.manual_seed(seed)

def init_rows_for_experts(tokens, topk, num_rows_per_expert):
    if num_rows_per_expert.shape[0] == 1:
        num_rows_per_expert[0] = tokens * topk
        return
    n_experts = num_rows_per_expert.numel()
    rand = torch.rand(tokens, n_experts, device=num_rows_per_expert.device)
    topk_idx = torch.topk(rand, topk, dim=1).indices  # [tokens, topk]
    flat_idx = topk_idx.flatten()
    num_rows_per_expert += torch.bincount(flat_idx, minlength=n_experts)


def test_xe_grouped_gemm(m, n, k, e, topk, dtype, has_bias):
    seed_everything(7)
    num_experts = e
    total_m = m * topk
    # input
    input_A = torch.randn((total_m, k), dtype=dtype,
                          device=DEVICE).contiguous()
    ref_A = input_A
    # weight
    input_B = torch.randn((num_experts, k, n), dtype=dtype, device=DEVICE)
    if has_bias:
        bias = torch.randn((num_experts, n), dtype=dtype, device=DEVICE)
    else:
        bias = None

    # output offset
    num_rows_per_expert = torch.zeros(num_experts,
                                      device=DEVICE,
                                      dtype=torch.int32)
    init_rows_for_experts(m, topk, num_rows_per_expert)
    output = torch.empty((total_m, n), dtype=dtype, device=DEVICE)

    cutlass_grouped_gemm_xe2(input_A, input_B, None, bias, output,
                             num_rows_per_expert, n, k, num_experts, False,
                             False)

    # ref gg
    ref = []
    pre_token_sum = 0
    for i in range(num_experts):
        cur_token_num = num_rows_per_expert[i]
        if cur_token_num == 0:
            continue
        input = ref_A[pre_token_sum:pre_token_sum + cur_token_num, :].to(
            torch.float32)
        weight = input_B[i, :, :].to(torch.float32)
        expert_output_fp32 = input @ weight
        if has_bias:
            expert_output_fp32 += bias[i]
        ref.append(expert_output_fp32.to(dtype))
        pre_token_sum += cur_token_num
    ref = torch.cat(ref, dim=0)

    torch.testing.assert_close(output, ref, rtol=2e-2, atol=1e-2)
    
    iters = 100
    startEvent = torch.Event(enable_timing=True)
    endEvent = torch.Event(enable_timing=True)
    startEvent.record()
    for i in range(iters):
        cutlass_grouped_gemm_xe2(input_A, input_B, None, bias, output,
                                num_rows_per_expert, n, k, num_experts, False,
                                False)
    endEvent.record()
    torch.accelerator.synchronize()
    print(f"Average latency: {startEvent.elapsed_time(endEvent) * 1000 / iters:.2f} us")


if __name__ == "__main__":
    print("Testing grouped GEMM on Xe...")
    print("Testing Qwen3-30B-A3B-Instruct with MNK factors (80, 768 * 2 // 4, 2048), num_experts=128, topk=8")
    test_xe_grouped_gemm(80, 768 * 2 // 4, 2048, 128, 8, torch.bfloat16, False)
    print("Testing Qwen3-30B-A3B-Instruct with MNK factors (8192, 768 * 2 // 4, 2048), num_experts=128, topk=8")
    test_xe_grouped_gemm(8192, 768 * 2 // 4, 2048, 128, 8, torch.bfloat16, False)
    # print("Testing Llama-4-scout with MNK factors (30, 8192 * 2, 5120), num_experts=16, topk=1")
    # test_xe_grouped_gemm(30, 8192 * 2, 5120, 16, 1, torch.bfloat16, False)
    # print("Testing Llama-4-scout with MNK factors (8192, 8192 * 2, 5120), num_experts=16, topk=1")
    # test_xe_grouped_gemm(8192, 8192 * 2, 5120, 16, 1, torch.bfloat16, False)

```

## Test Result

the performance comparison on B60:

<!DOCTYPE html>
Cases | Token Distribution | Before (us) | After (us)
-- | -- | -- | --
Qwen3-30B-A3B-Instruct with MNK factors (80, 768 * 2 // 4, 2048), num_experts=128, topk=8 | Uniform | 1520.04 | 530.11
Qwen3-30B-A3B-Instruct with MNK factors (8192, 768 * 2 // 4, 2048), num_experts=128, topk=8 | Uniform | 2677.47 | 1543.67


## (Optional) Documentation Update

**BEFORE SUBMITTING, PLEASE READ <https://docs.vllm.ai/en/latest/contributing>** (anything written below this line will be removed by GitHub Actions)
