### PR TITLE
fix is_causal impact on decode kernel

### DIFF
--- a/csrc/flash_attn/flash_api.cpp
+++ b/csrc/flash_attn/flash_api.cpp
@@ -184,6 +184,11 @@ std::vector<at::Tensor> mha_varlen_fwd(
 
     at::Tensor seqlens_k = is_paged ? *seqused_k : cu_seqlens_k;
 
+    // For paged decode (single query per sequence), causal masking is a
+    // no-op: seqused_k already constrains KV to only the valid past tokens,
+    // so there are no "future" tokens to mask. Passing is_causal=true
+    // triggers a seq_len formula that adds +q_sg_tile extra KV positions,
+    // causing invalid cache entries to pollute the attention output.
     cutlass_paged_decode_interface(
         queue,
         q,
@@ -204,7 +209,7 @@ std::vector<at::Tensor> mha_varlen_fwd(
         window_size_right,
         is_varlen,
         is_paged,
-        is_causal,
+        false,  // is_causal: always false for decode; see comment above
         is_local,
         is_sink,
         num_kv_splits);

--- a/tests/flash_attn/test_flash_attn_varlen_func.py
+++ b/tests/flash_attn/test_flash_attn_varlen_func.py
@@ -60,8 +60,7 @@ def ref_paged_attn(query: torch.Tensor,
     for i in range(num_seqs):
         query_len = query_lens[i]
         kv_len = kv_lens[i]
-        q = query[start_idx:start_idx + query_len]
-        q *= scale
+        q = query[start_idx:start_idx + query_len] * scale
 
         if is_paged:
             num_kv_blocks = (kv_len + block_size - 1) // block_size


### PR DESCRIPTION
For paged decode (single query per sequence), causal masking is a no-op: seqused_k already constrains KV to only the valid past tokens, so there are no "future" tokens to mask. Passing is_causal=true triggers a seq_len formula that adds +q_sg_tile extra KV positions, causing invalid cache entries to pollute the attention output.