### PR TITLE
Enalbe fused softmax/sigmoid + topk path for 1024 experts

### DIFF
--- a/csrc/moe/topk.cpp
+++ b/csrc/moe/topk.cpp
@@ -738,6 +738,10 @@ void topk_gating_kernel_launcher(
       LAUNCH_TOPK(
           512, WARPS_PER_TB, BYTES_PER_LDG_POWER_OF_2, ScoringFuncParam);
       break;
+    case 1024:
+      LAUNCH_TOPK(
+          1024, WARPS_PER_TB, BYTES_PER_LDG_POWER_OF_2, ScoringFuncParam);
+      break;
     case 192:
       LAUNCH_TOPK(
           192, WARPS_PER_TB, BYTES_PER_LDG_MULTIPLE_64, ScoringFuncParam);


### PR DESCRIPTION
Per measuring, the fused path delivers better performance when the number of experts is 1024 on B60.
1 token + 1024 experts: average uplift ~3% 
64 tokens + 1024 experts: average uplift ~6%
128 tokens + 1024 experts: average uplift ~7%
256 tokens + 1024 experts: average uplift ~45%
Current MoE models do not yet support as many as 1024 experts. However, when customers compare performance at 1024 experts, this optimization can provide better performance metrics.
p.s. benchmark/benchmark_topk.py already covers the performance of 1024 experts.

# Essential Elements of an Effective PR Description Checklist

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.

PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS ABOVE HAVE BEEN CONSIDERED.

## Purpose
Improve the performance of topk_softmax/topk_sigmoid
## Test Plan

## Test Result

## (Optional) Documentation Update

**BEFORE SUBMITTING, PLEASE READ <https://docs.vllm.ai/en/latest/contributing>** (anything written below this line will be removed by GitHub Actions)
