### PR TITLE
[Decode attn] tune num_kv_splits for page decode kernel

### DIFF
--- a/csrc/flash_attn/flash_api.cpp
+++ b/csrc/flash_attn/flash_api.cpp
@@ -22,17 +22,31 @@ inline int get_num_splits(
   int cur_parallel = batch_size * num_heads_kv;
   int kv_blocks = (max_seqlen_k + block_size - 1) / block_size;
 
-  // Below 128 KV blocks the per-split FMHA compute is too small relative
-  // to the ReduceSplitK overhead, regardless of block size.
-  if (kv_blocks < 128) return 1;
+  // Below a threshold number of KV blocks, the FMHA kernel time is flat
+  // regardless of split count — splitting only adds ReduceSplitK overhead.
+  // Smaller page sizes (≤64) benefit from splitting at fewer blocks because
+  // each WG has fewer subgroups (4 vs 8), so single-WG throughput is lower.
+  int min_kv_blocks = (block_size <= 64) ? 64 : 128;
+  if (kv_blocks < min_kv_blocks) return 1;
 
   int target_splits;
   if (cur_parallel < num_xe_cores) {
-    // Under-utilized: fill GPU cores.
-    // Scale by block_size since larger blocks mean more compute per WG.
-    int eff_parallel = cur_parallel * block_size / 64;
-    eff_parallel = std::max(1, eff_parallel);
-    target_splits = (num_xe_cores + eff_parallel - 1) / eff_parallel;
+    // Under-utilized: issue enough splits to fill GPU cores.
+    target_splits = num_xe_cores;
+    if (num_heads_kv >= 4) {
+      // Multi-head: larger blocks provide more compute per work-group,
+      // so fewer splits saturate the GPU.  Scale inversely with
+      // block_size (e.g. split=20 at p64, split=10 at p128 for 32/8).
+      target_splits = std::max(4, num_xe_cores * 64 / block_size);
+    }
+    if (num_heads_kv <= 2) {
+      // Few KV heads: each split finishes fast, so scale splits with
+      // block count.  Smaller page sizes need more aggressive splitting
+      // (~10 blocks/split for p64 vs ~17 for p128) because each WG has
+      // fewer subgroups and thus lower single-WG throughput.
+      int blocks_per_split = (block_size <= 64) ? 10 : 17;
+      target_splits = std::max(target_splits, kv_blocks / blocks_per_split);
+    }
   } else if (cur_parallel <= num_xe_cores * 2) {
     // Well-utilized zone (1x-2x oversubscription):
     // GPU is busy, splitting adds overhead without benefit.
@@ -47,11 +61,11 @@ inline int get_num_splits(
     target_splits = std::min(target_splits, par_cap);
   }
 
-  // Each split must process at least 32 KV blocks.
-  int max_splits_blocks = std::max(1, kv_blocks / 32);
-  // Hard cap: more splits give diminishing returns and increase
+  // Each split must process at least 3 KV blocks to amortize overhead.
+  int max_splits_blocks = std::max(1, kv_blocks / 3);
+  // Hard cap: beyond 40 splits, diminishing returns and increased
   // ReduceSplitK overhead and temporary buffer memory.
-  int num_splits = std::min({target_splits, max_splits_blocks, 8});
+  int num_splits = std::min({target_splits, max_splits_blocks, 40});
   return std::max(1, num_splits);
 }
 
@@ -208,11 +222,10 @@ std::vector<at::Tensor> mha_varlen_fwd(
             : at::empty(
                   {num_tokens, num_heads_q * num_kv_splits, v_head_dim},
                   q.options().device(q.device()));
-    at::Tensor max_logits = at::full(
+    at::Tensor max_logits = at::empty(
         {num_tokens, num_heads_q, num_kv_splits},
-        -std::numeric_limits<float>::infinity(),
         q.options().dtype(at::kFloat).device(q.device()));
-    at::Tensor exp_sums = at::zeros(
+    at::Tensor exp_sums = at::empty(
         {num_tokens, num_heads_q, num_kv_splits},
         q.options().dtype(at::kFloat).device(q.device()));
 

--- a/csrc/flash_attn/flash_api.cpp
+++ b/csrc/flash_attn/flash_api.cpp
@@ -25,36 +25,29 @@ inline int get_num_splits(
   // Minimum KV blocks to benefit from splitting, aligned with the kernel's
   // kMinBlocksForSplit.  Below this the kernel falls back to single-split
   // regardless, and splitting only adds ReduceSplitK overhead.
-  // p64: 32 blocks (2048 tokens).  p128: 128 blocks (16384 tokens).
   int min_kv_blocks = (block_size <= 64) ? 32 : 128;
   if (kv_blocks < min_kv_blocks) return 1;
 
-  // GPU already heavily saturated: splitting adds overhead without benefit.
-  if (cur_parallel >= num_xe_cores * 4) return 1;
+  // GPU well-utilized or saturated: splitting only adds ReduceSplitK
+  // overhead without improving FMHA throughput.
+  if (cur_parallel >= num_xe_cores) return 1;
 
+  // Under-utilized (cur_parallel < num_xe_cores): split to fill the GPU.
   int target_splits;
-
-  if (num_heads_kv <= 2) {
-    // Few KV heads — each WG iterates many blocks sequentially.
-    // Split so each WG handles ~blocks_per_split blocks, balancing
-    // FMHA parallelism against ReduceSplitK overhead.
-    int blocks_per_split = (block_size <= 64) ? 10 : 8;
-    int from_blocks = kv_blocks / blocks_per_split;
-    // Cap total work-groups at ~5× XE cores to limit oversubscription.
-    int from_wg_cap = std::max(1, num_xe_cores * 5 / cur_parallel);
-    target_splits = std::min(from_blocks, from_wg_cap);
+  if (num_heads_kv >= 4) {
+    // Many KV heads: each split adds kv_heads WGs.  Scale inversely
+    // with block_size — p64 gets ~20 splits, p128 gets ~10.
+    target_splits = std::max(4, num_xe_cores * 64 / block_size);
   } else {
-    // Many KV heads (≥4) — batch × kv_heads already provides base
-    // occupancy.  Target moderate total WG count (~3-4× XE cores) to
-    // keep scheduling overhead in check.
-    int target_wgs = num_xe_cores * ((block_size <= 64) ? 4 : 3);
-    target_splits = std::max(1, target_wgs / cur_parallel);
+    // Few KV heads: target at least num_xe_cores splits for parallelism;
+    // allow more for very long sequences (~10 blocks/split at p64).
+    int blocks_per_split = (block_size <= 64) ? 10 : 8;
+    target_splits = std::max(num_xe_cores, kv_blocks / blocks_per_split);
   }
 
   // Each split must process at least 3 KV blocks to amortize overhead.
   int max_splits_blocks = std::max(1, kv_blocks / 3);
-  // Hard cap: beyond 40 splits, diminishing returns and increased
-  // ReduceSplitK overhead and temporary buffer memory.
+  // Hard cap: beyond 40 splits, diminishing returns.
   int num_splits = std::min({target_splits, max_splits_blocks, 40});
   return std::max(1, num_splits);
 }

--- a/csrc/flash_attn/flash_api.cpp
+++ b/csrc/flash_attn/flash_api.cpp
@@ -22,43 +22,33 @@ inline int get_num_splits(
   int cur_parallel = batch_size * num_heads_kv;
   int kv_blocks = (max_seqlen_k + block_size - 1) / block_size;
 
-  // Below a threshold number of KV blocks, the FMHA kernel time is flat
-  // regardless of split count — splitting only adds ReduceSplitK overhead.
-  // Smaller page sizes (≤64) benefit from splitting at fewer blocks because
-  // each WG has fewer subgroups (4 vs 8), so single-WG throughput is lower.
-  int min_kv_blocks = (block_size <= 64) ? 64 : 128;
+  // Minimum KV blocks to benefit from splitting, aligned with the kernel's
+  // kMinBlocksForSplit.  Below this the kernel falls back to single-split
+  // regardless, and splitting only adds ReduceSplitK overhead.
+  // p64: 32 blocks (2048 tokens).  p128: 128 blocks (16384 tokens).
+  int min_kv_blocks = (block_size <= 64) ? 32 : 128;
   if (kv_blocks < min_kv_blocks) return 1;
 
+  // GPU already heavily saturated: splitting adds overhead without benefit.
+  if (cur_parallel >= num_xe_cores * 4) return 1;
+
   int target_splits;
-  if (cur_parallel < num_xe_cores) {
-    // Under-utilized: issue enough splits to fill GPU cores.
-    target_splits = num_xe_cores;
-    if (num_heads_kv >= 4) {
-      // Multi-head: larger blocks provide more compute per work-group,
-      // so fewer splits saturate the GPU.  Scale inversely with
-      // block_size (e.g. split=20 at p64, split=10 at p128 for 32/8).
-      target_splits = std::max(4, num_xe_cores * 64 / block_size);
-    }
-    if (num_heads_kv <= 2) {
-      // Few KV heads: each split finishes fast, so scale splits with
-      // block count.  Smaller page sizes need more aggressive splitting
-      // (~10 blocks/split for p64 vs ~17 for p128) because each WG has
-      // fewer subgroups and thus lower single-WG throughput.
-      int blocks_per_split = (block_size <= 64) ? 10 : 17;
-      target_splits = std::max(target_splits, kv_blocks / blocks_per_split);
-    }
-  } else if (cur_parallel <= num_xe_cores * 2) {
-    // Well-utilized zone (1x-2x oversubscription):
-    // GPU is busy, splitting adds overhead without benefit.
-    return 1;
+
+  if (num_heads_kv <= 2) {
+    // Few KV heads — each WG iterates many blocks sequentially.
+    // Split so each WG handles ~blocks_per_split blocks, balancing
+    // FMHA parallelism against ReduceSplitK overhead.
+    int blocks_per_split = (block_size <= 64) ? 10 : 8;
+    int from_blocks = kv_blocks / blocks_per_split;
+    // Cap total work-groups at ~5× XE cores to limit oversubscription.
+    int from_wg_cap = std::max(1, num_xe_cores * 5 / cur_parallel);
+    target_splits = std::min(from_blocks, from_wg_cap);
   } else {
-    // Heavily oversubscribed (>2x): shorter WGs help.
-    // But gate out when compute is already saturated.
-    int eff_parallel = cur_parallel * block_size / 64;
-    if (eff_parallel >= num_xe_cores * 8) return 1;
-    target_splits = std::max(1, kv_blocks / 64);
-    int par_cap = std::max(1, num_xe_cores * 8 / cur_parallel);
-    target_splits = std::min(target_splits, par_cap);
+    // Many KV heads (≥4) — batch × kv_heads already provides base
+    // occupancy.  Target moderate total WG count (~3-4× XE cores) to
+    // keep scheduling overhead in check.
+    int target_wgs = num_xe_cores * ((block_size <= 64) ? 4 : 3);
+    target_splits = std::max(1, target_wgs / cur_parallel);
   }
 
   // Each split must process at least 3 KV blocks to amortize overhead.

--- a/csrc/xpu/attn/xe_2/kernel/paged_decode_kernel.hpp
+++ b/csrc/xpu/attn/xe_2/kernel/paged_decode_kernel.hpp
@@ -323,7 +323,10 @@ class XeFMHAFwdSplitKVKernel {
       // Per-sequence split decision: short sequences are treated as
       // single-split even when num_kv_splits > 1, avoiding precision
       // loss from the split-reduce roundtrip.
-      constexpr int kMinBlocksForSplit = 128;
+      // Scale threshold with tile width: smaller tiles (p64) have fewer
+      // SGs per WG, so splitting becomes beneficial at fewer blocks.
+      constexpr int tile_n = get<1>(TileShapeQK{});
+      constexpr int kMinBlocksForSplit = (tile_n <= 64) ? 64 : 128;
       bool is_single_split =
           (num_kv_splits > 1) && (windowed_k_blocks < kMinBlocksForSplit);
 
@@ -620,6 +623,14 @@ class ReduceSplitK {
       int num_blocks_per_split =
           cute::ceil_div(windowed_k_blocks, num_kv_splits);
 
+      // Mirror the FMHA kernel's is_single_split decision so we only
+      // read split slots that were actually written.
+      constexpr int tile_n = get<1>(typename FMHAKernel_::TileShapeQK{});
+      constexpr int kMinBlocksForSplit = (tile_n <= 64) ? 64 : 128;
+      bool is_single_split =
+          (num_kv_splits > 1) && (windowed_k_blocks < kMinBlocksForSplit);
+      int effective_splits = is_single_split ? 1 : num_kv_splits;
+
       int offset_o = 0, offset_o_accum = 0;
       int offset_exp_sums = 0, offset_max_logits = 0;
 
@@ -693,7 +704,7 @@ class ReduceSplitK {
           cutlass::platform::numeric_limits<ElementLSE>::lowest()};
       ElementLSE global_exp_sums{0};
       // only first subgroup participates
-      if (thr_id < num_kv_splits &&
+      if (thr_id < effective_splits &&
           thr_id * num_blocks_per_split < windowed_k_blocks) {
         ElementLSE cur_max_logit = max_logits(seq_idx, thr_id, head_q, l_coord);
         global_max_logits = sycl::max(global_max_logits, cur_max_logit);
@@ -718,7 +729,7 @@ class ReduceSplitK {
            idx += SGPerWG::value * intel::sg_size) {
         ElementLSE acc = 0;
         global_exp_sums = 0;
-        for (int i = 0; i < num_kv_splits; ++i) {
+        for (int i = 0; i < effective_splits; ++i) {
           if (i * num_blocks_per_split >= windowed_k_blocks) {
             break;
           }

--- a/csrc/xpu/attn/xe_2/kernel/paged_decode_kernel.hpp
+++ b/csrc/xpu/attn/xe_2/kernel/paged_decode_kernel.hpp
@@ -326,7 +326,7 @@ class XeFMHAFwdSplitKVKernel {
       // Scale threshold with tile width: smaller tiles (p64) have fewer
       // SGs per WG, so splitting becomes beneficial at fewer blocks.
       constexpr int tile_n = get<1>(TileShapeQK{});
-      constexpr int kMinBlocksForSplit = (tile_n <= 64) ? 64 : 128;
+      constexpr int kMinBlocksForSplit = (tile_n <= 64) ? 32 : 128;
       bool is_single_split =
           (num_kv_splits > 1) && (windowed_k_blocks < kMinBlocksForSplit);
 
@@ -626,7 +626,7 @@ class ReduceSplitK {
       // Mirror the FMHA kernel's is_single_split decision so we only
       // read split slots that were actually written.
       constexpr int tile_n = get<1>(typename FMHAKernel_::TileShapeQK{});
-      constexpr int kMinBlocksForSplit = (tile_n <= 64) ? 64 : 128;
+      constexpr int kMinBlocksForSplit = (tile_n <= 64) ? 32 : 128;
       bool is_single_split =
           (num_kv_splits > 1) && (windowed_k_blocks < kMinBlocksForSplit);
       int effective_splits = is_single_split ? 1 : num_kv_splits;


### PR DESCRIPTION
Tune parameters for paged decode kernel perf for page size 64. 
Tests deepseek-ai/DeepSeek-R1-Distill-Llama-8B with page size 64 8192/2048 before and after optimizing. 
<img width="713" height="721" alt="image" src="https://github.com/user-attachments/assets/0112ef0e-6e69-4e6c-8208-6181d2463cf1" />
<img width="713" height="721" alt="image" src="https://github.com/user-attachments/assets/a725231e-bbc8-4d3e-a0d5-9b643284a61f" />
