### PR TITLE
WA: route XE3/XE3P platforms to XE2 cutlass kernels

### DIFF
--- a/csrc/utils.h
+++ b/csrc/utils.h
@@ -44,7 +44,15 @@ static inline bool is_xe2_arch(at::DeviceIndex device_index = -1) {
   auto arch = get_device_architecture(device_index);
   return arch == syclex::architecture::intel_gpu_bmg_g21 ||
          arch == syclex::architecture::intel_gpu_bmg_g31 ||
+         arch == syclex::architecture::intel_gpu_lnl_m ||
          arch == syclex::architecture::intel_gpu_pvc;
+}
+
+static inline bool is_xe3_arch(at::DeviceIndex device_index = -1) {
+  auto arch = get_device_architecture(device_index);
+  return arch == syclex::architecture::intel_gpu_ptl_h ||
+         arch == syclex::architecture::intel_gpu_ptl_u ||
+         arch == syclex::architecture::intel_gpu_wcl;
 }
 
 static inline std::optional<std::string> getEnv(const char* name) {

--- a/csrc/xpu/attn/attn_interface.cpp
+++ b/csrc/xpu/attn/attn_interface.cpp
@@ -28,9 +28,9 @@ void cutlass_chunk_prefill_interface(
     bool is_causal,
     bool is_local,
     bool is_sink) {
-  if (vllm::xpu::is_xe2_arch()) {
+  if (vllm::xpu::is_xe2_arch() || vllm::xpu::is_xe3_arch()) {
 #ifdef VLLM_XPU_ENABLE_XE2
-    // Use XE2 cutlass kernel
+    // Use XE2 cutlass kernel (also used as WA for XE3/XE3P)
     cutlass_chunk_prefill_xe2(
         queue,
         query,
@@ -57,7 +57,7 @@ void cutlass_chunk_prefill_interface(
     TORCH_CHECK(false, "XE2 cutlass kernel is not enabled in this build.");
 #endif
   } else {
-    TORCH_CHECK(false, "Only XE2 cutlass kernel is supported currently.");
+    TORCH_CHECK(false, "Only XE2/XE3 cutlass kernel is supported currently.");
   }
 }
 
@@ -88,9 +88,9 @@ void cutlass_paged_decode_interface(
     bool is_local,
     bool is_sink,
     int num_kv_splits) {
-  if (vllm::xpu::is_xe2_arch()) {
+  if (vllm::xpu::is_xe2_arch() || vllm::xpu::is_xe3_arch()) {
 #ifdef VLLM_XPU_ENABLE_XE2
-    // Use XE2 cutlass kernel
+    // Use XE2 cutlass kernel (also used as WA for XE3/XE3P)
     cutlass_paged_decode_xe2(
         queue,
         query,
@@ -121,6 +121,6 @@ void cutlass_paged_decode_interface(
     TORCH_CHECK(false, "XE2 cutlass kernel is not enabled in this build.");
 #endif
   } else {
-    TORCH_CHECK(false, "Only XE2 cutlass kernel is supported currently.");
+    TORCH_CHECK(false, "Only XE2/XE3 cutlass kernel is supported currently.");
   }
 }


### PR DESCRIPTION
Add is_xe3_arch() helper to detect Panther Lake (ptl_h, ptl_u) and Wildcat Lake (wcl) GPUs. Route these XE3/XE3P architectures to the existing XE2 cutlass kernel paths for paged decode so they can run instead of hitting TORCH_CHECK.