### PR TITLE
Fix the fmha bug for interleaved_kv_cache

### DIFF
--- a/csrc/xpu/attn/xe_2/chunk_prefill.hpp
+++ b/csrc/xpu/attn/xe_2/chunk_prefill.hpp
@@ -52,6 +52,7 @@ struct chunk_prefill_args_t {
   bool is_causal = false;
   bool is_local = false;
   bool is_sink = false;
+  bool is_interleaved_kv_cache = false;
   // Q/O strides in CUTLASS order: (seq, head_size=1, heads, batch)
   int q_stride_seq = 0;
   int q_stride_heads = 0;
@@ -174,7 +175,8 @@ struct KernelLauncher {
          args.max_blocks_per_seq,
          args.total_seqlen_k,
          args.window_size_left,
-         args.window_size_right},
+         args.window_size_right,
+         args.is_interleaved_kv_cache},
         {},
         hw_info};
 

--- a/csrc/xpu/attn/xe_2/collective/chunk_prefill_mainloop.hpp
+++ b/csrc/xpu/attn/xe_2/collective/chunk_prefill_mainloop.hpp
@@ -200,6 +200,8 @@ struct FMHAFwdMainloop<
     int total_seqlen_kv;
     // Local Mask
     int local_left, local_right;
+    // Interleaved KV Cache
+    bool is_interleaved_kv_cache;
   };
 
   // Kernel-facing parameters
@@ -229,7 +231,8 @@ struct FMHAFwdMainloop<
         args.max_pages_per_seq,
         args.total_seqlen_kv,
         args.local_left,
-        args.local_right};
+        args.local_right,
+        args.is_interleaved_kv_cache};
   }
 
   CUTLASS_HOST_DEVICE static bool can_implement(Arguments const&) {
@@ -246,8 +249,9 @@ struct FMHAFwdMainloop<
       page_local_idx = params.max_pages_per_seq - 1;
     }
 
-    return params.ptr_page_table[b_offset + page_local_idx] * tiles_per_page +
-           K % tiles_per_page;
+    int block_idx = params.ptr_page_table[b_offset + page_local_idx];
+    if (params.is_interleaved_kv_cache) block_idx *= 2;
+    return block_idx * tiles_per_page + K % tiles_per_page;
   }
 
   template <typename QVCoord>
@@ -689,6 +693,8 @@ struct DecodeFwdMainloop<
     // Local Mask
     int window_size_left;
     int window_size_right;
+    // Interleaved KV Cache
+    bool is_interleaved_kv_cache;
   };
 
   // Kernel-facing parameters
@@ -718,7 +724,8 @@ struct DecodeFwdMainloop<
         args.max_pages_per_seq,
         args.total_seqlen_kv,
         args.window_size_left,
