### PR TITLE
[Kernel] use different options for diff kernels

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,35 +150,6 @@ if(VLLM_GPU_LANG STREQUAL "SYCL")
   set(SYCL_FIRST_HEADER "${CMAKE_CURRENT_SOURCE_DIR}/csrc/sycl_first.h")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -include ${SYCL_FIRST_HEADER}")
 
-  # ============= COMPILE OPTIONS ==================
-  set(SYCL_FLAGS "")
-  set(SYCL_KERNEL_OPTIONS)
-
-  list(APPEND SYCL_FLAGS "-fsycl")
-
-  set(SYCL_COMPILE_FLAGS ${SYCL_FLAGS})
-
-  set(SYCL_TARGETS_OPTION -fsycl-targets=spir64_gen)
-  set(SYCL_KERNEL_OPTIONS ${SYCL_KERNEL_OPTIONS} ${SYCL_TARGETS_OPTION})
-  set(SYCL_COMPILE_FLAGS ${SYCL_COMPILE_FLAGS} ${SYCL_KERNEL_OPTIONS})
-
-  set(SYCL_COMPILE_FLAGS ${SYCL_COMPILE_FLAGS} "-O3" "-DNDEBUG")
-  # Final build option be like: icpx -fsycl -fsycl-target=spir64_gen
-  # ${SYCL_KERNEL_OPTIONS} -fsycl-host-compiler=gcc
-  # -fsycl-host-compiler-options='${CMAKE_HOST_FLAGS}' kernel.cpp -o kernel.o
-  set(VLLM_GPU_COMPILE_FLAGS ${SYCL_COMPILE_FLAGS})
-
-  # ============= LINK OPTIONS ==================
-  set(SYCL_LINK_FLAGS "")
-  list(APPEND SYCL_LINK_FLAGS "-fsycl")
-  set(SYCL_DEVICE_LINK_FLAGS ${SYCL_LINK_FLAGS})
-  set(SYCL_DEVICE_LINK_FLAGS ${SYCL_DEVICE_LINK_FLAGS}
-                             -fsycl-max-parallel-link-jobs=16)
-  set(SYCL_DEVICE_LINK_FLAGS
-      ${SYCL_DEVICE_LINK_FLAGS}
-      "-Xspirv-translator;-spirv-ext=+SPV_INTEL_split_barrier,+SPV_INTEL_2d_block_io,+SPV_INTEL_subgroup_matrix_multiply_accumulate"
-  )
-
   # AOT devices can be overridden via environment variables:
   # VLLM_XPU_AOT_DEVICES and VLLM_XPU_XE2_AOT_DEVICES Example: export
   # VLLM_XPU_AOT_DEVICES="pvc,bmg-g21-a0" export
@@ -195,14 +166,44 @@ if(VLLM_GPU_LANG STREQUAL "SYCL")
     set(XE2_AOT_DEVICES $ENV{VLLM_XPU_XE2_AOT_DEVICES})
   endif()
 
