### PR TITLE
[cri-ut] Skip gdn attention for the mini pytest profiler 

### DIFF
--- a/tests/gdn_attn/test_gdn_attn.py
+++ b/tests/gdn_attn/test_gdn_attn.py
@@ -34,6 +34,8 @@ MINI_PYTEST_PARAMS = {
     },
 }
 
+SKIP_TEST_FOR_MINI_SCOPE = os.getenv("XPU_KERNEL_PYTEST_PROFILER") == "MINI"
+
 
 def ref_gdn_attention(
     core_attn_out,
@@ -253,6 +255,8 @@ def simple_random_distribute(N, batch_size):
 @pytest.mark.parametrize("mode", MODE)
 @pytest.mark.parametrize("reorder_input", REORDER_INPUT)
 @pytest.mark.parametrize("dtype", DTYPES, ids=format_tc)
+@pytest.mark.skipif(SKIP_TEST_FOR_MINI_SCOPE,
+                    reason="Skip gdn attention for the mini pytest profiler.")
 @torch.inference_mode()
 def test_gdn_attention(num_actual_tokens, batch_size, num_k_heads, head_k_dim,
                        num_v_heads, head_v_dim, width, tp_size, has_bias,


### PR DESCRIPTION
# Essential Elements of an Effective PR Description Checklist

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.

PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS ABOVE HAVE BEEN CONSIDERED.

## Purpose
Running either the ref or the kernel alone is very slow, even when MINI_PYTEST_PARAMS is set to a very small value. Now the only option is to skip it.
## Test Plan
XPU_KERNEL_PYTEST_PROFILER=MINI pytest -s -v tests/gdn_attn/test_gdn_attn.py

## Test Result

## (Optional) Documentation Update

**BEFORE SUBMITTING, PLEASE READ <https://docs.vllm.ai/en/latest/contributing>** (anything written below this line will be removed by GitHub Actions)