-        args.window_size_right};
+        args.window_size_right,
+        args.is_interleaved_kv_cache};
   }
 
   CUTLASS_HOST_DEVICE static bool can_implement(Arguments const&) {
@@ -835,9 +842,9 @@ struct DecodeFwdMainloop<
     int b_offset = idx_b * params.max_pages_per_seq;
     if constexpr (PagedKV) {
       int page_local_idx = tile_idx * get<1>(TileShapeQK{}) / params.page_size;
-      tile_idx =
-          params.ptr_page_table[b_offset + page_local_idx] * tiles_per_page +
-          tile_idx % tiles_per_page;
+      int block_idx = params.ptr_page_table[b_offset + page_local_idx];
+      if (params.is_interleaved_kv_cache) block_idx *= 2;
+      tile_idx = block_idx * tiles_per_page + tile_idx % tiles_per_page;
     }
 
     /* Initialization steps for first block: Q/K prefetch, O init */
@@ -977,10 +984,11 @@ struct DecodeFwdMainloop<
         int next_page_local_idx =
             next_tile_idx * get<1>(TileShapeQK{}) / params.page_size;
         if (next_page_local_idx < params.max_pages_per_seq) {
+          int next_block_idx =
+              params.ptr_page_table[b_offset + next_page_local_idx];
+          if (params.is_interleaved_kv_cache) next_block_idx *= 2;
           next_tile_idx =
-              params.ptr_page_table[b_offset + next_page_local_idx] *
-                  tiles_per_page +
-              next_tile_idx % tiles_per_page;
+              next_block_idx * tiles_per_page + next_tile_idx % tiles_per_page;
         } else {
           // set to last page
           next_tile_idx = params.max_pages_per_seq * tiles_per_page - 1;

--- a/csrc/xpu/attn/xe_2/fmha_utils.hpp
+++ b/csrc/xpu/attn/xe_2/fmha_utils.hpp
@@ -48,22 +48,17 @@ aten_to_Cutlass_qk_dtype(const at::Tensor& q, const at::Tensor& k) {
   return CutlassQKType(aten_to_dtype(q), aten_to_dtype(k));
 }
 
-inline bool is_interleaved_kv_cache(const at::Tensor& key_cache, const at::Tensor& value_cache) {
-  auto key_data_ptr = key_cache.data_ptr();
-  auto value_data_ptr = value_cache.data_ptr();
-
-  auto key_element_size_bytes = key_cache.element_size();
-  auto value_element_size_bytes = value_cache.element_size();
-  auto key_shape = key_cache.sizes();
-  auto value_shape = value_cache.sizes();
-  auto key_stride = key_cache.strides();
+inline bool is_interleaved_kv_cache(
+    const at::Tensor& key_cache, const at::Tensor& value_cache) {
   auto value_stride = value_cache.strides();
 
   if (key_cache.dim() == value_cache.dim() &&
-      key_shape == value_shape &&
-      key_stride == value_stride &&
-      key_element_size_bytes == value_element_size_bytes &&
-      std::abs(static_cast<char*>(key_data_ptr) - static_cast<char*>(value_data_ptr)) == key_stride[0] / 2 * key_element_size_bytes) {
+      key_cache.sizes() == value_cache.sizes() &&
+      key_cache.strides() == value_stride &&
+      key_cache.element_size() == value_cache.element_size() &&
+      key_cache.storage().data_ptr() == value_cache.storage().data_ptr() &&
+      key_cache.storage_offset() == 0 &&
+      value_cache.storage_offset() == value_stride[0] / 2) {
     return true;
   }
 

--- a/csrc/xpu/attn/xe_2/fmha_utils.hpp
+++ b/csrc/xpu/attn/xe_2/fmha_utils.hpp
@@ -2,6 +2,7 @@
 #include "torch/all.h"
 #include <cute/tensor.hpp>
 
+#define INTERLEAVED_KV_CACHE_SCALE_FACTOR 2
 #define HEAD_SIZE_LIMIT_0 64
 #define HEAD_SIZE_LIMIT_1 96
 #define HEAD_SIZE_LIMIT_2 128
@@ -46,6 +47,28 @@ inline CutlassDType aten_to_dtype(const at::Tensor& t) {
 inline CutlassQKType
 aten_to_Cutlass_qk_dtype(const at::Tensor& q, const at::Tensor& k) {
   return CutlassQKType(aten_to_dtype(q), aten_to_dtype(k));
+}
+
+inline bool is_interleaved_kv_cache(const at::Tensor& key_cache, const at::Tensor& value_cache) {
+  auto key_data_ptr = key_cache.data_ptr();
+  auto value_data_ptr = value_cache.data_ptr();
+
+  auto key_element_size_bytes = key_cache.element_size();
+  auto value_element_size_bytes = value_cache.element_size();
+  auto key_shape = key_cache.sizes();
+  auto value_shape = value_cache.sizes();
+  auto key_stride = key_cache.strides();
+  auto value_stride = value_cache.strides();
+
+  if (key_cache.dim() == value_cache.dim() &&
+      key_shape == value_shape &&
+      key_stride == value_stride &&
+      key_element_size_bytes == value_element_size_bytes &&
+      std::abs(static_cast<char*>(key_data_ptr) - static_cast<char*>(value_data_ptr)) == key_stride[0] / INTERLEAVED_KV_CACHE_SCALE_FACTOR * key_element_size_bytes) {
+    return true;
+  }
+
+  return false;
 }
 
 using namespace cute;

--- a/csrc/xpu/attn/xe_2/fmha_utils.hpp
+++ b/csrc/xpu/attn/xe_2/fmha_utils.hpp
@@ -2,7 +2,6 @@
 #include "torch/all.h"
 #include <cute/tensor.hpp>
 
-#define INTERLEAVED_KV_CACHE_SCALE_FACTOR 2
 #define HEAD_SIZE_LIMIT_0 64
 #define HEAD_SIZE_LIMIT_1 96
 #define HEAD_SIZE_LIMIT_2 128
@@ -64,7 +63,7 @@ inline bool is_interleaved_kv_cache(const at::Tensor& key_cache, const at::Tenso
       key_shape == value_shape &&
       key_stride == value_stride &&
       key_element_size_bytes == value_element_size_bytes &&
-      std::abs(static_cast<char*>(key_data_ptr) - static_cast<char*>(value_data_ptr)) == key_stride[0] / INTERLEAVED_KV_CACHE_SCALE_FACTOR * key_element_size_bytes) {
+      std::abs(static_cast<char*>(key_data_ptr) - static_cast<char*>(value_data_ptr)) == key_stride[0] / 2 * key_element_size_bytes) {
     return true;
   }
 

--- a/csrc/xpu/attn/xe_2/fmha_xe2.cpp
+++ b/csrc/xpu/attn/xe_2/fmha_xe2.cpp
@@ -95,7 +95,7 @@ void cutlass_chunk_prefill_impl(
     max_seqlen_k = is_paged ? max_seqlen_q : key_cache.size(2);
   }
 
-  at::Tensor interleaved_block_table = block_table;
+  bool is_interleaved_kv = false;
 
   if (is_paged) {
     num_blocks = key_cache.size(0);
@@ -104,10 +104,7 @@ void cutlass_chunk_prefill_impl(
     max_blocks_per_seq = block_table.size(1);
     total_seqlen_k = num_blocks * block_size;
 
-    if (is_interleaved_kv_cache(key_cache, value_cache)) {
-      interleaved_block_table = block_table * INTERLEAVED_KV_CACHE_SCALE_FACTOR;
-      total_seqlen_k *= INTERLEAVED_KV_CACHE_SCALE_FACTOR;
-    }
+    is_interleaved_kv = is_interleaved_kv_cache(key_cache, value_cache);
   }
 
   if (is_local) {
@@ -129,13 +126,13 @@ void cutlass_chunk_prefill_impl(
       key_cache.data_ptr(),
       value_cache.data_ptr(),
       out.data_ptr(),
-      is_paged ? interleaved_block_table.data_ptr() : nullptr,
+      is_paged ? block_table.data_ptr() : nullptr,
       cu_seqlens_q.data_ptr(),
       cu_seqlens_k.data_ptr(),
       max_seqlen_q,
       max_seqlen_k,
       total_seqlen_q,
-      total_seqlen_k,
+      is_interleaved_kv ? total_seqlen_k * 2 : total_seqlen_k,
       is_fp8_kv ? k_scale.value().data_ptr() : nullptr,
       is_fp8_kv ? v_scale.value().data_ptr() : nullptr,
       static_cast<float>(sm_scale),
@@ -152,7 +149,8 @@ void cutlass_chunk_prefill_impl(
       is_paged,   // paged
       is_causal,
       is_local,
-      is_sink};
+      is_sink,
+      is_interleaved_kv};
 
   // Extract Q, K, V, O strides from tensors
   if (is_varlen) {

--- a/csrc/xpu/attn/xe_2/fmha_xe2.cpp
+++ b/csrc/xpu/attn/xe_2/fmha_xe2.cpp
@@ -94,12 +94,20 @@ void cutlass_chunk_prefill_impl(
     max_seqlen_q = query.size(2);
     max_seqlen_k = is_paged ? max_seqlen_q : key_cache.size(2);
   }
+
+  at::Tensor interleaved_block_table = block_table;
+
   if (is_paged) {
     num_blocks = key_cache.size(0);
     block_size = key_cache.size(1);
     num_heads_kv = key_cache.size(2);
     max_blocks_per_seq = block_table.size(1);
     total_seqlen_k = num_blocks * block_size;
+
+    if (is_interleaved_kv_cache(key_cache, value_cache)) {
+      interleaved_block_table = block_table * INTERLEAVED_KV_CACHE_SCALE_FACTOR;
+      total_seqlen_k *= INTERLEAVED_KV_CACHE_SCALE_FACTOR;
+    }
   }
 
   if (is_local) {
@@ -121,7 +129,7 @@ void cutlass_chunk_prefill_impl(
       key_cache.data_ptr(),
       value_cache.data_ptr(),
       out.data_ptr(),
-      is_paged ? block_table.data_ptr() : nullptr,
+      is_paged ? interleaved_block_table.data_ptr() : nullptr,
       cu_seqlens_q.data_ptr(),
       cu_seqlens_k.data_ptr(),
       max_seqlen_q,

--- a/csrc/xpu/attn/xe_2/paged_decode.hpp
+++ b/csrc/xpu/attn/xe_2/paged_decode.hpp
@@ -82,6 +82,7 @@ struct paged_decode_args_t {
   bool is_causal = false;
   bool is_local = false;
   bool is_sink = false;
+  bool is_interleaved_kv_cache = false;
   int num_kv_splits = 1;
   // KV cache strides [num_blocks, block_size, num_heads_kv, head_size]
   int64_t k_stride_page = 0;
@@ -252,7 +253,8 @@ struct DecodeKernelLauncher {
          args.max_blocks_per_seq,
          args.total_seqlen_k,
          args.window_size_left,
-         args.window_size_right},
+         args.window_size_right,
+         args.is_interleaved_kv_cache},
         {},
         hw_info,
         args.num_kv_splits};

--- a/csrc/xpu/attn/xe_2/paged_decode_xe2.cpp
+++ b/csrc/xpu/attn/xe_2/paged_decode_xe2.cpp
@@ -140,8 +140,7 @@ void cutlass_paged_decode_impl(
     max_seqlen_k = key_cache.size(2);
   }
 
-  at::Tensor interleaved_block_table = block_table;
-  bool is_interleaved_kv = is_paged && is_interleaved_kv_cache(key_cache, value_cache);
+  bool is_interleaved_kv = false;
 
   if (is_paged) {
     // num_blocks is used to build total_seqlen_k for shape_K in kernels
@@ -152,10 +151,7 @@ void cutlass_paged_decode_impl(
     max_blocks_per_seq = block_table.size(1);
     total_seqlen_k = num_blocks * block_size;
 
-    if (is_interleaved_kv) {
-      interleaved_block_table = block_table * INTERLEAVED_KV_CACHE_SCALE_FACTOR;
-      total_seqlen_k *= INTERLEAVED_KV_CACHE_SCALE_FACTOR;
-    }
+    is_interleaved_kv = is_interleaved_kv_cache(key_cache, value_cache);
   }
 
   if (is_local) {
@@ -172,13 +168,13 @@ void cutlass_paged_decode_impl(
       temp_out.data_ptr(),
       exp_sums.data_ptr(),
       max_logits.data_ptr(),
-      interleaved_block_table.data_ptr(),
+      block_table.data_ptr(),
       cu_seqlens_q.data_ptr(),
       cu_seqlens_k.data_ptr(),
       max_seqlen_q,
       max_seqlen_k,
       total_seqlen_q,
-      total_seqlen_k,
+      is_interleaved_kv ? total_seqlen_k * 2 : total_seqlen_k,
       is_fp8_kv ? k_scale.value().data_ptr() : nullptr,
       is_fp8_kv ? v_scale.value().data_ptr() : nullptr,
       static_cast<float>(sm_scale),
@@ -197,11 +193,12 @@ void cutlass_paged_decode_impl(
       is_causal,
       is_local,
       is_sink,
+      is_interleaved_kv,
       num_kv_splits,
-      is_interleaved_kv ? key_cache.stride(0) / INTERLEAVED_KV_CACHE_SCALE_FACTOR : key_cache.stride(0),
+      is_interleaved_kv ? key_cache.stride(0) / 2 : key_cache.stride(0),
       key_cache.stride(1),
       key_cache.stride(2),
-      is_interleaved_kv ? value_cache.stride(0) / INTERLEAVED_KV_CACHE_SCALE_FACTOR : value_cache.stride(0),
+      is_interleaved_kv ? value_cache.stride(0) / 2 : value_cache.stride(0),
       value_cache.stride(1),
       value_cache.stride(2)};
 

--- a/csrc/xpu/attn/xe_2/paged_decode_xe2.cpp
+++ b/csrc/xpu/attn/xe_2/paged_decode_xe2.cpp
@@ -139,6 +139,10 @@ void cutlass_paged_decode_impl(
     max_seqlen_q = query.size(2);
     max_seqlen_k = key_cache.size(2);
   }
+
+  at::Tensor interleaved_block_table = block_table;
+  bool is_interleaved_kv = is_paged && is_interleaved_kv_cache(key_cache, value_cache);
+
   if (is_paged) {
     // num_blocks is used to build total_seqlen_k for shape_K in kernels
     // it is not just the meaning of used blocks for kv.
@@ -147,6 +151,11 @@ void cutlass_paged_decode_impl(
     num_heads_kv = key_cache.size(2);
     max_blocks_per_seq = block_table.size(1);
     total_seqlen_k = num_blocks * block_size;
+
+    if (is_interleaved_kv) {
+      interleaved_block_table = block_table * INTERLEAVED_KV_CACHE_SCALE_FACTOR;
+      total_seqlen_k *= INTERLEAVED_KV_CACHE_SCALE_FACTOR;
+    }
   }
 
   if (is_local) {
@@ -163,7 +172,7 @@ void cutlass_paged_decode_impl(
       temp_out.data_ptr(),
       exp_sums.data_ptr(),
       max_logits.data_ptr(),
-      block_table.data_ptr(),
+      interleaved_block_table.data_ptr(),
       cu_seqlens_q.data_ptr(),
       cu_seqlens_k.data_ptr(),
       max_seqlen_q,
@@ -189,11 +198,10 @@ void cutlass_paged_decode_impl(
       is_local,
       is_sink,
       num_kv_splits,
-      // KV cache strides
-      key_cache.stride(0),
+      is_interleaved_kv ? key_cache.stride(0) / INTERLEAVED_KV_CACHE_SCALE_FACTOR : key_cache.stride(0),
       key_cache.stride(1),
       key_cache.stride(2),
-      value_cache.stride(0),
+      is_interleaved_kv ? value_cache.stride(0) / INTERLEAVED_KV_CACHE_SCALE_FACTOR : value_cache.stride(0),
       value_cache.stride(1),
       value_cache.stride(2)};
 

--- a/tests/flash_attn/test_flash_attn_varlen_func.py
+++ b/tests/flash_attn/test_flash_attn_varlen_func.py
@@ -405,7 +405,7 @@ def test_varlen_with_interleaved_paged_kv(
     if block_size == 128 and num_blocks == 32768 and head_size >= 192:
         pytest.skip("skip test cases that may run out of Memory.")
 
-    torch.manual_seed(4242)
+    torch.manual_seed(42)
     num_seqs = len(seq_lens)
     query_lens = [x[0] for x in seq_lens]
     kv_lens = [x[1] for x in seq_lens]

--- a/tests/flash_attn/test_flash_attn_varlen_func.py
+++ b/tests/flash_attn/test_flash_attn_varlen_func.py
@@ -475,7 +475,7 @@ def test_varlen_with_interleaved_paged_kv(
                                 window_size_right=window_size[1])
 
     atol, rtol = 1e-2, 1e-2
-    if window_size[0] != -1 or window_size[1] != -1:
+    if window_size[0] != -1 or window_size[1] != -1 or dtype == torch.bfloat16:
         atol, rtol = 1.5e-2, 1.5e-2
     torch.testing.assert_close(output, ref_output, atol=atol, rtol=rtol), \
         f"{torch.max(torch.abs(output - ref_output))}"

--- a/tests/flash_attn/test_flash_attn_varlen_func.py
+++ b/tests/flash_attn/test_flash_attn_varlen_func.py
@@ -135,6 +135,13 @@ MINI_PYTEST_PARAMS = {
         "is_paged": [True],
         "stride_pad": [0, 32]
     },
+    "test_varlen_with_interleaved_paged_kv": {
+        "seq_lens": [[(1, 1328), (5, 18), (129, 463)]],
+        "head_size": [64, 128],
+        "num_heads": [(8, 2)],
+        "num_blocks": [64],
+        "window_size": [(-1, -1), (127, 127)],
+    },
     "test_decode_with_paged_kv": {
         "seq_lens": [[(1, 1025), (1, 523), (1, 37)]],
         "num_heads": [(8, 2)],
@@ -357,6 +364,118 @@ def test_varlen_with_paged_kv(
     if window_size[0] != -1 or window_size[1] != -1:
         atol, rtol = 1.5e-2, 1.5e-2
     if fp8_dtype is not None:
+        atol, rtol = 1.5e-2, 1.5e-2
+    torch.testing.assert_close(output, ref_output, atol=atol, rtol=rtol), \
+        f"{torch.max(torch.abs(output - ref_output))}"
+    torch.xpu.empty_cache()
+
+
+@pytest.mark.parametrize("seq_lens", [[(1, 1328), (5, 18), (129, 463)]])
+@pytest.mark.parametrize("num_heads", NUM_HEADS)
+@pytest.mark.parametrize("head_size", HEAD_SIZES)
+@pytest.mark.parametrize("block_size", BLOCK_SIZES)
+@pytest.mark.parametrize("window_size", SLIDING_WINDOWS)
+@pytest.mark.parametrize("dtype", DTYPES, ids=format_tc)
+@pytest.mark.parametrize("num_blocks", NUM_BLOCKS)
+@pytest.mark.parametrize("is_sink", SINK)
+@pytest.mark.parametrize("is_casual", CASUAL)
+@torch.inference_mode()
+def test_varlen_with_interleaved_paged_kv(
+    seq_lens: list[tuple[int, int]],
+    num_heads: tuple[int, int],
+    head_size: int,
+    window_size: tuple[int, int],
+    dtype: torch.dtype,
+    block_size: int,
+    num_blocks: int,
+    is_sink: bool,
+    is_casual: bool,
+) -> None:
+    torch.set_default_device("xpu")
+    torch.xpu.set_device("xpu:0")
+    # # FIXME: remove skip
+    if (is_casual and seq_lens[1][0]
+            == 5) and (os.getenv("SKIP_HANG_KERNEL") is not None
+                       and os.getenv("SKIP_HANG_KERNEL") == "1"):
+        pytest.skip("skip casual for seqlen0 to avoid runtime hang on CI.")
+    if (window_size[0] != -1 or window_size[1]
+            != -1) and (os.getenv("SKIP_HANG_KERNEL") is not None
+                        and os.getenv("SKIP_HANG_KERNEL") == "1"):
+        pytest.skip("skip local attn to avoid runtime hang on CI.")
+    if block_size == 128 and num_blocks == 32768 and head_size >= 192:
+        pytest.skip("skip test cases that may run out of Memory.")
+
+    torch.manual_seed(4242)
+    num_seqs = len(seq_lens)
+    query_lens = [x[0] for x in seq_lens]
+    kv_lens = [x[1] for x in seq_lens]
+    num_query_heads = num_heads[0]
+    num_kv_heads = num_heads[1]
+    assert num_query_heads % num_kv_heads == 0
+    max_query_len = max(query_lens)
+    max_kv_len = max(kv_lens)
+    scale = head_size**-0.5
+
+    query = torch.randn(sum(query_lens),
+                        num_query_heads,
+                        head_size,
+                        dtype=dtype)
+
+    combined_kv = torch.randn(num_blocks,
+                              2 * block_size,
+                              num_kv_heads,
+                              head_size,
+                              dtype=dtype)
+    key_cache = combined_kv[:, :block_size, :, :]
+    value_cache = combined_kv[:, block_size:, :, :]
+
+    assert key_cache.shape == value_cache.shape
+    assert key_cache.stride(0) == 2 * block_size * num_kv_heads * head_size
+
+    cu_query_lens = torch.tensor([0] + query_lens,
+                                 dtype=torch.int32).cumsum(dim=0,
+                                                           dtype=torch.int32)
+    seq_k = torch.tensor(kv_lens, dtype=torch.int32)
+
+    max_num_blocks_per_seq = (max_kv_len + block_size - 1) // block_size
+    block_tables = torch.randint(0,
+                                 num_blocks,
+                                 (num_seqs, max_num_blocks_per_seq),
+                                 dtype=torch.int32)
+    sink = None
+    if is_sink:
+        sink = torch.randn(num_query_heads, dtype=dtype)
+
+    output = flash_attn_varlen_func(query,
+                                    key_cache,
+                                    value_cache,
+                                    max_query_len,
+                                    cu_query_lens,
+                                    max_kv_len,
+                                    seqused_k=seq_k,
+                                    softmax_scale=scale,
+                                    causal=is_casual,
+                                    block_table=block_tables,
+                                    window_size=window_size,
+                                    s_aux=sink)
+
+    key_cache_ref = key_cache.contiguous()
+    value_cache_ref = value_cache.contiguous()
+    ref_output = ref_paged_attn(query=query,
+                                key_cache=key_cache_ref,
+                                value_cache=value_cache_ref,
+                                query_lens=query_lens,
+                                kv_lens=kv_lens,
+                                block_tables=block_tables,
+                                scale=scale,
+                                casual=is_casual,
+                                is_paged=True,
+                                sink=sink,
+                                window_size_left=window_size[0],
+                                window_size_right=window_size[1])
+
+    atol, rtol = 1e-2, 1e-2
+    if window_size[0] != -1 or window_size[1] != -1:
         atol, rtol = 1.5e-2, 1.5e-2
     torch.testing.assert_close(output, ref_output, atol=atol, rtol=rtol), \
         f"{torch.max(torch.abs(output - ref_output))}"


### PR DESCRIPTION

## Purpose
When enabled FA2 feature on Qwen3.5 model, the interleaved_kv_cache can not be support in flash_attn kernels.
## Test Plan
To do the accuracy checking based on gsm8k testing set. 
## Test Result
**Accuracy:**
Command:  bash .buildkite/lm-eval-harness/run-lm-eval-gsm-vllm-baseline.sh -m Qwen/Qwen3.5-9B,reasoning_parser=qwen3,moe_backend=auto,language_model_only=true -b 20 -l 250 -f 5 -t 1 
<img width="1593" height="376" alt="image" src="https://github.com/user-attachments/assets/87acb457-8d99-4fa8-938f-d1eae48ac0ef" />
**Performance:**
Qwen3.5 9B 4K input / 1 K output / 200 prompts / torch compile mode
With this patch to remove k/v contiguous
<img width="762" height="652" alt="image" src="https://github.com/user-attachments/assets/0e2d5bff-f4a4-470e-80cc-7121b33cccc2" />
Without this patch to use k/v contiguous
<img width="771" height="650" alt="image" src="https://github.com/user-attachments/assets/2800769f-d842-4db8-b419-3f064cf421a6" />


## How to fix this issue
Since K/V cache use one unique buffer and be arranged as interleaved layout, to avoid do the KV cache's memcopy (it will use torch.contignous() function)  can modify the stride[0] of KV cache that it mean the length will be multiply with 2. The final layout is K-V-K-V.... with the same  stride and the same KV cache buffer.
