### PR TITLE
[Fusion][Torch.compiler] Add fuse_norm_quant, fuse_act_quant and fused_qk_norm_rope kernel

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -402,8 +402,10 @@ if(BASIC_KERNELS_ENABLED)
   set(VLLM_EXT_SRC
       "csrc/cache.cpp"
       "csrc/layernorm.cpp"
+      "csrc/layernorm_quant.cpp"
       "csrc/activation.cpp"
       "csrc/pos_encoding_kernels.cpp"
+      "csrc/fused_qknorm_rope.cpp"
       "csrc/torch_bindings.cpp"
       "csrc/quantization/fp8/fp8_quant.cpp"
       "csrc/quantization/fp4/mxfp4_quant.cpp"

--- a/csrc/activation.cpp
+++ b/csrc/activation.cpp
@@ -1,8 +1,14 @@
 #include <sycl/sycl.hpp>
 #include <cmath>
 #include <algorithm>
+#include <iostream>
+#include <numeric>
 #include "utils.h"
 #include "dispatch_utils.h"
+
+#include <c10/util/Float8_e4m3fn.h>
+#include <c10/util/Float8_e5m2.h>
+#include "quantization/fp8/quant_utils.h"
 
 #define VLLM_LDG(arg) *(arg)
 
@@ -164,6 +170,59 @@ class act_and_mul_vec_kernel {
   const int d_;
 };
 
+
+template <
+    typename scalar_t,
+    scalar_t (*ACT_FN)(const scalar_t&),
+    typename fp8_type,
+    int VEC_SIZE>
+class act_and_mul_quant_vec_kernel {
+ public:
+  act_and_mul_quant_vec_kernel(
+      fp8_type* __restrict__ out,           // [..., d]
+      const scalar_t* __restrict__ input,   // [..., 2 * d]
+      const float* __restrict__ scale,      // [1]
+      const int d)
+      : out_(out), input_(input), scale_(scale), d_(d) {}
+
+  void operator()(sycl::nd_item<1> item) const {
+    using vec_t = vllm::xpu::aligned_vec<scalar_t, VEC_SIZE>;
+
+    const int64_t token_idx = item.get_group(0);
+    const int64_t offset = item.get_local_linear_id();
+    const int64_t step = item.get_local_range(0);
+    const int64_t bound = d_ / VEC_SIZE;
+
+    const float inv_scale = 1.0f / (*scale_);
+    const float fp8_max =
+        static_cast<float>(fp8::quant_type_max_v<fp8_type>);
+
+    // x and y halves are laid out contiguously: [x0..xd-1, y0..yd-1]
+    const auto* v_x =
+        reinterpret_cast<const vec_t*>(input_) + token_idx * bound * 2;
+    const auto* v_y = v_x + bound;
+
+    for (int64_t i = offset; i < bound; i += step) {
+      vec_t xv = v_x[i];
+      vec_t yv = v_y[i];
+#pragma unroll
+      for (int j = 0; j < VEC_SIZE; j++) {
+        float val =
+            static_cast<float>(ACT_FN(xv[j]) * yv[j]) * inv_scale;
+        float clamped = sycl::fmax(-fp8_max, sycl::fmin(val, fp8_max));
+        out_[token_idx * d_ + i * VEC_SIZE + j] =
+            static_cast<fp8_type>(clamped);
+      }
+    }
+  }
+
+ private:
+  fp8_type* __restrict__ out_;           // [..., d]
+  const scalar_t* __restrict__ input_;   // [..., 2 * d]
+  const float* __restrict__ scale_;      // [1]
+  const int d_;
+};
+
 template <typename T>
 [[intel::device_indirectly_callable]] inline __attribute__((always_inline)) T
 swigluoai_and_mul(const T& gate, const T& up, float alpha, float limit) {
@@ -295,6 +354,73 @@ void silu_and_mul(
   VLLM_DISPATCH_FLOATING_TYPES(input.scalar_type(), "silu_and_mul", [&] {
     LAUNCH_ACTIVATION_GATE_KERNEL_VEC(vllm::silu_kernel, true);
   });
+}
+
+// Fused SiLU + Mul + FP8 Quantization
+// Input: [..., 2*d] in FP16/BF16, Output: [..., d] in FP8
+// Dispatches to the vectorized kernel (VEC_SIZE=1..8) based on alignment.
+#define LAUNCH_ACT_AND_MUL_QUANT_VEC(KERNEL, N)                               \
+  case N: {                                                                    \
+    int64_t wg_size = std::min(static_cast<int64_t>(d / N),                   \
+                               static_cast<int64_t>(1024));                    \
+    VLLM_DISPATCH_FP8_TYPES(                                                   \
+        out.scalar_type(), "act_and_mul_quant_vec_kernel_fp8", [&] {           \
+          auto out_ptr = out.data_ptr<fp8_t>();                                \
+          queue.submit([&](sycl::handler& cgh) {                               \
+            cgh.parallel_for(                                                  \
+                sycl::nd_range<1>(num_tokens * wg_size, wg_size),              \
+                vllm::act_and_mul_quant_vec_kernel<sycl_t, KERNEL, fp8_t, N>( \
+                    out_ptr, (sycl_t*)input_ptr, scale_ptr, d));               \
+          });                                                                   \
+        });                                                                    \
+    break;                                                                     \
+  }
+
+#define LAUNCH_ACTIVATION_GATE_QUANT_KERNEL(KERNEL)                        \
+  using sycl_t = vllm::xpu::SyclTypeTrait<scalar_t>::Type;                 \
+  int d = input.size(-1) / 2;                                             \
+  int64_t num_tokens = input.numel() / input.size(-1);                    \
+  if (num_tokens == 0) {                                                  \
+    return;                                                               \
+  }                                                                       \
+  auto input_ptr = input.data_ptr<scalar_t>();                            \
+  auto scale_ptr = scale.data_ptr<float>();                               \
+  at::DeviceGuard device_guard(input.device());                           \
+  auto& queue = vllm::xpu::vllmGetQueue();                                \
+  /* Compute vec_size like non-quant path: gcd(4*sizeof(float)/sizeof, d) */ \
+  int vec_size = static_cast<int>(sizeof(float) * 4 / sizeof(sycl_t));   \
+  {                                                                       \
+    int64_t tmp_wg =                                                      \
+        std::min(static_cast<int64_t>(d), static_cast<int64_t>(1024));    \
+    while (vec_size > 1 && (vec_size >> 1) * tmp_wg >= d) {              \
+      vec_size = vec_size >> 1;                                           \
+    }                                                                     \
+  }                                                                       \
+  if (d % vec_size != 0) vec_size = 1;                                   \
+  switch (vec_size) {                                                     \
+    LAUNCH_ACT_AND_MUL_QUANT_VEC(KERNEL, 1);                             \
+    LAUNCH_ACT_AND_MUL_QUANT_VEC(KERNEL, 2);                             \
+    LAUNCH_ACT_AND_MUL_QUANT_VEC(KERNEL, 4);                             \
+    LAUNCH_ACT_AND_MUL_QUANT_VEC(KERNEL, 8);                             \
+    LAUNCH_ACT_AND_MUL_QUANT_VEC(KERNEL, 16);                            \
+    default:                                                              \
+      TORCH_CHECK(false, "Unsupported vector size: ", vec_size);          \
+  }
+
+void silu_and_mul_quant(
+    torch::Tensor& out,    // [..., d] FP8
+    torch::Tensor& input,  // [..., 2 * d] FP16/BF16
+    torch::Tensor& scale)  // [1] FP32
+{
+  TORCH_CHECK(out.dtype() == torch::kFloat8_e4m3fn ||
+              out.dtype() == torch::kFloat8_e5m2);
+  TORCH_CHECK(input.dtype() == torch::kFloat16 ||
+              input.dtype() == torch::kBFloat16);
+  TORCH_CHECK(input.size(-1) % 2 == 0);
+  VLLM_DISPATCH_FLOATING_TYPES(
+      input.scalar_type(), "silu_and_mul_quant", [&] {
+        LAUNCH_ACTIVATION_GATE_QUANT_KERNEL(vllm::silu_kernel);
+      });
 }
 
 void mul_and_silu(

--- a/csrc/activation.cpp
+++ b/csrc/activation.cpp
@@ -178,7 +178,6 @@ class act_and_mul_vec_kernel {
   const int d_;
 };
 
-
 template <
     typename scalar_t,
     scalar_t (*ACT_FN)(const scalar_t&),
@@ -187,9 +186,9 @@ template <
 class act_and_mul_quant_vec_kernel {
  public:
   act_and_mul_quant_vec_kernel(
-      fp8_type* __restrict__ out,           // [..., d]
-      const scalar_t* __restrict__ input,   // [..., 2 * d]
-      const float* __restrict__ scale,      // [1]
+      fp8_type* __restrict__ out,          // [..., d]
+      const scalar_t* __restrict__ input,  // [..., 2 * d]
+      const float* __restrict__ scale,     // [1]
       const int d)
       : out_(out), input_(input), scale_(scale), d_(d) {}
 
@@ -202,8 +201,7 @@ class act_and_mul_quant_vec_kernel {
     const int64_t bound = d_ / VEC_SIZE;
 
     const float inv_scale = 1.0f / (*scale_);
-    const float fp8_max =
-        static_cast<float>(fp8::quant_type_max_v<fp8_type>);
+    const float fp8_max = static_cast<float>(fp8::quant_type_max_v<fp8_type>);
 
     // x and y halves are laid out contiguously: [x0..xd-1, y0..yd-1]
     const auto* v_x =
@@ -215,8 +213,7 @@ class act_and_mul_quant_vec_kernel {
       vec_t yv = v_y[i];
 #pragma unroll
       for (int j = 0; j < VEC_SIZE; j++) {
-        float val =
-            static_cast<float>(ACT_FN(xv[j]) * yv[j]) * inv_scale;
+        float val = static_cast<float>(ACT_FN(xv[j]) * yv[j]) * inv_scale;
         float clamped = sycl::fmax(-fp8_max, sycl::fmin(val, fp8_max));
         out_[token_idx * d_ + i * VEC_SIZE + j] =
             static_cast<fp8_type>(clamped);
@@ -225,9 +222,9 @@ class act_and_mul_quant_vec_kernel {
   }
 
  private:
-  fp8_type* __restrict__ out_;           // [..., d]
-  const scalar_t* __restrict__ input_;   // [..., 2 * d]
-  const float* __restrict__ scale_;      // [1]
+  fp8_type* __restrict__ out_;          // [..., d]
+  const scalar_t* __restrict__ input_;  // [..., 2 * d]
+  const float* __restrict__ scale_;     // [1]
   const int d_;
 };
 
@@ -415,51 +412,51 @@ void silu_and_mul(
 // Input: [..., 2*d] in FP16/BF16, Output: [..., d] in FP8
 // Dispatches to the vectorized kernel (VEC_SIZE=1..8) based on alignment.
 #define LAUNCH_ACT_AND_MUL_QUANT_VEC(KERNEL, N)                               \
-  case N: {                                                                    \
-    int64_t wg_size = std::min(static_cast<int64_t>(d / N),                   \
-                               static_cast<int64_t>(1024));                    \
-    VLLM_DISPATCH_FP8_TYPES(                                                   \
-        out.scalar_type(), "act_and_mul_quant_vec_kernel_fp8", [&] {           \
-          auto out_ptr = out.data_ptr<fp8_t>();                                \
-          queue.submit([&](sycl::handler& cgh) {                               \
-            cgh.parallel_for(                                                  \
-                sycl::nd_range<1>(num_tokens * wg_size, wg_size),              \
+  case N: {                                                                   \
+    int64_t wg_size =                                                         \
+        std::min(static_cast<int64_t>(d / N), static_cast<int64_t>(1024));    \
+    VLLM_DISPATCH_FP8_TYPES(                                                  \
+        out.scalar_type(), "act_and_mul_quant_vec_kernel_fp8", [&] {          \
+          auto out_ptr = out.data_ptr<fp8_t>();                               \
+          queue.submit([&](sycl::handler& cgh) {                              \
+            cgh.parallel_for(                                                 \
+                sycl::nd_range<1>(num_tokens * wg_size, wg_size),             \
                 vllm::act_and_mul_quant_vec_kernel<sycl_t, KERNEL, fp8_t, N>( \
-                    out_ptr, (sycl_t*)input_ptr, scale_ptr, d));               \
-          });                                                                   \
-        });                                                                    \
-    break;                                                                     \
+                    out_ptr, (sycl_t*)input_ptr, scale_ptr, d));              \
+          });                                                                 \
+        });                                                                   \
+    break;                                                                    \
   }
 
-#define LAUNCH_ACTIVATION_GATE_QUANT_KERNEL(KERNEL)                        \
-  using sycl_t = vllm::xpu::SyclTypeTrait<scalar_t>::Type;                 \
-  int d = input.size(-1) / 2;                                             \
-  int64_t num_tokens = input.numel() / input.size(-1);                    \
-  if (num_tokens == 0) {                                                  \
-    return;                                                               \
-  }                                                                       \
-  auto input_ptr = input.data_ptr<scalar_t>();                            \
-  auto scale_ptr = scale.data_ptr<float>();                               \
-  at::DeviceGuard device_guard(input.device());                           \
-  auto& queue = vllm::xpu::vllmGetQueue();                                \
+#define LAUNCH_ACTIVATION_GATE_QUANT_KERNEL(KERNEL)                          \
+  using sycl_t = vllm::xpu::SyclTypeTrait<scalar_t>::Type;                   \
+  int d = input.size(-1) / 2;                                                \
+  int64_t num_tokens = input.numel() / input.size(-1);                       \
+  if (num_tokens == 0) {                                                     \
+    return;                                                                  \
+  }                                                                          \
+  auto input_ptr = input.data_ptr<scalar_t>();                               \
+  auto scale_ptr = scale.data_ptr<float>();                                  \
+  at::DeviceGuard device_guard(input.device());                              \
+  auto& queue = vllm::xpu::vllmGetQueue();                                   \
   /* Compute vec_size like non-quant path: gcd(4*sizeof(float)/sizeof, d) */ \
-  int vec_size = static_cast<int>(sizeof(float) * 4 / sizeof(sycl_t));   \
-  {                                                                       \
-    int64_t tmp_wg =                                                      \
-        std::min(static_cast<int64_t>(d), static_cast<int64_t>(1024));    \
-    while (vec_size > 1 && (vec_size >> 1) * tmp_wg >= d) {              \
-      vec_size = vec_size >> 1;                                           \
-    }                                                                     \
-  }                                                                       \
-  if (d % vec_size != 0) vec_size = 1;                                   \
-  switch (vec_size) {                                                     \
-    LAUNCH_ACT_AND_MUL_QUANT_VEC(KERNEL, 1);                             \
-    LAUNCH_ACT_AND_MUL_QUANT_VEC(KERNEL, 2);                             \
-    LAUNCH_ACT_AND_MUL_QUANT_VEC(KERNEL, 4);                             \
-    LAUNCH_ACT_AND_MUL_QUANT_VEC(KERNEL, 8);                             \
-    LAUNCH_ACT_AND_MUL_QUANT_VEC(KERNEL, 16);                            \
-    default:                                                              \
-      TORCH_CHECK(false, "Unsupported vector size: ", vec_size);          \
+  int vec_size = static_cast<int>(sizeof(float) * 4 / sizeof(sycl_t));       \
+  {                                                                          \
+    int64_t tmp_wg =                                                         \
+        std::min(static_cast<int64_t>(d), static_cast<int64_t>(1024));       \
+    while (vec_size > 1 && (vec_size >> 1) * tmp_wg >= d) {                  \
+      vec_size = vec_size >> 1;                                              \
+    }                                                                        \
+  }                                                                          \
+  if (d % vec_size != 0) vec_size = 1;                                       \
+  switch (vec_size) {                                                        \
+    LAUNCH_ACT_AND_MUL_QUANT_VEC(KERNEL, 1);                                 \
+    LAUNCH_ACT_AND_MUL_QUANT_VEC(KERNEL, 2);                                 \
+    LAUNCH_ACT_AND_MUL_QUANT_VEC(KERNEL, 4);                                 \
+    LAUNCH_ACT_AND_MUL_QUANT_VEC(KERNEL, 8);                                 \
+    LAUNCH_ACT_AND_MUL_QUANT_VEC(KERNEL, 16);                                \
+    default:                                                                 \
+      TORCH_CHECK(false, "Unsupported vector size: ", vec_size);             \
   }
 
 void silu_and_mul_quant(
@@ -467,15 +464,15 @@ void silu_and_mul_quant(
     torch::Tensor& input,  // [..., 2 * d] FP16/BF16
     torch::Tensor& scale)  // [1] FP32
 {
-  TORCH_CHECK(out.dtype() == torch::kFloat8_e4m3fn ||
-              out.dtype() == torch::kFloat8_e5m2);
-  TORCH_CHECK(input.dtype() == torch::kFloat16 ||
-              input.dtype() == torch::kBFloat16);
+  TORCH_CHECK(
+      out.dtype() == torch::kFloat8_e4m3fn ||
+      out.dtype() == torch::kFloat8_e5m2);
+  TORCH_CHECK(
+      input.dtype() == torch::kFloat16 || input.dtype() == torch::kBFloat16);
   TORCH_CHECK(input.size(-1) % 2 == 0);
-  VLLM_DISPATCH_FLOATING_TYPES(
-      input.scalar_type(), "silu_and_mul_quant", [&] {
-        LAUNCH_ACTIVATION_GATE_QUANT_KERNEL(vllm::silu_kernel);
-      });
+  VLLM_DISPATCH_FLOATING_TYPES(input.scalar_type(), "silu_and_mul_quant", [&] {
+    LAUNCH_ACTIVATION_GATE_QUANT_KERNEL(vllm::silu_kernel);
+  });
 }
 
 void mul_and_silu(

--- a/csrc/activation.cpp
+++ b/csrc/activation.cpp
@@ -1,7 +1,6 @@
 #include <sycl/sycl.hpp>
 #include <cmath>
 #include <algorithm>
-#include <iostream>
 #include <numeric>
 #include "utils.h"
 #include "dispatch_utils.h"

--- a/csrc/fused_qknorm_rope.cpp
+++ b/csrc/fused_qknorm_rope.cpp
@@ -266,6 +266,9 @@ void launch_fused_qk_norm_rope(
     case 256:
       DISPATCH_HEAD_DIM(256);
       break;
+    case 512:
+      DISPATCH_HEAD_DIM(512);
+      break;
     default:
       TORCH_CHECK(
           false,

--- a/csrc/fused_qknorm_rope.cpp
+++ b/csrc/fused_qknorm_rope.cpp
@@ -1,0 +1,342 @@
+/*
+ * Ported from the CUDA implementation in csrc/fused_qknorm_rope_kernel.cu.
+ */
+
+#include <sycl/sycl.hpp>
+
+#include <ATen/DeviceGuard.h>
+#include <cmath>
+
+#include "dispatch_utils.h"
+#include "utils.h"
+
+namespace vllm {
+
+template <typename scalar_t, typename scalar_t_cache, int head_dim,
+          bool IS_NEOX>
+class fused_qk_norm_rope_kernel {
+ public:
+  static constexpr int SUB_GROUP_SIZE = 32;
+  static constexpr int NUM_ELEMS_PER_THREAD = head_dim / SUB_GROUP_SIZE;
+
+  static_assert(head_dim % (SUB_GROUP_SIZE * 2) == 0,
+                "head_dim must be divisible by 64");
+
+  fused_qk_norm_rope_kernel(
+      scalar_t* __restrict__ qkv_,
+      const int num_heads_q_,
+      const int num_heads_k_,
+      const int num_heads_v_,
+      const float eps_,
+      const scalar_t* __restrict__ q_weight_,
+      const scalar_t* __restrict__ k_weight_,
+      const scalar_t_cache* __restrict__ cos_sin_cache_,
+      const int64_t* __restrict__ position_ids_,
+      const int num_tokens_,
+      const int rotary_dim_)
+      : qkv(qkv_),
+        num_heads_q(num_heads_q_),
+        num_heads_k(num_heads_k_),
+        num_heads_v(num_heads_v_),
+        eps(eps_),
+        q_weight(q_weight_),
+        k_weight(k_weight_),
+        cos_sin_cache(cos_sin_cache_),
+        position_ids(position_ids_),
+        num_tokens(num_tokens_),
+        rotary_dim(rotary_dim_) {}
+
+  void operator()[[sycl::reqd_sub_group_size(SUB_GROUP_SIZE)]](
+      const sycl::nd_item<1>& item) const {
+    auto sg = item.get_sub_group();
+    const int lane_id = sg.get_local_linear_id();
+    const int sg_id_in_wg = sg.get_group_linear_id();
+    const int sgs_per_wg = sg.get_group_linear_range();
+    const int global_sg_id =
+        item.get_group(0) * sgs_per_wg + sg_id_in_wg;
+
+    const int total_qk_heads = num_heads_q + num_heads_k;
+    const int token_idx = global_sg_id / total_qk_heads;
+    const int local_head_idx = global_sg_id % total_qk_heads;
+
+    if (token_idx >= num_tokens) return;
+
+    const bool is_q = local_head_idx < num_heads_q;
+    const int head_idx =
+        is_q ? local_head_idx : local_head_idx - num_heads_q;
+    const int num_heads = num_heads_q + num_heads_k + num_heads_v;
+
+    // Compute the offset into the QKV tensor for this sub-group's head.
+    int offset_warp;
+    if (is_q) {
+      offset_warp = token_idx * num_heads * head_dim + head_idx * head_dim;
+    } else {
+      offset_warp = token_idx * num_heads * head_dim +
+                    num_heads_q * head_dim + head_idx * head_dim;
+    }
+    int offset_thread = offset_warp + lane_id * NUM_ELEMS_PER_THREAD;
+
+    // Load elements and compute sum of squares for RMSNorm.
+    float elements[NUM_ELEMS_PER_THREAD];
+    float sum_of_squares = 0.0f;
+
+#pragma unroll
+    for (int i = 0; i < NUM_ELEMS_PER_THREAD; i++) {
+      float val = static_cast<float>(qkv[offset_thread + i]);
+      elements[i] = val;
+      sum_of_squares += val * val;
+    }
+
+    // Reduce sum across sub-group.
+    sum_of_squares =
+        sycl::reduce_over_group(sg, sum_of_squares, sycl::plus<float>());
+
+    // Compute RMS normalization factor.
+    float rms_rcp =
+        sycl::rsqrt(sum_of_squares / static_cast<float>(head_dim) + eps);
+
+    // Apply RMSNorm with learned weights.
+    const scalar_t* weight = is_q ? q_weight : k_weight;
+#pragma unroll
+    for (int i = 0; i < NUM_ELEMS_PER_THREAD; i++) {
+      int dim = lane_id * NUM_ELEMS_PER_THREAD + i;
+      float w = static_cast<float>(weight[dim]);
+      elements[i] *= rms_rcp * w;
+    }
+
+    // Apply RoPE.
+    const int64_t pos_id = position_ids[token_idx];
+    const int embed_dim = rotary_dim / 2;
+    const scalar_t_cache* cache_ptr =
+        cos_sin_cache + pos_id * rotary_dim;
+    const scalar_t_cache* cos_ptr = cache_ptr;
+    const scalar_t_cache* sin_ptr = cache_ptr + embed_dim;
+
+    const int rotary_lanes = rotary_dim / NUM_ELEMS_PER_THREAD;
+
+    if (lane_id < rotary_lanes) {
+      if constexpr (!IS_NEOX) {
+        // Interleaved-style RoPE (GPT-J style).
+#pragma unroll
+        for (int i = 0; i < NUM_ELEMS_PER_THREAD / 2; ++i) {
+          const int idx0 = 2 * i;
+          const int idx1 = 2 * i + 1;
+          const int dim_idx = lane_id * NUM_ELEMS_PER_THREAD + idx0;
+
+          const float val0 = elements[idx0];
+          const float val1 = elements[idx1];
+
+          const int half_dim = dim_idx / 2;
+          const float cos_val = static_cast<float>(cos_ptr[half_dim]);
+          const float sin_val = static_cast<float>(sin_ptr[half_dim]);
+
+          elements[idx0] = val0 * cos_val - val1 * sin_val;
+          elements[idx1] = val0 * sin_val + val1 * cos_val;
+        }
+      } else {
+        // Neox-style RoPE: exchange data with partner lane.
+        sycl::group_barrier(sg);
+        const int pair_offset =
+            (rotary_dim / 2) / NUM_ELEMS_PER_THREAD;
+
+#pragma unroll
+        for (int i = 0; i < NUM_ELEMS_PER_THREAD; i++) {
+          float partner_val =
+              sycl::permute_group_by_xor(sg, elements[i], pair_offset);
+
+          if (lane_id < pair_offset) {
+            partner_val = -partner_val;
+          }
+
+          int dim_idx = lane_id * NUM_ELEMS_PER_THREAD + i;
+          dim_idx = (dim_idx * 2) % rotary_dim;
+          int half_dim = dim_idx / 2;
+
+          const float cos_val = static_cast<float>(cos_ptr[half_dim]);
+          const float sin_val = static_cast<float>(sin_ptr[half_dim]);
+
+          elements[i] = elements[i] * cos_val + partner_val * sin_val;
+        }
+        sycl::group_barrier(sg);
+      }
+    }
+
+    // Store results back in-place.
+#pragma unroll
+    for (int i = 0; i < NUM_ELEMS_PER_THREAD; i++) {
+      qkv[offset_thread + i] = static_cast<scalar_t>(elements[i]);
+    }
+  }
+
+ private:
+  scalar_t* __restrict__ qkv;
+  const int num_heads_q;
+  const int num_heads_k;
+  const int num_heads_v;
+  const float eps;
+  const scalar_t* __restrict__ q_weight;
+  const scalar_t* __restrict__ k_weight;
+  const scalar_t_cache* __restrict__ cos_sin_cache;
+  const int64_t* __restrict__ position_ids;
+  const int num_tokens;
+  const int rotary_dim;
+};
+
+template <typename scalar_t, typename scalar_t_cache>
+void launch_fused_qk_norm_rope(
+    torch::Tensor& qkv,
+    int num_tokens,
+    int num_heads_q,
+    int num_heads_k,
+    int num_heads_v,
+    int head_dim,
+    int rotary_dim,
+    float eps,
+    torch::Tensor& q_weight,
+    torch::Tensor& k_weight,
+    torch::Tensor& cos_sin_cache,
+    bool is_neox,
+    torch::Tensor& position_ids) {
+  using sycl_t = typename vllm::xpu::SyclTypeTrait<scalar_t>::Type;
+  using sycl_cache_t =
+      typename vllm::xpu::SyclTypeTrait<scalar_t_cache>::Type;
+
+  constexpr int block_size = 256;
+  constexpr int sgs_per_wg = block_size / 32;
+
+  const int total_qk_heads = num_heads_q + num_heads_k;
+  const int total_sgs = num_tokens * total_qk_heads;
+  const int grid_size = (total_sgs + sgs_per_wg - 1) / sgs_per_wg;
+
+  auto qkv_ptr = reinterpret_cast<sycl_t*>(qkv.data_ptr<scalar_t>());
+  auto q_weight_ptr =
+      reinterpret_cast<const sycl_t*>(q_weight.data_ptr<scalar_t>());
+  auto k_weight_ptr =
+      reinterpret_cast<const sycl_t*>(k_weight.data_ptr<scalar_t>());
+  auto cos_sin_cache_ptr = reinterpret_cast<const sycl_cache_t*>(
+      cos_sin_cache.data_ptr<scalar_t_cache>());
+  auto position_ids_ptr = position_ids.data_ptr<int64_t>();
+
+  auto& queue = vllm::xpu::vllmGetQueue();
+
+#define DISPATCH_HEAD_DIM(HEAD_DIM)                                        \
+  do {                                                                     \
+    if (is_neox) {                                                         \
+      queue.submit([&](sycl::handler& cgh) {                              \
+        cgh.parallel_for(                                                  \
+            sycl::nd_range<1>(grid_size * block_size, block_size),         \
+            fused_qk_norm_rope_kernel<sycl_t, sycl_cache_t, HEAD_DIM,     \
+                                      true>(                               \
+                qkv_ptr, num_heads_q, num_heads_k, num_heads_v, eps,       \
+                q_weight_ptr, k_weight_ptr, cos_sin_cache_ptr,             \
+                position_ids_ptr, num_tokens, rotary_dim));                \
+      });                                                                  \
+    } else {                                                               \
+      queue.submit([&](sycl::handler& cgh) {                              \
+        cgh.parallel_for(                                                  \
+            sycl::nd_range<1>(grid_size * block_size, block_size),         \
+            fused_qk_norm_rope_kernel<sycl_t, sycl_cache_t, HEAD_DIM,     \
+                                      false>(                              \
+                qkv_ptr, num_heads_q, num_heads_k, num_heads_v, eps,       \
+                q_weight_ptr, k_weight_ptr, cos_sin_cache_ptr,             \
+                position_ids_ptr, num_tokens, rotary_dim));                \
+      });                                                                  \
+    }                                                                      \
+  } while (0)
+
+  switch (head_dim) {
+    case 64:
+      DISPATCH_HEAD_DIM(64);
+      break;
+    case 128:
+      DISPATCH_HEAD_DIM(128);
+      break;
+    case 256:
+      DISPATCH_HEAD_DIM(256);
+      break;
+    default:
+      TORCH_CHECK(false,
+                  "Unsupported head dimension for fused_qk_norm_rope: ",
+                  head_dim);
+  }
+
+#undef DISPATCH_HEAD_DIM
+}
+
+}  // namespace vllm
+
+void fused_qk_norm_rope(
+    torch::Tensor& qkv,
+    int64_t num_heads_q,
+    int64_t num_heads_k,
+    int64_t num_heads_v,
+    int64_t head_dim,
+    double eps,
+    torch::Tensor& q_weight,
+    torch::Tensor& k_weight,
+    torch::Tensor& cos_sin_cache,
+    bool is_neox,
+    torch::Tensor& position_ids) {
+  const at::DeviceGuard device_guard(qkv.device());
+
+  CHECK_DEVICE(qkv);
+  CHECK_CONTIGUOUS(qkv);
+  CHECK_DEVICE(position_ids);
+  CHECK_CONTIGUOUS(position_ids);
+  CHECK_DEVICE(q_weight);
+  CHECK_CONTIGUOUS(q_weight);
+  CHECK_DEVICE(k_weight);
+  CHECK_CONTIGUOUS(k_weight);
+  CHECK_DEVICE(cos_sin_cache);
+  CHECK_CONTIGUOUS(cos_sin_cache);
+
+  TORCH_CHECK(position_ids.scalar_type() == torch::kInt64,
+              "position_ids must be int64");
+  TORCH_CHECK(qkv.dim() == 2,
+              "QKV tensor must be 2D: [num_tokens, "
+              "(num_heads_q+num_heads_k+num_heads_v)*head_dim]");
+  TORCH_CHECK(position_ids.dim() == 1,
+              "Position IDs must be 1D: [num_tokens]");
+  TORCH_CHECK(q_weight.dim() == 1, "Query weights must be 1D: [head_dim]");
+  TORCH_CHECK(k_weight.dim() == 1, "Key weights must be 1D: [head_dim]");
+  TORCH_CHECK(cos_sin_cache.dim() == 2,
+              "Cos/sin cache must be 2D: [max_position, rotary_dim]");
+  TORCH_CHECK(q_weight.size(0) == head_dim,
+              "Query weights size must match head dimension");
+  TORCH_CHECK(k_weight.size(0) == head_dim,
+              "Key weights size must match head dimension");
+  TORCH_CHECK(cos_sin_cache.size(1) % 2 == 0, "rotary_dim must be even");
+  TORCH_CHECK(cos_sin_cache.size(1) <= head_dim,
+              "rotary_dim must be less than or equal to head_dim");
+  TORCH_CHECK(qkv.scalar_type() == q_weight.scalar_type() &&
+                  qkv.scalar_type() == k_weight.scalar_type(),
+              "qkv, q_weight and k_weight must have the same dtype");
+
+  int64_t num_tokens = qkv.size(0);
+  TORCH_CHECK(position_ids.size(0) == num_tokens,
+              "Number of tokens in position_ids must match QKV");
+
+  int64_t total_heads = num_heads_q + num_heads_k + num_heads_v;
+  TORCH_CHECK(
+      qkv.size(1) == total_heads * head_dim,
+      "QKV tensor size must match total number of heads and head dimension");
+
+  VLLM_DISPATCH_HALF_TYPES(
+      qkv.scalar_type(), "fused_qk_norm_rope", [&] {
+        using qkv_scalar_t = scalar_t;
+        VLLM_DISPATCH_FLOATING_TYPES(
+            cos_sin_cache.scalar_type(), "fused_qk_norm_rope_cache", [&] {
+              using cache_scalar_t = scalar_t;
+              vllm::launch_fused_qk_norm_rope<qkv_scalar_t,
+                                               cache_scalar_t>(
+                  qkv, static_cast<int>(num_tokens),
+                  static_cast<int>(num_heads_q),
+                  static_cast<int>(num_heads_k),
+                  static_cast<int>(num_heads_v),
+                  static_cast<int>(head_dim),
+                  static_cast<int>(cos_sin_cache.size(1)),
+                  static_cast<float>(eps), q_weight, k_weight,
+                  cos_sin_cache, is_neox, position_ids);
+            });
+      });
+}

--- a/csrc/fused_qknorm_rope.cpp
+++ b/csrc/fused_qknorm_rope.cpp
@@ -12,15 +12,18 @@
 
 namespace vllm {
 
-template <typename scalar_t, typename scalar_t_cache, int head_dim,
-          bool IS_NEOX>
+template <
+    typename scalar_t,
+    typename scalar_t_cache,
+    int head_dim,
+    bool IS_NEOX>
 class fused_qk_norm_rope_kernel {
  public:
   static constexpr int SUB_GROUP_SIZE = 32;
   static constexpr int NUM_ELEMS_PER_THREAD = head_dim / SUB_GROUP_SIZE;
 
-  static_assert(head_dim % (SUB_GROUP_SIZE * 2) == 0,
-                "head_dim must be divisible by 64");
+  static_assert(
+      head_dim % (SUB_GROUP_SIZE * 2) == 0, "head_dim must be divisible by 64");
 
   fused_qk_norm_rope_kernel(
       scalar_t* __restrict__ qkv_,
@@ -46,14 +49,13 @@ class fused_qk_norm_rope_kernel {
         num_tokens(num_tokens_),
         rotary_dim(rotary_dim_) {}
 
-  void operator()[[sycl::reqd_sub_group_size(SUB_GROUP_SIZE)]](
+  void operator() [[sycl::reqd_sub_group_size(SUB_GROUP_SIZE)]] (
       const sycl::nd_item<1>& item) const {
     auto sg = item.get_sub_group();
     const int lane_id = sg.get_local_linear_id();
     const int sg_id_in_wg = sg.get_group_linear_id();
     const int sgs_per_wg = sg.get_group_linear_range();
-    const int global_sg_id =
-        item.get_group(0) * sgs_per_wg + sg_id_in_wg;
+    const int global_sg_id = item.get_group(0) * sgs_per_wg + sg_id_in_wg;
 
     const int total_qk_heads = num_heads_q + num_heads_k;
     const int token_idx = global_sg_id / total_qk_heads;
@@ -62,8 +64,7 @@ class fused_qk_norm_rope_kernel {
     if (token_idx >= num_tokens) return;
 
     const bool is_q = local_head_idx < num_heads_q;
-    const int head_idx =
-        is_q ? local_head_idx : local_head_idx - num_heads_q;
+    const int head_idx = is_q ? local_head_idx : local_head_idx - num_heads_q;
     const int num_heads = num_heads_q + num_heads_k + num_heads_v;
 
     // Compute the offset into the QKV tensor for this sub-group's head.
@@ -71,8 +72,8 @@ class fused_qk_norm_rope_kernel {
     if (is_q) {
       offset_warp = token_idx * num_heads * head_dim + head_idx * head_dim;
     } else {
-      offset_warp = token_idx * num_heads * head_dim +
-                    num_heads_q * head_dim + head_idx * head_dim;
+      offset_warp = token_idx * num_heads * head_dim + num_heads_q * head_dim +
+                    head_idx * head_dim;
     }
     int offset_thread = offset_warp + lane_id * NUM_ELEMS_PER_THREAD;
 
@@ -107,8 +108,7 @@ class fused_qk_norm_rope_kernel {
     // Apply RoPE.
     const int64_t pos_id = position_ids[token_idx];
     const int embed_dim = rotary_dim / 2;
-    const scalar_t_cache* cache_ptr =
-        cos_sin_cache + pos_id * rotary_dim;
+    const scalar_t_cache* cache_ptr = cos_sin_cache + pos_id * rotary_dim;
     const scalar_t_cache* cos_ptr = cache_ptr;
     const scalar_t_cache* sin_ptr = cache_ptr + embed_dim;
 
@@ -136,8 +136,7 @@ class fused_qk_norm_rope_kernel {
       } else {
         // Neox-style RoPE: exchange data with partner lane.
         sycl::group_barrier(sg);
-        const int pair_offset =
-            (rotary_dim / 2) / NUM_ELEMS_PER_THREAD;
+        const int pair_offset = (rotary_dim / 2) / NUM_ELEMS_PER_THREAD;
 
 #pragma unroll
         for (int i = 0; i < NUM_ELEMS_PER_THREAD; i++) {
@@ -198,8 +197,7 @@ void launch_fused_qk_norm_rope(
     bool is_neox,
     torch::Tensor& position_ids) {
   using sycl_t = typename vllm::xpu::SyclTypeTrait<scalar_t>::Type;
-  using sycl_cache_t =
-      typename vllm::xpu::SyclTypeTrait<scalar_t_cache>::Type;
+  using sycl_cache_t = typename vllm::xpu::SyclTypeTrait<scalar_t_cache>::Type;
 
   constexpr int block_size = 256;
   constexpr int sgs_per_wg = block_size / 32;
@@ -219,29 +217,43 @@ void launch_fused_qk_norm_rope(
 
   auto& queue = vllm::xpu::vllmGetQueue();
 
-#define DISPATCH_HEAD_DIM(HEAD_DIM)                                        \
-  do {                                                                     \
-    if (is_neox) {                                                         \
-      queue.submit([&](sycl::handler& cgh) {                              \
-        cgh.parallel_for(                                                  \
-            sycl::nd_range<1>(grid_size * block_size, block_size),         \
-            fused_qk_norm_rope_kernel<sycl_t, sycl_cache_t, HEAD_DIM,     \
-                                      true>(                               \
-                qkv_ptr, num_heads_q, num_heads_k, num_heads_v, eps,       \
-                q_weight_ptr, k_weight_ptr, cos_sin_cache_ptr,             \
-                position_ids_ptr, num_tokens, rotary_dim));                \
-      });                                                                  \
-    } else {                                                               \
-      queue.submit([&](sycl::handler& cgh) {                              \
-        cgh.parallel_for(                                                  \
-            sycl::nd_range<1>(grid_size * block_size, block_size),         \
-            fused_qk_norm_rope_kernel<sycl_t, sycl_cache_t, HEAD_DIM,     \
-                                      false>(                              \
-                qkv_ptr, num_heads_q, num_heads_k, num_heads_v, eps,       \
-                q_weight_ptr, k_weight_ptr, cos_sin_cache_ptr,             \
-                position_ids_ptr, num_tokens, rotary_dim));                \
-      });                                                                  \
-    }                                                                      \
+#define DISPATCH_HEAD_DIM(HEAD_DIM)                                           \
+  do {                                                                        \
+    if (is_neox) {                                                            \
+      queue.submit([&](sycl::handler& cgh) {                                  \
+        cgh.parallel_for(                                                     \
+            sycl::nd_range<1>(grid_size * block_size, block_size),            \
+            fused_qk_norm_rope_kernel<sycl_t, sycl_cache_t, HEAD_DIM, true>(  \
+                qkv_ptr,                                                      \
+                num_heads_q,                                                  \
+                num_heads_k,                                                  \
+                num_heads_v,                                                  \
+                eps,                                                          \
+                q_weight_ptr,                                                 \
+                k_weight_ptr,                                                 \
+                cos_sin_cache_ptr,                                            \
+                position_ids_ptr,                                             \
+                num_tokens,                                                   \
+                rotary_dim));                                                 \
+      });                                                                     \
+    } else {                                                                  \
+      queue.submit([&](sycl::handler& cgh) {                                  \
+        cgh.parallel_for(                                                     \
+            sycl::nd_range<1>(grid_size * block_size, block_size),            \
+            fused_qk_norm_rope_kernel<sycl_t, sycl_cache_t, HEAD_DIM, false>( \
+                qkv_ptr,                                                      \
+                num_heads_q,                                                  \
+                num_heads_k,                                                  \
+                num_heads_v,                                                  \
+                eps,                                                          \
+                q_weight_ptr,                                                 \
+                k_weight_ptr,                                                 \
+                cos_sin_cache_ptr,                                            \
+                position_ids_ptr,                                             \
+                num_tokens,                                                   \
+                rotary_dim));                                                 \
+      });                                                                     \
+    }                                                                         \
   } while (0)
 
   switch (head_dim) {
@@ -255,9 +267,10 @@ void launch_fused_qk_norm_rope(
       DISPATCH_HEAD_DIM(256);
       break;
     default:
-      TORCH_CHECK(false,
-                  "Unsupported head dimension for fused_qk_norm_rope: ",
-                  head_dim);
+      TORCH_CHECK(
+          false,
+          "Unsupported head dimension for fused_qk_norm_rope: ",
+          head_dim);
   }
 
 #undef DISPATCH_HEAD_DIM
@@ -290,53 +303,63 @@ void fused_qk_norm_rope(
   CHECK_DEVICE(cos_sin_cache);
   CHECK_CONTIGUOUS(cos_sin_cache);
 
-  TORCH_CHECK(position_ids.scalar_type() == torch::kInt64,
-              "position_ids must be int64");
-  TORCH_CHECK(qkv.dim() == 2,
-              "QKV tensor must be 2D: [num_tokens, "
-              "(num_heads_q+num_heads_k+num_heads_v)*head_dim]");
-  TORCH_CHECK(position_ids.dim() == 1,
-              "Position IDs must be 1D: [num_tokens]");
+  TORCH_CHECK(
+      position_ids.scalar_type() == torch::kInt64,
+      "position_ids must be int64");
+  TORCH_CHECK(
+      qkv.dim() == 2,
+      "QKV tensor must be 2D: [num_tokens, "
+      "(num_heads_q+num_heads_k+num_heads_v)*head_dim]");
+  TORCH_CHECK(position_ids.dim() == 1, "Position IDs must be 1D: [num_tokens]");
   TORCH_CHECK(q_weight.dim() == 1, "Query weights must be 1D: [head_dim]");
   TORCH_CHECK(k_weight.dim() == 1, "Key weights must be 1D: [head_dim]");
-  TORCH_CHECK(cos_sin_cache.dim() == 2,
-              "Cos/sin cache must be 2D: [max_position, rotary_dim]");
-  TORCH_CHECK(q_weight.size(0) == head_dim,
-              "Query weights size must match head dimension");
-  TORCH_CHECK(k_weight.size(0) == head_dim,
-              "Key weights size must match head dimension");
+  TORCH_CHECK(
+      cos_sin_cache.dim() == 2,
+      "Cos/sin cache must be 2D: [max_position, rotary_dim]");
+  TORCH_CHECK(
+      q_weight.size(0) == head_dim,
+      "Query weights size must match head dimension");
+  TORCH_CHECK(
+      k_weight.size(0) == head_dim,
+      "Key weights size must match head dimension");
   TORCH_CHECK(cos_sin_cache.size(1) % 2 == 0, "rotary_dim must be even");
-  TORCH_CHECK(cos_sin_cache.size(1) <= head_dim,
-              "rotary_dim must be less than or equal to head_dim");
-  TORCH_CHECK(qkv.scalar_type() == q_weight.scalar_type() &&
-                  qkv.scalar_type() == k_weight.scalar_type(),
-              "qkv, q_weight and k_weight must have the same dtype");
+  TORCH_CHECK(
+      cos_sin_cache.size(1) <= head_dim,
+      "rotary_dim must be less than or equal to head_dim");
+  TORCH_CHECK(
+      qkv.scalar_type() == q_weight.scalar_type() &&
+          qkv.scalar_type() == k_weight.scalar_type(),
+      "qkv, q_weight and k_weight must have the same dtype");
 
   int64_t num_tokens = qkv.size(0);
-  TORCH_CHECK(position_ids.size(0) == num_tokens,
-              "Number of tokens in position_ids must match QKV");
+  TORCH_CHECK(
+      position_ids.size(0) == num_tokens,
+      "Number of tokens in position_ids must match QKV");
 
   int64_t total_heads = num_heads_q + num_heads_k + num_heads_v;
   TORCH_CHECK(
       qkv.size(1) == total_heads * head_dim,
       "QKV tensor size must match total number of heads and head dimension");
 
-  VLLM_DISPATCH_HALF_TYPES(
-      qkv.scalar_type(), "fused_qk_norm_rope", [&] {
-        using qkv_scalar_t = scalar_t;
-        VLLM_DISPATCH_FLOATING_TYPES(
-            cos_sin_cache.scalar_type(), "fused_qk_norm_rope_cache", [&] {
-              using cache_scalar_t = scalar_t;
-              vllm::launch_fused_qk_norm_rope<qkv_scalar_t,
-                                               cache_scalar_t>(
-                  qkv, static_cast<int>(num_tokens),
-                  static_cast<int>(num_heads_q),
-                  static_cast<int>(num_heads_k),
-                  static_cast<int>(num_heads_v),
-                  static_cast<int>(head_dim),
-                  static_cast<int>(cos_sin_cache.size(1)),
-                  static_cast<float>(eps), q_weight, k_weight,
-                  cos_sin_cache, is_neox, position_ids);
-            });
-      });
+  VLLM_DISPATCH_HALF_TYPES(qkv.scalar_type(), "fused_qk_norm_rope", [&] {
+    using qkv_scalar_t = scalar_t;
+    VLLM_DISPATCH_FLOATING_TYPES(
+        cos_sin_cache.scalar_type(), "fused_qk_norm_rope_cache", [&] {
+          using cache_scalar_t = scalar_t;
+          vllm::launch_fused_qk_norm_rope<qkv_scalar_t, cache_scalar_t>(
+              qkv,
+              static_cast<int>(num_tokens),
+              static_cast<int>(num_heads_q),
+              static_cast<int>(num_heads_k),
+              static_cast<int>(num_heads_v),
+              static_cast<int>(head_dim),
+              static_cast<int>(cos_sin_cache.size(1)),
+              static_cast<float>(eps),
+              q_weight,
+              k_weight,
+              cos_sin_cache,
+              is_neox,
+              position_ids);
+        });
+  });
 }

--- a/csrc/layernorm.cpp
+++ b/csrc/layernorm.cpp
@@ -1,6 +1,7 @@
 #include <sycl/sycl.hpp>
 
 #include <algorithm>
+#include <ATen/DeviceGuard.h>
 #include "utils.h"
 #include "dispatch_utils.h"
 
@@ -331,6 +332,7 @@ void rms_norm(
     torch::Tensor& input,
     torch::Tensor& weight,
     double epsilon) {
+  const at::DeviceGuard device_guard(input.device());
   TORCH_CHECK(out.is_contiguous());
   if (input.stride(-1) != 1) {
     input = input.contiguous();
@@ -348,6 +350,7 @@ void fused_add_rms_norm(
     torch::Tensor& residual,
     torch::Tensor& weight,
     double epsilon) {
+  const at::DeviceGuard device_guard(input.device());
   int hidden_size = input.size(-1);
   int num_tokens = input.numel() / hidden_size;
 

--- a/csrc/layernorm_quant.cpp
+++ b/csrc/layernorm_quant.cpp
@@ -97,12 +97,11 @@ class rms_norm_dynamic_per_token_quant_kernel {
         computed_scale = (absmax > 0.0f) ? (absmax / 127.0f) : 1.0f;
       } else {
         // FP8
-        const float fp8_max =
-            static_cast<float>(fp8::quant_type_max_v<out_t>);
+        const float fp8_max = static_cast<float>(fp8::quant_type_max_v<out_t>);
         const float clamped_absmax =
             (scale_ub != nullptr) ? sycl::min(absmax, *scale_ub) : absmax;
-        computed_scale = sycl::max(clamped_absmax / fp8_max,
-                                   fp8::min_scaling_factor<out_t>::val());
+        computed_scale = sycl::max(
+            clamped_absmax / fp8_max, fp8::min_scaling_factor<out_t>::val());
       }
       s_local[1] = computed_scale;
       scales[token_idx] = computed_scale;
@@ -122,8 +121,7 @@ class rms_norm_dynamic_per_token_quant_kernel {
             sycl::max(sycl::min(sycl::rint(q), 127.0f), -128.0f));
       } else {
         // FP8
-        const float fp8_max =
-            static_cast<float>(fp8::quant_type_max_v<out_t>);
+        const float fp8_max = static_cast<float>(fp8::quant_type_max_v<out_t>);
         token_output[i] =
             static_cast<out_t>(sycl::max(sycl::min(q, fp8_max), -fp8_max));
       }
@@ -231,13 +229,12 @@ class rms_norm_per_block_quant_kernel {
           // FP8
           const float fp8_max =
               static_cast<float>(fp8::quant_type_max_v<out_t>);
-          group_scale = sycl::max(group_absmax / fp8_max,
-                                  fp8::min_scaling_factor<out_t>::val());
+          group_scale = sycl::max(
+              group_absmax / fp8_max, fp8::min_scaling_factor<out_t>::val());
         }
         s_local[1] = group_scale;
-        const int64_t scale_idx =
-            token_idx * scale_stride_token +
-            static_cast<int64_t>(g) * scale_stride_group;
+        const int64_t scale_idx = token_idx * scale_stride_token +
+                                  static_cast<int64_t>(g) * scale_stride_group;
         scales[scale_idx] = group_scale;
       }
       sycl::group_barrier(item.get_group());
@@ -279,7 +276,6 @@ class rms_norm_per_block_quant_kernel {
   const int64_t scale_stride_token;
   const int64_t scale_stride_group;
 };
-
 
 template <typename scalar_t, typename out_t, int VEC_SIZE>
 class rms_norm_static_fp8_quant_kernel {
@@ -347,8 +343,8 @@ class rms_norm_static_fp8_quant_kernel {
       for (int j = 0; j < VEC_SIZE; j++) {
         float x = static_cast<float>(src[j]);
         // Weight multiply in scalar_t precision to match unfused path
-        float norm_x = static_cast<float>(
-            static_cast<scalar_t>(x * inv_rms) * wgt[j]);
+        float norm_x =
+            static_cast<float>(static_cast<scalar_t>(x * inv_rms) * wgt[j]);
         float q = norm_x * scale_inv;
         token_output[i * VEC_SIZE + j] =
             static_cast<out_t>(sycl::max(sycl::min(q, fp8_max), -fp8_max));
@@ -365,7 +361,6 @@ class rms_norm_static_fp8_quant_kernel {
   const float epsilon;
   const int hidden_size;
 };
-
 
 template <typename scalar_t, typename out_t, int VEC_SIZE>
 class fused_add_rms_norm_static_fp8_quant_kernel {
@@ -442,8 +437,8 @@ class fused_add_rms_norm_static_fp8_quant_kernel {
       for (int j = 0; j < VEC_SIZE; j++) {
         float x = static_cast<float>(res[j]);
         // Weight multiply in scalar_t precision to match unfused path
-        float norm_x = static_cast<float>(
-            static_cast<scalar_t>(x * inv_rms) * wgt[j]);
+        float norm_x =
+            static_cast<float>(static_cast<scalar_t>(x * inv_rms) * wgt[j]);
         float q = norm_x * scale_inv;
         token_output[i * VEC_SIZE + j] =
             static_cast<out_t>(sycl::max(sycl::min(q, fp8_max), -fp8_max));
@@ -534,8 +529,7 @@ void call_rms_norm_per_block_quant_kernel(
   // Compute scale strides based on transposition
   const int64_t scale_stride_token =
       is_scale_transposed ? 1 : static_cast<int64_t>(num_groups);
-  const int64_t scale_stride_group =
-      is_scale_transposed ? num_tokens : 1LL;
+  const int64_t scale_stride_group = is_scale_transposed ? num_tokens : 1LL;
 
   auto* out_ptr = out.data_ptr<out_t>();
   auto* input_ptr = input.data_ptr<scalar_t>();
@@ -616,10 +610,18 @@ void call_rms_norm_static_fp8_quant_kernel(
 
   // Dispatch on vec_size (gcd guarantees hidden_size % vec_size == 0)
   switch (vec_size) {
-    case 8:  launch(std::integral_constant<int, 8>{}); break;
-    case 4:  launch(std::integral_constant<int, 4>{}); break;
-    case 2:  launch(std::integral_constant<int, 2>{}); break;
-    default: launch(std::integral_constant<int, 1>{}); break;
+    case 8:
+      launch(std::integral_constant<int, 8>{});
+      break;
+    case 4:
+      launch(std::integral_constant<int, 4>{});
+      break;
+    case 2:
+      launch(std::integral_constant<int, 2>{});
+      break;
+    default:
+      launch(std::integral_constant<int, 1>{});
+      break;
   }
 }
 
@@ -669,10 +671,18 @@ void call_fused_add_rms_norm_static_fp8_quant_kernel(
 
   // Dispatch on vec_size (gcd guarantees hidden_size % vec_size == 0)
   switch (vec_size) {
-    case 8:  launch(std::integral_constant<int, 8>{}); break;
-    case 4:  launch(std::integral_constant<int, 4>{}); break;
-    case 2:  launch(std::integral_constant<int, 2>{}); break;
-    default: launch(std::integral_constant<int, 1>{}); break;
+    case 8:
+      launch(std::integral_constant<int, 8>{});
+      break;
+    case 4:
+      launch(std::integral_constant<int, 4>{});
+      break;
+    case 2:
+      launch(std::integral_constant<int, 2>{});
+      break;
+    default:
+      launch(std::integral_constant<int, 1>{});
+      break;
   }
 }
 
@@ -689,36 +699,49 @@ void rms_norm_dynamic_per_token_quant(
   const at::DeviceGuard device_guard(input.device());
   TORCH_CHECK(input.is_contiguous(), "input must be contiguous");
   TORCH_CHECK(out.is_contiguous(), "out must be contiguous");
-  TORCH_CHECK(weight.dtype() == input.dtype(),
-              "weight and input must have the same dtype");
-  TORCH_CHECK(scales.dtype() == torch::kFloat32,
-              "scales must be float32");
+  TORCH_CHECK(
+      weight.dtype() == input.dtype(),
+      "weight and input must have the same dtype");
+  TORCH_CHECK(scales.dtype() == torch::kFloat32, "scales must be float32");
   TORCH_CHECK(
       out.dtype() == torch::kFloat8_e4m3fn || out.dtype() == torch::kInt8,
       "output must be float8_e4m3fn or int8");
   if (scale_ub.has_value()) {
-    TORCH_CHECK(out.dtype() == torch::kFloat8_e4m3fn,
-                "scale_ub is only supported for FP8 output");
+    TORCH_CHECK(
+        out.dtype() == torch::kFloat8_e4m3fn,
+        "scale_ub is only supported for FP8 output");
   }
   if (residual.has_value()) {
-    TORCH_CHECK(residual->scalar_type() == input.scalar_type(),
-                "residual and input must have the same dtype");
+    TORCH_CHECK(
+        residual->scalar_type() == input.scalar_type(),
+        "residual and input must have the same dtype");
     TORCH_CHECK(residual->is_contiguous(), "residual must be contiguous");
   }
 
   if (out.dtype() == torch::kFloat8_e4m3fn) {
     VLLM_DISPATCH_FLOATING_TYPES(
         input.scalar_type(), "rms_norm_dynamic_per_token_quant", [&] {
-          vllm::call_rms_norm_dynamic_per_token_quant_kernel<scalar_t,
-                                                             at::Float8_e4m3fn>(
-              out, residual, input, weight, scale_ub, scales,
+          vllm::call_rms_norm_dynamic_per_token_quant_kernel<
+              scalar_t,
+              at::Float8_e4m3fn>(
+              out,
+              residual,
+              input,
+              weight,
+              scale_ub,
+              scales,
               static_cast<float>(epsilon));
         });
   } else {
     VLLM_DISPATCH_FLOATING_TYPES(
         input.scalar_type(), "rms_norm_dynamic_per_token_quant_int8", [&] {
           vllm::call_rms_norm_dynamic_per_token_quant_kernel<scalar_t, int8_t>(
-              out, residual, input, weight, scale_ub, scales,
+              out,
+              residual,
+              input,
+              weight,
+              scale_ub,
+              scales,
               static_cast<float>(epsilon));
         });
   }
@@ -737,35 +760,46 @@ void rms_norm_per_block_quant(
   const at::DeviceGuard device_guard(input.device());
   TORCH_CHECK(input.is_contiguous(), "input must be contiguous");
   TORCH_CHECK(out.is_contiguous(), "out must be contiguous");
-  TORCH_CHECK(weight.dtype() == input.dtype(),
-              "weight and input must have the same dtype");
+  TORCH_CHECK(
+      weight.dtype() == input.dtype(),
+      "weight and input must have the same dtype");
   TORCH_CHECK(scales.dtype() == torch::kFloat32, "scales must be float32");
   TORCH_CHECK(
       out.dtype() == torch::kFloat8_e4m3fn || out.dtype() == torch::kInt8,
       "output must be float8_e4m3fn or int8");
-  TORCH_CHECK(input.size(-1) % group_size == 0,
-              "hidden_size must be divisible by group_size");
+  TORCH_CHECK(
+      input.size(-1) % group_size == 0,
+      "hidden_size must be divisible by group_size");
   if (residual.has_value()) {
-    TORCH_CHECK(residual->scalar_type() == input.scalar_type(),
-                "residual and input must have the same dtype");
+    TORCH_CHECK(
+        residual->scalar_type() == input.scalar_type(),
+        "residual and input must have the same dtype");
     TORCH_CHECK(residual->is_contiguous(), "residual must be contiguous");
   }
 
   if (out.dtype() == torch::kFloat8_e4m3fn) {
     VLLM_DISPATCH_FLOATING_TYPES(
         input.scalar_type(), "rms_norm_per_block_quant", [&] {
-          vllm::call_rms_norm_per_block_quant_kernel<scalar_t,
-                                                     at::Float8_e4m3fn>(
-              out, residual, input, weight, scales,
-              static_cast<float>(epsilon),
-              static_cast<int>(group_size),
-              is_scale_transposed);
+          vllm::
+              call_rms_norm_per_block_quant_kernel<scalar_t, at::Float8_e4m3fn>(
+                  out,
+                  residual,
+                  input,
+                  weight,
+                  scales,
+                  static_cast<float>(epsilon),
+                  static_cast<int>(group_size),
+                  is_scale_transposed);
         });
   } else {
     VLLM_DISPATCH_FLOATING_TYPES(
         input.scalar_type(), "rms_norm_per_block_quant_int8", [&] {
           vllm::call_rms_norm_per_block_quant_kernel<scalar_t, int8_t>(
-              out, residual, input, weight, scales,
+              out,
+              residual,
+              input,
+              weight,
+              scales,
               static_cast<float>(epsilon),
               static_cast<int>(group_size),
               is_scale_transposed);
@@ -781,16 +815,16 @@ void rms_norm_static_fp8_quant(
     double epsilon) {
   const at::DeviceGuard device_guard(input.device());
   TORCH_CHECK(out.is_contiguous(), "out must be contiguous");
-  TORCH_CHECK(weight.dtype() == input.dtype(),
-              "weight and input must have the same dtype");
+  TORCH_CHECK(
+      weight.dtype() == input.dtype(),
+      "weight and input must have the same dtype");
 
   VLLM_DISPATCH_FLOATING_TYPES(
       input.scalar_type(), "rms_norm_static_fp8_quant", [&] {
         VLLM_DISPATCH_FP8_TYPES(
             out.scalar_type(), "rms_norm_static_fp8_quant_fp8", [&] {
               vllm::call_rms_norm_static_fp8_quant_kernel<scalar_t, fp8_t>(
-                  out, input, weight, scale,
-                  static_cast<float>(epsilon));
+                  out, input, weight, scale, static_cast<float>(epsilon));
             });
       });
 }
@@ -805,18 +839,25 @@ void fused_add_rms_norm_static_fp8_quant(
   const at::DeviceGuard device_guard(input.device());
   TORCH_CHECK(out.is_contiguous(), "out must be contiguous");
   TORCH_CHECK(residual.is_contiguous(), "residual must be contiguous");
-  TORCH_CHECK(residual.scalar_type() == input.scalar_type(),
-              "residual and input must have the same dtype");
-  TORCH_CHECK(weight.scalar_type() == input.scalar_type(),
-              "weight and input must have the same dtype");
+  TORCH_CHECK(
+      residual.scalar_type() == input.scalar_type(),
+      "residual and input must have the same dtype");
+  TORCH_CHECK(
+      weight.scalar_type() == input.scalar_type(),
+      "weight and input must have the same dtype");
 
   VLLM_DISPATCH_FLOATING_TYPES(
       input.scalar_type(), "fused_add_rms_norm_static_fp8_quant", [&] {
         VLLM_DISPATCH_FP8_TYPES(
             out.scalar_type(), "fused_add_rms_norm_static_fp8_quant_fp8", [&] {
               vllm::call_fused_add_rms_norm_static_fp8_quant_kernel<
-                  scalar_t, fp8_t>(
-                  out, input, residual, weight, scale,
+                  scalar_t,
+                  fp8_t>(
+                  out,
+                  input,
+                  residual,
+                  weight,
+                  scale,
                   static_cast<float>(epsilon));
             });
       });

--- a/csrc/layernorm_quant.cpp
+++ b/csrc/layernorm_quant.cpp
@@ -586,8 +586,10 @@ void call_rms_norm_static_fp8_quant_kernel(
   const int max_block_size = (num_tokens < 256) ? 1024 : 256;
 
   // Dispatch VEC_SIZE = gcd(16 / sizeof(sycl_t), hidden_size) matching CUDA
-  const int vec_size =
+  const int candidate_vec_size =
       std::gcd(static_cast<int>(16 / sizeof(sycl_t)), hidden_size);
+  const int vec_size =
+      (input_stride % candidate_vec_size == 0) ? candidate_vec_size : 1;
   const int block_size = std::min(hidden_size / vec_size, max_block_size);
 
   auto& queue = vllm::xpu::vllmGetQueue();

--- a/csrc/layernorm_quant.cpp
+++ b/csrc/layernorm_quant.cpp
@@ -1,0 +1,823 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+#include <sycl/sycl.hpp>
+#include <iostream>
+#include <numeric>
+
+#include <c10/util/Float8_e4m3fn.h>
+#include <c10/util/Float8_e5m2.h>
+
+#include "dispatch_utils.h"
+#include "ops.h"
+#include "utils.h"
+#include "quantization/fp8/quant_utils.h"
+#include <ATen/DeviceGuard.h>
+
+namespace vllm {
+
+template <typename scalar_t>
+struct alignas(8) vec4_t {
+  scalar_t val[4];
+};
+
+template <typename scalar_t, typename out_t, bool has_residual>
+class rms_norm_dynamic_per_token_quant_kernel {
+ public:
+  rms_norm_dynamic_per_token_quant_kernel(
+      out_t* __restrict__ out_,
+      scalar_t* __restrict__ residual_,
+      const scalar_t* __restrict__ input_,
+      const scalar_t* __restrict__ weight_,
+      const float* __restrict__ scale_ub_,
+      float* __restrict__ scales_,
+      const float epsilon_,
+      const int hidden_size_)
+      : out(out_),
+        residual(residual_),
+        input(input_),
+        weight(weight_),
+        scale_ub(scale_ub_),
+        scales(scales_),
+        epsilon(epsilon_),
+        hidden_size(hidden_size_) {}
+
+  void operator()(sycl::nd_item<1> item) const {
+    const int tid = item.get_local_id(0);
+    const int local_range = item.get_local_range(0);
+    const int64_t token_idx = item.get_group(0);
+
+    // s_local[0] = inv_rms,  s_local[1] = scale
+    auto& s_local =
+        *sycl::ext::oneapi::group_local_memory_for_overwrite<float[2]>(
+            item.get_group());
+
+    const scalar_t* token_input = input + token_idx * hidden_size;
+    out_t* token_output = out + token_idx * hidden_size;
+    scalar_t* token_residual = nullptr;
+    if constexpr (has_residual) {
+      token_residual = residual + token_idx * hidden_size;
+    }
+
+    // Pass 1: optional residual add + compute variance
+    float variance = 0.0f;
+    for (int i = tid; i < hidden_size; i += local_range) {
+      float x = static_cast<float>(token_input[i]);
+      if constexpr (has_residual) {
+        x += static_cast<float>(token_residual[i]);
+        token_residual[i] = static_cast<scalar_t>(x);
+        // Read back the dtype-rounded value so variance is consistent with
+        // what pass 2 will use when reading token_residual.
+        x = static_cast<float>(token_residual[i]);
+      }
+      variance += x * x;
+    }
+    variance = sycl::reduce_over_group(
+        item.get_group(), variance, sycl::plus<float>());
+    if (tid == 0) {
+      s_local[0] = sycl::rsqrt(variance / hidden_size + epsilon);
+    }
+    sycl::group_barrier(item.get_group());
+    const float inv_rms = s_local[0];
+
+    // Pass 2: compute max |norm(x)| across the row → token scale
+    float absmax = 0.0f;
+    for (int i = tid; i < hidden_size; i += local_range) {
+      const float x = has_residual ? static_cast<float>(token_residual[i])
+                                   : static_cast<float>(token_input[i]);
+      const float norm_x = x * inv_rms * static_cast<float>(weight[i]);
+      absmax = sycl::max(absmax, sycl::fabs(norm_x));
+    }
+    absmax = sycl::reduce_over_group(
+        item.get_group(), absmax, sycl::maximum<float>());
+
+    if (tid == 0) {
+      float computed_scale;
+      if constexpr (std::is_same_v<out_t, int8_t>) {
+        computed_scale = (absmax > 0.0f) ? (absmax / 127.0f) : 1.0f;
+      } else {
+        // FP8
+        const float fp8_max =
+            static_cast<float>(fp8::quant_type_max_v<out_t>);
+        const float clamped_absmax =
+            (scale_ub != nullptr) ? sycl::min(absmax, *scale_ub) : absmax;
+        computed_scale = sycl::max(clamped_absmax / fp8_max,
+                                   fp8::min_scaling_factor<out_t>::val());
+      }
+      s_local[1] = computed_scale;
+      scales[token_idx] = computed_scale;
+    }
+    sycl::group_barrier(item.get_group());
+    const float inv_scale = 1.0f / s_local[1];
+
+    // Pass 3: normalize and quantize
+    for (int i = tid; i < hidden_size; i += local_range) {
+      const float x = has_residual ? static_cast<float>(token_residual[i])
+                                   : static_cast<float>(token_input[i]);
+      const float norm_x = x * inv_rms * static_cast<float>(weight[i]);
+      const float q = norm_x * inv_scale;
+
+      if constexpr (std::is_same_v<out_t, int8_t>) {
+        token_output[i] = static_cast<int8_t>(
+            sycl::max(sycl::min(sycl::rint(q), 127.0f), -128.0f));
+      } else {
+        // FP8
+        const float fp8_max =
+            static_cast<float>(fp8::quant_type_max_v<out_t>);
+        token_output[i] =
+            static_cast<out_t>(sycl::max(sycl::min(q, fp8_max), -fp8_max));
+      }
+    }
+  }
+
+ private:
+  out_t* __restrict__ out;
+  scalar_t* __restrict__ residual;
+  const scalar_t* __restrict__ input;
+  const scalar_t* __restrict__ weight;
+  const float* __restrict__ scale_ub;
+  float* __restrict__ scales;
+  const float epsilon;
+  const int hidden_size;
+};
+
+template <typename scalar_t, typename out_t, bool has_residual>
+class rms_norm_per_block_quant_kernel {
+ public:
+  rms_norm_per_block_quant_kernel(
+      out_t* __restrict__ out_,
+      scalar_t* __restrict__ residual_,
+      const scalar_t* __restrict__ input_,
+      const scalar_t* __restrict__ weight_,
+      float* __restrict__ scales_,
+      const float epsilon_,
+      const int hidden_size_,
+      const int group_size_,
+      const int num_tokens_,
+      const int64_t scale_stride_token_,
+      const int64_t scale_stride_group_)
+      : out(out_),
+        residual(residual_),
+        input(input_),
+        weight(weight_),
+        scales(scales_),
+        epsilon(epsilon_),
+        hidden_size(hidden_size_),
+        group_size(group_size_),
+        num_tokens(num_tokens_),
+        scale_stride_token(scale_stride_token_),
+        scale_stride_group(scale_stride_group_) {}
+
+  void operator()(sycl::nd_item<1> item) const {
+    const int tid = item.get_local_id(0);
+    const int local_range = item.get_local_range(0);
+    const int64_t token_idx = item.get_group(0);
+
+    // s_local[0] = inv_rms,  s_local[1] = current group scale
+    auto& s_local =
+        *sycl::ext::oneapi::group_local_memory_for_overwrite<float[2]>(
+            item.get_group());
+
+    const scalar_t* token_input = input + token_idx * hidden_size;
+    out_t* token_output = out + token_idx * hidden_size;
+    scalar_t* token_residual = nullptr;
+    if constexpr (has_residual) {
+      token_residual = residual + token_idx * hidden_size;
+    }
+
+    // Pass 1: optional residual add + compute full-row variance
+    float variance = 0.0f;
+    for (int i = tid; i < hidden_size; i += local_range) {
+      float x = static_cast<float>(token_input[i]);
+      if constexpr (has_residual) {
+        x += static_cast<float>(token_residual[i]);
+        token_residual[i] = static_cast<scalar_t>(x);
+        // Read back the dtype-rounded value so variance is consistent with
+        // what passes 2+3 will use when reading token_residual.
+        x = static_cast<float>(token_residual[i]);
+      }
+      variance += x * x;
+    }
+    variance = sycl::reduce_over_group(
+        item.get_group(), variance, sycl::plus<float>());
+    if (tid == 0) {
+      s_local[0] = sycl::rsqrt(variance / hidden_size + epsilon);
+    }
+    sycl::group_barrier(item.get_group());
+    const float inv_rms = s_local[0];
+
+    // Pass 2+3: for each column group, compute scale then quantize
+    const int num_groups = hidden_size / group_size;
+    for (int g = 0; g < num_groups; g++) {
+      const int group_start = g * group_size;
+
+      // Find max |norm(x)| within this group
+      float group_absmax = 0.0f;
+      for (int i = tid; i < group_size; i += local_range) {
+        const int col = group_start + i;
+        const float x = has_residual ? static_cast<float>(token_residual[col])
+                                     : static_cast<float>(token_input[col]);
+        const float norm_x = x * inv_rms * static_cast<float>(weight[col]);
+        group_absmax = sycl::max(group_absmax, sycl::fabs(norm_x));
+      }
+      group_absmax = sycl::reduce_over_group(
+          item.get_group(), group_absmax, sycl::maximum<float>());
+
+      if (tid == 0) {
+        float group_scale;
+        if constexpr (std::is_same_v<out_t, int8_t>) {
+          group_scale = (group_absmax > 0.0f) ? (group_absmax / 127.0f) : 1.0f;
+        } else {
+          // FP8
+          const float fp8_max =
+              static_cast<float>(fp8::quant_type_max_v<out_t>);
+          group_scale = sycl::max(group_absmax / fp8_max,
+                                  fp8::min_scaling_factor<out_t>::val());
+        }
+        s_local[1] = group_scale;
+        const int64_t scale_idx =
+            token_idx * scale_stride_token +
+            static_cast<int64_t>(g) * scale_stride_group;
+        scales[scale_idx] = group_scale;
+      }
+      sycl::group_barrier(item.get_group());
+      const float inv_scale = 1.0f / s_local[1];
+
+      // Quantize this group
+      for (int i = tid; i < group_size; i += local_range) {
+        const int col = group_start + i;
+        const float x = has_residual ? static_cast<float>(token_residual[col])
+                                     : static_cast<float>(token_input[col]);
+        const float norm_x = x * inv_rms * static_cast<float>(weight[col]);
+        const float q = norm_x * inv_scale;
+
+        if constexpr (std::is_same_v<out_t, int8_t>) {
+          token_output[col] = static_cast<int8_t>(
+              sycl::max(sycl::min(sycl::rint(q), 127.0f), -128.0f));
+        } else {
+          // FP8
+          const float fp8_max =
+              static_cast<float>(fp8::quant_type_max_v<out_t>);
+          token_output[col] =
+              static_cast<out_t>(sycl::max(sycl::min(q, fp8_max), -fp8_max));
+        }
+      }
+      sycl::group_barrier(item.get_group());
+    }
+  }
+
+ private:
+  out_t* __restrict__ out;
+  scalar_t* __restrict__ residual;
+  const scalar_t* __restrict__ input;
+  const scalar_t* __restrict__ weight;
+  float* __restrict__ scales;
+  const float epsilon;
+  const int hidden_size;
+  const int group_size;
+  const int num_tokens;
+  const int64_t scale_stride_token;
+  const int64_t scale_stride_group;
+};
+
+
+template <typename scalar_t, typename out_t, int VEC_SIZE>
+class rms_norm_static_fp8_quant_kernel {
+ public:
+  rms_norm_static_fp8_quant_kernel(
+      out_t* __restrict__ out_,
+      const scalar_t* __restrict__ input_,
+      const int input_stride_,
+      const scalar_t* __restrict__ weight_,
+      const float* __restrict__ scale_,
+      const float epsilon_,
+      const int hidden_size_)
+      : out(out_),
+        input(input_),
+        input_stride(input_stride_),
+        weight(weight_),
+        scale(scale_),
+        epsilon(epsilon_),
+        hidden_size(hidden_size_) {}
+
+  void operator()(sycl::nd_item<1> item) const {
+    using vec_t = vllm::xpu::aligned_vec<scalar_t, VEC_SIZE>;
+
+    const int tid = item.get_local_id(0);
+    const int local_range = item.get_local_range(0);
+    const int64_t token_idx = item.get_group(0);
+
+    auto& s_variance =
+        *sycl::ext::oneapi::group_local_memory_for_overwrite<float>(
+            item.get_group());
+
+    const scalar_t* token_input = input + token_idx * input_stride;
+    out_t* token_output = out + token_idx * hidden_size;
+    const int nvec = hidden_size / VEC_SIZE;
+
+    // Pass 1: compute variance — VEC_SIZE elements per work-item per iteration
+    float variance = 0.0f;
+    const auto* v_in = reinterpret_cast<const vec_t*>(token_input);
+    for (int i = tid; i < nvec; i += local_range) {
+      vec_t v = v_in[i];
+#pragma unroll
+      for (int j = 0; j < VEC_SIZE; j++) {
+        float x = static_cast<float>(v[j]);
+        variance += x * x;
+      }
+    }
+    variance = sycl::reduce_over_group(
+        item.get_group(), variance, sycl::plus<float>());
+    if (tid == 0) {
+      s_variance = sycl::rsqrt(variance / hidden_size + epsilon);
+    }
+    sycl::group_barrier(item.get_group());
+    const float inv_rms = s_variance;
+
+    // Invert scale to avoid division
+    const float scale_inv = 1.0f / (*scale);
+    const float fp8_max = static_cast<float>(fp8::quant_type_max_v<out_t>);
+
+    // Pass 2: normalize, apply weight, quantize — same vectorization as Pass 1
+    const auto* v_w = reinterpret_cast<const vec_t*>(weight);
+    for (int i = tid; i < nvec; i += local_range) {
+      vec_t src = v_in[i];
+      vec_t wgt = v_w[i];
+#pragma unroll
+      for (int j = 0; j < VEC_SIZE; j++) {
+        float x = static_cast<float>(src[j]);
+        // Weight multiply in scalar_t precision to match unfused path
+        float norm_x = static_cast<float>(
+            static_cast<scalar_t>(x * inv_rms) * wgt[j]);
+        float q = norm_x * scale_inv;
+        token_output[i * VEC_SIZE + j] =
+            static_cast<out_t>(sycl::max(sycl::min(q, fp8_max), -fp8_max));
+      }
+    }
+  }
+
+ private:
+  out_t* __restrict__ out;
+  const scalar_t* __restrict__ input;
+  const int input_stride;
+  const scalar_t* __restrict__ weight;
+  const float* __restrict__ scale;
+  const float epsilon;
+  const int hidden_size;
+};
+
+
+template <typename scalar_t, typename out_t, int VEC_SIZE>
+class fused_add_rms_norm_static_fp8_quant_kernel {
+ public:
+  fused_add_rms_norm_static_fp8_quant_kernel(
+      out_t* __restrict__ out_,
+      const scalar_t* __restrict__ input_,
+      const int input_stride_,
+      scalar_t* __restrict__ residual_,
+      const scalar_t* __restrict__ weight_,
+      const float* __restrict__ scale_,
+      const float epsilon_,
+      const int hidden_size_)
+      : out(out_),
+        input(input_),
+        input_stride(input_stride_),
+        residual(residual_),
+        weight(weight_),
+        scale(scale_),
+        epsilon(epsilon_),
+        hidden_size(hidden_size_) {}
+
+  void operator()(sycl::nd_item<1> item) const {
+    using vec_t = vllm::xpu::aligned_vec<scalar_t, VEC_SIZE>;
+
+    const int tid = item.get_local_id(0);
+    const int local_range = item.get_local_range(0);
+    const int64_t token_idx = item.get_group(0);
+
+    auto& s_variance =
+        *sycl::ext::oneapi::group_local_memory_for_overwrite<float>(
+            item.get_group());
+
+    const scalar_t* token_input = input + token_idx * input_stride;
+    scalar_t* token_residual = residual + token_idx * hidden_size;
+    out_t* token_output = out + token_idx * hidden_size;
+    const int nvec = hidden_size / VEC_SIZE;
+
+    // Pass 1: add residual + compute variance, VEC_SIZE elements per iteration
+    float variance = 0.0f;
+    const auto* v_in = reinterpret_cast<const vec_t*>(token_input);
+    auto* v_res = reinterpret_cast<vec_t*>(token_residual);
+    for (int i = tid; i < nvec; i += local_range) {
+      vec_t inp = v_in[i];
+      vec_t res = v_res[i];
+#pragma unroll
+      for (int j = 0; j < VEC_SIZE; j++) {
+        // Add in scalar_t precision to match fused_add_rms_norm kernel
+        scalar_t z = inp[j] + res[j];
+        res[j] = z;
+        float xf = static_cast<float>(z);
+        variance += xf * xf;
+      }
+      v_res[i] = res;  // write updated residual back
+    }
+    variance = sycl::reduce_over_group(
+        item.get_group(), variance, sycl::plus<float>());
+    if (tid == 0) {
+      s_variance = sycl::rsqrt(variance / hidden_size + epsilon);
+    }
+    sycl::group_barrier(item.get_group());
+    const float inv_rms = s_variance;
+
+    // Invert scale to avoid division
+    const float scale_inv = 1.0f / (*scale);
+    const float fp8_max = static_cast<float>(fp8::quant_type_max_v<out_t>);
+
+    // Pass 2: normalize from residual, apply weight, quantize
+    const auto* v_w = reinterpret_cast<const vec_t*>(weight);
+    for (int i = tid; i < nvec; i += local_range) {
+      vec_t res = v_res[i];
+      vec_t wgt = v_w[i];
+#pragma unroll
+      for (int j = 0; j < VEC_SIZE; j++) {
+        float x = static_cast<float>(res[j]);
+        // Weight multiply in scalar_t precision to match unfused path
+        float norm_x = static_cast<float>(
+            static_cast<scalar_t>(x * inv_rms) * wgt[j]);
+        float q = norm_x * scale_inv;
+        token_output[i * VEC_SIZE + j] =
+            static_cast<out_t>(sycl::max(sycl::min(q, fp8_max), -fp8_max));
+      }
+    }
+  }
+
+ private:
+  out_t* __restrict__ out;
+  const scalar_t* __restrict__ input;
+  const int input_stride;
+  scalar_t* __restrict__ residual;
+  const scalar_t* __restrict__ weight;
+  const float* __restrict__ scale;
+  const float epsilon;
+  const int hidden_size;
+};
+
+template <typename scalar_t, typename out_t>
+void call_rms_norm_dynamic_per_token_quant_kernel(
+    torch::Tensor& out,
+    std::optional<torch::Tensor>& residual,
+    torch::Tensor const& input,
+    torch::Tensor const& weight,
+    std::optional<torch::Tensor> const& scale_ub,
+    torch::Tensor& scales,
+    float epsilon) {
+  using sycl_t = typename vllm::xpu::SyclTypeTrait<scalar_t>::Type;
+
+  const int hidden_size = input.size(-1);
+  const int64_t num_tokens = input.numel() / hidden_size;
+  const int block_size = std::min(hidden_size, 1024);
+
+  auto* out_ptr = out.data_ptr<out_t>();
+  auto* input_ptr = input.data_ptr<scalar_t>();
+  auto* weight_ptr = weight.data_ptr<scalar_t>();
+  auto* scales_ptr = scales.data_ptr<float>();
+  const float* scale_ub_ptr =
+      scale_ub.has_value() ? scale_ub->data_ptr<float>() : nullptr;
+
+  auto& queue = vllm::xpu::vllmGetQueue();
+
+  auto launch = [&](auto has_residual_tag) {
+    constexpr bool has_residual = decltype(has_residual_tag)::value;
+    sycl_t* residual_ptr = nullptr;
+    if constexpr (has_residual) {
+      residual_ptr = (sycl_t*)residual->data_ptr<scalar_t>();
+    }
+    queue.submit([&](sycl::handler& cgh) {
+      cgh.parallel_for(
+          sycl::nd_range<1>(num_tokens * block_size, block_size),
+          rms_norm_dynamic_per_token_quant_kernel<sycl_t, out_t, has_residual>(
+              out_ptr,
+              residual_ptr,
+              (const sycl_t*)input_ptr,
+              (const sycl_t*)weight_ptr,
+              scale_ub_ptr,
+              scales_ptr,
+              epsilon,
+              hidden_size));
+    });
+  };
+
+  if (residual.has_value()) {
+    launch(std::true_type{});
+  } else {
+    launch(std::false_type{});
+  }
+}
+
+template <typename scalar_t, typename out_t>
+void call_rms_norm_per_block_quant_kernel(
+    torch::Tensor& out,
+    std::optional<torch::Tensor>& residual,
+    torch::Tensor const& input,
+    torch::Tensor const& weight,
+    torch::Tensor& scales,
+    float epsilon,
+    int group_size,
+    bool is_scale_transposed) {
+  using sycl_t = typename vllm::xpu::SyclTypeTrait<scalar_t>::Type;
+
+  const int hidden_size = input.size(-1);
+  const int64_t num_tokens = input.numel() / hidden_size;
+  const int num_groups = hidden_size / group_size;
+  const int block_size = std::min(hidden_size, 1024);
+
+  // Compute scale strides based on transposition
+  const int64_t scale_stride_token =
+      is_scale_transposed ? 1 : static_cast<int64_t>(num_groups);
+  const int64_t scale_stride_group =
+      is_scale_transposed ? num_tokens : 1LL;
+
+  auto* out_ptr = out.data_ptr<out_t>();
+  auto* input_ptr = input.data_ptr<scalar_t>();
+  auto* weight_ptr = weight.data_ptr<scalar_t>();
+  auto* scales_ptr = scales.data_ptr<float>();
+
+  auto& queue = vllm::xpu::vllmGetQueue();
+
+  auto launch = [&](auto has_residual_tag) {
+    constexpr bool has_residual = decltype(has_residual_tag)::value;
+    sycl_t* residual_ptr = nullptr;
+    if constexpr (has_residual) {
+      residual_ptr = (sycl_t*)residual->data_ptr<scalar_t>();
+    }
+    queue.submit([&](sycl::handler& cgh) {
+      cgh.parallel_for(
+          sycl::nd_range<1>(num_tokens * block_size, block_size),
+          rms_norm_per_block_quant_kernel<sycl_t, out_t, has_residual>(
+              out_ptr,
+              residual_ptr,
+              (const sycl_t*)input_ptr,
+              (const sycl_t*)weight_ptr,
+              scales_ptr,
+              epsilon,
+              hidden_size,
+              group_size,
+              static_cast<int>(num_tokens),
+              scale_stride_token,
+              scale_stride_group));
+    });
+  };
+
+  if (residual.has_value()) {
+    launch(std::true_type{});
+  } else {
+    launch(std::false_type{});
+  }
+}
+
+template <typename scalar_t, typename out_t>
+void call_rms_norm_static_fp8_quant_kernel(
+    torch::Tensor& out,
+    torch::Tensor const& input,
+    torch::Tensor const& weight,
+    torch::Tensor const& scale,
+    float epsilon) {
+  using sycl_t = typename vllm::xpu::SyclTypeTrait<scalar_t>::Type;
+
+  const int hidden_size = input.size(-1);
+  const int input_stride = input.stride(-2);
+  const int64_t num_tokens = input.numel() / hidden_size;
+
+  // Match CUDA: smaller blocks when num_tokens is large for better occupancy
+  const int max_block_size = (num_tokens < 256) ? 1024 : 256;
+
+  // Dispatch VEC_SIZE = gcd(16 / sizeof(sycl_t), hidden_size) matching CUDA
+  const int vec_size =
+      std::gcd(static_cast<int>(16 / sizeof(sycl_t)), hidden_size);
+  const int block_size = std::min(hidden_size / vec_size, max_block_size);
+
+  auto& queue = vllm::xpu::vllmGetQueue();
+
+  auto launch = [&](auto vec_tag) {
+    constexpr int VS = decltype(vec_tag)::value;
+    queue.submit([&](sycl::handler& cgh) {
+      cgh.parallel_for(
+          sycl::nd_range<1>(num_tokens * block_size, block_size),
+          rms_norm_static_fp8_quant_kernel<sycl_t, out_t, VS>(
+              out.data_ptr<out_t>(),
+              (const sycl_t*)input.data_ptr<scalar_t>(),
+              input_stride,
+              (const sycl_t*)weight.data_ptr<scalar_t>(),
+              scale.data_ptr<float>(),
+              epsilon,
+              hidden_size));
+    });
+  };
+
+  // Dispatch on vec_size (gcd guarantees hidden_size % vec_size == 0)
+  switch (vec_size) {
+    case 8:  launch(std::integral_constant<int, 8>{}); break;
+    case 4:  launch(std::integral_constant<int, 4>{}); break;
+    case 2:  launch(std::integral_constant<int, 2>{}); break;
+    default: launch(std::integral_constant<int, 1>{}); break;
+  }
+}
+
+template <typename scalar_t, typename out_t>
+void call_fused_add_rms_norm_static_fp8_quant_kernel(
+    torch::Tensor& out,
+    torch::Tensor& input,
+    torch::Tensor& residual,
+    torch::Tensor const& weight,
+    torch::Tensor const& scale,
+    float epsilon) {
+  using sycl_t = typename vllm::xpu::SyclTypeTrait<scalar_t>::Type;
+
+  const int hidden_size = input.size(-1);
+  const int input_stride = input.stride(-2);
+  const int64_t num_tokens = input.numel() / hidden_size;
+
+  // Match CUDA: smaller blocks when num_tokens is large for better occupancy
+  const int max_block_size = (num_tokens < 256) ? 1024 : 256;
+
+  // Dispatch VEC_SIZE = gcd(16 / sizeof(sycl_t), hidden_size) matching CUDA.
+  // Also require input_stride % vec_size == 0 for safe vectorized input reads.
+  int vec_size = std::gcd(static_cast<int>(16 / sizeof(sycl_t)), hidden_size);
+  if (input_stride % vec_size != 0) {
+    vec_size = 1;
+  }
+  const int block_size = std::min(hidden_size / vec_size, max_block_size);
+
+  auto& queue = vllm::xpu::vllmGetQueue();
+
+  auto launch = [&](auto vec_tag) {
+    constexpr int VS = decltype(vec_tag)::value;
+    queue.submit([&](sycl::handler& cgh) {
+      cgh.parallel_for(
+          sycl::nd_range<1>(num_tokens * block_size, block_size),
+          fused_add_rms_norm_static_fp8_quant_kernel<sycl_t, out_t, VS>(
+              out.data_ptr<out_t>(),
+              (const sycl_t*)input.data_ptr<scalar_t>(),
+              input_stride,
+              (sycl_t*)residual.data_ptr<scalar_t>(),
+              (const sycl_t*)weight.data_ptr<scalar_t>(),
+              scale.data_ptr<float>(),
+              epsilon,
+              hidden_size));
+    });
+  };
+
+  // Dispatch on vec_size (gcd guarantees hidden_size % vec_size == 0)
+  switch (vec_size) {
+    case 8:  launch(std::integral_constant<int, 8>{}); break;
+    case 4:  launch(std::integral_constant<int, 4>{}); break;
+    case 2:  launch(std::integral_constant<int, 2>{}); break;
+    default: launch(std::integral_constant<int, 1>{}); break;
+  }
+}
+
+}  // namespace vllm
+
+void rms_norm_dynamic_per_token_quant(
+    torch::Tensor& out,
+    torch::Tensor const& input,
+    torch::Tensor const& weight,
+    torch::Tensor& scales,
+    double const epsilon,
+    std::optional<torch::Tensor> scale_ub,
+    std::optional<torch::Tensor> residual) {
+  const at::DeviceGuard device_guard(input.device());
+  TORCH_CHECK(input.is_contiguous(), "input must be contiguous");
+  TORCH_CHECK(out.is_contiguous(), "out must be contiguous");
+  TORCH_CHECK(weight.dtype() == input.dtype(),
+              "weight and input must have the same dtype");
+  TORCH_CHECK(scales.dtype() == torch::kFloat32,
+              "scales must be float32");
+  TORCH_CHECK(
+      out.dtype() == torch::kFloat8_e4m3fn || out.dtype() == torch::kInt8,
+      "output must be float8_e4m3fn or int8");
+  if (scale_ub.has_value()) {
+    TORCH_CHECK(out.dtype() == torch::kFloat8_e4m3fn,
+                "scale_ub is only supported for FP8 output");
+  }
+  if (residual.has_value()) {
+    TORCH_CHECK(residual->scalar_type() == input.scalar_type(),
+                "residual and input must have the same dtype");
+    TORCH_CHECK(residual->is_contiguous(), "residual must be contiguous");
+  }
+
+  if (out.dtype() == torch::kFloat8_e4m3fn) {
+    VLLM_DISPATCH_FLOATING_TYPES(
+        input.scalar_type(), "rms_norm_dynamic_per_token_quant", [&] {
+          vllm::call_rms_norm_dynamic_per_token_quant_kernel<scalar_t,
+                                                             at::Float8_e4m3fn>(
+              out, residual, input, weight, scale_ub, scales,
+              static_cast<float>(epsilon));
+        });
+  } else {
+    VLLM_DISPATCH_FLOATING_TYPES(
+        input.scalar_type(), "rms_norm_dynamic_per_token_quant_int8", [&] {
+          vllm::call_rms_norm_dynamic_per_token_quant_kernel<scalar_t, int8_t>(
+              out, residual, input, weight, scale_ub, scales,
+              static_cast<float>(epsilon));
+        });
+  }
+}
+
+void rms_norm_per_block_quant(
+    torch::Tensor& out,
+    torch::Tensor const& input,
+    torch::Tensor const& weight,
+    torch::Tensor& scales,
+    double const epsilon,
+    std::optional<torch::Tensor> scale_ub,
+    std::optional<torch::Tensor> residual,
+    int64_t group_size,
+    bool is_scale_transposed) {
+  const at::DeviceGuard device_guard(input.device());
+  TORCH_CHECK(input.is_contiguous(), "input must be contiguous");
+  TORCH_CHECK(out.is_contiguous(), "out must be contiguous");
+  TORCH_CHECK(weight.dtype() == input.dtype(),
+              "weight and input must have the same dtype");
+  TORCH_CHECK(scales.dtype() == torch::kFloat32, "scales must be float32");
+  TORCH_CHECK(
+      out.dtype() == torch::kFloat8_e4m3fn || out.dtype() == torch::kInt8,
+      "output must be float8_e4m3fn or int8");
+  TORCH_CHECK(input.size(-1) % group_size == 0,
+              "hidden_size must be divisible by group_size");
+  if (residual.has_value()) {
+    TORCH_CHECK(residual->scalar_type() == input.scalar_type(),
+                "residual and input must have the same dtype");
+    TORCH_CHECK(residual->is_contiguous(), "residual must be contiguous");
+  }
+
+  if (out.dtype() == torch::kFloat8_e4m3fn) {
+    VLLM_DISPATCH_FLOATING_TYPES(
+        input.scalar_type(), "rms_norm_per_block_quant", [&] {
+          vllm::call_rms_norm_per_block_quant_kernel<scalar_t,
+                                                     at::Float8_e4m3fn>(
+              out, residual, input, weight, scales,
+              static_cast<float>(epsilon),
+              static_cast<int>(group_size),
+              is_scale_transposed);
+        });
+  } else {
+    VLLM_DISPATCH_FLOATING_TYPES(
+        input.scalar_type(), "rms_norm_per_block_quant_int8", [&] {
+          vllm::call_rms_norm_per_block_quant_kernel<scalar_t, int8_t>(
+              out, residual, input, weight, scales,
+              static_cast<float>(epsilon),
+              static_cast<int>(group_size),
+              is_scale_transposed);
+        });
+  }
+}
+
+void rms_norm_static_fp8_quant(
+    torch::Tensor& out,
+    torch::Tensor& input,
+    torch::Tensor& weight,
+    torch::Tensor& scale,
+    double epsilon) {
+  const at::DeviceGuard device_guard(input.device());
+  TORCH_CHECK(out.is_contiguous(), "out must be contiguous");
+  TORCH_CHECK(weight.dtype() == input.dtype(),
+              "weight and input must have the same dtype");
+
+  VLLM_DISPATCH_FLOATING_TYPES(
+      input.scalar_type(), "rms_norm_static_fp8_quant", [&] {
+        VLLM_DISPATCH_FP8_TYPES(
+            out.scalar_type(), "rms_norm_static_fp8_quant_fp8", [&] {
+              vllm::call_rms_norm_static_fp8_quant_kernel<scalar_t, fp8_t>(
+                  out, input, weight, scale,
+                  static_cast<float>(epsilon));
+            });
+      });
+}
+
+void fused_add_rms_norm_static_fp8_quant(
+    torch::Tensor& out,
+    torch::Tensor& input,
+    torch::Tensor& residual,
+    torch::Tensor& weight,
+    torch::Tensor& scale,
+    double epsilon) {
+  const at::DeviceGuard device_guard(input.device());
+  TORCH_CHECK(out.is_contiguous(), "out must be contiguous");
+  TORCH_CHECK(residual.is_contiguous(), "residual must be contiguous");
+  TORCH_CHECK(residual.scalar_type() == input.scalar_type(),
+              "residual and input must have the same dtype");
+  TORCH_CHECK(weight.scalar_type() == input.scalar_type(),
+              "weight and input must have the same dtype");
+
+  VLLM_DISPATCH_FLOATING_TYPES(
+      input.scalar_type(), "fused_add_rms_norm_static_fp8_quant", [&] {
+        VLLM_DISPATCH_FP8_TYPES(
+            out.scalar_type(), "fused_add_rms_norm_static_fp8_quant_fp8", [&] {
+              vllm::call_fused_add_rms_norm_static_fp8_quant_kernel<
+                  scalar_t, fp8_t>(
+                  out, input, residual, weight, scale,
+                  static_cast<float>(epsilon));
+            });
+      });
+}

--- a/csrc/ops.h
+++ b/csrc/ops.h
@@ -16,7 +16,49 @@ void fused_add_rms_norm(
     torch::Tensor& weight,
     double epsilon);
 
+// Fused RMSNorm + dynamic per-token quantization (FP8 or INT8 output).
+void rms_norm_dynamic_per_token_quant(
+    torch::Tensor& out,
+    torch::Tensor const& input,
+    torch::Tensor const& weight,
+    torch::Tensor& scales,
+    double const epsilon,
+    std::optional<torch::Tensor> scale_ub,
+    std::optional<torch::Tensor> residual);
+
+// Fused RMSNorm + per-column-block quantization (FP8 or INT8 output).
+void rms_norm_per_block_quant(
+    torch::Tensor& out,
+    torch::Tensor const& input,
+    torch::Tensor const& weight,
+    torch::Tensor& scales,
+    double const epsilon,
+    std::optional<torch::Tensor> scale_ub,
+    std::optional<torch::Tensor> residual,
+    int64_t group_size,
+    bool is_scale_transposed);
+
+void rms_norm_static_fp8_quant(
+    torch::Tensor& out,
+    torch::Tensor& input,
+    torch::Tensor& weight,
+    torch::Tensor& scale,
+    double epsilon);
+
+void fused_add_rms_norm_static_fp8_quant(
+    torch::Tensor& out,
+    torch::Tensor& input,
+    torch::Tensor& residual,
+    torch::Tensor& weight,
+    torch::Tensor& scale,
+    double epsilon);
+
 void silu_and_mul(torch::Tensor& out, torch::Tensor& input);
+
+void silu_and_mul_quant(
+    torch::Tensor& out,
+    torch::Tensor& input,
+    torch::Tensor& scale);
 
 void mul_and_silu(torch::Tensor& out, torch::Tensor& input);
 
@@ -37,6 +79,19 @@ void rotary_embedding(
     int64_t head_size,
     torch::Tensor& cos_sin_cache,
     bool is_neox);
+
+void fused_qk_norm_rope(
+    torch::Tensor& qkv,
+    int64_t num_heads_q,
+    int64_t num_heads_k,
+    int64_t num_heads_v,
+    int64_t head_dim,
+    double eps,
+    torch::Tensor& q_weight,
+    torch::Tensor& k_weight,
+    torch::Tensor& cos_sin_cache,
+    bool is_neox,
+    torch::Tensor& position_ids);
 
 void reshape_and_cache(
     torch::Tensor& key,

--- a/csrc/ops.h
+++ b/csrc/ops.h
@@ -56,9 +56,7 @@ void fused_add_rms_norm_static_fp8_quant(
 void silu_and_mul(torch::Tensor& out, torch::Tensor& input);
 
 void silu_and_mul_quant(
-    torch::Tensor& out,
-    torch::Tensor& input,
-    torch::Tensor& scale);
+    torch::Tensor& out, torch::Tensor& input, torch::Tensor& scale);
 
 void mul_and_silu(torch::Tensor& out, torch::Tensor& input);
 

--- a/csrc/quantization/fp4/mxfp4_quant.cpp
+++ b/csrc/quantization/fp4/mxfp4_quant.cpp
@@ -48,8 +48,7 @@ void per_token_group_quant_mxfp4(
     return;
   }
 
-  at::Device curDevice = at::Device(at::kXPU, at::xpu::current_device());
-  at::DeviceGuard device_guard(curDevice);
+  const at::DeviceGuard device_guard(input.device());
 
   // Choose how many sub-groups to pack into one work-group.
   constexpr int THREADS_PER_GROUP = 32;

--- a/csrc/quantization/fp8/fp8_quant.cpp
+++ b/csrc/quantization/fp8/fp8_quant.cpp
@@ -504,8 +504,7 @@ void static_scaled_fp8_quant(
   const int64_t in_row_stride = input.stride(-2);
   const int64_t out_row_stride = out.stride(-2);
 
-  at::Device curDevice = at::Device(at::kXPU, at::xpu::current_device());
-  at::DeviceGuard device_guard(curDevice);
+  const at::DeviceGuard device_guard(input.device());
 
   auto& queue = vllm::xpu::vllmGetQueue();
   VLLM_DISPATCH_FLOATING_TYPES(
@@ -562,8 +561,7 @@ void dynamic_scaled_fp8_quant(
   int64_t in_row_stride = input.stride(-2);
   int64_t out_row_stride = out.stride(-2);
 
-  at::Device curDevice = at::Device(at::kXPU, at::xpu::current_device());
-  at::DeviceGuard device_guard(curDevice);
+  const at::DeviceGuard device_guard(input.device());
 
   auto& queue = vllm::xpu::vllmGetQueue();
   VLLM_DISPATCH_FLOATING_TYPES(
@@ -616,8 +614,7 @@ void per_token_group_quant_fp8(
   TORCH_CHECK(input.numel() % group_size == 0);
   TORCH_CHECK(output_s.dim() == 2);
 
-  at::Device curDevice = at::Device(at::kXPU, at::xpu::current_device());
-  at::DeviceGuard device_guard(curDevice);
+  const at::DeviceGuard device_guard(input.device());
 
   constexpr int THREADS_PER_GROUP = 32;
 
@@ -684,8 +681,7 @@ void dynamic_per_token_scaled_fp8_quant(
   sycl::range<1> grid(num_tokens);
   sycl::range<1> block(std::min(hidden_size, 1024));
 
-  at::Device curDevice = at::Device(at::kXPU, at::xpu::current_device());
-  at::DeviceGuard device_guard(curDevice);
+  const at::DeviceGuard device_guard(input.device());
 
   auto& queue = vllm::xpu::vllmGetQueue();
   VLLM_DISPATCH_FLOATING_TYPES(

--- a/csrc/torch_bindings.cpp
+++ b/csrc/torch_bindings.cpp
@@ -21,10 +21,10 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
 
   // Layernorm
   // Apply Root Mean Square (RMS) Normalization to the input tensor.
+  // FIXME: torch op check consider input & weight is mutable in some ut
+  // cases. so we make it mutable here.
   ops.def(
-      // FIXME: torch op check consider input & weight is mutable in some ut
-      // cases. so we make it mutable here.
-      "rms_norm(Tensor! result, Tensor! input, Tensor! weight, float epsilon) "
+      "rms_norm(Tensor! result, Tensor input, Tensor weight, float epsilon) "
       "-> "
       "()");
   ops.impl("rms_norm", torch::kXPU, &rms_norm);
@@ -35,26 +35,63 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
       "float epsilon) -> ()");
   ops.impl("fused_add_rms_norm", torch::kXPU, &fused_add_rms_norm);
 
+  // Fused RMSNorm + dynamic per-token quantization (FP8 or INT8).
+  ops.def(
+      "rms_norm_dynamic_per_token_quant(Tensor! result, Tensor input, "
+      "Tensor weight, Tensor! scale, float epsilon, "
+      "Tensor? scale_ub, Tensor!? residual) -> ()");
+  ops.impl("rms_norm_dynamic_per_token_quant", torch::kXPU,
+           &rms_norm_dynamic_per_token_quant);
+
+  // Fused RMSNorm + per-column-block quantization (FP8 or INT8).
+  ops.def(
+      "rms_norm_per_block_quant(Tensor! result, Tensor input, "
+      "Tensor weight, Tensor! scale, float epsilon, "
+      "Tensor? scale_ub, Tensor!? residual, int group_size, "
+      "bool is_scale_transposed) -> ()");
+  ops.impl("rms_norm_per_block_quant", torch::kXPU,
+           &rms_norm_per_block_quant);
+
+  // Fused RMSNorm + static FP8 quantization.
+  ops.def(
+      "rms_norm_static_fp8_quant(Tensor! result, Tensor input, Tensor weight, "
+      "Tensor scale, float epsilon) -> ()");
+  ops.impl("rms_norm_static_fp8_quant", torch::kXPU,
+           &rms_norm_static_fp8_quant);
+
+  // In-place fused Add + RMSNorm + static FP8 quantization.
+  ops.def(
+      "fused_add_rms_norm_static_fp8_quant(Tensor! result, Tensor input, "
+      "Tensor! residual, Tensor weight, "
+      "Tensor scale, float epsilon) -> ()");
+  ops.impl("fused_add_rms_norm_static_fp8_quant", torch::kXPU,
+           &fused_add_rms_norm_static_fp8_quant);
+
   // activation ops
-  ops.def("silu_and_mul(Tensor! out, Tensor! input) -> ()");
+  ops.def("silu_and_mul(Tensor! result, Tensor input) -> ()");
   ops.impl("silu_and_mul", torch::kXPU, &silu_and_mul);
 
-  ops.def("mul_and_silu(Tensor! out, Tensor! input) -> ()");
+  // Fused SiLU + Mul + FP8 Quantization
+  ops.def(
+      "silu_and_mul_quant(Tensor! result, Tensor input, Tensor scale) -> ()");
+  ops.impl("silu_and_mul_quant", torch::kXPU, &silu_and_mul_quant);
+
+  ops.def("mul_and_silu(Tensor! out, Tensor input) -> ()");
   ops.impl("mul_and_silu", torch::kXPU, &mul_and_silu);
 
-  ops.def("gelu_and_mul(Tensor! out, Tensor! input) -> ()");
+  ops.def("gelu_and_mul(Tensor! out, Tensor input) -> ()");
   ops.impl("gelu_and_mul", torch::kXPU, &gelu_and_mul);
 
-  ops.def("gelu_tanh_and_mul(Tensor! out, Tensor! input) -> ()");
+  ops.def("gelu_tanh_and_mul(Tensor! out, Tensor input) -> ()");
   ops.impl("gelu_tanh_and_mul", torch::kXPU, &gelu_tanh_and_mul);
 
-  ops.def("gelu_fast(Tensor! out, Tensor! input) -> ()");
+  ops.def("gelu_fast(Tensor! out, Tensor input) -> ()");
   ops.impl("gelu_fast", torch::kXPU, &gelu_fast);
 
-  ops.def("gelu_new(Tensor! out, Tensor! input) -> ()");
+  ops.def("gelu_new(Tensor! out, Tensor input) -> ()");
   ops.impl("gelu_new", torch::kXPU, &gelu_new);
 
-  ops.def("gelu_quick(Tensor! out, Tensor! input) -> ()");
+  ops.def("gelu_quick(Tensor! out, Tensor input) -> ()");
   ops.impl("gelu_quick", torch::kXPU, &gelu_quick);
 
   // pos_embedding
@@ -63,6 +100,14 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
       "                 Tensor!? key, int head_size,"
       "                 Tensor cos_sin_cache, bool is_neox) -> ()");
   ops.impl("rotary_embedding", torch::kXPU, &rotary_embedding);
+
+  // Fused QK RMSNorm + RoPE
+  ops.def(
+      "fused_qk_norm_rope(Tensor! qkv, int num_heads_q, "
+      "int num_heads_k, int num_heads_v, int head_dim, float eps, "
+      "Tensor q_weight, Tensor k_weight, Tensor cos_sin_cache, "
+      "bool is_neox, Tensor position_ids) -> ()");
+  ops.impl("fused_qk_norm_rope", torch::kXPU, &fused_qk_norm_rope);
 
   // Compute FP8 quantized tensor for given scaling factor.
   ops.def(

--- a/csrc/torch_bindings.cpp
+++ b/csrc/torch_bindings.cpp
@@ -40,8 +40,10 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
       "rms_norm_dynamic_per_token_quant(Tensor! result, Tensor input, "
       "Tensor weight, Tensor! scale, float epsilon, "
       "Tensor? scale_ub, Tensor!? residual) -> ()");
-  ops.impl("rms_norm_dynamic_per_token_quant", torch::kXPU,
-           &rms_norm_dynamic_per_token_quant);
+  ops.impl(
+      "rms_norm_dynamic_per_token_quant",
+      torch::kXPU,
+      &rms_norm_dynamic_per_token_quant);
 
   // Fused RMSNorm + per-column-block quantization (FP8 or INT8).
   ops.def(
@@ -49,23 +51,24 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
       "Tensor weight, Tensor! scale, float epsilon, "
       "Tensor? scale_ub, Tensor!? residual, int group_size, "
       "bool is_scale_transposed) -> ()");
-  ops.impl("rms_norm_per_block_quant", torch::kXPU,
-           &rms_norm_per_block_quant);
+  ops.impl("rms_norm_per_block_quant", torch::kXPU, &rms_norm_per_block_quant);
 
   // Fused RMSNorm + static FP8 quantization.
   ops.def(
       "rms_norm_static_fp8_quant(Tensor! result, Tensor input, Tensor weight, "
       "Tensor scale, float epsilon) -> ()");
-  ops.impl("rms_norm_static_fp8_quant", torch::kXPU,
-           &rms_norm_static_fp8_quant);
+  ops.impl(
+      "rms_norm_static_fp8_quant", torch::kXPU, &rms_norm_static_fp8_quant);
 
   // In-place fused Add + RMSNorm + static FP8 quantization.
   ops.def(
       "fused_add_rms_norm_static_fp8_quant(Tensor! result, Tensor input, "
       "Tensor! residual, Tensor weight, "
       "Tensor scale, float epsilon) -> ()");
-  ops.impl("fused_add_rms_norm_static_fp8_quant", torch::kXPU,
-           &fused_add_rms_norm_static_fp8_quant);
+  ops.impl(
+      "fused_add_rms_norm_static_fp8_quant",
+      torch::kXPU,
+      &fused_add_rms_norm_static_fp8_quant);
 
   // activation ops
   ops.def("silu_and_mul(Tensor! result, Tensor input) -> ()");

--- a/tests/register_ops.py
+++ b/tests/register_ops.py
@@ -26,6 +26,11 @@ def silu_and_mul(out: torch.Tensor, input: torch.Tensor) -> None:
     torch.ops._C.silu_and_mul(out, input)
 
 
+def silu_and_mul_quant(out: torch.Tensor, input: torch.Tensor,
+                       scale: torch.Tensor) -> None:
+    torch.ops._C.silu_and_mul_quant(out, input, scale)
+
+
 def gelu_fast(out: torch.Tensor, input: torch.Tensor) -> None:
     torch.ops._C.gelu_fast(out, input)
 

--- a/tests/test_fused_norm_quant.py
+++ b/tests/test_fused_norm_quant.py
@@ -1,0 +1,425 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+# UT for fused RMSNorm + Quantization kernels.
+# Adapted from tests/kernels/core/test_fused_quant_layernorm.py (CUDA).
+
+import pytest
+import torch
+
+import vllm_xpu_kernels._C  # noqa: F401 – registers torch.ops._C.*
+
+from tests.ops.layernorm_op import RMSNorm
+
+DTYPES = [torch.half, torch.bfloat16]
+# XPU FP8 default is e4m3fn; INT8 is always tested
+QUANT_DTYPES = [torch.float8_e4m3fn, torch.int8]
+
+NUM_TOKENS = [1, 7, 83, 2048]
+HIDDEN_SIZES = [64, 128, 1024, 5120]
+ADD_RESIDUAL = [False, True]
+GROUP_SIZES = [64, 128]
+SEEDS = [0]
+EPS = 1e-6
+
+XPU_DEVICES = [
+    f"xpu:{i}" for i in range(1 if torch.xpu.device_count() == 1 else 2)
+]
+
+
+MINI_PYTEST_PARAMS = {
+    "default": {
+        "num_tokens": [4],
+        "HIDDEN_SIZES": [64],
+        "GROUP_SIZES": [64],
+    },
+}
+
+def _ref_rms_norm(
+    layer: RMSNorm,
+    x: torch.Tensor,
+    residual: torch.Tensor | None,
+) -> tuple[torch.Tensor, torch.Tensor | None]:
+    x_f32 = x.float()
+    if residual is not None:
+        residual = residual.clone()
+        # Kernel: z = input + residual, stored as orig_dtype, then read back
+        z_half = (x_f32 + residual.float()).to(x.dtype)
+        residual = z_half.clone()
+        x_f32 = z_half.float()
+    variance = x_f32.pow(2).mean(dim=-1, keepdim=True)
+    inv_rms = torch.rsqrt(variance + layer.variance_epsilon)
+    normed = x_f32 * inv_rms * layer.weight.float()
+    return normed, residual
+
+
+def _ref_per_token_quant(
+    normed: torch.Tensor,
+    quant_dtype: torch.dtype,
+    scale_ub: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Reference dynamic per-token quantization."""
+    num_tokens = normed.numel() // normed.shape[-1]
+    normed_2d = normed.view(num_tokens, -1).float()
+
+    if quant_dtype == torch.int8:
+        absmax = normed_2d.abs().amax(dim=1, keepdim=True)  # [T, 1]
+        scale = torch.where(absmax > 0, absmax / 127.0, torch.ones_like(absmax))
+        q = (normed_2d / scale).round().clamp(-128, 127).to(torch.int8)
+        return q, scale.squeeze(1)
+    else:
+        # FP8 e4m3fn
+        fp8_max = torch.finfo(quant_dtype).max
+        absmax = normed_2d.abs().amax(dim=1, keepdim=True)  # [T, 1]
+        if scale_ub is not None:
+            absmax = torch.min(absmax, scale_ub.float())
+        min_sf = 1.0 / (fp8_max * 512.0)
+        scale = torch.clamp(absmax / fp8_max, min=min_sf)  # [T, 1]
+        inv_scale = 1.0 / scale
+        q = (normed_2d * inv_scale).clamp(-fp8_max, fp8_max).to(quant_dtype)
+        return q, scale.squeeze(1)
+
+
+def _ref_per_group_quant(
+    normed: torch.Tensor,
+    group_size: int,
+    quant_dtype: torch.dtype,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Reference dynamic per-column-group quantization."""
+    num_tokens = normed.numel() // normed.shape[-1]
+    hidden = normed.shape[-1]
+    num_groups = hidden // group_size
+    normed_2d = normed.view(num_tokens, hidden).float()
+
+    q_out = torch.empty_like(normed_2d, dtype=quant_dtype)
+    scales = torch.empty(num_tokens, num_groups, dtype=torch.float32,
+                         device=normed.device)
+
+    fp8_max = torch.finfo(quant_dtype).max if quant_dtype != torch.int8 else 127.0
+    min_sf = 1.0 / (fp8_max * 512.0) if quant_dtype != torch.int8 else 0.0
+
+    for g in range(num_groups):
+        chunk = normed_2d[:, g * group_size:(g + 1) * group_size]  # [T, G]
+        absmax = chunk.abs().amax(dim=1, keepdim=True)              # [T, 1]
+
+        if quant_dtype == torch.int8:
+            scale = torch.where(absmax > 0, absmax / 127.0,
+                                torch.ones_like(absmax))
+            q = (chunk / scale).round().clamp(-128, 127).to(torch.int8)
+        else:
+            scale = torch.clamp(absmax / fp8_max, min=min_sf)
+            inv_scale = 1.0 / scale
+            q = (chunk * inv_scale).clamp(-fp8_max, fp8_max).to(quant_dtype)
+
+        q_out[:, g * group_size:(g + 1) * group_size] = q
+        scales[:, g] = scale.squeeze(1)
+
+    return q_out, scales
+
+
+def _ops_per_token_quant(
+    weight: torch.Tensor,
+    x: torch.Tensor,
+    quant_dtype: torch.dtype,
+    residual: torch.Tensor | None,
+    scale_ub: torch.Tensor | None,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None]:
+    x = x.contiguous()
+    out = torch.empty_like(x, dtype=quant_dtype)
+    num_tokens = x.numel() // x.shape[-1]
+    scales = torch.empty(num_tokens, dtype=torch.float32, device=x.device)
+    if residual is not None:
+        residual = residual.clone().contiguous()
+    torch.ops._C.rms_norm_dynamic_per_token_quant(
+        out, x, weight, scales, EPS, scale_ub, residual)
+    return out, scales, residual
+
+
+def _ops_per_group_quant(
+    weight: torch.Tensor,
+    x: torch.Tensor,
+    quant_dtype: torch.dtype,
+    group_size: int,
+    residual: torch.Tensor | None,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None]:
+    x = x.contiguous()
+    out = torch.empty_like(x, dtype=quant_dtype)
+    num_tokens = x.numel() // x.shape[-1]
+    num_groups = x.shape[-1] // group_size
+    scales = torch.empty(num_tokens, num_groups, dtype=torch.float32,
+                         device=x.device)
+    if residual is not None:
+        residual = residual.clone().contiguous()
+    torch.ops._C.rms_norm_per_block_quant(
+        out, x, weight, scales, EPS,
+        None,           # scale_ub (not used for per-block)
+        residual,
+        group_size,
+        False,          # is_scale_transposed
+    )
+    return out, scales, residual
+
+
+@pytest.mark.parametrize("num_tokens", NUM_TOKENS)
+@pytest.mark.parametrize("hidden_size", HIDDEN_SIZES)
+@pytest.mark.parametrize("add_residual", ADD_RESIDUAL)
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("quant_dtype", QUANT_DTYPES)
+@pytest.mark.parametrize("seed", SEEDS)
+@pytest.mark.parametrize("device", XPU_DEVICES)
+@torch.inference_mode()
+def test_rms_norm_dynamic_per_token_quant(
+    num_tokens: int,
+    hidden_size: int,
+    add_residual: bool,
+    dtype: torch.dtype,
+    quant_dtype: torch.dtype,
+    seed: int,
+    device: str,
+) -> None:
+    torch.manual_seed(seed)
+    torch.set_default_device("xpu")
+    torch.xpu.set_device(device)
+
+    layer = RMSNorm(hidden_size, eps=EPS).to(dtype=dtype)
+    layer.weight.data.normal_(mean=1.0, std=0.1)
+
+    scale = 1.0 / hidden_size
+    x = torch.randn(num_tokens, hidden_size, dtype=dtype) * scale
+    residual = torch.randn_like(x) * scale if add_residual else None
+
+    # Reference: native RMSNorm + per-token quant
+    ref_normed, ref_residual = _ref_rms_norm(layer, x, residual)
+    ref_q, ref_scales = _ref_per_token_quant(ref_normed, quant_dtype)
+
+    # Kernel
+    ops_q, ops_scales, ops_residual = _ops_per_token_quant(
+        layer.weight.data, x, quant_dtype, residual, None)
+
+    assert ops_q.dtype == quant_dtype
+    assert ops_scales.dtype == torch.float32
+
+    if quant_dtype == torch.int8:
+        torch.testing.assert_close(ref_scales, ops_scales, atol=1e-6, rtol=1e-6)
+        torch.testing.assert_close(ref_q, ops_q, atol=1, rtol=0)
+    else:
+        # FP8: scales should be close; compare quantized values or dequantized
+        torch.testing.assert_close(ref_scales, ops_scales, atol=1e-5, rtol=1e-5)
+        ref_qf = ref_q.float()
+        ops_qf = ops_q.float()
+        if not torch.allclose(ref_qf, ops_qf, atol=1e-6):
+            # Fallback: dequantize both with their own scales and compare.
+            # NOTE: It is possible that some future test cases trigger this
+            # max diff due to precision issues. If such an error is
+            # encountered, it's recommended to inspect the differences between
+            # all corresponding elements from each tensor (e.g. by looping over
+            # them) and checking how many the max diff error shows up on (just
+            # a few bad elements should still be considered acceptable).
+            ref_deq = ref_qf * ref_scales.view(-1, 1)
+            ops_deq = ops_qf * ops_scales.view(-1, 1)
+            torch.testing.assert_close(ref_deq, ops_deq, atol=0.2, rtol=0.15)
+
+    if add_residual:
+        torch.testing.assert_close(ref_residual, ops_residual,
+                                   atol=1e-2, rtol=1e-2)
+
+
+@pytest.mark.parametrize("num_tokens", [1, 7, 83, 2048])
+@pytest.mark.parametrize("hidden_size", [128, 1024, 5120])
+@pytest.mark.parametrize("group_size", GROUP_SIZES)
+@pytest.mark.parametrize("add_residual", ADD_RESIDUAL)
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("quant_dtype", [torch.float8_e4m3fn, torch.int8])
+@pytest.mark.parametrize("seed", SEEDS)
+@pytest.mark.parametrize("device", XPU_DEVICES)
+@torch.inference_mode()
+def test_rms_norm_per_block_quant(
+    num_tokens: int,
+    hidden_size: int,
+    group_size: int,
+    add_residual: bool,
+    dtype: torch.dtype,
+    quant_dtype: torch.dtype,
+    seed: int,
+    device: str,
+) -> None:
+    if hidden_size % group_size != 0:
+        pytest.skip(f"hidden_size {hidden_size} not divisible by group_size {group_size}")
+
+    torch.manual_seed(seed)
+    torch.set_default_device("xpu")
+    torch.xpu.set_device(device)
+
+    layer = RMSNorm(hidden_size, eps=EPS).to(dtype=dtype)
+    layer.weight.data.normal_(mean=1.0, std=0.1)
+
+    scale = 1.0 / hidden_size
+    x = torch.randn(num_tokens, hidden_size, dtype=dtype) * scale
+    residual = torch.randn_like(x) * scale if add_residual else None
+
+    # Reference: native RMSNorm + per-group quant
+    ref_normed, ref_residual = _ref_rms_norm(layer, x, residual)
+    ref_q, ref_scales = _ref_per_group_quant(ref_normed, group_size, quant_dtype)
+
+    # Kernel
+    ops_q, ops_scales, ops_residual = _ops_per_group_quant(
+        layer.weight.data, x, quant_dtype, group_size, residual)
+
+    assert ops_q.dtype == quant_dtype
+    assert ops_scales.dtype == torch.float32
+    assert ops_scales.shape == (num_tokens, hidden_size // group_size)
+
+    torch.testing.assert_close(ref_scales, ops_scales, atol=1e-4, rtol=1e-4)
+
+    if quant_dtype == torch.int8:
+        torch.testing.assert_close(ref_q, ops_q, atol=1, rtol=0)
+    else:
+        num_groups = hidden_size // group_size
+        ref_qf = ref_q.float().view(num_tokens, num_groups, group_size)
+        ops_qf = ops_q.float().view(num_tokens, num_groups, group_size)
+        if not torch.allclose(ref_qf, ops_qf, atol=1e-6):
+            ref_scales_e = ref_scales.unsqueeze(-1)
+            ops_scales_e = ops_scales.unsqueeze(-1)
+            ref_deq = ref_qf * ref_scales_e
+            ops_deq = ops_qf * ops_scales_e
+            torch.testing.assert_close(ref_deq, ops_deq, atol=0.2, rtol=0.15)
+
+    if add_residual:
+        torch.testing.assert_close(ref_residual, ops_residual,
+                                   atol=1e-2, rtol=1e-2)
+
+
+def _ops_rms_norm_static_fp8_quant(
+    weight: torch.Tensor,
+    x: torch.Tensor,
+    scale: torch.Tensor,
+) -> torch.Tensor:
+    out = torch.empty_like(x, dtype=torch.float8_e4m3fn)
+    torch.ops._C.rms_norm_static_fp8_quant(out, x, weight, scale, EPS)
+    return out
+
+
+def _ops_fused_add_rms_norm_static_fp8_quant(
+    weight: torch.Tensor,
+    x: torch.Tensor,
+    residual: torch.Tensor,
+    scale: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    out = torch.empty(x.shape[-1],
+                      dtype=torch.float8_e4m3fn,
+                      device=x.device).expand_as(x).contiguous()
+    residual = residual.clone().contiguous()
+    torch.ops._C.fused_add_rms_norm_static_fp8_quant(
+        out, x, residual, weight, scale, EPS)
+    return out, residual
+
+
+def _ref_static_fp8_quant(
+    normed: torch.Tensor,
+    scale: torch.Tensor,
+) -> torch.Tensor:
+    """Reference static FP8 quantization with pre-computed scale."""
+    fp8_max = torch.finfo(torch.float8_e4m3fn).max
+    inv_scale = 1.0 / scale.float()
+    q = (normed.float() * inv_scale).clamp(-fp8_max, fp8_max)
+    return q.to(torch.float8_e4m3fn)
+
+
+@pytest.mark.parametrize("num_tokens", NUM_TOKENS)
+@pytest.mark.parametrize("hidden_size", HIDDEN_SIZES)
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("seed", SEEDS)
+@pytest.mark.parametrize("device", XPU_DEVICES)
+@pytest.mark.parametrize("strided_input", [False, True])
+@torch.inference_mode()
+def test_rms_norm_static_fp8_quant(
+    num_tokens: int,
+    hidden_size: int,
+    dtype: torch.dtype,
+    seed: int,
+    device: str,
+    strided_input: bool,
+) -> None:
+    torch.manual_seed(seed)
+    torch.set_default_device("xpu")
+    torch.xpu.set_device(device)
+
+    layer = RMSNorm(hidden_size, eps=EPS).to(dtype=dtype)
+    layer.weight.data.normal_(mean=1.0, std=0.1)
+
+    scale_val = 1.0
+    quant_scale = torch.tensor(scale_val, dtype=torch.float32)
+    input_scale = 1.0 / hidden_size
+    last_dim = 2 * hidden_size if strided_input else hidden_size
+    x = torch.randn(num_tokens, last_dim, dtype=dtype) * input_scale
+    x = x[..., :hidden_size]
+    if num_tokens > 1:
+        assert x.is_contiguous() != strided_input
+
+    # Reference: native RMSNorm then static FP8 quant
+    ref_normed, _ = _ref_rms_norm(layer, x, None)
+    ref_q = _ref_static_fp8_quant(ref_normed, quant_scale)
+
+    # Kernel
+    ops_q = _ops_rms_norm_static_fp8_quant(layer.weight.data, x, quant_scale)
+
+    assert ops_q.dtype == torch.float8_e4m3fn
+    # FP8 has coarse quantization; boundary elements may differ by up to 1 LSB.
+    ref_qf = ref_q.float()
+    ops_qf = ops_q.float()
+    if not torch.allclose(ref_qf, ops_qf, atol=1e-6):
+        ref_deq = ref_qf * quant_scale
+        ops_deq = ops_qf * quant_scale
+        torch.testing.assert_close(ref_deq, ops_deq, atol=0.2, rtol=0.15)
+
+
+@pytest.mark.parametrize("num_tokens", NUM_TOKENS)
+@pytest.mark.parametrize("hidden_size", HIDDEN_SIZES)
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("seed", SEEDS)
+@pytest.mark.parametrize("device", XPU_DEVICES)
+@pytest.mark.parametrize("strided_input", [False, True])
+@torch.inference_mode()
+def test_fused_add_rms_norm_static_fp8_quant(
+    num_tokens: int,
+    hidden_size: int,
+    dtype: torch.dtype,
+    seed: int,
+    device: str,
+    strided_input: bool,
+) -> None:
+    torch.manual_seed(seed)
+    torch.set_default_device("xpu")
+    torch.xpu.set_device(device)
+
+    layer = RMSNorm(hidden_size, eps=EPS).to(dtype=dtype)
+    layer.weight.data.normal_(mean=1.0, std=0.1)
+
+    scale_val = 1.0
+    quant_scale = torch.tensor(scale_val, dtype=torch.float32)
+    input_scale = 1.0 / hidden_size
+    last_dim = 2 * hidden_size if strided_input else hidden_size
+    x = torch.randn(num_tokens, last_dim, dtype=dtype) * input_scale
+    x = x[..., :hidden_size]
+    if num_tokens > 1:
+        assert x.is_contiguous() != strided_input
+    residual = torch.randn(num_tokens, hidden_size, dtype=dtype) * input_scale
+
+    # Reference: native RMSNorm (with residual) then static FP8 quant
+    ref_normed, ref_residual = _ref_rms_norm(layer, x, residual)
+    ref_q = _ref_static_fp8_quant(ref_normed, quant_scale)
+
+    # Kernel
+    ops_q, ops_residual = _ops_fused_add_rms_norm_static_fp8_quant(
+        layer.weight.data, x, residual, quant_scale)
+
+    assert ops_q.dtype == torch.float8_e4m3fn
+    # Compare quantized values first, then fall back to dequantized comparison.
+    ref_qf = ref_q.float()
+    ops_qf = ops_q.float()
+    if not torch.allclose(ref_qf, ops_qf, atol=1e-6):
+        ref_deq = ref_qf * quant_scale
+        ops_deq = ops_qf * quant_scale
+        torch.testing.assert_close(ref_deq, ops_deq, atol=0.2, rtol=0.15)
+    torch.testing.assert_close(
+        ops_residual, ref_residual, atol=1e-2, rtol=1e-2)

--- a/tests/test_fused_norm_quant.py
+++ b/tests/test_fused_norm_quant.py
@@ -8,7 +8,6 @@ import pytest
 import torch
 
 import vllm_xpu_kernels._C  # noqa: F401 – registers torch.ops._C.*
-
 from tests.ops.layernorm_op import RMSNorm
 
 DTYPES = [torch.half, torch.bfloat16]
@@ -26,7 +25,6 @@ XPU_DEVICES = [
     f"xpu:{i}" for i in range(1 if torch.xpu.device_count() == 1 else 2)
 ]
 
-
 MINI_PYTEST_PARAMS = {
     "default": {
         "num_tokens": [4],
@@ -34,6 +32,7 @@ MINI_PYTEST_PARAMS = {
         "GROUP_SIZES": [64],
     },
 }
+
 
 def _ref_rms_norm(
     layer: RMSNorm,
@@ -64,7 +63,8 @@ def _ref_per_token_quant(
 
     if quant_dtype == torch.int8:
         absmax = normed_2d.abs().amax(dim=1, keepdim=True)  # [T, 1]
-        scale = torch.where(absmax > 0, absmax / 127.0, torch.ones_like(absmax))
+        scale = torch.where(absmax > 0, absmax / 127.0,
+                            torch.ones_like(absmax))
         q = (normed_2d / scale).round().clamp(-128, 127).to(torch.int8)
         return q, scale.squeeze(1)
     else:
@@ -92,15 +92,18 @@ def _ref_per_group_quant(
     normed_2d = normed.view(num_tokens, hidden).float()
 
     q_out = torch.empty_like(normed_2d, dtype=quant_dtype)
-    scales = torch.empty(num_tokens, num_groups, dtype=torch.float32,
+    scales = torch.empty(num_tokens,
+                         num_groups,
+                         dtype=torch.float32,
                          device=normed.device)
 
-    fp8_max = torch.finfo(quant_dtype).max if quant_dtype != torch.int8 else 127.0
+    fp8_max = torch.finfo(
+        quant_dtype).max if quant_dtype != torch.int8 else 127.0
     min_sf = 1.0 / (fp8_max * 512.0) if quant_dtype != torch.int8 else 0.0
 
     for g in range(num_groups):
         chunk = normed_2d[:, g * group_size:(g + 1) * group_size]  # [T, G]
-        absmax = chunk.abs().amax(dim=1, keepdim=True)              # [T, 1]
+        absmax = chunk.abs().amax(dim=1, keepdim=True)  # [T, 1]
 
         if quant_dtype == torch.int8:
             scale = torch.where(absmax > 0, absmax / 127.0,
@@ -130,8 +133,8 @@ def _ops_per_token_quant(
     scales = torch.empty(num_tokens, dtype=torch.float32, device=x.device)
     if residual is not None:
         residual = residual.clone().contiguous()
-    torch.ops._C.rms_norm_dynamic_per_token_quant(
-        out, x, weight, scales, EPS, scale_ub, residual)
+    torch.ops._C.rms_norm_dynamic_per_token_quant(out, x, weight, scales, EPS,
+                                                  scale_ub, residual)
     return out, scales, residual
 
 
@@ -146,16 +149,22 @@ def _ops_per_group_quant(
     out = torch.empty_like(x, dtype=quant_dtype)
     num_tokens = x.numel() // x.shape[-1]
     num_groups = x.shape[-1] // group_size
-    scales = torch.empty(num_tokens, num_groups, dtype=torch.float32,
+    scales = torch.empty(num_tokens,
+                         num_groups,
+                         dtype=torch.float32,
                          device=x.device)
     if residual is not None:
         residual = residual.clone().contiguous()
     torch.ops._C.rms_norm_per_block_quant(
-        out, x, weight, scales, EPS,
-        None,           # scale_ub (not used for per-block)
+        out,
+        x,
+        weight,
+        scales,
+        EPS,
+        None,  # scale_ub (not used for per-block)
         residual,
         group_size,
-        False,          # is_scale_transposed
+        False,  # is_scale_transposed
     )
     return out, scales, residual
 
@@ -200,11 +209,17 @@ def test_rms_norm_dynamic_per_token_quant(
     assert ops_scales.dtype == torch.float32
 
     if quant_dtype == torch.int8:
-        torch.testing.assert_close(ref_scales, ops_scales, atol=1e-6, rtol=1e-6)
+        torch.testing.assert_close(ref_scales,
+                                   ops_scales,
+                                   atol=1e-6,
+                                   rtol=1e-6)
         torch.testing.assert_close(ref_q, ops_q, atol=1, rtol=0)
     else:
         # FP8: scales should be close; compare quantized values or dequantized
-        torch.testing.assert_close(ref_scales, ops_scales, atol=1e-5, rtol=1e-5)
+        torch.testing.assert_close(ref_scales,
+                                   ops_scales,
+                                   atol=1e-5,
+                                   rtol=1e-5)
         ref_qf = ref_q.float()
         ops_qf = ops_q.float()
         if not torch.allclose(ref_qf, ops_qf, atol=1e-6):
@@ -220,8 +235,10 @@ def test_rms_norm_dynamic_per_token_quant(
             torch.testing.assert_close(ref_deq, ops_deq, atol=0.2, rtol=0.15)
 
     if add_residual:
-        torch.testing.assert_close(ref_residual, ops_residual,
-                                   atol=1e-2, rtol=1e-2)
+        torch.testing.assert_close(ref_residual,
+                                   ops_residual,
+                                   atol=1e-2,
+                                   rtol=1e-2)
 
 
 @pytest.mark.parametrize("num_tokens", [1, 7, 83, 2048])
@@ -244,7 +261,8 @@ def test_rms_norm_per_block_quant(
     device: str,
 ) -> None:
     if hidden_size % group_size != 0:
-        pytest.skip(f"hidden_size {hidden_size} not divisible by group_size {group_size}")
+        pytest.skip(f"hidden_size {hidden_size} not divisible by \
+            group_size {group_size}")
 
     torch.manual_seed(seed)
     torch.set_default_device("xpu")
@@ -259,7 +277,8 @@ def test_rms_norm_per_block_quant(
 
     # Reference: native RMSNorm + per-group quant
     ref_normed, ref_residual = _ref_rms_norm(layer, x, residual)
-    ref_q, ref_scales = _ref_per_group_quant(ref_normed, group_size, quant_dtype)
+    ref_q, ref_scales = _ref_per_group_quant(ref_normed, group_size,
+                                             quant_dtype)
 
     # Kernel
     ops_q, ops_scales, ops_residual = _ops_per_group_quant(
@@ -285,8 +304,10 @@ def test_rms_norm_per_block_quant(
             torch.testing.assert_close(ref_deq, ops_deq, atol=0.2, rtol=0.15)
 
     if add_residual:
-        torch.testing.assert_close(ref_residual, ops_residual,
-                                   atol=1e-2, rtol=1e-2)
+        torch.testing.assert_close(ref_residual,
+                                   ops_residual,
+                                   atol=1e-2,
+                                   rtol=1e-2)
 
 
 def _ops_rms_norm_static_fp8_quant(
@@ -305,12 +326,11 @@ def _ops_fused_add_rms_norm_static_fp8_quant(
     residual: torch.Tensor,
     scale: torch.Tensor,
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    out = torch.empty(x.shape[-1],
-                      dtype=torch.float8_e4m3fn,
+    out = torch.empty(x.shape[-1], dtype=torch.float8_e4m3fn,
                       device=x.device).expand_as(x).contiguous()
     residual = residual.clone().contiguous()
-    torch.ops._C.fused_add_rms_norm_static_fp8_quant(
-        out, x, residual, weight, scale, EPS)
+    torch.ops._C.fused_add_rms_norm_static_fp8_quant(out, x, residual, weight,
+                                                     scale, EPS)
     return out, residual
 
 
@@ -421,5 +441,7 @@ def test_fused_add_rms_norm_static_fp8_quant(
         ref_deq = ref_qf * quant_scale
         ops_deq = ops_qf * quant_scale
         torch.testing.assert_close(ref_deq, ops_deq, atol=0.2, rtol=0.15)
-    torch.testing.assert_close(
-        ops_residual, ref_residual, atol=1e-2, rtol=1e-2)
+    torch.testing.assert_close(ops_residual,
+                               ref_residual,
+                               atol=1e-2,
+                               rtol=1e-2)

--- a/tests/test_fused_qk_norm_rope.py
+++ b/tests/test_fused_qk_norm_rope.py
@@ -1,0 +1,258 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+
+import vllm_xpu_kernels._C  # noqa: F401 - registers torch.ops._C ops
+from tests.utils import opcheck
+
+DTYPES = [torch.half, torch.bfloat16]
+IS_NEOX = [True, False]
+EPS_VALUES = [1e-5, 1e-6]
+HEAD_DIMS = [64, 128]
+NUM_TOKENS = [1, 4, 32]
+HEAD_CONFIGS = [(16, 4), (32, 8)]  # (num_heads_q, num_heads_kv)
+ROTARY_RATIOS = [1.0, 0.5]
+SEEDS = [13]
+XPU_DEVICES = [
+    f"xpu:{i}" for i in range(1 if torch.xpu.device_count() == 1 else 2)
+]
+
+MINI_PYTEST_PARAMS = {
+    "default": {
+        "num_tokens": [4],
+        "head_dim": [128],
+        "head_config": [(16, 4)],
+        "rotary_ratio": [1.0],
+    },
+}
+
+
+def _rms_norm(x: torch.Tensor, weight: torch.Tensor,
+              eps: float) -> torch.Tensor:
+    """Reference RMSNorm: x is [..., head_dim], weight is [head_dim]."""
+    variance = x.to(torch.float32).pow(2).mean(dim=-1, keepdim=True)
+    x_normed = x * torch.rsqrt(variance + eps)
+    return (x_normed * weight).to(x.dtype)
+
+
+def _apply_rotary_emb(x: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor,
+                       is_neox: bool) -> torch.Tensor:
+    """Apply RoPE to x. x shape: [num_tokens, num_heads, head_dim].
+    cos/sin shape: [num_tokens, rotary_dim/2]."""
+    rotary_dim = cos.shape[-1] * 2
+    x_rot = x[..., :rotary_dim].float()
+    x_pass = x[..., rotary_dim:]
+
+    if is_neox:
+        # Neox style: first half and second half
+        half = rotary_dim // 2
+        x1 = x_rot[..., :half]
+        x2 = x_rot[..., half:]
+        cos_val = cos.unsqueeze(1)  # [tokens, 1, rotary_dim/2]
+        sin_val = sin.unsqueeze(1)
+        o1 = x1 * cos_val - x2 * sin_val
+        o2 = x2 * cos_val + x1 * sin_val
+        x_rot = torch.cat([o1, o2], dim=-1)
+    else:
+        # Interleaved style: pairs of (x0, x1)
+        x_rot = x_rot.view(*x_rot.shape[:-1], -1, 2)
+        x0 = x_rot[..., 0]
+        x1 = x_rot[..., 1]
+        cos_val = cos.unsqueeze(1)
+        sin_val = sin.unsqueeze(1)
+        o0 = x0 * cos_val - x1 * sin_val
+        o1 = x0 * sin_val + x1 * cos_val
+        x_rot = torch.stack([o0, o1], dim=-1).flatten(-2)
+
+    return torch.cat([x_rot.to(x.dtype), x_pass], dim=-1)
+
+
+def _reference_fused_qk_norm_rope(
+    qkv: torch.Tensor,
+    num_heads_q: int,
+    num_heads_kv: int,
+    head_dim: int,
+    eps: float,
+    q_weight: torch.Tensor,
+    k_weight: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    is_neox: bool,
+    positions: torch.Tensor,
+) -> torch.Tensor:
+    """Pure PyTorch reference implementation."""
+    q_size = num_heads_q * head_dim
+    kv_size = num_heads_kv * head_dim
+
+    q, k, v = qkv.split([q_size, kv_size, kv_size], dim=-1)
+
+    # RMSNorm on Q heads
+    q_by_head = q.view(-1, num_heads_q, head_dim)
+    q_by_head = _rms_norm(q_by_head, q_weight, eps)
+
+    # RMSNorm on K heads
+    k_by_head = k.view(-1, num_heads_kv, head_dim)
+    k_by_head = _rms_norm(k_by_head, k_weight, eps)
+
+    # Get cos/sin for the given positions
+    rotary_dim = cos_sin_cache.shape[1]
+    embed_dim = rotary_dim // 2
+    cos_sin = cos_sin_cache[positions]  # [num_tokens, rotary_dim]
+    cos = cos_sin[:, :embed_dim].float()
+    sin = cos_sin[:, embed_dim:].float()
+
+    # Apply RoPE
+    q_by_head = _apply_rotary_emb(q_by_head, cos, sin, is_neox)
+    k_by_head = _apply_rotary_emb(k_by_head, cos, sin, is_neox)
+
+    q = q_by_head.view(-1, q_size)
+    k = k_by_head.view(-1, kv_size)
+
+    return torch.cat([q, k, v], dim=-1)
+
+
+@pytest.mark.parametrize("device", XPU_DEVICES)
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("is_neox", IS_NEOX)
+@pytest.mark.parametrize("eps", EPS_VALUES)
+@pytest.mark.parametrize("head_dim", HEAD_DIMS)
+@pytest.mark.parametrize("num_tokens", NUM_TOKENS)
+@pytest.mark.parametrize("head_config", HEAD_CONFIGS)
+@pytest.mark.parametrize("rotary_ratio", ROTARY_RATIOS)
+@pytest.mark.parametrize("seed", SEEDS)
+@torch.inference_mode()
+def test_fused_qk_norm_rope(
+    device: str,
+    dtype: torch.dtype,
+    is_neox: bool,
+    eps: float,
+    head_dim: int,
+    num_tokens: int,
+    head_config: tuple,
+    rotary_ratio: float,
+    seed: int,
+) -> None:
+    torch.manual_seed(seed)
+    torch.set_default_device("xpu")
+    torch.xpu.set_device(device)
+
+    num_heads_q, num_heads_kv = head_config
+    rotary_dim = int(head_dim * rotary_ratio)
+    max_position = 4096
+
+    total_dim = (num_heads_q + 2 * num_heads_kv) * head_dim
+    qkv_base = torch.randn(num_tokens, total_dim, dtype=dtype, device=device)
+    qkv_fused = qkv_base.clone()
+    positions = torch.randint(0,
+                              max_position, (num_tokens,),
+                              dtype=torch.long,
+                              device=device)
+
+    q_weight = torch.empty(head_dim, dtype=dtype, device=device)
+    q_weight.normal_(mean=1.0, std=0.1)
+    k_weight = torch.empty(head_dim, dtype=dtype, device=device)
+    k_weight.normal_(mean=1.0, std=0.1)
+
+    # Build cos_sin_cache: [max_position, rotary_dim]
+    # Layout: [cos_0..cos_{rotary_dim/2-1}, sin_0..sin_{rotary_dim/2-1}]
+    inv_freq = 1.0 / (10000.0**(
+        torch.arange(0, rotary_dim // 2, dtype=torch.float32, device=device) /
+        (rotary_dim // 2)))
+    t = torch.arange(max_position, dtype=torch.float32, device=device)
+    freqs = torch.outer(t, inv_freq)
+    cos_sin_cache = torch.cat([freqs.cos(), freqs.sin()], dim=-1)
+
+    # Reference (before in-place op)
+    ref_result = _reference_fused_qk_norm_rope(
+        qkv_base,
+        num_heads_q,
+        num_heads_kv,
+        head_dim,
+        eps,
+        q_weight,
+        k_weight,
+        cos_sin_cache,
+        is_neox,
+        positions,
+    )
+
+    # Run fused kernel (in-place on qkv_fused)
+    torch.ops._C.fused_qk_norm_rope(
+        qkv_fused,
+        num_heads_q,
+        num_heads_kv,
+        num_heads_kv,
+        head_dim,
+        eps,
+        q_weight,
+        k_weight,
+        cos_sin_cache,
+        is_neox,
+        positions,
+    )
+
+    if dtype == torch.float16:
+        ATOL, RTOL = (2e-3, 2e-3)
+    else:
+        ATOL, RTOL = (1e-2, 1e-2)
+
+    torch.testing.assert_close(
+        qkv_fused,
+        ref_result,
+        atol=ATOL,
+        rtol=RTOL,
+    )
+
+
+@pytest.mark.parametrize("device", XPU_DEVICES)
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("is_neox", IS_NEOX)
+@torch.inference_mode()
+def test_fused_qk_norm_rope_opcheck(
+    device: str,
+    dtype: torch.dtype,
+    is_neox: bool,
+) -> None:
+    """Validate the op schema and registration with opcheck."""
+    torch.manual_seed(42)
+    torch.set_default_device("xpu")
+    torch.xpu.set_device(device)
+
+    num_heads_q, num_heads_kv = 16, 4
+    head_dim = 128
+    num_tokens = 4
+    eps = 1e-5
+    max_position = 4096
+    rotary_dim = head_dim
+
+    total_dim = (num_heads_q + 2 * num_heads_kv) * head_dim
+    qkv = torch.randn(num_tokens, total_dim, dtype=dtype, device=device)
+    positions = torch.arange(num_tokens, dtype=torch.long, device=device)
+
+    q_weight = torch.ones(head_dim, dtype=dtype, device=device)
+    k_weight = torch.ones(head_dim, dtype=dtype, device=device)
+
+    inv_freq = 1.0 / (10000.0**(
+        torch.arange(0, rotary_dim // 2, dtype=torch.float32, device=device) /
+        (rotary_dim // 2)))
+    t = torch.arange(max_position, dtype=torch.float32, device=device)
+    freqs = torch.outer(t, inv_freq)
+    cos_sin_cache = torch.cat([freqs.cos(), freqs.sin()], dim=-1)
+
+    opcheck(
+        torch.ops._C.fused_qk_norm_rope,
+        (
+            qkv,
+            num_heads_q,
+            num_heads_kv,
+            num_heads_kv,
+            head_dim,
+            eps,
+            q_weight,
+            k_weight,
+            cos_sin_cache,
+            is_neox,
+            positions,
+        ),
+    )

--- a/tests/test_fused_qk_norm_rope.py
+++ b/tests/test_fused_qk_norm_rope.py
@@ -38,7 +38,7 @@ def _rms_norm(x: torch.Tensor, weight: torch.Tensor,
 
 
 def _apply_rotary_emb(x: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor,
-                       is_neox: bool) -> torch.Tensor:
+                      is_neox: bool) -> torch.Tensor:
     """Apply RoPE to x. x shape: [num_tokens, num_heads, head_dim].
     cos/sin shape: [num_tokens, rotary_dim/2]."""
     rotary_dim = cos.shape[-1] * 2
@@ -145,7 +145,7 @@ def test_fused_qk_norm_rope(
     qkv_base = torch.randn(num_tokens, total_dim, dtype=dtype, device=device)
     qkv_fused = qkv_base.clone()
     positions = torch.randint(0,
-                              max_position, (num_tokens,),
+                              max_position, (num_tokens, ),
                               dtype=torch.long,
                               device=device)
 

--- a/tests/test_fused_quant_activation.py
+++ b/tests/test_fused_quant_activation.py
@@ -1,0 +1,118 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+import tests.register_ops as ops
+from tests.utils import seed_everything
+
+DTYPES = [torch.half, torch.bfloat16]
+FP8_DTYPES = [torch.float8_e4m3fn, torch.float8_e5m2]
+NUM_TOKENS = [1, 7, 83, 512]
+HIDDEN_SIZES = [16, 128, 512, 4096]
+SEEDS = [0]
+XPU_DEVICES = [
+    f"xpu:{i}" for i in range(1 if torch.xpu.device_count() == 1 else 2)
+]
+
+MINI_PYTEST_PARAMS = {
+    "default": {
+        "num_tokens": [1],
+        "HIDDEN_SIZES": [16],
+    },
+}
+
+def ref_silu_and_mul_quant(
+    x: torch.Tensor,
+    scale: torch.Tensor,
+    fp8_dtype: torch.dtype,
+) -> torch.Tensor:
+    """Reference implementation: SiLU+Mul then static FP8 quant."""
+    d = x.shape[-1] // 2
+    silu_mul_out = F.silu(x[..., :d]) * x[..., d:]
+
+    fp8_max = torch.finfo(fp8_dtype).max
+    inv_scale = 1.0 / scale.item()
+    result = (silu_mul_out.float() * inv_scale).clamp(-fp8_max, fp8_max)
+    return result.to(fp8_dtype)
+
+
+@pytest.mark.parametrize("num_tokens", NUM_TOKENS)
+@pytest.mark.parametrize("hidden_size", HIDDEN_SIZES)
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("fp8_dtype", FP8_DTYPES)
+@pytest.mark.parametrize("seed", SEEDS)
+@pytest.mark.parametrize("device", XPU_DEVICES)
+@torch.inference_mode()
+def test_silu_and_mul_quant(
+    num_tokens: int,
+    hidden_size: int,
+    dtype: torch.dtype,
+    fp8_dtype: torch.dtype,
+    seed: int,
+    device: str,
+) -> None:
+    seed_everything(seed)
+    torch.set_default_device(device)
+
+    x = torch.randn(num_tokens, hidden_size * 2, dtype=dtype)
+    scale = torch.tensor([0.5], dtype=torch.float32, device=device)
+
+    # Reference
+    ref_out = ref_silu_and_mul_quant(x, scale, fp8_dtype)
+
+    # Fused kernel
+    d = x.shape[-1] // 2
+    out = torch.empty(num_tokens, d, dtype=fp8_dtype, device=device)
+    ops.silu_and_mul_quant(out, x, scale)
+
+    assert out.dtype == fp8_dtype
+    assert out.shape == ref_out.shape
+    torch.testing.assert_close(
+        out.to(dtype=torch.float32),
+        ref_out.to(dtype=torch.float32),
+    )
+
+
+@pytest.mark.parametrize("num_tokens", NUM_TOKENS)
+@pytest.mark.parametrize("hidden_size", HIDDEN_SIZES)
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("fp8_dtype", FP8_DTYPES)
+@pytest.mark.parametrize("seed", SEEDS)
+@pytest.mark.parametrize("device", XPU_DEVICES)
+@torch.inference_mode()
+def test_silu_and_mul_quant_vs_separate(
+    num_tokens: int,
+    hidden_size: int,
+    dtype: torch.dtype,
+    fp8_dtype: torch.dtype,
+    seed: int,
+    device: str,
+) -> None:
+    """Verify fused kernel matches separate silu_and_mul + static_scaled_fp8_quant."""
+    seed_everything(seed)
+    torch.set_default_device(device)
+
+    x = torch.randn(num_tokens, hidden_size * 2, dtype=dtype)
+    scale = torch.tensor([0.5], dtype=torch.float32, device=device)
+
+    # Separate ops
+    d = x.shape[-1] // 2
+    silu_mul_out = torch.empty(num_tokens, d, dtype=dtype, device=device)
+    ops.silu_and_mul(silu_mul_out, x)
+
+    separate_out = torch.empty(num_tokens, d, dtype=fp8_dtype, device=device)
+    ops.static_scaled_fp8_quant(separate_out, silu_mul_out, scale)
+
+    # Fused kernel
+    fused_out = torch.empty(num_tokens, d, dtype=fp8_dtype, device=device)
+    ops.silu_and_mul_quant(fused_out, x, scale)
+
+    assert fused_out.dtype == fp8_dtype
+    assert fused_out.shape == separate_out.shape
+    torch.testing.assert_close(
+        fused_out.to(dtype=torch.float32),
+        separate_out.to(dtype=torch.float32),
+    )

--- a/tests/test_fused_quant_activation.py
+++ b/tests/test_fused_quant_activation.py
@@ -24,6 +24,7 @@ MINI_PYTEST_PARAMS = {
     },
 }
 
+
 def ref_silu_and_mul_quant(
     x: torch.Tensor,
     scale: torch.Tensor,
@@ -91,7 +92,6 @@ def test_silu_and_mul_quant_vs_separate(
     seed: int,
     device: str,
 ) -> None:
-    """Verify fused kernel matches separate silu_and_mul + static_scaled_fp8_quant."""
     seed_everything(seed)
     torch.set_default_device(device)
 


### PR DESCRIPTION
Add fuse_norm_quant, fuse_act_quant and fused_qk_norm_rope kernel. 

Run RedHatAI/Meta-Llama-3-8B-Instruct-FP8 model：
Call compilerdfxgraph one time improved from 1.976ms to 1.711ms
before fusion:
<img width="1312" height="383" alt="image" src="https://github.com/user-attachments/assets/61766d5a-da98-4d6f-9925-6bfc7f1a93d1" />
after fusion:
<img width="1320" height="313" alt="image" src="https://github.com/user-attachments/assets/82857206-0234-4ce5-b37d-455f76f4a403" />


