### PR TITLE
Optimize Moe GEMM

### DIFF
--- a/csrc/xpu/grouped_gemm/xe_2/gemm_xe2.hpp
+++ b/csrc/xpu/grouped_gemm/xe_2/gemm_xe2.hpp
@@ -352,11 +352,6 @@ CUTE_DEVICE void xe_gemm_4bits(
   using scaleStoreType = conditional_t<is_same_v<TA, half_t>, half_t, float>;
   scaleStoreType scales[thr_N * channel_num];
 
-  ElementS frag_load[thr_N * channel_num / 2];
-  Tensor scales_load =
-      make_tensor(make_rmem_ptr(frag_load),
-                  make_layout(make_shape(Int<thr_N * channel_num / 2>{})));
-
   clear(tCrC);
 
   using ElementB = typename BTensor::element_type;
@@ -414,35 +409,6 @@ CUTE_DEVICE void xe_gemm_4bits(
           scales[n * channel_num + c] = scale;
         }
       }
-
-      // auto scales_tensor = make_tensor(
-      //     make_gmem_ptr(reinterpret_cast<const ElementS *>(
-      //       Scales + (n_tile_start + n_sg_start) * group_num + group_idx)),
-      //     make_layout(make_shape(Int<SG_N>{}, Int<1>{}), make_stride(group_num, Int<1>{})));
-      // auto copy_scales = make_block_2d_copy(
-      //     XE_LOAD_2D<sizeof_bits_v<ElementS>, SG_N, 1>{},
-      //     scales_tensor);
-      // auto thr_copy_scales = copy_scales.get_slice(sg_local_id);
-      // auto scales_per_thread = thr_copy_scales.partition_S(make_identity_tensor(make_shape(Int<SG_N>{}, Int<1>{})));
-      // copy(copy_scales, scales_per_thread(_, 0, 0), scales_load);
-      // // reorder(scales_e8m0_sg_tensor, scales_float_sg_tensor);
-      
-      // int i = 0;
-      // CUTLASS_PRAGMA_UNROLL
-      // for(int e = sg_local_id; e < SG_N; e += sg_local_range, ++i){
-      //   // scales_load[i] = Scales[(n_tile_start + n_sg_start + e) * group_num + group_idx];
-
-      //   scaleStoreType scale;
-      //   if constexpr (std::is_same_v<TB, int4_t>) {
-      //     scale = scales_load[i];
-      //   } else if constexpr (std::is_same_v<TB, float_e2m1_t>) {
-      //     uint32_t scale_u32 = scales_load[i] << 23;
-      //     scale = static_cast<scaleStoreType>(reinterpret_cast<float&>(scale_u32));
-      //   }
-
-      //   scales[i * 2] = scale;
-      //   scales[i * 2 + 1] = scale;
-      // }
 
       if((group_idx + prefetch_dist) * group_size < shape<1>(A)){
         auto next_scales_tensor = make_tensor(

--- a/csrc/xpu/grouped_gemm/xe_2/gemm_xe2.hpp
+++ b/csrc/xpu/grouped_gemm/xe_2/gemm_xe2.hpp
@@ -52,8 +52,10 @@ namespace MoE {
 
 using namespace cute;
 
-template <typename TB> CUTE_DEVICE TB apply_scale(TB &x, float &y) {
-  static_assert(is_any_of_v<TB, bfloat16_t, half_t>, "Only BF16 & FP16 are supported");
+template <typename TB>
+CUTE_DEVICE TB apply_scale(TB& x, float& y) {
+  static_assert(
+      is_any_of_v<TB, bfloat16_t, half_t>, "Only BF16 & FP16 are supported");
   uint16_t z = sycl::bit_cast<uint16_t>(x);
 #if defined(__SYCL_DEVICE_ONLY__) && defined(SYCL_INTEL_TARGET)
   if constexpr (is_same_v<TB, half_t>) {
@@ -264,8 +266,6 @@ CUTE_DEVICE void xe_gemm_4bits(
   auto wg_n = get<1>(blk_coord);
   int local_id = item.get_local_linear_id();
 
-  auto gemm_n = get<0>(B.shape());
-
   Tensor cA = make_identity_tensor(A.shape());
   Tensor cB = make_identity_tensor(B.shape());
   Tensor cC = make_identity_tensor(C.shape());
@@ -348,7 +348,7 @@ CUTE_DEVICE void xe_gemm_4bits(
   int n_sg_start = sg_local_n_coord * SG_N;
   int group_num = get<1>(A.shape()) / group_size;
   int x_idx = sg_local_id / channel_num;
-  
+
   using scaleStoreType = conditional_t<is_same_v<TA, half_t>, half_t, float>;
   scaleStoreType scales[thr_N * channel_num];
 
@@ -364,15 +364,20 @@ CUTE_DEVICE void xe_gemm_4bits(
     prefetch(prefetch_a, pAgA(_, _, _, k_tile_prefetch));
     prefetch(prefetch_b, pBgB(_, _, _, k_tile_prefetch));
 
-    if(k_tile_prefetch * group_size < shape<1>(A)){
+    if (k_tile_prefetch * group_size < shape<1>(A)) {
       auto next_scales_tensor = make_tensor(
-          make_gmem_ptr(reinterpret_cast<const ElementS *>(
-            Scales + (n_tile_start + n_sg_start) * group_num + k_tile_prefetch)),
-          make_layout(make_shape(Int<SG_N>{}, Int<1>{}), make_stride(group_num, Int<1>{})));
+          make_gmem_ptr(
+              reinterpret_cast<const ElementS*>(
+                  Scales + (n_tile_start + n_sg_start) * group_num +
+                  k_tile_prefetch)),
+          make_layout(
+              make_shape(Int<SG_N>{}, Int<1>{}),
+              make_stride(group_num, Int<1>{})));
       auto prefetch_scales = make_block_2d_prefetch<1>(
           make_shape(Int<SG_N>{}, Int<1>{}), next_scales_tensor);
       auto thr_prefetch_scales = prefetch_scales.get_slice(sg_local_id);
-      auto pSgS = thr_prefetch_scales.partition_S(make_identity_tensor(make_shape(Int<SG_N>{}, Int<1>{})));
+      auto pSgS = thr_prefetch_scales.partition_S(
+          make_identity_tensor(make_shape(Int<SG_N>{}, Int<1>{})));
       prefetch(prefetch_scales, pSgS(_, 0, 0));
     }
   }
@@ -403,22 +408,28 @@ CUTE_DEVICE void xe_gemm_4bits(
                     [(n_tile_start + n_sg_start + sg_local_n) * group_num +
                      group_idx]
                 << 23;
-            scale = static_cast<scaleStoreType>(reinterpret_cast<float&>(scale_u32));
+            scale = static_cast<scaleStoreType>(
+                reinterpret_cast<float&>(scale_u32));
           }
 
           scales[n * channel_num + c] = scale;
         }
       }
 
-      if((group_idx + prefetch_dist) * group_size < shape<1>(A)){
+      if ((group_idx + prefetch_dist) * group_size < shape<1>(A)) {
         auto next_scales_tensor = make_tensor(
-            make_gmem_ptr(reinterpret_cast<const ElementS *>(
-              Scales + (n_tile_start + n_sg_start) * group_num + group_idx + prefetch_dist)),
-            make_layout(make_shape(Int<SG_N>{}, Int<1>{}), make_stride(group_num, Int<1>{})));
+            make_gmem_ptr(
+                reinterpret_cast<const ElementS*>(
+                    Scales + (n_tile_start + n_sg_start) * group_num +
+                    group_idx + prefetch_dist)),
+            make_layout(
+                make_shape(Int<SG_N>{}, Int<1>{}),
+                make_stride(group_num, Int<1>{})));
         auto prefetch_scales = make_block_2d_prefetch<1>(
             make_shape(Int<SG_N>{}, Int<1>{}), next_scales_tensor);
         auto thr_prefetch_scales = prefetch_scales.get_slice(sg_local_id);
-        auto pSgS = thr_prefetch_scales.partition_S(make_identity_tensor(make_shape(Int<SG_N>{}, Int<1>{})));
+        auto pSgS = thr_prefetch_scales.partition_S(
+            make_identity_tensor(make_shape(Int<SG_N>{}, Int<1>{})));
         prefetch(prefetch_scales, pSgS(_, 0, 0));
       }
     }
@@ -440,7 +451,8 @@ CUTE_DEVICE void xe_gemm_4bits(
           if constexpr (std::is_same_v<TA, half_t>) {
             tCrB(cute::tuple(c, _), n, _)[i] *= scales[n * channel_num + c];
           } else {
-            tCrB(cute::tuple(c, _), n, _)[i] = apply_scale(tCrB(cute::tuple(c, _), n, _)[i], scales[n * channel_num + c]);
+            tCrB(cute::tuple(c, _), n, _)[i] = apply_scale(
+                tCrB(cute::tuple(c, _), n, _)[i], scales[n * channel_num + c]);
           }
         }
       }

--- a/csrc/xpu/grouped_gemm/xe_2/gemm_xe2.hpp
+++ b/csrc/xpu/grouped_gemm/xe_2/gemm_xe2.hpp
@@ -346,8 +346,9 @@ CUTE_DEVICE void xe_gemm_4bits(
   int n_sg_start = sg_local_n_coord * SG_N;
   int group_num = get<1>(A.shape()) / group_size;
   int x_idx = sg_local_id / channel_num;
-
-  float scales[thr_N * channel_num];
+  
+  using scaleStoreType = conditional_t<is_same_v<TA, half_t>, half_t, float>;
+  scaleStoreType scales[thr_N * channel_num];
 
   clear(tCrC);
 
@@ -377,7 +378,7 @@ CUTE_DEVICE void xe_gemm_4bits(
         for (int c = 0; c < channel_num; ++c) {
           int real_idx = x_idx + c * (sg_local_range / channel_num);
           int sg_local_n = n * sg_local_range + real_idx;
-          float scale;
+          scaleStoreType scale;
           if constexpr (std::is_same_v<TB, int4_t>) {
             scale = Scales
                 [(n_tile_start + n_sg_start + sg_local_n) * group_num +
@@ -388,7 +389,7 @@ CUTE_DEVICE void xe_gemm_4bits(
                     [(n_tile_start + n_sg_start + sg_local_n) * group_num +
                      group_idx]
                 << 23;
-            scale = reinterpret_cast<float&>(scale_u32);
+            scale = static_cast<scaleStoreType>(reinterpret_cast<float&>(scale_u32));
           }
 
           scales[n * channel_num + c] = scale;
@@ -408,10 +409,13 @@ CUTE_DEVICE void xe_gemm_4bits(
     for (int n = 0; n < thr_N; ++n) {
       CUTLASS_PRAGMA_UNROLL
       for (int c = 0; c < channel_num; ++c) {
-        float scale = scales[n * channel_num + c];
         CUTLASS_PRAGMA_UNROLL
         for (int i = 0; i < tCrB.size() / thr_N / channel_num; ++i) {
-          tCrB(cute::tuple(c, _), n, _)[i] = apply_scale(tCrB(cute::tuple(c, _), n, _)[i], scale);
+          if constexpr (std::is_same_v<TA, half_t>) {
+            tCrB(cute::tuple(c, _), n, _)[i] *= scales[n * channel_num + c];
+          } else {
+            tCrB(cute::tuple(c, _), n, _)[i] = apply_scale(tCrB(cute::tuple(c, _), n, _)[i], scales[n * channel_num + c]);
+          }
         }
       }
     }

--- a/csrc/xpu/grouped_gemm/xe_2/gemm_xe2.hpp
+++ b/csrc/xpu/grouped_gemm/xe_2/gemm_xe2.hpp
@@ -52,6 +52,31 @@ namespace MoE {
 
 using namespace cute;
 
+template <typename TB> CUTE_DEVICE TB apply_scale(TB &x, float &y) {
+  static_assert(is_any_of_v<TB, bfloat16_t, half_t>, "Only BF16 & FP16 are supported");
+  uint16_t z = sycl::bit_cast<uint16_t>(x);
+#if defined(__SYCL_DEVICE_ONLY__) && defined(SYCL_INTEL_TARGET)
+  if constexpr (is_same_v<TB, half_t>) {
+    asm("{\n"
+        ".decl Z_FP16 v_type=G type=HF num_elts=16 alias=<%0,0>\n"
+        ".decl Y_FP32 v_type=G type=F num_elts=16 alias=<%1,0>\n"
+        "mul (M1, 16) Z_FP16(0,0)<1> Z_FP16(0,0)<1;1,0> Y_FP32(0,0)<1;1,0>\n"
+        "}\n"
+        : "+rw"(z)
+        : "rw"(y));
+  } else {
+    asm("{\n"
+        ".decl Z_BF16 v_type=G type=BF num_elts=16 alias=<%0,0>\n"
+        ".decl Y_FP32 v_type=G type=F num_elts=16 alias=<%1,0>\n"
+        "mul (M1, 16) Z_BF16(0,0)<1> Z_BF16(0,0)<1;1,0> Y_FP32(0,0)<1;1,0>\n"
+        "}\n"
+        : "+rw"(z)
+        : "rw"(y));
+  }
+#endif
+  return sycl::bit_cast<TB>(z);
+}
+
 template <
     class GmemTiledCopyA,
     class GmemTiledCopyB,
@@ -322,7 +347,7 @@ CUTE_DEVICE void xe_gemm_4bits(
   int group_num = get<1>(A.shape()) / group_size;
   int x_idx = sg_local_id / channel_num;
 
-  TA scales[thr_N * channel_num];
+  float scales[thr_N * channel_num];
 
   clear(tCrC);
 
@@ -352,7 +377,7 @@ CUTE_DEVICE void xe_gemm_4bits(
         for (int c = 0; c < channel_num; ++c) {
           int real_idx = x_idx + c * (sg_local_range / channel_num);
           int sg_local_n = n * sg_local_range + real_idx;
-          TA scale;
+          float scale;
           if constexpr (std::is_same_v<TB, int4_t>) {
             scale = Scales
                 [(n_tile_start + n_sg_start + sg_local_n) * group_num +
@@ -363,7 +388,7 @@ CUTE_DEVICE void xe_gemm_4bits(
                     [(n_tile_start + n_sg_start + sg_local_n) * group_num +
                      group_idx]
                 << 23;
-            scale = static_cast<TA>(reinterpret_cast<float&>(scale_u32));
+            scale = reinterpret_cast<float&>(scale_u32);
           }
 
           scales[n * channel_num + c] = scale;
@@ -383,9 +408,10 @@ CUTE_DEVICE void xe_gemm_4bits(
     for (int n = 0; n < thr_N; ++n) {
       CUTLASS_PRAGMA_UNROLL
       for (int c = 0; c < channel_num; ++c) {
+        float scale = scales[n * channel_num + c];
         CUTLASS_PRAGMA_UNROLL
         for (int i = 0; i < tCrB.size() / thr_N / channel_num; ++i) {
-          tCrB(cute::tuple(c, _), n, _)[i] *= scales[n * channel_num + c];
+          tCrB(cute::tuple(c, _), n, _)[i] = apply_scale(tCrB(cute::tuple(c, _), n, _)[i], scale);
         }
       }
     }

--- a/csrc/xpu/grouped_gemm/xe_2/gemm_xe2.hpp
+++ b/csrc/xpu/grouped_gemm/xe_2/gemm_xe2.hpp
@@ -368,6 +368,18 @@ CUTE_DEVICE void xe_gemm_4bits(
   for (; k_tile_prefetch < prefetch_dist; k_tile_prefetch++) {
     prefetch(prefetch_a, pAgA(_, _, _, k_tile_prefetch));
     prefetch(prefetch_b, pBgB(_, _, _, k_tile_prefetch));
+
+    if(k_tile_prefetch * group_size < shape<1>(A)){
+      auto next_scales_tensor = make_tensor(
+          make_gmem_ptr(reinterpret_cast<const ElementS *>(
+            Scales + (n_tile_start + n_sg_start) * group_num + k_tile_prefetch)),
+          make_layout(make_shape(Int<SG_N>{}, Int<1>{}), make_stride(group_num, Int<1>{})));
+      auto prefetch_scales = make_block_2d_prefetch<1>(
+          make_shape(Int<SG_N>{}, Int<1>{}), next_scales_tensor);
+      auto thr_prefetch_scales = prefetch_scales.get_slice(sg_local_id);
+      auto pSgS = thr_prefetch_scales.partition_S(make_identity_tensor(make_shape(Int<SG_N>{}, Int<1>{})));
+      prefetch(prefetch_scales, pSgS(_, 0, 0));
+    }
   }
 
   for (int k_tile = 0; k_tile < k_tile_count; k_tile++, k_tile_prefetch++) {
@@ -432,10 +444,10 @@ CUTE_DEVICE void xe_gemm_4bits(
       //   scales[i * 2 + 1] = scale;
       // }
 
-      if((k_tile + 1) * tile_k < shape<1>(A)){
+      if((group_idx + prefetch_dist) * group_size < shape<1>(A)){
         auto next_scales_tensor = make_tensor(
             make_gmem_ptr(reinterpret_cast<const ElementS *>(
-              Scales + (n_tile_start + n_sg_start) * group_num + group_idx + 1)),
+              Scales + (n_tile_start + n_sg_start) * group_num + group_idx + prefetch_dist)),
             make_layout(make_shape(Int<SG_N>{}, Int<1>{}), make_stride(group_num, Int<1>{})));
         auto prefetch_scales = make_block_2d_prefetch<1>(
             make_shape(Int<SG_N>{}, Int<1>{}), next_scales_tensor);

--- a/csrc/xpu/grouped_gemm/xe_2/gemm_xe2.hpp
+++ b/csrc/xpu/grouped_gemm/xe_2/gemm_xe2.hpp
@@ -264,6 +264,8 @@ CUTE_DEVICE void xe_gemm_4bits(
   auto wg_n = get<1>(blk_coord);
   int local_id = item.get_local_linear_id();
 
+  auto gemm_n = get<0>(B.shape());
+
   Tensor cA = make_identity_tensor(A.shape());
   Tensor cB = make_identity_tensor(B.shape());
   Tensor cC = make_identity_tensor(C.shape());
@@ -315,7 +317,7 @@ CUTE_DEVICE void xe_gemm_4bits(
   auto pAgA = thr_prefetch_A.partition_S(gA);
   auto pBgB = thr_prefetch_B.partition_S(gB);
 
-  const int prefetch_dist = 3;
+  const int prefetch_dist = 6;
 
   constexpr int barrier_scope = 2;
 
@@ -349,6 +351,11 @@ CUTE_DEVICE void xe_gemm_4bits(
   
   using scaleStoreType = conditional_t<is_same_v<TA, half_t>, half_t, float>;
   scaleStoreType scales[thr_N * channel_num];
+
+  ElementS frag_load[thr_N * channel_num / 2];
+  Tensor scales_load =
+      make_tensor(make_rmem_ptr(frag_load),
+                  make_layout(make_shape(Int<thr_N * channel_num / 2>{})));
 
   clear(tCrC);
 
@@ -394,6 +401,47 @@ CUTE_DEVICE void xe_gemm_4bits(
 
           scales[n * channel_num + c] = scale;
         }
+      }
+
+      // auto scales_tensor = make_tensor(
+      //     make_gmem_ptr(reinterpret_cast<const ElementS *>(
+      //       Scales + (n_tile_start + n_sg_start) * group_num + group_idx)),
+      //     make_layout(make_shape(Int<SG_N>{}, Int<1>{}), make_stride(group_num, Int<1>{})));
+      // auto copy_scales = make_block_2d_copy(
+      //     XE_LOAD_2D<sizeof_bits_v<ElementS>, SG_N, 1>{},
+      //     scales_tensor);
+      // auto thr_copy_scales = copy_scales.get_slice(sg_local_id);
+      // auto scales_per_thread = thr_copy_scales.partition_S(make_identity_tensor(make_shape(Int<SG_N>{}, Int<1>{})));
+      // copy(copy_scales, scales_per_thread(_, 0, 0), scales_load);
+      // // reorder(scales_e8m0_sg_tensor, scales_float_sg_tensor);
+      
+      // int i = 0;
+      // CUTLASS_PRAGMA_UNROLL
+      // for(int e = sg_local_id; e < SG_N; e += sg_local_range, ++i){
+      //   // scales_load[i] = Scales[(n_tile_start + n_sg_start + e) * group_num + group_idx];
+
+      //   scaleStoreType scale;
+      //   if constexpr (std::is_same_v<TB, int4_t>) {
+      //     scale = scales_load[i];
+      //   } else if constexpr (std::is_same_v<TB, float_e2m1_t>) {
+      //     uint32_t scale_u32 = scales_load[i] << 23;
+      //     scale = static_cast<scaleStoreType>(reinterpret_cast<float&>(scale_u32));
+      //   }
+
+      //   scales[i * 2] = scale;
+      //   scales[i * 2 + 1] = scale;
+      // }
+
+      if((k_tile + 1) * tile_k < shape<1>(A)){
+        auto next_scales_tensor = make_tensor(
+            make_gmem_ptr(reinterpret_cast<const ElementS *>(
+              Scales + (n_tile_start + n_sg_start) * group_num + group_idx + 1)),
+            make_layout(make_shape(Int<SG_N>{}, Int<1>{}), make_stride(group_num, Int<1>{})));
+        auto prefetch_scales = make_block_2d_prefetch<1>(
+            make_shape(Int<SG_N>{}, Int<1>{}), next_scales_tensor);
+        auto thr_prefetch_scales = prefetch_scales.get_slice(sg_local_id);
+        auto pSgS = thr_prefetch_scales.partition_S(make_identity_tensor(make_shape(Int<SG_N>{}, Int<1>{})));
+        prefetch(prefetch_scales, pSgS(_, 0, 0));
       }
     }
 

--- a/csrc/xpu/grouped_gemm/xe_2/gemm_xe2_policy.hpp
+++ b/csrc/xpu/grouped_gemm/xe_2/gemm_xe2_policy.hpp
@@ -19,6 +19,18 @@ class xe_gemm_policy_base {
 
 class w16a16_policy : public xe_gemm_policy_base {};
 
+class w16a16_policy_n_128 : public xe_gemm_policy_base {
+ public:
+  using WGTile = Shape<_256, _128, _32>;
+  using SGLayout = Layout<Shape<_8, _2, _1>, Stride<_2, _1, _0>>;
+};
+
+class w16a16_policy_n_64 : public xe_gemm_policy_base {
+ public:
+  using WGTile = Shape<_256, _64, _32>;
+  using SGLayout = Layout<Shape<_8, _1, _1>, Stride<_1, _1, _0>>;
+};
+
 class w16a16_policy_m_8 : public xe_gemm_policy_base {
  public:
   using WGTile = Shape<_8, _64, _32>;

--- a/csrc/xpu/grouped_gemm/xe_2/grouped_gemm_xe2_interface.hpp
+++ b/csrc/xpu/grouped_gemm/xe_2/grouped_gemm_xe2_interface.hpp
@@ -286,8 +286,6 @@ at::Tensor cutlass_grouped_gemm_xe2_impl(
     }                                                                       \
   }
 
-    const char* val = std::getenv("MY_ENV_VAR");
-
     if (A_avg_M <= 4) {
       using policy = w4a16_policy_m_8;
       W4A16LauncherCallER(policy);
@@ -354,14 +352,14 @@ at::Tensor cutlass_grouped_gemm_xe2_impl(
     if (A_avg_M <= 8) {
       using policy = w16a16_policy_m_16;
       W16A16LauncherCallER(policy);
-    } else if(A_avg_M <= 16){
+    } else if (A_avg_M <= 16) {
       using policy = w16a16_policy_m_32;
       W16A16LauncherCallER(policy);
     } else {
-      if(B_N <= 64){
+      if (B_N <= 64) {
         using policy = w16a16_policy_n_64;
         W16A16LauncherCallER(policy);
-      } else if(B_N <= 512){
+      } else if (B_N <= 512) {
         using policy = w16a16_policy_n_128;
         W16A16LauncherCallER(policy);
       } else {

--- a/csrc/xpu/grouped_gemm/xe_2/grouped_gemm_xe2_interface.hpp
+++ b/csrc/xpu/grouped_gemm/xe_2/grouped_gemm_xe2_interface.hpp
@@ -286,7 +286,12 @@ at::Tensor cutlass_grouped_gemm_xe2_impl(
     }                                                                       \
   }
 
-    if (A_avg_M <= 32) {
+    const char* val = std::getenv("MY_ENV_VAR");
+
+    if (A_avg_M <= 4) {
+      using policy = w4a16_policy_m_8;
+      W4A16LauncherCallER(policy);
+    } else if (A_avg_M <= 8) {
       using policy = w4a16_policy_m_16;
       W4A16LauncherCallER(policy);
     } else if (A_avg_M <= 128) {
@@ -322,10 +327,10 @@ at::Tensor cutlass_grouped_gemm_xe2_impl(
     MoEGEMMLauncherCallER('R', 'R', policy, scalar_t, float_e5m2_t, float); \
   }
 
-    if (A_avg_M <= 32) {
+    if (A_avg_M <= 8) {
       using policy = w8a16_policy_m_16;
       W8A16LauncherCallER(policy);
-    } else if (A_avg_M <= 128) {
+    } else if (A_avg_M <= 32) {
       using policy = w8a16_policy_m_32;
       W8A16LauncherCallER(policy);
     } else {
@@ -346,12 +351,23 @@ at::Tensor cutlass_grouped_gemm_xe2_impl(
     MoEGEMMLauncherCallER('R', 'R', policy, scalar_t, scalar_t, scalar_t); \
   }
 
-    if (A_avg_M <= 4) {
+    if (A_avg_M <= 8) {
       using policy = w16a16_policy_m_16;
       W16A16LauncherCallER(policy);
-    } else {
-      using policy = w16a16_policy;
+    } else if(A_avg_M <= 16){
+      using policy = w16a16_policy_m_32;
       W16A16LauncherCallER(policy);
+    } else {
+      if(B_N <= 64){
+        using policy = w16a16_policy_n_64;
+        W16A16LauncherCallER(policy);
+      } else if(B_N <= 512){
+        using policy = w16a16_policy_n_128;
+        W16A16LauncherCallER(policy);
+      } else {
+        using policy = w16a16_policy;
+        W16A16LauncherCallER(policy);
+      }
     }
 #undef W16A16LauncherCallER
   }


### PR DESCRIPTION
1. Optimize W4BF16:
- Replace native data accumulating by asm code
- Add prefetch for scale
Results with NK=[3072 * 2, 3072] (gpt-oss shape), topk=4:
  <img width="200" height="300" alt="image" src="https://github.com/user-attachments/assets/6ce6c216-bd99-4ba1-963e-2f5d1e7f0e4e" />
2. Finetune policy
- With NK=[5120, 8192] (Llama-4-scout shape), topk=1, when m=128, 256, kernel time decrease from 4.814ms, 4.725ms to 3.009ms, 3.0061ms.
- With NK=[768 * 2 // 4, 2048](Qwen-30B-A3B shape), topk=8, when m=80, 8192, kernel time decrease from 1.476ms, 2.578ms to 472.320us, 1.492ms.