+  # ============= COMPILE OPTIONS ==================
+  set(SYCL_FLAGS "")
+  set(SYCL_KERNEL_OPTIONS)
+
+  list(APPEND SYCL_FLAGS "-fsycl")
+
+  set(SYCL_COMPILE_FLAGS ${SYCL_FLAGS})
+  set(SYCL_COMPILE_FLAGS ${SYCL_COMPILE_FLAGS} "-O3" "-DNDEBUG")
+  if(AOT_DEVICES)
+    set(SYCL_COMPILE_FLAGS ${SYCL_COMPILE_FLAGS} -fsycl-targets=spir64_gen)
+  endif()
+  # Final build option be like: icpx -fsycl -fsycl-target=spir64_gen
+  # ${SYCL_KERNEL_OPTIONS} -fsycl-host-compiler=gcc
+  # -fsycl-host-compiler-options='${CMAKE_HOST_FLAGS}' kernel.cpp -o kernel.o
+  set(VLLM_GPU_COMPILE_FLAGS ${SYCL_COMPILE_FLAGS})
+
+  # ============= LINK OPTIONS ==================
+  set(SYCL_LINK_FLAGS "")
+  list(APPEND SYCL_LINK_FLAGS "-fsycl")
+  set(SYCL_DEVICE_LINK_FLAGS ${SYCL_LINK_FLAGS})
+  set(SYCL_DEVICE_LINK_FLAGS ${SYCL_DEVICE_LINK_FLAGS}
+                             -fsycl-max-parallel-link-jobs=16)
+  set(SYCL_DEVICE_LINK_FLAGS
+      ${SYCL_DEVICE_LINK_FLAGS}
+      "-Xspirv-translator;-spirv-ext=+SPV_INTEL_split_barrier,+SPV_INTEL_2d_block_io,+SPV_INTEL_subgroup_matrix_multiply_accumulate"
+  )
+  if(AOT_DEVICES)
+    list(APPEND SYCL_DEVICE_LINK_FLAGS -fsycl-targets=spir64_gen
+         -Xsycl-target-backend=spir64_gen)
+  endif()
+
   # Final link option be like: icpx -fsycl -fsycl-target=spir64_gen
   # ${SYCL_DEVICE_LINK_FLAGS} -Xsycl-target-backend=spir64_gen
   # '${SYCL_OFFLINE_COMPILER_FLAGS}' kernel.o -o device-code.o
   set(FINAL_LINK_OPTIONS "")
   list(APPEND FINAL_LINK_OPTIONS ${SYCL_DEVICE_LINK_FLAGS})
   if(AOT_DEVICES)
-    list(APPEND FINAL_LINK_OPTIONS -fsycl-targets=spir64_gen
-         -Xsycl-target-backend=spir64_gen "-device ${AOT_DEVICES}")
+    list(APPEND FINAL_LINK_OPTIONS "-device ${AOT_DEVICES}")
   endif()
 
   set(VLLM_GPU_LINK_FLAGS ${FINAL_LINK_OPTIONS})

--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -601,8 +601,6 @@ function(add_xe2_kernel_library LIBRARY_NAME)
     list(
       APPEND
       XE2_GPU_LINK_FLAGS
-      -fsycl-targets=spir64_gen
-      -Xsycl-target-backend=spir64_gen
       "-device ${XE2_AOT_DEVICES} -internal_options -cl-intel-256-GRF-per-thread"
     )
   endif()
@@ -669,8 +667,7 @@ function(add_xe_default_kernel_library LIBRARY_NAME)
   set(XE_DEFAULT_GPU_LINK_FLAGS ${SYCL_DEVICE_LINK_FLAGS})
   if(AOT_DEVICES)
     list(
-      APPEND XE_DEFAULT_GPU_LINK_FLAGS -fsycl-targets=spir64_gen
-      -Xsycl-target-backend=spir64_gen
+      APPEND XE_DEFAULT_GPU_LINK_FLAGS
       "-device ${AOT_DEVICES} -internal_options -cl-intel-256-GRF-per-thread")
   endif()
   target_link_options(${LIBRARY_NAME} PRIVATE ${XE_DEFAULT_GPU_LINK_FLAGS})


### PR DESCRIPTION
1. remove AOT option `-internal_options -cl-intel-256-GRF-per-thread` for sycl kernel.
    kernel  like  fused_rms_norm, rotary_embedding and activation gain perf above 40%
2. refine AOT option, currently support
a. default, will build `pvc,bmg,bmg-g21-a0,bmg-g31-a0`
b. use env var set manually by: `VLLM_XPU_AOT_DEVICES="bmg" VLLM_XPU_XE2_AOT_DEVICES="bmg"`
c. not use aot: `VLLM_XPU_AOT_DEVICES="" VLLM_XPU_XE2_AOT_DEVICES=""`

- use different compile option for element-wise and attn kernels
<img width="877" height="113" alt="image" src="https://github.com/user-attachments/assets/27acca5a-d3ed-49a7-a3a1-1b2bd11e228c" />


