### PR TITLE
Fix moe_align kernel bug

### DIFF
--- a/csrc/moe/moe_align_sum_kernels.cpp
+++ b/csrc/moe/moe_align_sum_kernels.cpp
@@ -344,7 +344,7 @@ void _moe_align_block_size_small_batch_expert(
   if (local_id_x >= fill_threads) {
     if (tid < num_experts) {
       tokens_cnts[tid] = 0;
-      for (int i = 1; i <= stride; ++i) {
+      for (size_t i = 1; i <= stride; ++i) {
         tokens_cnts[i * num_experts + tid] +=
             tokens_cnts[(i - 1) * num_experts + tid];
       }


### PR DESCRIPTION
Sometimes the comparation of int and size_t returns wrong result.
Fix the kernel by align dtype.