### PR TITLE
Support f32 ssm_state in GDN kernel for Qwen3.5

### DIFF
--- a/csrc/xpu/gdn_attn/gated_delta_rule.hpp
+++ b/csrc/xpu/gdn_attn/gated_delta_rule.hpp
@@ -5,7 +5,7 @@
 
 namespace gdn {
 static constexpr int sub_group_size = 32;
-template <typename T, int k_bucket_size>
+template <typename T, typename StateT, int k_bucket_size>
 struct gated_delta_rule_kernel {
  public:
   static constexpr int group_size = 256;
@@ -23,7 +23,7 @@ struct gated_delta_rule_kernel {
       const T* a,
       const T* A_log,
       const T* dt_bias,
-      T* ssm_state,
+      StateT* ssm_state,
       const int ssm_state_stride_0,
       const int* query_start_loc,
       const int* cache_indices,
@@ -102,7 +102,7 @@ struct gated_delta_rule_kernel {
     float k_local[k_bucket_size];
     float v_local[v_dim_per_sg];
 
-    T* ssm_state_ptr =
+    StateT* ssm_state_ptr =
         ssm_state +
         static_cast<int64_t>(cache_indices[batch_id]) * ssm_state_stride_0;
 
@@ -112,10 +112,11 @@ struct gated_delta_rule_kernel {
       for (int j = 0; j < v_dim_per_sg; ++j) {
 #pragma unroll
         for (int i = 0; i < k_bucket_size; ++i) {
-          state_local[j * k_bucket_size + i] = ssm_state_ptr
-              [num_v_heads_id * head_k_dim * head_v_dim +
-               (k_bucket_size * sg_local_id + i) +
-               (head_v_dim_id + j) * head_k_dim];
+          state_local[j * k_bucket_size + i] =
+              static_cast<float>(ssm_state_ptr
+                                     [num_v_heads_id * head_k_dim * head_v_dim +
+                                      (k_bucket_size * sg_local_id + i) +
+                                      (head_v_dim_id + j) * head_k_dim]);
         }
       }
     } else {
@@ -237,7 +238,7 @@ struct gated_delta_rule_kernel {
             [num_v_heads_id * head_k_dim * head_v_dim +
              (k_bucket_size * sg_local_id + i) +
              (head_v_dim_id + j) * head_k_dim] =
-                state_local[j * k_bucket_size + i];
+                static_cast<StateT>(state_local[j * k_bucket_size + i]);
       }
     }
   }
@@ -251,7 +252,7 @@ struct gated_delta_rule_kernel {
   const T* a;
   const T* A_log;
   const T* dt_bias;
-  T* ssm_state;
+  StateT* ssm_state;
   const int ssm_state_stride_0;
   const int* query_start_loc;
   const int* cache_indices;
@@ -264,7 +265,7 @@ struct gated_delta_rule_kernel {
   const int head_v_dim;
 };
 
-template <typename T, int k_bucket_size>
+template <typename T, typename StateT, int k_bucket_size>
 void kernel_launcher(
     sycl::queue& queue,
     T* core_attn_out,
@@ -275,7 +276,7 @@ void kernel_launcher(
     const T* a,
     const T* A_log,
     const T* dt_bias,
-    T* ssm_state,
+    StateT* ssm_state,
     const int ssm_state_stride_0,
     const int* query_start_loc,
     const int* cache_indices,
@@ -286,7 +287,7 @@ void kernel_launcher(
     const int head_k_dim,
     const int num_v_heads,
     const int head_v_dim) {
-  using KERNEL = gated_delta_rule_kernel<T, k_bucket_size>;
+  using KERNEL = gated_delta_rule_kernel<T, StateT, k_bucket_size>;
   auto range = KERNEL::get_nd_range(batch_size, num_v_heads, head_v_dim);
   assert(head_v_dim % KERNEL::v_dim_per_group == 0);
   queue.submit([&](sycl::handler& cgh) {
@@ -351,8 +352,8 @@ void gated_delta_rule(
   TORCH_CHECK(head_k_dim % sub_group_size == 0);
   const int k_bucket_size = head_k_dim / sub_group_size;
 
-#define KERNEL_LAUNCHER(scalar_t, k_bucket_size)                   \
-  kernel_launcher<scalar_t, k_bucket_size>(                        \
+#define KERNEL_LAUNCHER(scalar_t, state_scalar_t, k_bucket_size)   \
+  kernel_launcher<scalar_t, state_scalar_t, k_bucket_size>(        \
       queue,                                                       \
       reinterpret_cast<scalar_t*>(core_attn_out.data_ptr()),       \
       reinterpret_cast<scalar_t*>(q.data_ptr()),                   \
@@ -362,7 +363,7 @@ void gated_delta_rule(
       reinterpret_cast<scalar_t*>(a.data_ptr()),                   \
       reinterpret_cast<scalar_t*>(A_log.data_ptr()),               \
       reinterpret_cast<scalar_t*>(dt_bias.data_ptr()),             \
-      reinterpret_cast<scalar_t*>(ssm_state.data_ptr()),           \
+      reinterpret_cast<state_scalar_t*>(ssm_state.data_ptr()),     \
       ssm_state_stride_0,                                          \
       reinterpret_cast<int*>(query_start_loc.data_ptr()),          \
       reinterpret_cast<int*>(cache_indices.data_ptr()),            \
@@ -376,34 +377,54 @@ void gated_delta_rule(
       num_v_heads,                                                 \
       head_v_dim);
 
-#define BUCKET_DISPATCH(scalar_t, k_bucket_size) \
-  switch (k_bucket_size) {                       \
-    case 1:                                      \
-      KERNEL_LAUNCHER(scalar_t, 1)               \
-      break;                                     \
-    case 2:                                      \
-      KERNEL_LAUNCHER(scalar_t, 2)               \
-      break;                                     \
-    case 4:                                      \
-      KERNEL_LAUNCHER(scalar_t, 4)               \
-      break;                                     \
-    case 8:                                      \
-      KERNEL_LAUNCHER(scalar_t, 8)               \
-      break;                                     \
-    default:                                     \
-      TORCH_CHECK(false);                        \
+#define BUCKET_DISPATCH(scalar_t, state_scalar_t, k_bucket_size) \
+  switch (k_bucket_size) {                                       \
+    case 1:                                                      \
+      KERNEL_LAUNCHER(scalar_t, state_scalar_t, 1)               \
+      break;                                                     \
+    case 2:                                                      \
+      KERNEL_LAUNCHER(scalar_t, state_scalar_t, 2)               \
+      break;                                                     \
+    case 4:                                                      \
+      KERNEL_LAUNCHER(scalar_t, state_scalar_t, 4)               \
+      break;                                                     \
+    case 8:                                                      \
+      KERNEL_LAUNCHER(scalar_t, state_scalar_t, 8)               \
+      break;                                                     \
+    default:                                                     \
+      TORCH_CHECK(false);                                        \
   }
+
+#define DISPATCH_STATE_DTYPE(scalar_t)                                  \
+  do {                                                                  \
+    if (ssm_state.scalar_type() == at::kFloat) {                        \
+      using state_scalar_t = float;                                     \
+      BUCKET_DISPATCH(scalar_t, state_scalar_t, k_bucket_size)          \
+    } else if (ssm_state.scalar_type() == at::kBFloat16) {              \
+      using state_scalar_t = sycl::ext::oneapi::bfloat16;               \
+      BUCKET_DISPATCH(scalar_t, state_scalar_t, k_bucket_size)          \
+    } else if (ssm_state.scalar_type() == at::kHalf) {                  \
+      using state_scalar_t = sycl::half;                                \
+      BUCKET_DISPATCH(scalar_t, state_scalar_t, k_bucket_size)          \
+    } else {                                                            \
+      TORCH_CHECK(                                                      \
+          false,                                                        \
+          "ssm_state dtype must be float32/float16/bfloat16, but got ", \
+          ssm_state.scalar_type());                                     \
+    }                                                                   \
+  } while (0)
 
   if (core_attn_out.scalar_type() == at::kBFloat16) {
     using scalar_t = sycl::ext::oneapi::bfloat16;
-    BUCKET_DISPATCH(scalar_t, k_bucket_size)
+    DISPATCH_STATE_DTYPE(scalar_t);
   } else if (core_attn_out.scalar_type() == at::kHalf) {
     using scalar_t = sycl::half;
-    BUCKET_DISPATCH(scalar_t, k_bucket_size)
+    DISPATCH_STATE_DTYPE(scalar_t);
   } else {
     using scalar_t = float;
-    BUCKET_DISPATCH(scalar_t, k_bucket_size)
+    DISPATCH_STATE_DTYPE(scalar_t);
   }
+#undef DISPATCH_STATE_DTYPE
 #undef BUCKET_DISPATCH
 #undef KERNEL_LAUNCHER
 }

--- a/csrc/xpu/gdn_attn/xe_2/chunk_gated_delta_rule_kernels_xe2.hpp
+++ b/csrc/xpu/gdn_attn/xe_2/chunk_gated_delta_rule_kernels_xe2.hpp
@@ -915,19 +915,18 @@ CUTE_DEVICE void chunk_compute_wu_kernel(
   }
 }
 
-template <typename T, class TiledMMA>
+template <typename T, typename StateT, class TiledMMA>
 CUTE_DEVICE void chunk_fwd_o_kernel(
-    const sycl::local_accessor<float, 1>& slm_mem_const,
-    T* core_attn_out,
-    T* A,
-    T* w,
-    T* u,
-    const T* q,
-    const T* k,
+    const sycl::local_accessor<float, 1>& slm_mem_const,  // [3 * chunk_size]
+    T* core_attn_out,  // [total_seqlen, num_v_heads, head_v_dim]
+    T* A,  // [num_v_heads, total_virtual_seqlen, chunk_size], temp O2 buffer
+    T* w,  // [num_v_heads, total_virtual_seqlen, head_k_dim]
+    T* u,  // [num_v_heads, total_virtual_seqlen, head_v_dim]
+    const T* q,  // [total_virtual_seqlen, num_k_heads, head_k_dim]
+    const T* k,  // [total_virtual_seqlen, num_k_heads, head_k_dim]
     const float* a,
-    const T* A_log,
-    const T* dt_bias,
-    T* ssm_state,
+    StateT*
+        ssm_state,  // [cache_batch_size, num_v_heads, head_v_dim, head_k_dim]
     const int ssm_state_stride_0,
     const int* query_start_loc,
     const int* cache_indices,
@@ -945,8 +944,6 @@ CUTE_DEVICE void chunk_fwd_o_kernel(
   int local_range = item.get_local_range(2);
 
   auto sg = item.get_sub_group();
-  int sg_id = sg.get_group_linear_id();
-  int sg_range = sg.get_group_linear_range();
   int sg_local_id = sg.get_local_linear_id();
 
   float* slm_mem = static_cast<float*>(
@@ -955,9 +952,6 @@ CUTE_DEVICE void chunk_fwd_o_kernel(
   float* g_slm_ptr = slm_mem;
   float* g_multi_slm_ptr = slm_mem + chunk_size;
   float* g_exp_slm_ptr = g_multi_slm_ptr + chunk_size;
-
-  float A_log_exp_h = -sycl::exp(static_cast<float>(A_log[v_head_id]));
-  float dt_bias_h = static_cast<float>(dt_bias[v_head_id]);
 
   TiledMMA mma{};
   auto wg_tile = mma.tile_mnk();
@@ -981,9 +975,7 @@ CUTE_DEVICE void chunk_fwd_o_kernel(
   int n_sg_start = sg_local_n_coord * SG_N;
 
   const int kv_ratio = num_v_heads / num_k_heads;
-
-  constexpr int prefetch_dist = 3;
-  constexpr int barrier_scope = 2;
+  const int kv_head_id = v_head_id / kv_ratio;
 
   int pre_chunks = 0;
 
@@ -1000,12 +992,13 @@ CUTE_DEVICE void chunk_fwd_o_kernel(
       continue;
     }
 
-    T* ssm_state_ptr =
+    StateT* ssm_state_ptr =
         ssm_state +
         static_cast<int64_t>(cache_indices[batch_id]) * ssm_state_stride_0 +
         v_head_id * head_v_dim * head_k_dim;
 
     for (int chunk_id = 0; chunk_id < current_chunks; ++chunk_id) {
+      const bool has_prev_state = (chunk_id != 0) || initial_state;
       const int out_chunk_offset = seq_start_offset + chunk_id * chunk_size;
       const int chunk_offset = (pre_chunks + chunk_id) * chunk_size;
 
@@ -1050,7 +1043,7 @@ CUTE_DEVICE void chunk_fwd_o_kernel(
           make_gmem_ptr(U_ptr),
           make_layout(U_tensor_shape, make_stride(head_v_dim, _1{})));
 
-      T* S_ptr = ssm_state_ptr;
+      StateT* S_ptr = ssm_state_ptr;
       auto S_tensor_shape = make_shape(head_v_dim, head_k_dim);
       auto S_tensor = make_tensor(
           make_gmem_ptr(S_ptr),
@@ -1066,7 +1059,7 @@ CUTE_DEVICE void chunk_fwd_o_kernel(
 
       auto thr_mma = mma.get_slice(local_id);
 
-      if (chunk_id != 0 || initial_state) {
+      if (has_prev_state) {
         for (int dv = 0; dv < head_v_dim / chunk_size; ++dv) {
           Tensor gU_C =
               local_tile(cU, wg_tile, make_coord(0, dv, 0), Step<_1, _1, X>{});
@@ -1094,16 +1087,16 @@ CUTE_DEVICE void chunk_fwd_o_kernel(
         item.barrier(sycl::access::fence_space::local_space);
       }
 
-      auto q_ptr = q + chunk_offset * num_k_heads * head_k_dim +
-                   (v_head_id / kv_ratio) * head_k_dim;
+      auto q_ptr =
+          q + chunk_offset * num_k_heads * head_k_dim + kv_head_id * head_k_dim;
       auto Q_tensor_shape = make_shape(current_chunk_size, head_k_dim);
       auto Q_tensor = make_tensor(
           make_gmem_ptr(q_ptr),
           make_layout(
               Q_tensor_shape, make_stride(head_k_dim * num_k_heads, _1{})));
 
-      auto k_ptr = k + chunk_offset * num_k_heads * head_k_dim +
-                   (v_head_id / kv_ratio) * head_k_dim;
+      auto k_ptr =
+          k + chunk_offset * num_k_heads * head_k_dim + kv_head_id * head_k_dim;
       auto K_tensor_shape = make_shape(chunk_size, head_k_dim);
       auto K_tensor = make_tensor(
           make_gmem_ptr(k_ptr),
@@ -1164,7 +1157,7 @@ CUTE_DEVICE void chunk_fwd_o_kernel(
       auto copy_O_c = get_block_2d_copy_D<void>(mma, O_tensor);
       auto thr_copy_O_c = copy_O_c.get_slice(local_id);
 
-      if (chunk_id != 0 || initial_state) {
+      if (has_prev_state) {
         for (int dv = 0; dv < head_v_dim / chunk_size; ++dv) {
           Tensor gO_C =
               local_tile(cO, wg_tile, make_coord(0, dv, 0), Step<_1, _1, X>{});
@@ -1197,10 +1190,8 @@ CUTE_DEVICE void chunk_fwd_o_kernel(
               K_tensor_T_shape, make_stride(_1{}, head_k_dim * num_k_heads)));
 
       Tensor cS = make_identity_tensor(S_tensor.shape());
-
       auto copy_S_c = get_block_2d_copy_C<void>(mma, S_tensor);
       auto copy_S_d = get_block_2d_copy_D<void>(mma, S_tensor);
-
       auto thr_copy_S_c = copy_S_c.get_slice(local_id);
       auto thr_copy_S_d = copy_S_d.get_slice(local_id);
 
@@ -1212,7 +1203,9 @@ CUTE_DEVICE void chunk_fwd_o_kernel(
           auto tCgS_d = thr_copy_S_d.partition_D(gS_C);
           auto tSrS_d = thr_mma.partition_sg_fragment_C(gS_C);
 
-          if (chunk_id != 0 || initial_state) {
+          // Seed accumulator with exp(g_last) * S_prev when previous state
+          // exists; otherwise start from zeros.
+          if (has_prev_state) {
             auto tCgS_c = thr_copy_S_c.partition_S(gS_C);
             auto tCrS_c = thr_copy_S_c.partition_sg_fragment_D(gS_C);
             copy(copy_S_c, tCgS_c, tCrS_c);
@@ -1233,7 +1226,7 @@ CUTE_DEVICE void chunk_fwd_o_kernel(
         }
       }
 
-      if (chunk_id == 0 && !initial_state) {
+      if (!has_prev_state) {
         for (int dv = 0; dv < head_v_dim / chunk_size; ++dv) {
           Tensor gO_C =
               local_tile(cO, wg_tile, make_coord(0, dv, 0), Step<_1, _1, X>{});
@@ -1252,25 +1245,25 @@ CUTE_DEVICE void chunk_fwd_o_kernel(
   }
 }
 
-template <typename T>
+template <typename T, typename StateTag>
 class ChunkPrepareKernel;
 
-template <typename T>
+template <typename T, typename StateTag>
 class ChunkComputeAKernel;
 
-template <typename T>
+template <typename T, typename StateTag>
 class ChunkInverseOptKernel;
 
-template <typename T>
+template <typename T, typename StateTag>
 class ChunkInverseKernel;
 
-template <typename T>
+template <typename T, typename StateTag>
 class ChunkComputeWUKernel;
 
-template <typename T>
+template <typename T, typename StateT>
 class ChunkFwdOKernel;
 
-template <typename T>
+template <typename T, typename StateT>
 void kernel_launcher(
     sycl::queue& queue,
     T* core_attn_out,
@@ -1284,7 +1277,7 @@ void kernel_launcher(
     const float* a,
     const T* A_log,
     const T* dt_bias,
-    T* ssm_state,
+    StateT* ssm_state,
     const int ssm_state_stride_0,
     const int* query_start_loc,
     const int* cache_indices,
@@ -1315,7 +1308,7 @@ void kernel_launcher(
   int slm_size_prepare = num_v_heads * 2 + chunk_size;
 
   auto event_prepare = queue.submit([&](sycl::handler& cgh) {
-    cgh.parallel_for<ChunkPrepareKernel<T>>(
+    cgh.parallel_for<ChunkPrepareKernel<T, StateT>>(
         sycl::nd_range<3>{global_prepare * local_prepare, local_prepare},
         kernel_props,
         [=](auto) {
@@ -1353,7 +1346,7 @@ void kernel_launcher(
   auto event_compute_A = queue.submit([&](sycl::handler& cgh) {
     sycl::local_accessor<float, 1> local_mem(
         sycl::range<1>(slm_size_compute_A), cgh);
-    cgh.parallel_for<ChunkComputeAKernel<T>>(
+    cgh.parallel_for<ChunkComputeAKernel<T, StateT>>(
         sycl::nd_range<3>{global_compute_A * local_compute_A, local_compute_A},
         kernel_props,
         [=](auto) {
@@ -1394,7 +1387,7 @@ void kernel_launcher(
         1);
 
     auto event_inverse = queue.submit([&](sycl::handler& cgh) {
-      cgh.parallel_for<ChunkInverseOptKernel<T>>(
+      cgh.parallel_for<ChunkInverseOptKernel<T, StateT>>(
           sycl::nd_range<3>{global_inverse * local_inverse, local_inverse},
           kernel_props,
           [=](auto) {
@@ -1423,7 +1416,7 @@ void kernel_launcher(
     auto event_inverse = queue.submit([&](sycl::handler& cgh) {
       sycl::local_accessor<float, 1> local_mem(
           sycl::range<1>(slm_size_inverse), cgh);
-      cgh.parallel_for<ChunkInverseKernel<T>>(
+      cgh.parallel_for<ChunkInverseKernel<T, StateT>>(
           sycl::nd_range<3>{global_inverse * local_inverse, local_inverse},
           kernel_props,
           [=](auto) {
@@ -1459,7 +1452,7 @@ void kernel_launcher(
   auto event_compute_wu = queue.submit([&](sycl::handler& cgh) {
     sycl::local_accessor<float, 1> local_mem(
         sycl::range<1>(slm_size_compute_wu), cgh);
-    cgh.parallel_for<ChunkComputeWUKernel<T>>(
+    cgh.parallel_for<ChunkComputeWUKernel<T, StateT>>(
         sycl::nd_range<3>{
             global_compute_wu * local_compute_wu, local_compute_wu},
         kernel_props,
@@ -1504,11 +1497,11 @@ void kernel_launcher(
   auto event_fwd_o = queue.submit([&](sycl::handler& cgh) {
     sycl::local_accessor<float, 1> local_mem(
         sycl::range<1>(slm_size_fwd_o), cgh);
-    cgh.parallel_for<ChunkFwdOKernel<T>>(
+    cgh.parallel_for<ChunkFwdOKernel<T, StateT>>(
         sycl::nd_range<3>{global_fwd_o * local_fwd_o, local_fwd_o},
         kernel_props,
         [=](auto) {
-          chunk_fwd_o_kernel<T, MMAFwdO>(
+          chunk_fwd_o_kernel<T, StateT, MMAFwdO>(
               local_mem,
               core_attn_out,
               A,
@@ -1517,8 +1510,6 @@ void kernel_launcher(
               q,
               k,
               a,
-              A_log,
-              dt_bias,
               ssm_state,
               ssm_state_stride_0,
               query_start_loc,
@@ -1586,8 +1577,8 @@ void chunk_gated_delta_rule_impl_xe2(
       {num_v_heads, total_seqlen + padding_size, head_v_dim},
       torch::dtype(dtype).device(device).requires_grad(false));
 
-#define KERNEL_LAUNCHER(scalar_t)                                  \
-  kernel_launcher<scalar_t>(                                       \
+#define KERNEL_LAUNCHER(scalar_t, state_scalar_t)                  \
+  kernel_launcher<scalar_t, state_scalar_t>(                       \
       queue,                                                       \
       reinterpret_cast<scalar_t*>(core_attn_out.data_ptr()),       \
       reinterpret_cast<scalar_t*>(q.data_ptr()),                   \
@@ -1600,7 +1591,7 @@ void chunk_gated_delta_rule_impl_xe2(
       reinterpret_cast<float*>(a.data_ptr()),                      \
       reinterpret_cast<scalar_t*>(A_log.data_ptr()),               \
       reinterpret_cast<scalar_t*>(dt_bias.data_ptr()),             \
-      reinterpret_cast<scalar_t*>(ssm_state.data_ptr()),           \
+      reinterpret_cast<state_scalar_t*>(ssm_state.data_ptr()),     \
       ssm_state_stride_0,                                          \
       reinterpret_cast<int*>(query_start_loc.data_ptr()),          \
       reinterpret_cast<int*>(cache_indices.data_ptr()),            \
@@ -1614,14 +1605,39 @@ void chunk_gated_delta_rule_impl_xe2(
       num_v_heads,                                                 \
       head_v_dim);
 
+#define DISPATCH_STATE_DTYPE(scalar_t)                                  \
+  do {                                                                  \
+    if (ssm_state.scalar_type() == at::kFloat) {                        \
+      using state_scalar_t = float;                                     \
+      KERNEL_LAUNCHER(scalar_t, state_scalar_t)                         \
+    } else if (ssm_state.scalar_type() == at::kBFloat16) {              \
+      using state_scalar_t = bfloat16_t;                                \
+      KERNEL_LAUNCHER(scalar_t, state_scalar_t)                         \
+    } else if (ssm_state.scalar_type() == at::kHalf) {                  \
+      using state_scalar_t = half_t;                                    \
+      KERNEL_LAUNCHER(scalar_t, state_scalar_t)                         \
+    } else {                                                            \
+      TORCH_CHECK(                                                      \
+          false,                                                        \
+          "ssm_state dtype must be float32/float16/bfloat16, but got ", \
+          ssm_state.scalar_type());                                     \
+    }                                                                   \
+  } while (0)
+
   if (core_attn_out.scalar_type() == at::kBFloat16) {
     using scalar_t = bfloat16_t;
-    KERNEL_LAUNCHER(scalar_t)
+    DISPATCH_STATE_DTYPE(scalar_t);
   } else if (core_attn_out.scalar_type() == at::kHalf) {
     using scalar_t = half_t;
-    KERNEL_LAUNCHER(scalar_t)
+    DISPATCH_STATE_DTYPE(scalar_t);
+  } else {
+    TORCH_CHECK(
+        false,
+        "core_attn_out dtype must be float16/bfloat16, but got ",
+        core_attn_out.scalar_type());
   }
 
+#undef DISPATCH_STATE_DTYPE
 #undef KERNEL_LAUNCHER
 }
 

--- a/tests/gdn_attn/test_gdn_attn.py
+++ b/tests/gdn_attn/test_gdn_attn.py
@@ -25,7 +25,8 @@ HAS_BIAS = [True, False]
 ACTIVATION = ["silu"]
 MODE = ["prefill", "decode", "mix_mode"]
 REORDER_INPUT = [True, False]
-DTYPES = [torch.float16]
+DTYPES = [torch.float16, torch.bfloat16]
+SSM_STATE_IS_FP32 = [False, True]
 
 # Override pytest parameters when enabling mini pytest
 MINI_PYTEST_PARAMS = {
@@ -228,7 +229,7 @@ def ref_gdn_attention(
                                        q_t.unsqueeze(1)).sum(dim=-1).to(dtype)
 
         ssm_state[non_spec_state_indices_tensor[batch]] = ssm_state_batch.to(
-            dtype)
+            ssm_state.dtype)
 
 
 def simple_random_distribute(N, batch_size):
@@ -253,10 +254,12 @@ def simple_random_distribute(N, batch_size):
 @pytest.mark.parametrize("mode", MODE)
 @pytest.mark.parametrize("reorder_input", REORDER_INPUT)
 @pytest.mark.parametrize("dtype", DTYPES, ids=format_tc)
+@pytest.mark.parametrize("ssm_state_is_fp32", SSM_STATE_IS_FP32)
 @torch.inference_mode()
 def test_gdn_attention(num_actual_tokens, batch_size, num_k_heads, head_k_dim,
                        num_v_heads, head_v_dim, width, tp_size, has_bias,
-                       activation, reorder_input, mode, dtype):
+                       activation, reorder_input, mode, dtype,
+                       ssm_state_is_fp32):
     # FIXME: remove skip
     if (os.getenv("SKIP_ACC_ERROR_KERNEL") is not None
             and os.getenv("SKIP_ACC_ERROR_KERNEL") == "1"):
@@ -265,6 +268,7 @@ def test_gdn_attention(num_actual_tokens, batch_size, num_k_heads, head_k_dim,
     device = "xpu"
     random.seed(42)
     torch.manual_seed(42)
+    ssm_state_dtype = torch.float32 if ssm_state_is_fp32 else dtype
 
     assert head_k_dim == head_v_dim
 
@@ -303,7 +307,7 @@ def test_gdn_attention(num_actual_tokens, batch_size, num_k_heads, head_k_dim,
     ref_conv_state = conv_state.clone()
     ssm_state = torch.randn(
         (cache_batch_size, num_v_heads // tp_size, head_v_dim, head_k_dim),
-        dtype=dtype,
+        dtype=ssm_state_dtype,
         device=device)
     ref_ssm_state = ssm_state.clone()
 


### PR DESCRIPTION
## Changes

- Enable f32 ssm_state dtype to support qwen3.5 native config
- Update tests to cover fp32 case