### PR TITLE
Replace int with size_t for size/count/stride/index variables across csrc 

### DIFF
--- a/csrc/activation.cpp
+++ b/csrc/activation.cpp
@@ -92,7 +92,7 @@ class act_kernel {
   act_kernel(
       scalar_t* __restrict__ out,          // [..., d]
       const scalar_t* __restrict__ input,  // [..., d]
-      const int d)
+      const size_t d)
       : out_(out), input_(input), d_(d) {}
 
   void operator() [[sycl::reqd_sub_group_size(32)]] (
@@ -108,7 +108,7 @@ class act_kernel {
  private:
   scalar_t* __restrict__ out_;          // [..., d]
   const scalar_t* __restrict__ input_;  // [..., d]
-  const int d_;
+  const size_t d_;
 };
 
 template <
@@ -120,7 +120,7 @@ class act_and_mul_kernel {
   act_and_mul_kernel(
       scalar_t* __restrict__ out,          // [..., d]
       const scalar_t* __restrict__ input,  // [..., 2, d]
-      const int d)
+      const size_t d)
       : out_(out), input_(input), d_(d) {}
 
   void operator() [[sycl::reqd_sub_group_size(32)]] (
@@ -137,7 +137,7 @@ class act_and_mul_kernel {
  private:
   scalar_t* __restrict__ out_;          // [..., d]
   const scalar_t* __restrict__ input_;  // [..., 2, d]
-  const int d_;
+  const size_t d_;
 };
 
 // Vectorized version of act_and_mul_kernel using aligned vector loads/stores.
@@ -153,7 +153,7 @@ class act_and_mul_vec_kernel {
   act_and_mul_vec_kernel(
       scalar_t* __restrict__ out,
       const scalar_t* __restrict__ input,
-      const int d)
+      const size_t d)
       : out_(out), input_(input), d_(d) {}
 
   void operator()(sycl::nd_item<1> item) const {
@@ -170,7 +170,7 @@ class act_and_mul_vec_kernel {
           input_)[token_idx * bound * 2 + i + bound];
       vec_t out_vec;
 #pragma unroll
-      for (int j = 0; j < VEC_SIZE; ++j) {
+      for (size_t j = 0; j < VEC_SIZE; ++j) {
         out_vec[j] = compute<scalar_t, ACT_FN, act_first>(x_vec[j], y_vec[j]);
       }
       reinterpret_cast<vec_t*>(out_)[token_idx * bound + i] = out_vec;
@@ -180,7 +180,7 @@ class act_and_mul_vec_kernel {
  private:
   scalar_t* __restrict__ out_;
   const scalar_t* __restrict__ input_;
-  const int d_;
+  const size_t d_;
 };
 
 template <
@@ -194,7 +194,7 @@ class act_and_mul_quant_vec_kernel {
       fp8_type* __restrict__ out,          // [..., d]
       const scalar_t* __restrict__ input,  // [..., 2 * d]
       const float* __restrict__ scale,     // [1]
-      const int d)
+      const size_t d)
       : out_(out), input_(input), scale_(scale), d_(d) {}
 
   void operator()(sycl::nd_item<1> item) const {
@@ -217,7 +217,7 @@ class act_and_mul_quant_vec_kernel {
       vec_t xv = v_x[i];
       vec_t yv = v_y[i];
 #pragma unroll
-      for (int j = 0; j < VEC_SIZE; j++) {
+      for (size_t j = 0; j < VEC_SIZE; j++) {
         float val = static_cast<float>(ACT_FN(xv[j]) * yv[j]) * inv_scale;
         float clamped = sycl::fmax(-fp8_max, sycl::fmin(val, fp8_max));
         out_[token_idx * d_ + i * VEC_SIZE + j] =
@@ -230,7 +230,7 @@ class act_and_mul_quant_vec_kernel {
   fp8_type* __restrict__ out_;          // [..., d]
   const scalar_t* __restrict__ input_;  // [..., 2 * d]
   const float* __restrict__ scale_;     // [1]
-  const int d_;
+  const size_t d_;
 };
 
 template <
@@ -242,7 +242,7 @@ class act_and_mul_with_param_vec_kernel {
   act_and_mul_with_param_vec_kernel(
       scalar_t* __restrict__ out,
       const scalar_t* __restrict__ input,
-      const int d,
+      const size_t d,
       const float param)
       : out_(out), input_(input), d_(d), param_(param) {}
 
@@ -260,7 +260,7 @@ class act_and_mul_with_param_vec_kernel {
           input_)[token_idx * bound * 2 + i + bound];
       vec_t out_vec;
 #pragma unroll
-      for (int j = 0; j < VEC_SIZE; ++j) {
+      for (size_t j = 0; j < VEC_SIZE; ++j) {
         out_vec[j] = ACT_FN(x_vec[j], param_) * y_vec[j];
       }
       reinterpret_cast<vec_t*>(out_)[token_idx * bound + i] = out_vec;
@@ -270,7 +270,7 @@ class act_and_mul_with_param_vec_kernel {
  private:
   scalar_t* __restrict__ out_;
   const scalar_t* __restrict__ input_;
-  const int d_;
+  const size_t d_;
   const float param_;
 };
 
@@ -319,7 +319,7 @@ class swigluoai_and_mul_kernel {
   swigluoai_and_mul_kernel(
       scalar_t* __restrict__ out,          // [..., d]
       const scalar_t* __restrict__ input,  // [..., 2, d]
-      const int d,
+      const size_t d,
       const float alpha,
       const float limit)
       : out(out), input(input), d(d), alpha(alpha), limit(limit) {}
@@ -340,7 +340,7 @@ class swigluoai_and_mul_kernel {
  private:
   scalar_t* out;          // [..., d]
   const scalar_t* input;  // [..., topk, d]
-  const int d;
+  const size_t d;
   const float alpha;
   const float limit;
 };
@@ -353,7 +353,7 @@ class swiglustep_and_mul_kernel {
   swiglustep_and_mul_kernel(
       scalar_t* __restrict__ out,          // [..., d]
       const scalar_t* __restrict__ input,  // [..., 2 * d]
-      const int d,
+      const size_t d,
       const float limit)
       : out(out), input(input), d(d), limit(limit) {}
 
@@ -372,7 +372,7 @@ class swiglustep_and_mul_kernel {
  private:
   scalar_t* out;
   const scalar_t* input;
-  const int d;
+  const size_t d;
   const float limit;
 };
 
@@ -383,10 +383,10 @@ class swiglustep_and_mul_kernel {
 // first.
 #define LAUNCH_ACTIVATION_GATE_KERNEL(KERNEL, ACT_FIRST)     \
   using sycl_t = vllm::xpu::SyclTypeTrait<scalar_t>::Type;   \
-  int d = input.size(-1) / 2;                                \
+  size_t d = input.size(-1) / 2;                                \
   int64_t num_tokens = input.numel() / input.size(-1);       \
   sycl::range<3> grid(1, 1, num_tokens);                     \
-  sycl::range<3> block(1, 1, std::min(d, 1024));             \
+  sycl::range<3> block(1, 1, std::min<size_t>(d, 1024));             \
   if (num_tokens == 0) {                                     \
     return;                                                  \
   }                                                          \
@@ -426,7 +426,7 @@ class swiglustep_and_mul_kernel {
 
 #define LAUNCH_ACTIVATION_GATE_KERNEL_VEC(KERNEL, ACT_FIRST)             \
   using sycl_t = vllm::xpu::SyclTypeTrait<scalar_t>::Type;               \
-  int d = input.size(-1) / 2;                                            \
+  size_t d = input.size(-1) / 2;                                            \
   int64_t num_tokens = input.numel() / input.size(-1);                   \
   if (num_tokens == 0) {                                                 \
     return;                                                              \
@@ -435,7 +435,7 @@ class swiglustep_and_mul_kernel {
   auto input_ptr = input.data_ptr<scalar_t>();                           \
   at::DeviceGuard device_guard(input.device());                          \
   auto& queue = vllm::xpu::vllmGetQueue();                               \
-  int vec_size = static_cast<int>(sizeof(float) * 4 / sizeof(scalar_t)); \
+  size_t vec_size = sizeof(float) * 4 / sizeof(scalar_t); \
   {                                                                      \
     int64_t tmp_wg =                                                     \
         std::min(static_cast<int64_t>(d), static_cast<int64_t>(1024));   \
@@ -458,7 +458,7 @@ class swiglustep_and_mul_kernel {
 
 #define LAUNCH_ACTIVATION_GATE_KERNEL_WITH_PARAM_VEC(KERNEL, PARAM)      \
   using sycl_t = vllm::xpu::SyclTypeTrait<scalar_t>::Type;               \
-  int d = input.size(-1) / 2;                                            \
+  size_t d = input.size(-1) / 2;                                            \
   int64_t num_tokens = input.numel() / input.size(-1);                   \
   if (num_tokens == 0) {                                                 \
     return;                                                              \
@@ -468,7 +468,7 @@ class swiglustep_and_mul_kernel {
   const float param = static_cast<float>(PARAM);                         \
   at::DeviceGuard device_guard(input.device());                          \
   auto& queue = vllm::xpu::vllmGetQueue();                               \
-  int vec_size = static_cast<int>(sizeof(float) * 4 / sizeof(scalar_t)); \
+  size_t vec_size = sizeof(float) * 4 / sizeof(scalar_t); \
   {                                                                      \
     int64_t tmp_wg =                                                     \
         std::min(static_cast<int64_t>(d), static_cast<int64_t>(1024));   \
@@ -520,7 +520,7 @@ void silu_and_mul(
 
 #define LAUNCH_ACTIVATION_GATE_QUANT_KERNEL(KERNEL)                          \
   using sycl_t = vllm::xpu::SyclTypeTrait<scalar_t>::Type;                   \
-  int d = input.size(-1) / 2;                                                \
+  size_t d = input.size(-1) / 2;                                                \
   int64_t num_tokens = input.numel() / input.size(-1);                       \
   if (num_tokens == 0) {                                                     \
     return;                                                                  \
@@ -530,7 +530,7 @@ void silu_and_mul(
   at::DeviceGuard device_guard(input.device());                              \
   auto& queue = vllm::xpu::vllmGetQueue();                                   \
   /* Compute vec_size like non-quant path: gcd(4*sizeof(float)/sizeof, d) */ \
-  int vec_size = static_cast<int>(sizeof(float) * 4 / sizeof(sycl_t));       \
+  size_t vec_size = sizeof(float) * 4 / sizeof(sycl_t);       \
   {                                                                          \
     int64_t tmp_wg =                                                         \
         std::min(static_cast<int64_t>(d), static_cast<int64_t>(1024));       \
@@ -605,10 +605,10 @@ void fatrelu_and_mul(
 // Launch element-wise activation kernel.
 #define LAUNCH_ACTIVATION_KERNEL(KERNEL)                   \
   using sycl_t = vllm::xpu::SyclTypeTrait<scalar_t>::Type; \
-  int d = input.size(-1);                                  \
+  size_t d = input.size(-1);                                  \
   int64_t num_tokens = input.numel() / input.size(-1);     \
   sycl::range<3> grid(1, 1, num_tokens);                   \
-  sycl::range<3> block(1, 1, std::min(d, 1024));           \
+  sycl::range<3> block(1, 1, std::min<size_t>(d, 1024));           \
   if (num_tokens == 0) {                                   \
     return;                                                \
   }                                                        \
@@ -624,10 +624,10 @@ void fatrelu_and_mul(
   });
 
 #define LAUNCH_SWIGLUOAI_AND_MUL(KERNEL, ALPHA, LIMIT)                    \
-  int d = input.size(-1) / 2;                                             \
+  size_t d = input.size(-1) / 2;                                             \
   int64_t num_tokens = input.numel() / input.size(-1);                    \
   sycl::range<1> grid(num_tokens);                                        \
-  sycl::range<1> block(std::min(d, 1024));                                \
+  sycl::range<1> block(std::min<size_t>(d, 1024));                                \
   at::DeviceGuard device_guard(input.device());                           \
   auto& queue = vllm::xpu::vllmGetQueue();                                \
   VLLM_DISPATCH_FLOATING_TYPES(                                           \
@@ -689,10 +689,10 @@ void swigluoai_and_mul(
 }
 
 #define LAUNCH_SWIGLUSTEP_AND_MUL(KERNEL, LIMIT)                           \
-  int d = input.size(-1) / 2;                                              \
+  size_t d = input.size(-1) / 2;                                              \
   int64_t num_tokens = input.numel() / input.size(-1);                     \
   sycl::range<1> grid(num_tokens);                                         \
-  sycl::range<1> block(std::min(d, 1024));                                 \
+  sycl::range<1> block(std::min<size_t>(d, 1024));                                 \
   at::DeviceGuard device_guard(input.device());                            \
   auto& queue = vllm::xpu::vllmGetQueue();                                 \
   VLLM_DISPATCH_FLOATING_TYPES(                                            \

--- a/csrc/activation.cpp
+++ b/csrc/activation.cpp
@@ -383,10 +383,10 @@ class swiglustep_and_mul_kernel {
 // first.
 #define LAUNCH_ACTIVATION_GATE_KERNEL(KERNEL, ACT_FIRST)     \
   using sycl_t = vllm::xpu::SyclTypeTrait<scalar_t>::Type;   \
-  size_t d = input.size(-1) / 2;                                \
+  size_t d = input.size(-1) / 2;                             \
   int64_t num_tokens = input.numel() / input.size(-1);       \
   sycl::range<3> grid(1, 1, num_tokens);                     \
-  sycl::range<3> block(1, 1, std::min<size_t>(d, 1024));             \
+  sycl::range<3> block(1, 1, std::min<size_t>(d, 1024));     \
   if (num_tokens == 0) {                                     \
     return;                                                  \
   }                                                          \
@@ -424,69 +424,69 @@ class swiglustep_and_mul_kernel {
     break;                                                            \
   }
 
-#define LAUNCH_ACTIVATION_GATE_KERNEL_VEC(KERNEL, ACT_FIRST)             \
-  using sycl_t = vllm::xpu::SyclTypeTrait<scalar_t>::Type;               \
-  size_t d = input.size(-1) / 2;                                            \
-  int64_t num_tokens = input.numel() / input.size(-1);                   \
-  if (num_tokens == 0) {                                                 \
-    return;                                                              \
-  }                                                                      \
-  auto out_ptr = out.data_ptr<scalar_t>();                               \
-  auto input_ptr = input.data_ptr<scalar_t>();                           \
-  at::DeviceGuard device_guard(input.device());                          \
-  auto& queue = vllm::xpu::vllmGetQueue();                               \
-  size_t vec_size = sizeof(float) * 4 / sizeof(scalar_t); \
-  {                                                                      \
-    int64_t tmp_wg =                                                     \
-        std::min(static_cast<int64_t>(d), static_cast<int64_t>(1024));   \
-    while (vec_size > 1 && (vec_size >> 1) * tmp_wg >= d) {              \
-      vec_size = vec_size >> 1;                                          \
-    }                                                                    \
-  }                                                                      \
-  if (d % vec_size != 0) vec_size = 1;                                   \
-  int64_t wg_size = std::min(                                            \
-      static_cast<int64_t>(d / vec_size), static_cast<int64_t>(1024));   \
-  switch (vec_size) {                                                    \
-    VEC_LAUNCH_ACT_AND_MUL(KERNEL, ACT_FIRST, 1);                        \
-    VEC_LAUNCH_ACT_AND_MUL(KERNEL, ACT_FIRST, 2);                        \
-    VEC_LAUNCH_ACT_AND_MUL(KERNEL, ACT_FIRST, 4);                        \
-    VEC_LAUNCH_ACT_AND_MUL(KERNEL, ACT_FIRST, 8);                        \
-    VEC_LAUNCH_ACT_AND_MUL(KERNEL, ACT_FIRST, 16);                       \
-    default:                                                             \
-      TORCH_CHECK(false, "Unsupported vector size: ", vec_size);         \
+#define LAUNCH_ACTIVATION_GATE_KERNEL_VEC(KERNEL, ACT_FIRST)           \
+  using sycl_t = vllm::xpu::SyclTypeTrait<scalar_t>::Type;             \
+  size_t d = input.size(-1) / 2;                                       \
+  int64_t num_tokens = input.numel() / input.size(-1);                 \
+  if (num_tokens == 0) {                                               \
+    return;                                                            \
+  }                                                                    \
+  auto out_ptr = out.data_ptr<scalar_t>();                             \
+  auto input_ptr = input.data_ptr<scalar_t>();                         \
+  at::DeviceGuard device_guard(input.device());                        \
+  auto& queue = vllm::xpu::vllmGetQueue();                             \
+  size_t vec_size = sizeof(float) * 4 / sizeof(scalar_t);              \
+  {                                                                    \
+    int64_t tmp_wg =                                                   \
+        std::min(static_cast<int64_t>(d), static_cast<int64_t>(1024)); \
+    while (vec_size > 1 && (vec_size >> 1) * tmp_wg >= d) {            \
+      vec_size = vec_size >> 1;                                        \
+    }                                                                  \
+  }                                                                    \
+  if (d % vec_size != 0) vec_size = 1;                                 \
+  int64_t wg_size = std::min(                                          \
+      static_cast<int64_t>(d / vec_size), static_cast<int64_t>(1024)); \
+  switch (vec_size) {                                                  \
+    VEC_LAUNCH_ACT_AND_MUL(KERNEL, ACT_FIRST, 1);                      \
+    VEC_LAUNCH_ACT_AND_MUL(KERNEL, ACT_FIRST, 2);                      \
+    VEC_LAUNCH_ACT_AND_MUL(KERNEL, ACT_FIRST, 4);                      \
+    VEC_LAUNCH_ACT_AND_MUL(KERNEL, ACT_FIRST, 8);                      \
+    VEC_LAUNCH_ACT_AND_MUL(KERNEL, ACT_FIRST, 16);                     \
+    default:                                                           \
+      TORCH_CHECK(false, "Unsupported vector size: ", vec_size);       \
   }
 
-#define LAUNCH_ACTIVATION_GATE_KERNEL_WITH_PARAM_VEC(KERNEL, PARAM)      \
-  using sycl_t = vllm::xpu::SyclTypeTrait<scalar_t>::Type;               \
-  size_t d = input.size(-1) / 2;                                            \
-  int64_t num_tokens = input.numel() / input.size(-1);                   \
-  if (num_tokens == 0) {                                                 \
-    return;                                                              \
-  }                                                                      \
-  auto out_ptr = out.data_ptr<scalar_t>();                               \
-  auto input_ptr = input.data_ptr<scalar_t>();                           \
-  const float param = static_cast<float>(PARAM);                         \
-  at::DeviceGuard device_guard(input.device());                          \
-  auto& queue = vllm::xpu::vllmGetQueue();                               \
-  size_t vec_size = sizeof(float) * 4 / sizeof(scalar_t); \
-  {                                                                      \
-    int64_t tmp_wg =                                                     \
-        std::min(static_cast<int64_t>(d), static_cast<int64_t>(1024));   \
-    while (vec_size > 1 && (vec_size >> 1) * tmp_wg >= d) {              \
-      vec_size = vec_size >> 1;                                          \
-    }                                                                    \
-  }                                                                      \
-  if (d % vec_size != 0) vec_size = 1;                                   \
-  int64_t wg_size = std::min(                                            \
-      static_cast<int64_t>(d / vec_size), static_cast<int64_t>(1024));   \
-  switch (vec_size) {                                                    \
-    VEC_LAUNCH_ACT_AND_MUL_WITH_PARAM(KERNEL, 1);                        \
-    VEC_LAUNCH_ACT_AND_MUL_WITH_PARAM(KERNEL, 2);                        \
-    VEC_LAUNCH_ACT_AND_MUL_WITH_PARAM(KERNEL, 4);                        \
-    VEC_LAUNCH_ACT_AND_MUL_WITH_PARAM(KERNEL, 8);                        \
-    VEC_LAUNCH_ACT_AND_MUL_WITH_PARAM(KERNEL, 16);                       \
-    default:                                                             \
-      TORCH_CHECK(false, "Unsupported vector size: ", vec_size);         \
+#define LAUNCH_ACTIVATION_GATE_KERNEL_WITH_PARAM_VEC(KERNEL, PARAM)    \
+  using sycl_t = vllm::xpu::SyclTypeTrait<scalar_t>::Type;             \
+  size_t d = input.size(-1) / 2;                                       \
+  int64_t num_tokens = input.numel() / input.size(-1);                 \
+  if (num_tokens == 0) {                                               \
+    return;                                                            \
+  }                                                                    \
+  auto out_ptr = out.data_ptr<scalar_t>();                             \
+  auto input_ptr = input.data_ptr<scalar_t>();                         \
+  const float param = static_cast<float>(PARAM);                       \
+  at::DeviceGuard device_guard(input.device());                        \
+  auto& queue = vllm::xpu::vllmGetQueue();                             \
+  size_t vec_size = sizeof(float) * 4 / sizeof(scalar_t);              \
+  {                                                                    \
+    int64_t tmp_wg =                                                   \
+        std::min(static_cast<int64_t>(d), static_cast<int64_t>(1024)); \
+    while (vec_size > 1 && (vec_size >> 1) * tmp_wg >= d) {            \
+      vec_size = vec_size >> 1;                                        \
+    }                                                                  \
+  }                                                                    \
+  if (d % vec_size != 0) vec_size = 1;                                 \
+  int64_t wg_size = std::min(                                          \
+      static_cast<int64_t>(d / vec_size), static_cast<int64_t>(1024)); \
+  switch (vec_size) {                                                  \
+    VEC_LAUNCH_ACT_AND_MUL_WITH_PARAM(KERNEL, 1);                      \
+    VEC_LAUNCH_ACT_AND_MUL_WITH_PARAM(KERNEL, 2);                      \
+    VEC_LAUNCH_ACT_AND_MUL_WITH_PARAM(KERNEL, 4);                      \
+    VEC_LAUNCH_ACT_AND_MUL_WITH_PARAM(KERNEL, 8);                      \
+    VEC_LAUNCH_ACT_AND_MUL_WITH_PARAM(KERNEL, 16);                     \
+    default:                                                           \
+      TORCH_CHECK(false, "Unsupported vector size: ", vec_size);       \
   }
 
 void silu_and_mul(
@@ -520,7 +520,7 @@ void silu_and_mul(
 
 #define LAUNCH_ACTIVATION_GATE_QUANT_KERNEL(KERNEL)                          \
   using sycl_t = vllm::xpu::SyclTypeTrait<scalar_t>::Type;                   \
-  size_t d = input.size(-1) / 2;                                                \
+  size_t d = input.size(-1) / 2;                                             \
   int64_t num_tokens = input.numel() / input.size(-1);                       \
   if (num_tokens == 0) {                                                     \
     return;                                                                  \
@@ -530,7 +530,7 @@ void silu_and_mul(
   at::DeviceGuard device_guard(input.device());                              \
   auto& queue = vllm::xpu::vllmGetQueue();                                   \
   /* Compute vec_size like non-quant path: gcd(4*sizeof(float)/sizeof, d) */ \
-  size_t vec_size = sizeof(float) * 4 / sizeof(sycl_t);       \
+  size_t vec_size = sizeof(float) * 4 / sizeof(sycl_t);                      \
   {                                                                          \
     int64_t tmp_wg =                                                         \
         std::min(static_cast<int64_t>(d), static_cast<int64_t>(1024));       \
@@ -605,10 +605,10 @@ void fatrelu_and_mul(
 // Launch element-wise activation kernel.
 #define LAUNCH_ACTIVATION_KERNEL(KERNEL)                   \
   using sycl_t = vllm::xpu::SyclTypeTrait<scalar_t>::Type; \
-  size_t d = input.size(-1);                                  \
+  size_t d = input.size(-1);                               \
   int64_t num_tokens = input.numel() / input.size(-1);     \
   sycl::range<3> grid(1, 1, num_tokens);                   \
-  sycl::range<3> block(1, 1, std::min<size_t>(d, 1024));           \
+  sycl::range<3> block(1, 1, std::min<size_t>(d, 1024));   \
   if (num_tokens == 0) {                                   \
     return;                                                \
   }                                                        \
@@ -624,10 +624,10 @@ void fatrelu_and_mul(
   });
 
 #define LAUNCH_SWIGLUOAI_AND_MUL(KERNEL, ALPHA, LIMIT)                    \
-  size_t d = input.size(-1) / 2;                                             \
+  size_t d = input.size(-1) / 2;                                          \
   int64_t num_tokens = input.numel() / input.size(-1);                    \
   sycl::range<1> grid(num_tokens);                                        \
-  sycl::range<1> block(std::min<size_t>(d, 1024));                                \
+  sycl::range<1> block(std::min<size_t>(d, 1024));                        \
   at::DeviceGuard device_guard(input.device());                           \
   auto& queue = vllm::xpu::vllmGetQueue();                                \
   VLLM_DISPATCH_FLOATING_TYPES(                                           \
@@ -689,10 +689,10 @@ void swigluoai_and_mul(
 }
 
 #define LAUNCH_SWIGLUSTEP_AND_MUL(KERNEL, LIMIT)                           \
-  size_t d = input.size(-1) / 2;                                              \
+  size_t d = input.size(-1) / 2;                                           \
   int64_t num_tokens = input.numel() / input.size(-1);                     \
   sycl::range<1> grid(num_tokens);                                         \
-  sycl::range<1> block(std::min<size_t>(d, 1024));                                 \
+  sycl::range<1> block(std::min<size_t>(d, 1024));                         \
   at::DeviceGuard device_guard(input.device());                            \
   auto& queue = vllm::xpu::vllmGetQueue();                                 \
   VLLM_DISPATCH_FLOATING_TYPES(                                            \

--- a/csrc/cache.cpp
+++ b/csrc/cache.cpp
@@ -23,12 +23,12 @@ class reshape_and_cache_kernel {
       cache_t* __restrict__ key_cache,
       cache_t* __restrict__ value_cache,
       const int64_t* __restrict__ slot_mapping,
-      int key_stride,
-      int value_stride,
-      int num_heads,
-      int head_size,
-      int block_size,
-      int x,
+      size_t key_stride,
+      size_t value_stride,
+      size_t num_heads,
+      size_t head_size,
+      size_t block_size,
+      size_t x,
       const float* k_scale,
       const float* v_scale)
       : key_(key),
@@ -46,29 +46,29 @@ class reshape_and_cache_kernel {
         v_scale_(v_scale) {}
 
   void operator()(const sycl::nd_item<1>& item) const {
-    int group_idx = item.get_group(0);
-    int local_idx = item.get_local_id(0);
-    int local_range = item.get_local_range(0);
+    size_t group_idx = item.get_group(0);
+    size_t local_idx = item.get_local_id(0);
+    size_t local_range = item.get_local_range(0);
     int slot_idx = slot_mapping_[group_idx];
     if (slot_idx < 0) return;
 
     const int block_idx = slot_idx / block_size_;
     const int block_offset = slot_idx % block_size_;
-    const int n = num_heads_ * head_size_;
-    for (int i = local_idx; i < n; i += local_range) {
-      const int src_key_idx = group_idx * key_stride_ + i;
-      const int src_value_idx = group_idx * value_stride_ + i;
-      const int head_idx = i / head_size_;
-      const int head_offset = i % head_size_;
-      const int x_idx = head_offset / x_;
-      const int x_offset = head_offset % x_;
-      const int dst_key_idx =
+    const size_t n = num_heads_ * head_size_;
+    for (size_t i = local_idx; i < n; i += local_range) {
+      const size_t src_key_idx = group_idx * key_stride_ + i;
+      const size_t src_value_idx = group_idx * value_stride_ + i;
+      const size_t head_idx = i / head_size_;
+      const size_t head_offset = i % head_size_;
+      const size_t x_idx = head_offset / x_;
+      const size_t x_offset = head_offset % x_;
+      const size_t dst_key_idx =
           block_idx * num_heads_ * (head_size_ / x_) * block_size_ * x_ +
           head_idx * (head_size_ / x_) * block_size_ * x_ +
           x_idx * block_size_ * x_ + block_offset * x_ + x_offset;
-      const int dst_value_idx = block_idx * n * block_size_ +
-                                head_idx * head_size_ * block_size_ +
-                                head_offset * block_size_ + block_offset;
+      const size_t dst_value_idx = block_idx * n * block_size_ +
+                                   head_idx * head_size_ * block_size_ +
+                                   head_offset * block_size_ + block_offset;
       scalar_t tgt_key = key_[src_key_idx];
       scalar_t tgt_value = value_[src_value_idx];
       if constexpr (kv_dt == Fp8KVCacheDataType::kFp8E5M2) {
@@ -96,12 +96,12 @@ class reshape_and_cache_kernel {
   cache_t* __restrict__ value_cache_;   // [num_blocks, num_heads, head_size,
                                         // block_size]
   const int64_t* __restrict__ slot_mapping_;  // [num_tokens]
-  const int key_stride_;
-  const int value_stride_;
-  const int num_heads_;
-  const int head_size_;
-  const int block_size_;
-  const int x_;
+  const size_t key_stride_;
+  const size_t value_stride_;
+  const size_t num_heads_;
+  const size_t head_size_;
+  const size_t block_size_;
+  const size_t x_;
   const float* k_scale_;
   const float* v_scale_;
 };
@@ -120,9 +120,9 @@ class reshape_and_cache_flash_kernel {
       const int64_t head_stride,
       const int64_t key_stride,
       const int64_t value_stride,
-      const int num_heads,
-      const int head_size,
-      const int block_size,
+      const size_t num_heads,
+      const size_t head_size,
+      const size_t block_size,
       const float* k_scale,
       const float* v_scale)
       : key_(key),
@@ -144,13 +144,13 @@ class reshape_and_cache_flash_kernel {
   void operator()(const sycl::nd_item<1>& item) const {
     int64_t group_idx = item.get_group(0);
     int64_t local_idx = item.get_local_id(0);
-    int local_range = item.get_local_range(0);
+    size_t local_range = item.get_local_range(0);
     int64_t slot_idx = slot_mapping_[group_idx];
     if (slot_idx < 0) return;
 
     const int64_t block_idx = slot_idx / block_size_;
     const int64_t block_offset = slot_idx % block_size_;
-    const int n = num_heads_ * head_size_;
+    const size_t n = num_heads_ * head_size_;
 
     // pointers to the beginning of the source row for this token.
     const scalar_t* __restrict__ key_src = key_ + group_idx * key_stride_;
@@ -185,9 +185,9 @@ class reshape_and_cache_flash_kernel {
   const int64_t head_stride_;
   const int64_t key_stride_;
   const int64_t value_stride_;
-  const int num_heads_;
-  const int head_size_;
-  const int block_size_;
+  const size_t num_heads_;
+  const size_t head_size_;
+  const size_t block_size_;
   const float* k_scale_;
   const float* v_scale_;
 };
@@ -200,13 +200,13 @@ class concat_and_cache_mla_kernel {
       const scalar_t* __restrict__ k_pe,
       cache_t* __restrict__ kv_cache,
       const int64_t* __restrict__ slot_mapping,
-      const int block_stride,
-      const int entry_stride,
-      const int kv_c_stride,
-      const int k_pe_stride,
-      const int kv_lora_rank,
-      const int pe_dim,
-      const int block_size,
+      const size_t block_stride,
+      const size_t entry_stride,
+      const size_t kv_c_stride,
+      const size_t k_pe_stride,
+      const size_t kv_lora_rank,
+      const size_t pe_dim,
+      const size_t block_size,
       const float* scale)
       : kv_c(kv_c),
         k_pe(k_pe),
@@ -233,14 +233,14 @@ class concat_and_cache_mla_kernel {
 
     auto copy = [&](const scalar_t* __restrict__ src,
                     cache_t* dst,
-                    int src_stride,
-                    int dst_stride,
-                    int size,
-                    int offset) {
-      for (int i = item_id.get_local_id(0); i < size;
+                    size_t src_stride,
+                    size_t dst_stride,
+                    size_t size,
+                    size_t offset) {
+      for (size_t i = item_id.get_local_id(0); i < size;
            i += item_id.get_local_range(0)) {
-        const int src_idx = token_idx * src_stride + i;
-        const int dst_idx =
+        const size_t src_idx = token_idx * src_stride + i;
+        const size_t dst_idx =
             block_idx * block_stride + block_offset * entry_stride + i + offset;
         if constexpr (kv_dt == Fp8KVCacheDataType::kFp8E4M3) {
           dst[dst_idx] = static_cast<at::Float8_e4m3fn>(src[src_idx] * *scale);
@@ -262,13 +262,13 @@ class concat_and_cache_mla_kernel {
   cache_t* __restrict__ kv_cache;  // [num_blocks, block_size, (kv_lora_rank +
                                    // pe_dim)]
   const int64_t* __restrict__ slot_mapping;  // [num_tokens]
-  const int block_stride;                    //
-  const int entry_stride;                    //
-  const int kv_c_stride;                     //
-  const int k_pe_stride;                     //
-  const int kv_lora_rank;                    //
-  const int pe_dim;                          //
-  const int block_size;                      //
+  const size_t block_stride;                 //
+  const size_t entry_stride;                 //
+  const size_t kv_c_stride;                  //
+  const size_t k_pe_stride;                  //
+  const size_t kv_lora_rank;                 //
+  const size_t pe_dim;                       //
+  const size_t block_size;                   //
   const float* scale;                        //
 };
 
@@ -392,10 +392,10 @@ class indexer_k_quant_and_cache_kernel {
       const scalar_t* __restrict__ k,
       cache_t* __restrict__ kv_cache,
       const int64_t* __restrict__ slot_mapping,
-      const int head_dim,
-      const int quant_block_size,
-      const int cache_block_size,
-      const int cache_stride,
+      const size_t head_dim,
+      const size_t quant_block_size,
+      const size_t cache_block_size,
+      const size_t cache_stride,
       bool use_ue8m0)
       : k_(k),
         kv_cache_(kv_cache),
@@ -481,14 +481,14 @@ class cp_gather_indexer_k_quant_cache_kernel {
       const int32_t* __restrict__ block_table,
       const int32_t* __restrict__ cu_seq_lens,
       sycl::local_accessor<int, 1> batch_idx_acc,
-      const int batch_size,
+      const size_t batch_size,
       const int64_t token_stride,
       const int64_t head_dim,
       const int64_t block_stride,
       const int64_t cache_block_size,
-      const int num_blocks,
-      const int num_tokens,
-      const int quant_block_size)
+      const size_t num_blocks,
+      const size_t num_tokens,
+      const size_t quant_block_size)
       : kv_cache_(kv_cache),
         dst_k_(dst_k),
         dst_scale_(dst_scale),
@@ -509,17 +509,14 @@ class cp_gather_indexer_k_quant_cache_kernel {
     // This matches CUDA's float4 vectorised load/store of fp8 bytes.
     constexpr int VEC_SIZE = 16;
 
-    const int local_x = static_cast<int>(item.get_local_id(0));
-    const int local_y = static_cast<int>(item.get_local_id(1));
-    const int local_range_x =
-        static_cast<int>(item.get_local_range(0));  // BLOCK_Y_SIZE
-    const int local_range_y = static_cast<int>(item.get_local_range(1));  // 8
+    const size_t local_x = item.get_local_id(0);
+    const size_t local_y = item.get_local_id(1);
+    const size_t local_range_x = item.get_local_range(0);  // BLOCK_Y_SIZE
+    const size_t local_range_y = item.get_local_range(1);  // 8
 
-    const int token_idx =
-        static_cast<int>(item.get_group(0) * local_range_x + local_x);
-    const int head_idx =
-        static_cast<int>(item.get_group(1) * local_range_y + local_y) *
-        VEC_SIZE;
+    const size_t token_idx = item.get_group(0) * local_range_x + local_x;
+    const size_t head_idx =
+        (item.get_group(1) * local_range_y + local_y) * VEC_SIZE;
 
     // Initialise SLM to 0 before the search to avoid stale values
     // from the previous work-group that ran on the same EU.
@@ -527,9 +524,9 @@ class cp_gather_indexer_k_quant_cache_kernel {
       batch_idx_acc_[local_x] = 0;
     }
 
-    for (int iter = 0; iter < (batch_size_ + local_range_y - 1) / local_range_y;
-         ++iter) {
-      int tid = iter * local_range_y + local_y;
+    for (size_t iter = 0;
+         iter < (batch_size_ + local_range_y - 1) / local_range_y; ++iter) {
+      size_t tid = iter * local_range_y + local_y;
       if (tid < batch_size_) {
         const int seq_start = cu_seq_lens_[tid];
         const int seq_end = cu_seq_lens_[tid + 1];
@@ -543,7 +540,7 @@ class cp_gather_indexer_k_quant_cache_kernel {
     item.barrier(sycl::access::fence_space::local_space);
 
     // Exit threads after barrier to make sure nothing to write.
-    if (head_idx >= static_cast<int>(head_dim_) || token_idx >= num_tokens_) {
+    if (head_idx >= static_cast<size_t>(head_dim_) || token_idx >= num_tokens_) {
       return;
     }
 
@@ -567,15 +564,15 @@ class cp_gather_indexer_k_quant_cache_kernel {
     const bool src_aligned = (src_inblock_offset % VEC_SIZE) == 0;
     const bool dst_aligned = (dst_inblock_offset % VEC_SIZE) == 0;
     const bool full_chunk =
-        (head_idx + VEC_SIZE <= static_cast<int>(head_dim_));
+        (head_idx + VEC_SIZE <= static_cast<size_t>(head_dim_));
     if (full_chunk && src_aligned && dst_aligned) {
       *reinterpret_cast<sycl::float4*>(dst_k_ + dst_inblock_offset) =
           *reinterpret_cast<const sycl::float4*>(
               kv_cache_ + src_inblock_offset);
     } else {
-      int remains =
-          full_chunk ? VEC_SIZE : static_cast<int>(head_dim_) - head_idx;
-      for (int i = 0; i < remains; i++) {
+      size_t remains =
+          full_chunk ? VEC_SIZE : static_cast<size_t>(head_dim_) - head_idx;
+      for (size_t i = 0; i < remains; i++) {
         dst_k_[dst_inblock_offset + i] = kv_cache_[src_inblock_offset + i];
       }
     }
@@ -599,14 +596,14 @@ class cp_gather_indexer_k_quant_cache_kernel {
   const int32_t* block_table_;
   const int32_t* cu_seq_lens_;
   sycl::local_accessor<int, 1> batch_idx_acc_;
-  int batch_size_;
+  size_t batch_size_;
   int64_t token_stride_;
   int64_t head_dim_;
   int64_t block_stride_;
   int64_t cache_block_size_;
-  int num_blocks_;
-  int num_tokens_;
-  int quant_block_size_;
+  size_t num_blocks_;
+  size_t num_tokens_;
+  size_t quant_block_size_;
 };
 
 // grid is launched with dimensions (num_tokens)
@@ -742,17 +739,17 @@ void reshape_and_cache(
     const std::string& kv_cache_dtype,
     torch::Tensor& k_scale,
     torch::Tensor& v_scale) {
-  int num_tokens = slot_mapping.size(0);
-  int num_heads = key.size(1);
-  int head_size = key.size(2);
-  int block_size = key_cache.size(3);
-  int x = key_cache.size(4);
+  size_t num_tokens = slot_mapping.size(0);
+  size_t num_heads = key.size(1);
+  size_t head_size = key.size(2);
+  size_t block_size = key_cache.size(3);
+  size_t x = key_cache.size(4);
 
-  int key_stride = key.stride(0);
-  int value_stride = value.stride(0);
+  size_t key_stride = key.stride(0);
+  size_t value_stride = value.stride(0);
 
   sycl::range<1> grid(num_tokens);
-  sycl::range<1> block(std::min(num_heads * head_size, 1024));
+  sycl::range<1> block(std::min(num_heads * head_size, size_t{1024}));
   const at::DeviceGuard device_guard(key.device());
   auto& queue = vllm::xpu::vllmGetQueue();
 
@@ -794,10 +791,10 @@ void reshape_and_cache_flash(
     const std::string& kv_cache_dtype,
     torch::Tensor& k_scale,
     torch::Tensor& v_scale) {
-  int num_tokens = slot_mapping.size(0);
-  int num_heads = key.size(1);
-  int head_size = key.size(2);
-  int block_size = key_cache.size(1);
+  size_t num_tokens = slot_mapping.size(0);
+  size_t num_heads = key.size(1);
+  size_t head_size = key.size(2);
+  size_t block_size = key_cache.size(1);
 
   int64_t key_stride = key.stride(0);
   int64_t value_stride = value.stride(0);
@@ -807,7 +804,7 @@ void reshape_and_cache_flash(
   TORCH_CHECK(key_cache.stride(0) == value_cache.stride(0));
 
   sycl::range<1> grid(num_tokens);
-  sycl::range<1> block(std::min(num_heads * head_size, 1024));
+  sycl::range<1> block(std::min(num_heads * head_size, size_t{1024}));
   const at::DeviceGuard device_guard(key.device());
   auto& queue = vllm::xpu::vllmGetQueue();
 
@@ -855,20 +852,20 @@ void concat_and_cache_mla(
   // before padding.
   // For compatibility with both cases, we use slot_mapping.size(0) as the
   // number of tokens.
-  int num_tokens = slot_mapping.size(0);
-  int kv_lora_rank = kv_c.size(1);
-  int pe_dim = k_pe.size(1);
-  int block_size = kv_cache.size(1);
+  size_t num_tokens = slot_mapping.size(0);
+  size_t kv_lora_rank = kv_c.size(1);
+  size_t pe_dim = k_pe.size(1);
+  size_t block_size = kv_cache.size(1);
 
   TORCH_CHECK(kv_cache.size(2) == kv_lora_rank + pe_dim);
 
-  int kv_c_stride = kv_c.stride(0);
-  int k_pe_stride = k_pe.stride(0);
-  int block_stride = kv_cache.stride(0);
-  int entry_stride = kv_cache.stride(1);
+  size_t kv_c_stride = kv_c.stride(0);
+  size_t k_pe_stride = k_pe.stride(0);
+  size_t block_stride = kv_cache.stride(0);
+  size_t entry_stride = kv_cache.stride(1);
 
   sycl::range<1> grid(num_tokens);
-  sycl::range<1> block(std::min(kv_lora_rank, 1024));
+  sycl::range<1> block(std::min(kv_lora_rank, size_t{1024}));
   const at::DeviceGuard device_guard(kv_c.device());
   auto& queue = vllm::xpu::vllmGetQueue();
 
@@ -1379,10 +1376,10 @@ void indexer_k_quant_and_cache(
     torch::Tensor& slot_mapping,  // [num_tokens]
     int64_t quant_block_size,     // quantization block size
     const std::string& scale_fmt) {
-  int num_tokens = k.size(0);
-  int head_dim = k.size(1);
-  int cache_block_size = kv_cache.size(1);
-  int cache_stride = kv_cache.size(2);
+  size_t num_tokens = k.size(0);
+  size_t head_dim = k.size(1);
+  size_t cache_block_size = kv_cache.size(1);
+  size_t cache_stride = kv_cache.size(2);
   bool use_ue8m0 = scale_fmt == "ue8m0";
 
   TORCH_CHECK(
@@ -1434,7 +1431,7 @@ void indexer_k_quant_and_cache(
               head_dim,                                                 \
               kv_cache.stride(0),                                       \
               kv_cache.size(1),                                         \
-              static_cast<int>(block_table.size(1)),                    \
+              static_cast<size_t>(block_table.size(1)),                    \
               num_tokens,                                               \
               quant_block_size));                                       \
     });                                                                 \
@@ -1447,10 +1444,10 @@ void cp_gather_indexer_k_quant_cache(
     const torch::Tensor& block_table,  // [batch_size, num_blocks]
     const torch::Tensor& cu_seq_lens   // [batch_size + 1]
 ) {
-  int batch_size = static_cast<int>(block_table.size(0));
-  int num_tokens = static_cast<int>(dst_k.size(0));
+  size_t batch_size = block_table.size(0);
+  size_t num_tokens = dst_k.size(0);
   int64_t head_dim = dst_k.size(1);
-  int quant_block_size = static_cast<int>(head_dim * 4 / dst_scale.size(1));
+  size_t quant_block_size = head_dim * 4 / dst_scale.size(1);
 
   TORCH_CHECK(
       kv_cache.device() == dst_k.device(),

--- a/csrc/cache.cpp
+++ b/csrc/cache.cpp
@@ -525,7 +525,8 @@ class cp_gather_indexer_k_quant_cache_kernel {
     }
 
     for (size_t iter = 0;
-         iter < (batch_size_ + local_range_y - 1) / local_range_y; ++iter) {
+         iter < (batch_size_ + local_range_y - 1) / local_range_y;
+         ++iter) {
       size_t tid = iter * local_range_y + local_y;
       if (tid < batch_size_) {
         const int seq_start = cu_seq_lens_[tid];
@@ -540,7 +541,8 @@ class cp_gather_indexer_k_quant_cache_kernel {
     item.barrier(sycl::access::fence_space::local_space);
 
     // Exit threads after barrier to make sure nothing to write.
-    if (head_idx >= static_cast<size_t>(head_dim_) || token_idx >= num_tokens_) {
+    if (head_idx >= static_cast<size_t>(head_dim_) ||
+        token_idx >= num_tokens_) {
       return;
     }
 
@@ -1431,7 +1433,7 @@ void indexer_k_quant_and_cache(
               head_dim,                                                 \
               kv_cache.stride(0),                                       \
               kv_cache.size(1),                                         \
-              static_cast<size_t>(block_table.size(1)),                    \
+              static_cast<size_t>(block_table.size(1)),                 \
               num_tokens,                                               \
               quant_block_size));                                       \
     });                                                                 \

--- a/csrc/fused_qknorm_rope.cpp
+++ b/csrc/fused_qknorm_rope.cpp
@@ -27,16 +27,16 @@ class fused_qk_norm_rope_kernel {
 
   fused_qk_norm_rope_kernel(
       scalar_t* __restrict__ qkv_,
-      const int num_heads_q_,
-      const int num_heads_k_,
-      const int num_heads_v_,
+      const size_t num_heads_q_,
+      const size_t num_heads_k_,
+      const size_t num_heads_v_,
       const float eps_,
       const scalar_t* __restrict__ q_weight_,
       const scalar_t* __restrict__ k_weight_,
       const scalar_t_cache* __restrict__ cos_sin_cache_,
       const int64_t* __restrict__ position_ids_,
-      const int num_tokens_,
-      const int rotary_dim_)
+      const size_t num_tokens_,
+      const size_t rotary_dim_)
       : qkv(qkv_),
         num_heads_q(num_heads_q_),
         num_heads_k(num_heads_k_),
@@ -52,37 +52,37 @@ class fused_qk_norm_rope_kernel {
   void operator() [[sycl::reqd_sub_group_size(SUB_GROUP_SIZE)]] (
       const sycl::nd_item<1>& item) const {
     auto sg = item.get_sub_group();
-    const int lane_id = sg.get_local_linear_id();
-    const int sg_id_in_wg = sg.get_group_linear_id();
-    const int sgs_per_wg = sg.get_group_linear_range();
-    const int global_sg_id = item.get_group(0) * sgs_per_wg + sg_id_in_wg;
+    const size_t lane_id = sg.get_local_linear_id();
+    const size_t sg_id_in_wg = sg.get_group_linear_id();
+    const size_t sgs_per_wg = sg.get_group_linear_range();
+    const size_t global_sg_id = item.get_group(0) * sgs_per_wg + sg_id_in_wg;
 
-    const int total_qk_heads = num_heads_q + num_heads_k;
-    const int token_idx = global_sg_id / total_qk_heads;
-    const int local_head_idx = global_sg_id % total_qk_heads;
+    const size_t total_qk_heads = num_heads_q + num_heads_k;
+    const size_t token_idx = global_sg_id / total_qk_heads;
+    const size_t local_head_idx = global_sg_id % total_qk_heads;
 
     if (token_idx >= num_tokens) return;
 
     const bool is_q = local_head_idx < num_heads_q;
-    const int head_idx = is_q ? local_head_idx : local_head_idx - num_heads_q;
-    const int num_heads = num_heads_q + num_heads_k + num_heads_v;
+    const size_t head_idx = is_q ? local_head_idx : local_head_idx - num_heads_q;
+    const size_t num_heads = num_heads_q + num_heads_k + num_heads_v;
 
     // Compute the offset into the QKV tensor for this sub-group's head.
-    int offset_warp;
+    size_t offset_warp;
     if (is_q) {
       offset_warp = token_idx * num_heads * head_dim + head_idx * head_dim;
     } else {
       offset_warp = token_idx * num_heads * head_dim + num_heads_q * head_dim +
                     head_idx * head_dim;
     }
-    int offset_thread = offset_warp + lane_id * NUM_ELEMS_PER_THREAD;
+    size_t offset_thread = offset_warp + lane_id * NUM_ELEMS_PER_THREAD;
 
     // Load elements and compute sum of squares for RMSNorm.
     float elements[NUM_ELEMS_PER_THREAD];
     float sum_of_squares = 0.0f;
 
 #pragma unroll
-    for (int i = 0; i < NUM_ELEMS_PER_THREAD; i++) {
+    for (size_t i = 0; i < NUM_ELEMS_PER_THREAD; i++) {
       float val = static_cast<float>(qkv[offset_thread + i]);
       elements[i] = val;
       sum_of_squares += val * val;
@@ -99,34 +99,34 @@ class fused_qk_norm_rope_kernel {
     // Apply RMSNorm with learned weights.
     const scalar_t* weight = is_q ? q_weight : k_weight;
 #pragma unroll
-    for (int i = 0; i < NUM_ELEMS_PER_THREAD; i++) {
-      int dim = lane_id * NUM_ELEMS_PER_THREAD + i;
+    for (size_t i = 0; i < NUM_ELEMS_PER_THREAD; i++) {
+      size_t dim = lane_id * NUM_ELEMS_PER_THREAD + i;
       float w = static_cast<float>(weight[dim]);
       elements[i] *= rms_rcp * w;
     }
 
     // Apply RoPE.
     const int64_t pos_id = position_ids[token_idx];
-    const int embed_dim = rotary_dim / 2;
+    const size_t embed_dim = rotary_dim / 2;
     const scalar_t_cache* cache_ptr = cos_sin_cache + pos_id * rotary_dim;
     const scalar_t_cache* cos_ptr = cache_ptr;
     const scalar_t_cache* sin_ptr = cache_ptr + embed_dim;
 
-    const int rotary_lanes = rotary_dim / NUM_ELEMS_PER_THREAD;
+    const size_t rotary_lanes = rotary_dim / NUM_ELEMS_PER_THREAD;
 
     if (lane_id < rotary_lanes) {
       if constexpr (!IS_NEOX) {
         // Interleaved-style RoPE (GPT-J style).
 #pragma unroll
-        for (int i = 0; i < NUM_ELEMS_PER_THREAD / 2; ++i) {
-          const int idx0 = 2 * i;
-          const int idx1 = 2 * i + 1;
-          const int dim_idx = lane_id * NUM_ELEMS_PER_THREAD + idx0;
+        for (size_t i = 0; i < NUM_ELEMS_PER_THREAD / 2; ++i) {
+          const size_t idx0 = 2 * i;
+          const size_t idx1 = 2 * i + 1;
+          const size_t dim_idx = lane_id * NUM_ELEMS_PER_THREAD + idx0;
 
           const float val0 = elements[idx0];
           const float val1 = elements[idx1];
 
-          const int half_dim = dim_idx / 2;
+          const size_t half_dim = dim_idx / 2;
           const float cos_val = static_cast<float>(cos_ptr[half_dim]);
           const float sin_val = static_cast<float>(sin_ptr[half_dim]);
 
@@ -136,10 +136,10 @@ class fused_qk_norm_rope_kernel {
       } else {
         // Neox-style RoPE: exchange data with partner lane.
         sycl::group_barrier(sg);
-        const int pair_offset = (rotary_dim / 2) / NUM_ELEMS_PER_THREAD;
+        const size_t pair_offset = (rotary_dim / 2) / NUM_ELEMS_PER_THREAD;
 
 #pragma unroll
-        for (int i = 0; i < NUM_ELEMS_PER_THREAD; i++) {
+        for (size_t i = 0; i < NUM_ELEMS_PER_THREAD; i++) {
           float partner_val =
               sycl::permute_group_by_xor(sg, elements[i], pair_offset);
 
@@ -147,9 +147,9 @@ class fused_qk_norm_rope_kernel {
             partner_val = -partner_val;
           }
 
-          int dim_idx = lane_id * NUM_ELEMS_PER_THREAD + i;
+          size_t dim_idx = lane_id * NUM_ELEMS_PER_THREAD + i;
           dim_idx = (dim_idx * 2) % rotary_dim;
-          int half_dim = dim_idx / 2;
+          size_t half_dim = dim_idx / 2;
 
           const float cos_val = static_cast<float>(cos_ptr[half_dim]);
           const float sin_val = static_cast<float>(sin_ptr[half_dim]);
@@ -162,34 +162,34 @@ class fused_qk_norm_rope_kernel {
 
     // Store results back in-place.
 #pragma unroll
-    for (int i = 0; i < NUM_ELEMS_PER_THREAD; i++) {
+    for (size_t i = 0; i < NUM_ELEMS_PER_THREAD; i++) {
       qkv[offset_thread + i] = static_cast<scalar_t>(elements[i]);
     }
   }
 
  private:
   scalar_t* __restrict__ qkv;
-  const int num_heads_q;
-  const int num_heads_k;
-  const int num_heads_v;
+  const size_t num_heads_q;
+  const size_t num_heads_k;
+  const size_t num_heads_v;
   const float eps;
   const scalar_t* __restrict__ q_weight;
   const scalar_t* __restrict__ k_weight;
   const scalar_t_cache* __restrict__ cos_sin_cache;
   const int64_t* __restrict__ position_ids;
-  const int num_tokens;
-  const int rotary_dim;
+  const size_t num_tokens;
+  const size_t rotary_dim;
 };
 
 template <typename scalar_t, typename scalar_t_cache>
 void launch_fused_qk_norm_rope(
     torch::Tensor& qkv,
-    int num_tokens,
-    int num_heads_q,
-    int num_heads_k,
-    int num_heads_v,
-    int head_dim,
-    int rotary_dim,
+    size_t num_tokens,
+    size_t num_heads_q,
+    size_t num_heads_k,
+    size_t num_heads_v,
+    size_t head_dim,
+    size_t rotary_dim,
     float eps,
     torch::Tensor& q_weight,
     torch::Tensor& k_weight,
@@ -202,9 +202,9 @@ void launch_fused_qk_norm_rope(
   constexpr int block_size = 256;
   constexpr int sgs_per_wg = block_size / 32;
 
-  const int total_qk_heads = num_heads_q + num_heads_k;
-  const int total_sgs = num_tokens * total_qk_heads;
-  const int grid_size = (total_sgs + sgs_per_wg - 1) / sgs_per_wg;
+  const size_t total_qk_heads = num_heads_q + num_heads_k;
+  const size_t total_sgs = num_tokens * total_qk_heads;
+  const size_t grid_size = (total_sgs + sgs_per_wg - 1) / sgs_per_wg;
 
   auto qkv_ptr = reinterpret_cast<sycl_t*>(qkv.data_ptr<scalar_t>());
   auto q_weight_ptr =
@@ -351,12 +351,12 @@ void fused_qk_norm_rope(
           using cache_scalar_t = scalar_t;
           vllm::launch_fused_qk_norm_rope<qkv_scalar_t, cache_scalar_t>(
               qkv,
-              static_cast<int>(num_tokens),
-              static_cast<int>(num_heads_q),
-              static_cast<int>(num_heads_k),
-              static_cast<int>(num_heads_v),
-              static_cast<int>(head_dim),
-              static_cast<int>(cos_sin_cache.size(1)),
+              static_cast<size_t>(num_tokens),
+              static_cast<size_t>(num_heads_q),
+              static_cast<size_t>(num_heads_k),
+              static_cast<size_t>(num_heads_v),
+              static_cast<size_t>(head_dim),
+              static_cast<size_t>(cos_sin_cache.size(1)),
               static_cast<float>(eps),
               q_weight,
               k_weight,

--- a/csrc/fused_qknorm_rope.cpp
+++ b/csrc/fused_qknorm_rope.cpp
@@ -64,7 +64,8 @@ class fused_qk_norm_rope_kernel {
     if (token_idx >= num_tokens) return;
 
     const bool is_q = local_head_idx < num_heads_q;
-    const size_t head_idx = is_q ? local_head_idx : local_head_idx - num_heads_q;
+    const size_t head_idx =
+        is_q ? local_head_idx : local_head_idx - num_heads_q;
     const size_t num_heads = num_heads_q + num_heads_k + num_heads_v;
 
     // Compute the offset into the QKV tensor for this sub-group's head.

--- a/csrc/layernorm.cpp
+++ b/csrc/layernorm.cpp
@@ -27,8 +27,8 @@ class rms_norm_kernel {
       const int64_t input_shape_d3_,   // input.size(-3)
       const scalar_t* weight_,
       const float epsilon_,
-      const int num_tokens_,
-      const int hidden_size_,
+      const size_t num_tokens_,
+      const size_t hidden_size_,
       sycl::local_accessor<float, 1> s_variance_)
       : out(out_),
         input(input_),
@@ -55,23 +55,23 @@ class rms_norm_kernel {
       input_row = input + item_ct1.get_group(2) * input_stride_d2;
     } else if constexpr (NUM_DIMS == 3) {
       // 3D for q/k norm [batch_size, num_heads, head_size]
-      int batch_idx = item_ct1.get_group(2) / input_shape_d2;
-      int head_idx = item_ct1.get_group(2) % input_shape_d2;
+      size_t batch_idx = item_ct1.get_group(2) / input_shape_d2;
+      size_t head_idx = item_ct1.get_group(2) % input_shape_d2;
       input_row =
           input + batch_idx * input_stride_d3 + head_idx * input_stride_d2;
     } else if constexpr (NUM_DIMS == 4) {
       // 4D for transformers model_impl qk norm [batch, seq, head, head_dim]
-      int batch_idx = item_ct1.get_group(2) / (input_shape_d3 * input_shape_d2);
-      int remaining = item_ct1.get_group(2) % (input_shape_d3 * input_shape_d2);
-      int seq_idx = remaining / input_shape_d2;
-      int head_idx = remaining % input_shape_d2;
+      size_t batch_idx = item_ct1.get_group(2) / (input_shape_d3 * input_shape_d2);
+      size_t remaining = item_ct1.get_group(2) % (input_shape_d3 * input_shape_d2);
+      size_t seq_idx = remaining / input_shape_d2;
+      size_t head_idx = remaining % input_shape_d2;
       input_row = input + batch_idx * input_stride_d4 +
                   seq_idx * input_stride_d3 + head_idx * input_stride_d2;
     }
 
     auto vec_op = [&variance](
-                      const vec4_t<scalar_t>& vec, int vec_size = VEC_SIZE) {
-      for (int i = 0; i < vec_size; ++i) {
+                      const vec4_t<scalar_t>& vec, size_t vec_size = VEC_SIZE) {
+      for (size_t i = 0; i < vec_size; ++i) {
         float x = static_cast<float>(vec.val[i]);
         variance += x * x;
       }
@@ -90,20 +90,20 @@ class rms_norm_kernel {
     if (can_vec) {
       int64_t const num_vec_elems = hidden_size / VEC_SIZE;
       auto const* vec_in = reinterpret_cast<const vec4_t<scalar_t>*>(input_row);
-      for (int i = item_ct1.get_local_id(2); i < num_vec_elems;
+      for (size_t i = item_ct1.get_local_id(2); i < num_vec_elems;
            i += item_ct1.get_local_range(2)) {
         vec4_t<scalar_t> tmp = vec_in[i];
         vec_op(tmp);
       }
     } else {
-      int misalignment_offset = addr_in & (WIDTH - 1);
-      int alignment_bytes = WIDTH - misalignment_offset;
-      int prefix_elems = alignment_bytes & (WIDTH - 1);
+      size_t misalignment_offset = addr_in & (WIDTH - 1);
+      size_t alignment_bytes = WIDTH - misalignment_offset;
+      size_t prefix_elems = alignment_bytes & (WIDTH - 1);
       prefix_elems /= sizeof(scalar_t);
       prefix_elems = prefix_elems < hidden_size ? prefix_elems : hidden_size;
 
       // 1. handle the possibly unaligned prefix with scalar access.
-      for (int i = item_ct1.get_local_id(2); i < prefix_elems;
+      for (size_t i = item_ct1.get_local_id(2); i < prefix_elems;
            i += item_ct1.get_local_range(2)) {
         scalar_op(input_row[i]);
       }
@@ -111,14 +111,14 @@ class rms_norm_kernel {
       int64_t const num_vec_elems = (hidden_size - prefix_elems) / VEC_SIZE;
       auto const* vec_in =
           reinterpret_cast<const vec4_t<scalar_t>*>(input_row + prefix_elems);
-      for (int i = item_ct1.get_local_id(2); i < num_vec_elems;
+      for (size_t i = item_ct1.get_local_id(2); i < num_vec_elems;
            i += item_ct1.get_local_range(2)) {
         vec4_t<scalar_t> tmp = vec_in[i];
         vec_op(tmp);
       }
 
       // 3. handle remaining tail elements.
-      for (int i = item_ct1.get_local_id(2) + num_vec_elems * VEC_SIZE;
+      for (size_t i = item_ct1.get_local_id(2) + num_vec_elems * VEC_SIZE;
            i < hidden_size - prefix_elems;
            i += item_ct1.get_local_range(2)) {
         scalar_op((input_row + prefix_elems)[i]);
@@ -148,7 +148,7 @@ class rms_norm_kernel {
       auto* v_out = reinterpret_cast<vec4_t<scalar_t>*>(out_row);
       int64_t const out_num_vec_elems = hidden_size / VEC_SIZE;
       float s_variance_val = *s_variance_ptr;
-      for (int idx = item_ct1.get_local_id(2); idx < out_num_vec_elems;
+      for (size_t idx = item_ct1.get_local_id(2); idx < out_num_vec_elems;
            idx += item_ct1.get_local_range(2)) {
         vec4_t<scalar_t> dst;
         vec4_t<scalar_t> src1 = v_in[idx];
@@ -160,7 +160,7 @@ class rms_norm_kernel {
         v_out[idx] = dst;
       }
     } else {
-      for (int idx = item_ct1.get_local_id(2); idx < hidden_size;
+      for (size_t idx = item_ct1.get_local_id(2); idx < hidden_size;
            idx += item_ct1.get_local_range(2)) {
         float x = (float)input_row[idx];
         out_row[idx] = ((scalar_t)(x * (*s_variance_ptr))) * weight[idx];
@@ -178,8 +178,8 @@ class rms_norm_kernel {
   const int64_t input_shape_d3;
   const scalar_t* __restrict__ weight;  // [hidden_size]
   const float epsilon;
-  const int num_tokens;
-  const int hidden_size;
+  const size_t num_tokens;
+  const size_t hidden_size;
   sycl::local_accessor<float, 1> s_variance;
 };
 
@@ -190,9 +190,9 @@ void call_rms_norm_kernel(
     torch::Tensor& weight,
     float epsilon) {
   using sycl_t = typename vllm::xpu::SyclTypeTrait<scalar_t>::Type;
-  int hidden_size = input.size(-1);
-  int num_tokens = input.numel() / hidden_size;
-  int num_dims = input.dim();
+  size_t hidden_size = input.size(-1);
+  size_t num_tokens = input.numel() / hidden_size;
+  size_t num_dims = input.dim();
   int64_t input_stride_d2 = input.stride(-2);
   int64_t input_stride_d3 = (num_dims >= 3) ? input.stride(-3) : 0;
   int64_t input_stride_d4 = (num_dims >= 4) ? input.stride(-4) : 0;
@@ -203,7 +203,7 @@ void call_rms_norm_kernel(
   auto input_ptr = input.data_ptr<scalar_t>();
   auto weight_ptr = weight.data_ptr<scalar_t>();
   sycl::range<3> grid(1, 1, num_tokens);
-  sycl::range<3> block(1, 1, std::min(hidden_size, 1024));
+  sycl::range<3> block(1, 1, std::min(hidden_size, static_cast<size_t>(1024)));
   auto& queue = vllm::xpu::vllmGetQueue();
 
   VLLM_DISPATCH_RANK234(num_dims, [&]() {
@@ -237,8 +237,8 @@ class fused_add_rms_norm_kernel {
       const int64_t input_stride_,
       const scalar_t* __restrict__ weight_,  // [hidden_size]
       const float epsilon_,
-      const int num_tokens_,
-      const int hidden_size_,
+      const size_t num_tokens_,
+      const size_t hidden_size_,
       sycl::local_accessor<float, 1> s_variance_)
       : input(input_),
         residual(residual_),
@@ -255,7 +255,7 @@ class fused_add_rms_norm_kernel {
         s_variance.template get_multi_ptr<sycl::access::decorated::no>().get();
     float variance = 0.0f;
 
-    for (int idx = item_ct1.get_local_id(2); idx < hidden_size;
+    for (size_t idx = item_ct1.get_local_id(2); idx < hidden_size;
          idx += item_ct1.get_local_range(2)) {
       scalar_t z = (scalar_t)input[item_ct1.get_group(2) * input_stride + idx];
       z += residual[item_ct1.get_group(2) * hidden_size + idx];
@@ -274,7 +274,7 @@ class fused_add_rms_norm_kernel {
 
     item_ct1.barrier(sycl::access::fence_space::local_space);
 
-    for (int idx = item_ct1.get_local_id(2); idx < hidden_size;
+    for (size_t idx = item_ct1.get_local_id(2); idx < hidden_size;
          idx += item_ct1.get_local_range(2)) {
       float x = (float)residual[item_ct1.get_group(2) * hidden_size + idx];
       input[item_ct1.get_group(2) * input_stride + idx] =
@@ -288,8 +288,8 @@ class fused_add_rms_norm_kernel {
   const int64_t input_stride;
   const scalar_t* __restrict__ weight;  // [hidden_size]
   const float epsilon;
-  const int num_tokens;
-  const int hidden_size;
+  const size_t num_tokens;
+  const size_t hidden_size;
   sycl::local_accessor<float, 1> s_variance;  // local memory for variance
 };
 
@@ -300,14 +300,14 @@ void call_fused_add_rms_norm_kernel(
     torch::Tensor& weight,
     float epsilon) {
   using sycl_t = typename vllm::xpu::SyclTypeTrait<scalar_t>::Type;
-  int hidden_size = input.size(-1);
-  int num_tokens = input.numel() / hidden_size;
+  size_t hidden_size = input.size(-1);
+  size_t num_tokens = input.numel() / hidden_size;
   auto input_ptr = input.data_ptr<scalar_t>();
   auto residual_ptr = residual.data_ptr<scalar_t>();
   auto weight_ptr = weight.data_ptr<scalar_t>();
   int64_t input_stride = input.stride(-2);
   sycl::range<3> grid(1, 1, num_tokens);
-  sycl::range<3> block(1, 1, std::min(hidden_size, 1024));
+  sycl::range<3> block(1, 1, std::min(hidden_size, static_cast<size_t>(1024)));
   auto& queue = vllm::xpu::vllmGetQueue();
   queue.submit([&](sycl::handler& cgh) {
     sycl::local_accessor<float, 1> s_variance(sycl::range<1>(1), cgh);
@@ -351,8 +351,8 @@ void fused_add_rms_norm(
     torch::Tensor& weight,
     double epsilon) {
   const at::DeviceGuard device_guard(input.device());
-  int hidden_size = input.size(-1);
-  int num_tokens = input.numel() / hidden_size;
+  size_t hidden_size = input.size(-1);
+  size_t num_tokens = input.numel() / hidden_size;
 
   VLLM_DISPATCH_FLOATING_TYPES(
       input.scalar_type(), "call_fused_add_rms_norm_kernel", [&] {

--- a/csrc/layernorm.cpp
+++ b/csrc/layernorm.cpp
@@ -61,8 +61,10 @@ class rms_norm_kernel {
           input + batch_idx * input_stride_d3 + head_idx * input_stride_d2;
     } else if constexpr (NUM_DIMS == 4) {
       // 4D for transformers model_impl qk norm [batch, seq, head, head_dim]
-      size_t batch_idx = item_ct1.get_group(2) / (input_shape_d3 * input_shape_d2);
-      size_t remaining = item_ct1.get_group(2) % (input_shape_d3 * input_shape_d2);
+      size_t batch_idx =
+          item_ct1.get_group(2) / (input_shape_d3 * input_shape_d2);
+      size_t remaining =
+          item_ct1.get_group(2) % (input_shape_d3 * input_shape_d2);
       size_t seq_idx = remaining / input_shape_d2;
       size_t head_idx = remaining % input_shape_d2;
       input_row = input + batch_idx * input_stride_d4 +

--- a/csrc/layernorm_quant.cpp
+++ b/csrc/layernorm_quant.cpp
@@ -32,7 +32,7 @@ class rms_norm_dynamic_per_token_quant_kernel {
       const float* __restrict__ scale_ub_,
       float* __restrict__ scales_,
       const float epsilon_,
-      const int hidden_size_)
+      const size_t hidden_size_)
       : out(out_),
         residual(residual_),
         input(input_),
@@ -43,8 +43,8 @@ class rms_norm_dynamic_per_token_quant_kernel {
         hidden_size(hidden_size_) {}
 
   void operator()(sycl::nd_item<1> item) const {
-    const int tid = item.get_local_id(0);
-    const int local_range = item.get_local_range(0);
+    const size_t tid = item.get_local_id(0);
+    const size_t local_range = item.get_local_range(0);
     const int64_t token_idx = item.get_group(0);
 
     // s_local[0] = inv_rms,  s_local[1] = scale
@@ -61,7 +61,7 @@ class rms_norm_dynamic_per_token_quant_kernel {
 
     // Pass 1: optional residual add + compute variance
     float variance = 0.0f;
-    for (int i = tid; i < hidden_size; i += local_range) {
+    for (size_t i = tid; i < hidden_size; i += local_range) {
       float x = static_cast<float>(token_input[i]);
       if constexpr (has_residual) {
         x += static_cast<float>(token_residual[i]);
@@ -82,7 +82,7 @@ class rms_norm_dynamic_per_token_quant_kernel {
 
     // Pass 2: compute max |norm(x)| across the row → token scale
     float absmax = 0.0f;
-    for (int i = tid; i < hidden_size; i += local_range) {
+    for (size_t i = tid; i < hidden_size; i += local_range) {
       const float x = has_residual ? static_cast<float>(token_residual[i])
                                    : static_cast<float>(token_input[i]);
       const float norm_x = x * inv_rms * static_cast<float>(weight[i]);
@@ -110,7 +110,7 @@ class rms_norm_dynamic_per_token_quant_kernel {
     const float inv_scale = 1.0f / s_local[1];
 
     // Pass 3: normalize and quantize
-    for (int i = tid; i < hidden_size; i += local_range) {
+    for (size_t i = tid; i < hidden_size; i += local_range) {
       const float x = has_residual ? static_cast<float>(token_residual[i])
                                    : static_cast<float>(token_input[i]);
       const float norm_x = x * inv_rms * static_cast<float>(weight[i]);
@@ -136,7 +136,7 @@ class rms_norm_dynamic_per_token_quant_kernel {
   const float* __restrict__ scale_ub;
   float* __restrict__ scales;
   const float epsilon;
-  const int hidden_size;
+  const size_t hidden_size;
 };
 
 template <typename scalar_t, typename out_t, bool has_residual>
@@ -149,9 +149,9 @@ class rms_norm_per_block_quant_kernel {
       const scalar_t* __restrict__ weight_,
       float* __restrict__ scales_,
       const float epsilon_,
-      const int hidden_size_,
-      const int group_size_,
-      const int num_tokens_,
+      const size_t hidden_size_,
+      const size_t group_size_,
+      const size_t num_tokens_,
       const int64_t scale_stride_token_,
       const int64_t scale_stride_group_)
       : out(out_),
@@ -167,8 +167,8 @@ class rms_norm_per_block_quant_kernel {
         scale_stride_group(scale_stride_group_) {}
 
   void operator()(sycl::nd_item<1> item) const {
-    const int tid = item.get_local_id(0);
-    const int local_range = item.get_local_range(0);
+    const size_t tid = item.get_local_id(0);
+    const size_t local_range = item.get_local_range(0);
     const int64_t token_idx = item.get_group(0);
 
     // s_local[0] = inv_rms,  s_local[1] = current group scale
@@ -185,7 +185,7 @@ class rms_norm_per_block_quant_kernel {
 
     // Pass 1: optional residual add + compute full-row variance
     float variance = 0.0f;
-    for (int i = tid; i < hidden_size; i += local_range) {
+    for (size_t i = tid; i < hidden_size; i += local_range) {
       float x = static_cast<float>(token_input[i]);
       if constexpr (has_residual) {
         x += static_cast<float>(token_residual[i]);
@@ -205,14 +205,14 @@ class rms_norm_per_block_quant_kernel {
     const float inv_rms = s_local[0];
 
     // Pass 2+3: for each column group, compute scale then quantize
-    const int num_groups = hidden_size / group_size;
-    for (int g = 0; g < num_groups; g++) {
-      const int group_start = g * group_size;
+    const size_t num_groups = hidden_size / group_size;
+    for (size_t g = 0; g < num_groups; g++) {
+      const size_t group_start = g * group_size;
 
       // Find max |norm(x)| within this group
       float group_absmax = 0.0f;
-      for (int i = tid; i < group_size; i += local_range) {
-        const int col = group_start + i;
+      for (size_t i = tid; i < group_size; i += local_range) {
+        const size_t col = group_start + i;
         const float x = has_residual ? static_cast<float>(token_residual[col])
                                      : static_cast<float>(token_input[col]);
         const float norm_x = x * inv_rms * static_cast<float>(weight[col]);
@@ -241,8 +241,8 @@ class rms_norm_per_block_quant_kernel {
       const float inv_scale = 1.0f / s_local[1];
 
       // Quantize this group
-      for (int i = tid; i < group_size; i += local_range) {
-        const int col = group_start + i;
+      for (size_t i = tid; i < group_size; i += local_range) {
+        const size_t col = group_start + i;
         const float x = has_residual ? static_cast<float>(token_residual[col])
                                      : static_cast<float>(token_input[col]);
         const float norm_x = x * inv_rms * static_cast<float>(weight[col]);
@@ -270,9 +270,9 @@ class rms_norm_per_block_quant_kernel {
   const scalar_t* __restrict__ weight;
   float* __restrict__ scales;
   const float epsilon;
-  const int hidden_size;
-  const int group_size;
-  const int num_tokens;
+  const size_t hidden_size;
+  const size_t group_size;
+  const size_t num_tokens;
   const int64_t scale_stride_token;
   const int64_t scale_stride_group;
 };
@@ -283,11 +283,11 @@ class rms_norm_static_fp8_quant_kernel {
   rms_norm_static_fp8_quant_kernel(
       out_t* __restrict__ out_,
       const scalar_t* __restrict__ input_,
-      const int input_stride_,
+      const size_t input_stride_,
       const scalar_t* __restrict__ weight_,
       const float* __restrict__ scale_,
       const float epsilon_,
-      const int hidden_size_)
+      const size_t hidden_size_)
       : out(out_),
         input(input_),
         input_stride(input_stride_),
@@ -299,8 +299,8 @@ class rms_norm_static_fp8_quant_kernel {
   void operator()(sycl::nd_item<1> item) const {
     using vec_t = vllm::xpu::aligned_vec<scalar_t, VEC_SIZE>;
 
-    const int tid = item.get_local_id(0);
-    const int local_range = item.get_local_range(0);
+    const size_t tid = item.get_local_id(0);
+    const size_t local_range = item.get_local_range(0);
     const int64_t token_idx = item.get_group(0);
 
     auto& s_variance =
@@ -309,12 +309,12 @@ class rms_norm_static_fp8_quant_kernel {
 
     const scalar_t* token_input = input + token_idx * input_stride;
     out_t* token_output = out + token_idx * hidden_size;
-    const int nvec = hidden_size / VEC_SIZE;
+    const size_t nvec = hidden_size / VEC_SIZE;
 
     // Pass 1: compute variance — VEC_SIZE elements per work-item per iteration
     float variance = 0.0f;
     const auto* v_in = reinterpret_cast<const vec_t*>(token_input);
-    for (int i = tid; i < nvec; i += local_range) {
+    for (size_t i = tid; i < nvec; i += local_range) {
       vec_t v = v_in[i];
 #pragma unroll
       for (int j = 0; j < VEC_SIZE; j++) {
@@ -336,7 +336,7 @@ class rms_norm_static_fp8_quant_kernel {
 
     // Pass 2: normalize, apply weight, quantize — same vectorization as Pass 1
     const auto* v_w = reinterpret_cast<const vec_t*>(weight);
-    for (int i = tid; i < nvec; i += local_range) {
+    for (size_t i = tid; i < nvec; i += local_range) {
       vec_t src = v_in[i];
       vec_t wgt = v_w[i];
 #pragma unroll
@@ -355,11 +355,11 @@ class rms_norm_static_fp8_quant_kernel {
  private:
   out_t* __restrict__ out;
   const scalar_t* __restrict__ input;
-  const int input_stride;
+  const size_t input_stride;
   const scalar_t* __restrict__ weight;
   const float* __restrict__ scale;
   const float epsilon;
-  const int hidden_size;
+  const size_t hidden_size;
 };
 
 template <typename scalar_t, typename out_t, int VEC_SIZE>
@@ -368,12 +368,12 @@ class fused_add_rms_norm_static_fp8_quant_kernel {
   fused_add_rms_norm_static_fp8_quant_kernel(
       out_t* __restrict__ out_,
       const scalar_t* __restrict__ input_,
-      const int input_stride_,
+      const size_t input_stride_,
       scalar_t* __restrict__ residual_,
       const scalar_t* __restrict__ weight_,
       const float* __restrict__ scale_,
       const float epsilon_,
-      const int hidden_size_)
+      const size_t hidden_size_)
       : out(out_),
         input(input_),
         input_stride(input_stride_),
@@ -386,8 +386,8 @@ class fused_add_rms_norm_static_fp8_quant_kernel {
   void operator()(sycl::nd_item<1> item) const {
     using vec_t = vllm::xpu::aligned_vec<scalar_t, VEC_SIZE>;
 
-    const int tid = item.get_local_id(0);
-    const int local_range = item.get_local_range(0);
+    const size_t tid = item.get_local_id(0);
+    const size_t local_range = item.get_local_range(0);
     const int64_t token_idx = item.get_group(0);
 
     auto& s_variance =
@@ -397,13 +397,13 @@ class fused_add_rms_norm_static_fp8_quant_kernel {
     const scalar_t* token_input = input + token_idx * input_stride;
     scalar_t* token_residual = residual + token_idx * hidden_size;
     out_t* token_output = out + token_idx * hidden_size;
-    const int nvec = hidden_size / VEC_SIZE;
+    const size_t nvec = hidden_size / VEC_SIZE;
 
     // Pass 1: add residual + compute variance, VEC_SIZE elements per iteration
     float variance = 0.0f;
     const auto* v_in = reinterpret_cast<const vec_t*>(token_input);
     auto* v_res = reinterpret_cast<vec_t*>(token_residual);
-    for (int i = tid; i < nvec; i += local_range) {
+    for (size_t i = tid; i < nvec; i += local_range) {
       vec_t inp = v_in[i];
       vec_t res = v_res[i];
 #pragma unroll
@@ -430,7 +430,7 @@ class fused_add_rms_norm_static_fp8_quant_kernel {
 
     // Pass 2: normalize from residual, apply weight, quantize
     const auto* v_w = reinterpret_cast<const vec_t*>(weight);
-    for (int i = tid; i < nvec; i += local_range) {
+    for (size_t i = tid; i < nvec; i += local_range) {
       vec_t res = v_res[i];
       vec_t wgt = v_w[i];
 #pragma unroll
@@ -449,12 +449,12 @@ class fused_add_rms_norm_static_fp8_quant_kernel {
  private:
   out_t* __restrict__ out;
   const scalar_t* __restrict__ input;
-  const int input_stride;
+  const size_t input_stride;
   scalar_t* __restrict__ residual;
   const scalar_t* __restrict__ weight;
   const float* __restrict__ scale;
   const float epsilon;
-  const int hidden_size;
+  const size_t hidden_size;
 };
 
 template <typename scalar_t, typename out_t>
@@ -468,9 +468,9 @@ void call_rms_norm_dynamic_per_token_quant_kernel(
     float epsilon) {
   using sycl_t = typename vllm::xpu::SyclTypeTrait<scalar_t>::Type;
 
-  const int hidden_size = input.size(-1);
+  const size_t hidden_size = input.size(-1);
   const int64_t num_tokens = input.numel() / hidden_size;
-  const int block_size = std::min(hidden_size, 1024);
+  const size_t block_size = std::min(hidden_size, static_cast<size_t>(1024));
 
   auto* out_ptr = out.data_ptr<out_t>();
   auto* input_ptr = input.data_ptr<scalar_t>();
@@ -521,10 +521,10 @@ void call_rms_norm_per_block_quant_kernel(
     bool is_scale_transposed) {
   using sycl_t = typename vllm::xpu::SyclTypeTrait<scalar_t>::Type;
 
-  const int hidden_size = input.size(-1);
+  const size_t hidden_size = input.size(-1);
   const int64_t num_tokens = input.numel() / hidden_size;
-  const int num_groups = hidden_size / group_size;
-  const int block_size = std::min(hidden_size, 1024);
+  const size_t num_groups = hidden_size / group_size;
+  const size_t block_size = std::min(hidden_size, static_cast<size_t>(1024));
 
   // Compute scale strides based on transposition
   const int64_t scale_stride_token =
@@ -556,7 +556,7 @@ void call_rms_norm_per_block_quant_kernel(
               epsilon,
               hidden_size,
               group_size,
-              static_cast<int>(num_tokens),
+              static_cast<size_t>(num_tokens),
               scale_stride_token,
               scale_stride_group));
     });
@@ -578,19 +578,19 @@ void call_rms_norm_static_fp8_quant_kernel(
     float epsilon) {
   using sycl_t = typename vllm::xpu::SyclTypeTrait<scalar_t>::Type;
 
-  const int hidden_size = input.size(-1);
-  const int input_stride = input.stride(-2);
+  const size_t hidden_size = input.size(-1);
+  const size_t input_stride = input.stride(-2);
   const int64_t num_tokens = input.numel() / hidden_size;
 
   // Match CUDA: smaller blocks when num_tokens is large for better occupancy
-  const int max_block_size = (num_tokens < 256) ? 1024 : 256;
+  const size_t max_block_size = (num_tokens < 256) ? 1024 : 256;
 
   // Dispatch VEC_SIZE = gcd(16 / sizeof(sycl_t), hidden_size) matching CUDA
-  const int candidate_vec_size =
-      std::gcd(static_cast<int>(16 / sizeof(sycl_t)), hidden_size);
-  const int vec_size =
+  const size_t candidate_vec_size =
+      std::gcd(static_cast<size_t>(16 / sizeof(sycl_t)), hidden_size);
+  const size_t vec_size =
       (input_stride % candidate_vec_size == 0) ? candidate_vec_size : 1;
-  const int block_size = std::min(hidden_size / vec_size, max_block_size);
+  const size_t block_size = std::min(hidden_size / vec_size, max_block_size);
 
   auto& queue = vllm::xpu::vllmGetQueue();
 
@@ -637,20 +637,20 @@ void call_fused_add_rms_norm_static_fp8_quant_kernel(
     float epsilon) {
   using sycl_t = typename vllm::xpu::SyclTypeTrait<scalar_t>::Type;
 
-  const int hidden_size = input.size(-1);
-  const int input_stride = input.stride(-2);
+  const size_t hidden_size = input.size(-1);
+  const size_t input_stride = input.stride(-2);
   const int64_t num_tokens = input.numel() / hidden_size;
 
   // Match CUDA: smaller blocks when num_tokens is large for better occupancy
-  const int max_block_size = (num_tokens < 256) ? 1024 : 256;
+  const size_t max_block_size = (num_tokens < 256) ? 1024 : 256;
 
   // Dispatch VEC_SIZE = gcd(16 / sizeof(sycl_t), hidden_size) matching CUDA.
   // Also require input_stride % vec_size == 0 for safe vectorized input reads.
-  int vec_size = std::gcd(static_cast<int>(16 / sizeof(sycl_t)), hidden_size);
+  size_t vec_size = std::gcd(static_cast<size_t>(16 / sizeof(sycl_t)), hidden_size);
   if (input_stride % vec_size != 0) {
     vec_size = 1;
   }
-  const int block_size = std::min(hidden_size / vec_size, max_block_size);
+  const size_t block_size = std::min(hidden_size / vec_size, max_block_size);
 
   auto& queue = vllm::xpu::vllmGetQueue();
 

--- a/csrc/layernorm_quant.cpp
+++ b/csrc/layernorm_quant.cpp
@@ -646,7 +646,8 @@ void call_fused_add_rms_norm_static_fp8_quant_kernel(
 
   // Dispatch VEC_SIZE = gcd(16 / sizeof(sycl_t), hidden_size) matching CUDA.
   // Also require input_stride % vec_size == 0 for safe vectorized input reads.
-  size_t vec_size = std::gcd(static_cast<size_t>(16 / sizeof(sycl_t)), hidden_size);
+  size_t vec_size =
+      std::gcd(static_cast<size_t>(16 / sizeof(sycl_t)), hidden_size);
   if (input_stride % vec_size != 0) {
     vec_size = 1;
   }

--- a/csrc/moe/fused_moe_prologue.cpp
+++ b/csrc/moe/fused_moe_prologue.cpp
@@ -15,7 +15,7 @@ void fused_moe_prologue_impl(
     int64_t ep_rank,
     int64_t ep_size,
     int64_t num_experts_on_rank) {
-  int experts_per_token = token_selected_experts.size(1);
+  size_t experts_per_token = token_selected_experts.size(1);
   int64_t num_rows = input.size(0);
 
   assert(ep_rank >= 0 && ep_rank < ep_size);

--- a/csrc/moe/init_expert_map.cpp
+++ b/csrc/moe/init_expert_map.cpp
@@ -10,9 +10,9 @@ class InitExpertMap {
  public:
   InitExpertMap(
       int* expert_map,
-      const int num_experts,
-      const int ep_rank,
-      const int ep_size)
+      const size_t num_experts,
+      const size_t ep_rank,
+      const size_t ep_size)
       : expert_map(expert_map),
         num_experts(num_experts),
         ep_rank(ep_rank),
@@ -22,8 +22,8 @@ class InitExpertMap {
   static constexpr int WARP_SIZE = 32;
 
   static inline sycl::nd_range<1>
-  get_nd_range(const int num_experts, const int ep_size) {
-    int group_nums =
+  get_nd_range(const size_t num_experts, const size_t ep_size) {
+    size_t group_nums =
         (ep_size * num_experts + GroupWorkItem - 1) / GroupWorkItem;
     sycl::range<1> local(GroupWorkItem);
     sycl::range<1> group(group_nums);
@@ -54,16 +54,16 @@ class InitExpertMap {
 
  private:
   int* expert_map;
-  const int num_experts;
-  const int ep_rank;
-  const int ep_size;
+  const size_t num_experts;
+  const size_t ep_rank;
+  const size_t ep_size;
 };
 
 void InitExpertMapLauncher(
     int* expert_map,
-    const int num_experts,
-    const int ep_rank,
-    const int ep_size,
+    const size_t num_experts,
+    const size_t ep_rank,
+    const size_t ep_size,
     sycl::queue& queue) {
   queue.submit([&](sycl::handler& cgh) {
     cgh.parallel_for(

--- a/csrc/moe/moe_gather.cpp
+++ b/csrc/moe/moe_gather.cpp
@@ -15,9 +15,9 @@ class MoeGather {
       const float* topk_weights,
       const int* unpermuted_row_to_permuted_row,
       const int64_t* expert_first_token_offset,
-      const int num_experts,
-      const int num_tokens,
-      const int hidden_size)
+      const size_t num_experts,
+      const size_t num_tokens,
+      const size_t hidden_size)
       : output(output),
         moe_output(moe_output),
         topk_weights(topk_weights),
@@ -31,7 +31,7 @@ class MoeGather {
   static constexpr int WARP_SIZE = 32;
   static constexpr int Stride = GroupWorkItem * ElemsPerItem;
 
-  static inline sycl::nd_range<1> get_nd_range(const int num_tokens) {
+  static inline sycl::nd_range<1> get_nd_range(const size_t num_tokens) {
     sycl::range<1> local(GroupWorkItem);
     sycl::range<1> group(num_tokens);
     return sycl::nd_range<1>(local * group, local);
@@ -43,7 +43,7 @@ class MoeGather {
     auto local_id_x = item.get_local_id(0);
     auto group_id_x = item.get_group(0);
 
-    const int token_idx = group_id_x;
+    const size_t token_idx = group_id_x;
 
     int moe_ids[TOPK];
 #pragma unroll
@@ -57,10 +57,10 @@ class MoeGather {
       scores[i] = topk_weights[token_idx * TOPK + i];
     }
 
-    const int loop_count = (hidden_size + Stride - 1) / Stride;
+    const size_t loop_count = (hidden_size + Stride - 1) / Stride;
 
-    for (int i = 0; i < loop_count; ++i) {
-      const int hidden_idx = i * Stride + local_id_x * ElemsPerItem;
+    for (size_t i = 0; i < loop_count; ++i) {
+      const size_t hidden_idx = i * Stride + local_id_x * ElemsPerItem;
       if (hidden_idx < hidden_size) {
         float accum[ElemsPerItem];
 #pragma unroll
@@ -95,9 +95,9 @@ class MoeGather {
   const float* topk_weights;
   const int* unpermuted_row_to_permuted_row;
   const int64_t* expert_first_token_offset;
-  const int num_experts;
-  const int num_tokens;
-  const int hidden_size;
+  const size_t num_experts;
+  const size_t num_tokens;
+  const size_t hidden_size;
 };
 
 template <typename T>
@@ -107,10 +107,10 @@ void MoeGatherLauncher(
     const float* topk_weights,
     const int* unpermuted_row_to_permuted_row,
     const int64_t* expert_first_token_offset,
-    const int num_experts,
-    const int num_tokens,
-    const int topk,
-    const int hidden_size,
+    const size_t num_experts,
+    const size_t num_tokens,
+    const size_t topk,
+    const size_t hidden_size,
     sycl::queue& queue) {
   int elems_per_item = sizeof(float) * 4 / sizeof(T);
   while (hidden_size % elems_per_item != 0) {
@@ -170,9 +170,9 @@ void moe_gather(
     const torch::Tensor& expert_first_token_offset,       // [num_experts + 1]
     const int64_t num_experts) {
   // Implementation of the gather operation
-  const int num_tokens = topk_weights.size(0);
-  const int topk = topk_weights.size(1);
-  const int hidden_size = output.size(1);
+  const size_t num_tokens = topk_weights.size(0);
+  const size_t topk = topk_weights.size(1);
+  const size_t hidden_size = output.size(1);
 
   TORCH_CHECK(
       topk_weights.scalar_type() == torch::kFloat32,

--- a/csrc/moe/remap_hidden_states.cpp
+++ b/csrc/moe/remap_hidden_states.cpp
@@ -26,8 +26,8 @@ class RowsPerExpertCount {
   static constexpr int WARP_SIZE = 32;
 
   static inline sycl::nd_range<1>
-  get_nd_range(const int num_rows, const int TopK) {
-    int group_nums = (num_rows * TopK + GroupWorkItem - 1) / GroupWorkItem;
+  get_nd_range(const size_t num_rows, const int TopK) {
+    size_t group_nums = (num_rows * TopK + GroupWorkItem - 1) / GroupWorkItem;
     sycl::range<1> local(GroupWorkItem);
     sycl::range<1> group(group_nums);
     return sycl::nd_range<1>(local * group, local);
@@ -69,8 +69,8 @@ class RowsPerExpertCount {
   int64_t* expert_first_token_offset;
   int64_t* topk_ids;
   int* unpermuted_row_to_permuted_row;
-  const int num_rows;
-  const int TopK;
+  const size_t num_rows;
+  const size_t TopK;
 };
 
 class CalculateFristTokenOffset {
@@ -143,7 +143,7 @@ class RemapHiddenStates {
       int* unpermuted_row_to_permuted_row,
       int64_t* expert_first_token_offset,
       int64_t* topk_ids,
-      const int num_rows,
+      const size_t num_rows,
       const int hidden_size,
       const int block_k,
       const int total_experts_num)
@@ -165,7 +165,7 @@ class RemapHiddenStates {
   static constexpr int ElemsPerItem = sizeof(float) * 4 / sizeof(TA);
 
   static inline sycl::nd_range<1>
-  get_nd_range(const int num_rows, const int hidden_size) {
+  get_nd_range(const size_t num_rows, const int hidden_size) {
     int local_num = GroupWorkItem;
     if (local_num * ElemsPerItem > hidden_size) {
       local_num = (hidden_size + ElemsPerItem - 1) / ElemsPerItem;
@@ -305,7 +305,7 @@ class RemapHiddenStates {
   int* unpermuted_row_to_permuted_row;
   int64_t* expert_first_token_offset;
   int64_t* topk_ids;
-  const int num_rows;
+  const size_t num_rows;
   const int hidden_size;
   const int block_k;
   const int total_experts_num;
@@ -321,7 +321,7 @@ void RemapHiddenStatesLauncher(
     int64_t* expert_first_token_offset,
     int* unpermuted_row_to_permuted_row,
     int64_t* topk_ids,
-    const int num_rows,
+    const size_t num_rows,
     const int hidden_size,
     const int block_k,
     const int total_experts_num,
@@ -419,7 +419,7 @@ void remap_hidden_states(
   TORCH_CHECK(
       topk_ids.scalar_type() == torch::kInt64, "topk_ids must be int64");
 
-  int num_rows = hidden_states.size(0);
+  size_t num_rows = hidden_states.size(0);
   int hidden_size = hidden_states.size(1);
   int TopK = topk_ids.size(1);
   int block_k = 1;

--- a/csrc/moe/remap_hidden_states.cpp
+++ b/csrc/moe/remap_hidden_states.cpp
@@ -13,8 +13,8 @@ class RowsPerExpertCount {
       int64_t* expert_first_token_offset,
       int64_t* topk_ids,
       int* unpermuted_row_to_permuted_row,
-      const int num_rows,
-      const int TopK)
+      const size_t num_rows,
+      const size_t TopK)
       : expert_map(expert_map),
         expert_first_token_offset(expert_first_token_offset),
         topk_ids(topk_ids),

--- a/csrc/moe/topk.cpp
+++ b/csrc/moe/topk.cpp
@@ -562,7 +562,8 @@ class TopKGating {
     }
 
     if (renormalize) {
-      for (size_t k_idx = thread_group_idx; k_idx < k; k_idx += THREADS_PER_ROW) {
+      for (size_t k_idx = thread_group_idx; k_idx < k;
+           k_idx += THREADS_PER_ROW) {
         const size_t idx = k * thread_row + k_idx;
         output[idx] /= sum_val;
       }

--- a/csrc/moe/topk.cpp
+++ b/csrc/moe/topk.cpp
@@ -33,7 +33,7 @@ class MoeSoftmax {
       const InputdType* input,
       const bool* finished,
       float* output,
-      const int num_cols)
+      const size_t num_cols)
       : slm(slm),
         input(input),
         finished(finished),
@@ -52,7 +52,7 @@ class MoeSoftmax {
     auto local_id_x = item.get_local_id(0);
     auto group_id_x = item.get_group(0);
 
-    const int thread_row_offset = group_id_x * num_cols;
+    const size_t thread_row_offset = group_id_x * num_cols;
 
     float threadData(INFINITY * -1);
 
@@ -61,8 +61,8 @@ class MoeSoftmax {
       return;
     }
 
-    for (int ii = local_id_x; ii < num_cols; ii += TPB) {
-      const int idx = thread_row_offset + ii;
+    for (size_t ii = local_id_x; ii < num_cols; ii += TPB) {
+      const size_t idx = thread_row_offset + ii;
       threadData = MAX(static_cast<float>(input[idx]), threadData);
     }
 
@@ -75,8 +75,8 @@ class MoeSoftmax {
 
     threadData = 0;
 
-    for (int ii = local_id_x; ii < num_cols; ii += TPB) {
-      const int idx = thread_row_offset + ii;
+    for (size_t ii = local_id_x; ii < num_cols; ii += TPB) {
+      const size_t idx = thread_row_offset + ii;
       threadData += sycl::exp((static_cast<float>(input[idx]) - *float_max));
     }
 
@@ -87,8 +87,8 @@ class MoeSoftmax {
     }
     item.barrier(sycl::access::fence_space::local_space);
 
-    for (int ii = local_id_x; ii < num_cols; ii += TPB) {
-      const int idx = thread_row_offset + ii;
+    for (size_t ii = local_id_x; ii < num_cols; ii += TPB) {
+      const size_t idx = thread_row_offset + ii;
       const float val =
           sycl::exp((static_cast<float>(input[idx]) - (*float_max))) *
           (*normalizing_factor);
@@ -101,7 +101,7 @@ class MoeSoftmax {
   const InputdType* input;
   const bool* finished;
   float* output;
-  const int num_cols;
+  const size_t num_cols;
 };
 
 template <int TPB, typename InputdType>
@@ -111,7 +111,7 @@ class MoeSigmoid {
       const InputdType* input,
       const bool* finished,
       float* output,
-      const int num_cols)
+      const size_t num_cols)
       : input(input), finished(finished), output(output), num_cols(num_cols) {}
 
   void operator()
@@ -119,15 +119,15 @@ class MoeSigmoid {
     auto local_id_x = item.get_local_id(0);
     auto group_id_x = item.get_group(0);
 
-    const int thread_row_offset = group_id_x * num_cols;
+    const size_t thread_row_offset = group_id_x * num_cols;
 
     // Don't touch finished rows.
     if ((finished != nullptr) && finished[group_id_x]) {
       return;
     }
 
-    for (int ii = local_id_x; ii < num_cols; ii += TPB) {
-      const int idx = thread_row_offset + ii;
+    for (size_t ii = local_id_x; ii < num_cols; ii += TPB) {
+      const size_t idx = thread_row_offset + ii;
       output[idx] = sigmoid_typed(input[idx]);
     }
   }
@@ -136,7 +136,7 @@ class MoeSigmoid {
   const InputdType* input;
   const bool* finished;
   float* output;
-  const int num_cols;
+  const size_t num_cols;
 };
 
 template <int TPB, typename IndType>
@@ -148,10 +148,10 @@ class MoeTopK {
       float* output,
       IndType* indices,
       int* source_rows,
-      const int num_experts,
+      const size_t num_experts,
       const int k,
-      const int start_expert,
-      const int end_expert,
+      const size_t start_expert,
+      const size_t end_expert,
       const bool renormalize,
       const float* bias)
       : inputs_after_softmax(inputs_after_softmax),
@@ -175,20 +175,20 @@ class MoeTopK {
     auto local_id_x = item.get_local_id(0);
     auto group_id_x = item.get_group(0);
 
-    const int num_rows = item.get_group_range(0);
-    const int block_row = group_id_x;
+    const size_t num_rows = item.get_group_range(0);
+    const size_t block_row = group_id_x;
 
     const bool row_is_active = finished ? !finished[block_row] : true;
-    const int thread_read_offset = group_id_x * num_experts;
+    const size_t thread_read_offset = group_id_x * num_experts;
     float sum_val = 0.0f;
-    for (int k_idx = 0; k_idx < k; ++k_idx) {
+    for (size_t k_idx = 0; k_idx < k; ++k_idx) {
       kIdx = 0;
       kVal = -1.f;  // This is OK because inputs are probabilities
 
       int inpIdx;
       float inpVal;
-      for (int expert = local_id_x; expert < num_experts; expert += TPB) {
-        const int idx = thread_read_offset + expert;
+      for (size_t expert = local_id_x; expert < num_experts; expert += TPB) {
+        const size_t idx = thread_read_offset + expert;
         inpIdx = expert;
         inpVal =
             inputs_after_softmax[idx] + (bias != nullptr ? bias[expert] : 0.0f);
@@ -221,7 +221,7 @@ class MoeTopK {
             expert >= start_expert && expert < end_expert;
         const bool should_process_row = row_is_active && node_uses_expert;
 
-        const int idx = k * block_row + k_idx;
+        const size_t idx = k * block_row + k_idx;
         output[idx] = inputs_after_softmax[thread_read_offset + expert];
         indices[idx] =
             should_process_row ? (expert - start_expert) : num_experts;
@@ -233,8 +233,8 @@ class MoeTopK {
 
     if (renormalize) {
       auto local_range_x = item.get_local_range(0);
-      for (int k_idx = local_id_x; k_idx < k; k_idx += local_range_x) {
-        const int idx = k * block_row + k_idx;
+      for (size_t k_idx = local_id_x; k_idx < k; k_idx += local_range_x) {
+        const size_t idx = k * block_row + k_idx;
         output[idx] /= sum_val;
       }
     }
@@ -246,10 +246,10 @@ class MoeTopK {
   float* output;
   IndType* indices;
   int* source_rows;
-  const int num_experts;
+  const size_t num_experts;
   const int k;
-  const int start_expert;
-  const int end_expert;
+  const size_t start_expert;
+  const size_t end_expert;
   const bool renormalize;
   const float* bias;
 };
@@ -286,12 +286,12 @@ class TopKGating {
       const InputdType* input,
       const bool* finished,
       float* output,
-      const int num_rows,
+      const size_t num_rows,
       IndType* indices,
       int* source_rows,
       const int k,
-      const int start_expert,
-      const int end_expert,
+      const size_t start_expert,
+      const size_t end_expert,
       const bool renormalize,
       const float* bias)
       : input(input),
@@ -355,11 +355,11 @@ class TopKGating {
     // Compute CTA and warp rows. We pack multiple rows into a single warp, and
     // a block contains WARPS_PER_CTA warps. This, each block processes a chunk
     // of rows. We start by computing the start row for each block.
-    const int cta_base_row = group_id_x * ROWS_PER_CTA;
+    const size_t cta_base_row = group_id_x * ROWS_PER_CTA;
 
     // Now, using the base row per thread block, we compute the base row per
     // warp.
-    const int warp_base_row = cta_base_row + local_id_y * ROWS_PER_WARP;
+    const size_t warp_base_row = cta_base_row + local_id_y * ROWS_PER_WARP;
 
     // The threads in a warp are split into sub-groups that will work on a row.
     // We compute row offset for each thread sub-group
@@ -386,7 +386,7 @@ class TopKGating {
     // Finally, we pull in the data from global mem
     InputdType row_chunk_load[VPT];
 #pragma unroll
-    for (int ii = 0; ii < LDG_PER_THREAD; ++ii) {
+    for (size_t ii = 0; ii < LDG_PER_THREAD; ++ii) {
 #pragma unroll
       for (int jj = 0; jj < ELTS_PER_LDG; ++jj) {
         row_chunk_load[ii * ELTS_PER_LDG + jj] =
@@ -396,7 +396,7 @@ class TopKGating {
 
     float row_chunk[VPT];
 #pragma unroll
-    for (int ii = 0; ii < VPT; ++ii) {
+    for (size_t ii = 0; ii < VPT; ++ii) {
       row_chunk[ii] = static_cast<float>(row_chunk_load[ii]);
     }
 
@@ -406,7 +406,7 @@ class TopKGating {
     if constexpr (ScoringFuncParam == ScoringFunc::SOFTMAX) {
       float thread_max = row_chunk[0];
 #pragma unroll
-      for (int ii = 1; ii < VPT; ++ii) {
+      for (size_t ii = 1; ii < VPT; ++ii) {
         thread_max = MAX(thread_max, row_chunk[ii]);
       }
 
@@ -425,7 +425,7 @@ class TopKGating {
       // the exp. We also compute the thread local sum.
       float row_sum = 0;
 #pragma unroll
-      for (int ii = 0; ii < VPT; ++ii) {
+      for (size_t ii = 0; ii < VPT; ++ii) {
         row_chunk[ii] = sycl::exp(row_chunk[ii] - thread_max);
         row_sum += row_chunk[ii];
       }
@@ -447,12 +447,12 @@ class TopKGating {
       const float reciprocal_row_sum = 1.f / row_sum;
 
 #pragma unroll
-      for (int ii = 0; ii < VPT; ++ii) {
+      for (size_t ii = 0; ii < VPT; ++ii) {
         row_chunk[ii] = row_chunk[ii] * reciprocal_row_sum;
       }
     } else {
 #pragma unroll
-      for (int ii = 0; ii < VPT; ++ii) {
+      for (size_t ii = 0; ii < VPT; ++ii) {
         row_chunk[ii] = sigmoid_typed(static_cast<InputdType>(row_chunk[ii]));
       }
     }
@@ -466,7 +466,7 @@ class TopKGating {
 #pragma unroll
       for (int ldg = 0; ldg < LDG_PER_THREAD; ++ldg) {
 #pragma unroll
-        for (int ii = 0; ii < ELTS_PER_LDG; ++ii) {
+        for (size_t ii = 0; ii < ELTS_PER_LDG; ++ii) {
           const int expert =
               first_elt_read_by_thread + ldg * COLS_PER_GROUP_LDG + ii;
           float bias_val = expert < NUM_EXPERTS ? bias[expert] : 0.0f;
@@ -476,7 +476,7 @@ class TopKGating {
       }
     } else {
 #pragma unroll
-      for (int ii = 0; ii < VPT; ++ii) {
+      for (size_t ii = 0; ii < VPT; ++ii) {
         row_chunk_with_bias[ii] = row_chunk[ii];
       }
     }
@@ -486,7 +486,7 @@ class TopKGating {
     int start_col = first_elt_read_by_thread;
     float sum_val = 0.0f;
 
-    for (int k_idx = 0; k_idx < k; ++k_idx) {
+    for (size_t k_idx = 0; k_idx < k; ++k_idx) {
       // First, each thread does the local argmax
       float max_val_with_bias = row_chunk_with_bias[0];
       float max_val = row_chunk[0];
@@ -496,7 +496,7 @@ class TopKGating {
       for (int ldg = 0, col = start_col; ldg < LDG_PER_THREAD;
            ++ldg, col += COLS_PER_GROUP_LDG) {
 #pragma unroll
-        for (int ii = 0; ii < ELTS_PER_LDG; ++ii) {
+        for (size_t ii = 0; ii < ELTS_PER_LDG; ++ii) {
           float val_with_bias = row_chunk_with_bias[ldg * ELTS_PER_LDG + ii];
           float val = row_chunk[ldg * ELTS_PER_LDG + ii];
 
@@ -547,7 +547,7 @@ class TopKGating {
         // The lead thread from each sub-group will write out the final results
         // to global memory. (This will be a single) thread per row of the
         // input/output matrices.
-        const int idx = k * thread_row + k_idx;
+        const size_t idx = k * thread_row + k_idx;
         output[idx] = max_val;
         indices[idx] =
             should_process_row ? (expert - start_expert) : NUM_EXPERTS;
@@ -562,8 +562,8 @@ class TopKGating {
     }
 
     if (renormalize) {
-      for (int k_idx = thread_group_idx; k_idx < k; k_idx += THREADS_PER_ROW) {
-        const int idx = k * thread_row + k_idx;
+      for (size_t k_idx = thread_group_idx; k_idx < k; k_idx += THREADS_PER_ROW) {
+        const size_t idx = k * thread_row + k_idx;
         output[idx] /= sum_val;
       }
     }
@@ -577,8 +577,8 @@ class TopKGating {
   IndType* indices;
   int* source_rows;
   const int k;
-  const int start_expert;
-  const int end_expert;
+  const size_t start_expert;
+  const size_t end_expert;
   const bool renormalize;
   const float* bias;
 };
@@ -619,10 +619,10 @@ void topk_gating_launcher_helper(
     float* output,
     IndType* indices,
     int* source_row,
-    const int num_rows,
+    const size_t num_rows,
     const int k,
-    const int start_expert,
-    const int end_expert,
+    const size_t start_expert,
+    const size_t end_expert,
     bool renormalize,
     float* bias,
     sycl::queue& queue) {
@@ -695,7 +695,7 @@ void topk_gating_kernel_launcher(
     int* token_expert_indices,
     float* scoring_workspace,
     const int num_tokens,
-    const int num_experts,
+    const size_t num_experts,
     const int topk,
     const bool renormalize,
     float* bias,
@@ -831,9 +831,9 @@ void topk_softmax(
     torch::Tensor& gating_output,         // [num_tokens, num_experts]
     const bool renormalize,
     std::optional<torch::Tensor> bias) {
-  const int num_experts = gating_output.size(-1);
+  const size_t num_experts = gating_output.size(-1);
   const auto num_tokens = gating_output.numel() / num_experts;
-  const int topk = topk_weights.size(-1);
+  const size_t topk = topk_weights.size(-1);
 
   const bool is_pow_2 =
       (num_experts != 0) && ((num_experts & (num_experts - 1)) == 0);
@@ -882,9 +882,9 @@ void topk_sigmoid(
     torch::Tensor& gating_output,         // [num_tokens, num_experts]
     const bool renormalize,
     std::optional<torch::Tensor> bias) {
-  const int num_experts = gating_output.size(-1);
+  const size_t num_experts = gating_output.size(-1);
   const auto num_tokens = gating_output.numel() / num_experts;
-  const int topk = topk_weights.size(-1);
+  const size_t topk = topk_weights.size(-1);
 
   const bool is_pow_2 =
       (num_experts != 0) && ((num_experts & (num_experts - 1)) == 0);

--- a/csrc/pos_encoding_kernels.cpp
+++ b/csrc/pos_encoding_kernels.cpp
@@ -203,7 +203,8 @@ void call_rotary_embedding_kernel(
 
   // Make sure query and key have consistent number of heads
   size_t num_heads = query_hidden_size / head_size;
-  size_t num_kv_heads = key.has_value() ? key_hidden_size / head_size : num_heads;
+  size_t num_kv_heads =
+      key.has_value() ? key_hidden_size / head_size : num_heads;
   TORCH_CHECK(num_heads % num_kv_heads == 0);
 
   size_t rot_dim = cos_sin_cache.size(1);

--- a/csrc/pos_encoding_kernels.cpp
+++ b/csrc/pos_encoding_kernels.cpp
@@ -11,9 +11,9 @@ inline void apply_token_rotary_embedding(
     scalar_t* __restrict__ arr,
     const scalar_t* __restrict__ cos_ptr,
     const scalar_t* __restrict__ sin_ptr,
-    int rot_offset,
-    int embed_dim) {
-  int x_index, y_index;
+    size_t rot_offset,
+    size_t embed_dim) {
+  size_t x_index, y_index;
   scalar_t cos, sin;
   if (IS_NEOX) {
     // GPT-NeoX style rotary embedding.
@@ -45,38 +45,38 @@ inline void apply_rotary_embedding(
                                    // head_size] or [num_tokens, num_kv_heads,
                                    // head_size]
     const scalar_t* cache_ptr,
-    const int head_size,
-    const int num_heads,
-    const int num_kv_heads,
-    const int rot_dim,
+    const size_t head_size,
+    const size_t num_heads,
+    const size_t num_kv_heads,
+    const size_t rot_dim,
     const int token_idx,
     const int64_t query_stride,
     const int64_t key_stride,
     const int64_t head_stride,
     const sycl::nd_item<3>& item_ct1) {
-  const int embed_dim = rot_dim / 2;
+  const size_t embed_dim = rot_dim / 2;
   const scalar_t* cos_ptr = cache_ptr;
   const scalar_t* sin_ptr = cache_ptr + embed_dim;
 
-  const int nq = num_heads * embed_dim;
-  for (int i = item_ct1.get_local_id(2); i < nq;
+  const size_t nq = num_heads * embed_dim;
+  for (size_t i = item_ct1.get_local_id(2); i < nq;
        i += item_ct1.get_local_range(2)) {
-    const int head_idx = i / embed_dim;
+    const size_t head_idx = i / embed_dim;
     const int64_t token_head =
         token_idx * query_stride + head_idx * head_stride;
-    const int rot_offset = i % embed_dim;
+    const size_t rot_offset = i % embed_dim;
     apply_token_rotary_embedding<scalar_t, IS_NEOX>(
         query + token_head, cos_ptr, sin_ptr, rot_offset, embed_dim);
   }
 
   if (key != nullptr) {
-    const int nk = num_kv_heads * embed_dim;
-    for (int i = item_ct1.get_local_id(2); i < nk;
+    const size_t nk = num_kv_heads * embed_dim;
+    for (size_t i = item_ct1.get_local_id(2); i < nk;
          i += item_ct1.get_local_range(2)) {
-      const int head_idx = i / embed_dim;
+      const size_t head_idx = i / embed_dim;
       const int64_t token_head =
           token_idx * key_stride + head_idx * head_stride;
-      const int rot_offset = i % embed_dim;
+      const size_t rot_offset = i % embed_dim;
       apply_token_rotary_embedding<scalar_t, IS_NEOX>(
           key + token_head, cos_ptr, sin_ptr, rot_offset, embed_dim);
     }
@@ -98,13 +98,13 @@ class rotary_embedding_kernel {
       // head_size]
       const scalar_t* __restrict__ cos_sin_cache_,  // [max_position, 2, rot_dim
                                                     // // 2]
-      const int rot_dim_,
+      const size_t rot_dim_,
       const int64_t query_stride_,
       const int64_t key_stride_,
       const int64_t head_stride_,
-      const int num_heads_,
-      const int num_kv_heads_,
-      const int head_size_)
+      const size_t num_heads_,
+      const size_t num_kv_heads_,
+      const size_t head_size_)
       : positions(positions_),
         query(query_),
         key(key_),
@@ -151,13 +151,13 @@ class rotary_embedding_kernel {
                                // head_size]
   const scalar_t* __restrict__ cos_sin_cache;  // [max_position, 2, rot_dim //
                                                // 2]
-  const int rot_dim;
+  const size_t rot_dim;
   const int64_t query_stride;
   const int64_t key_stride;
   const int64_t head_stride;
-  const int num_heads;
-  const int num_kv_heads;
-  const int head_size;
+  const size_t num_heads;
+  const size_t num_kv_heads;
+  const size_t head_size;
 };
 
 }  // namespace vllm
@@ -173,7 +173,7 @@ void call_rotary_embedding_kernel(
   using sycl_t = typename vllm::xpu::SyclTypeTrait<scalar_t>::Type;
   // num_tokens = batch_size * seq_len
   int64_t num_tokens = positions.numel();
-  int positions_ndim = positions.dim();
+  size_t positions_ndim = positions.dim();
 
   // Make sure num_tokens dim is consistent across positions, query, and key
   TORCH_CHECK(
@@ -196,24 +196,24 @@ void call_rotary_embedding_kernel(
 
   // Make sure head_size is valid for query and key
   // hidden_size = num_heads * head_size
-  int query_hidden_size = query.numel() / num_tokens;
-  int key_hidden_size = key.has_value() ? key->numel() / num_tokens : 0;
+  size_t query_hidden_size = query.numel() / num_tokens;
+  size_t key_hidden_size = key.has_value() ? key->numel() / num_tokens : 0;
   TORCH_CHECK(query_hidden_size % head_size == 0);
   TORCH_CHECK(key_hidden_size % head_size == 0);
 
   // Make sure query and key have consistent number of heads
-  int num_heads = query_hidden_size / head_size;
-  int num_kv_heads = key.has_value() ? key_hidden_size / head_size : num_heads;
+  size_t num_heads = query_hidden_size / head_size;
+  size_t num_kv_heads = key.has_value() ? key_hidden_size / head_size : num_heads;
   TORCH_CHECK(num_heads % num_kv_heads == 0);
 
-  int rot_dim = cos_sin_cache.size(1);
-  int seq_dim_idx = positions_ndim - 1;
+  size_t rot_dim = cos_sin_cache.size(1);
+  size_t seq_dim_idx = positions_ndim - 1;
   int64_t query_stride = query.stride(seq_dim_idx);
   int64_t key_stride = key.has_value() ? key->stride(seq_dim_idx) : 0;
   // Determine head stride: for [*, heads, head_size] use stride of last dim;
   // for flat [*, heads*head_size], heads blocks are contiguous of size
   // head_size
-  int query_ndim = query.dim();
+  size_t query_ndim = query.dim();
   int64_t head_stride =
       (query_ndim == positions_ndim + 2) ? query.stride(-2) : head_size;
 
@@ -223,7 +223,7 @@ void call_rotary_embedding_kernel(
   auto cos_sin_cache_ptr = cos_sin_cache.data_ptr<scalar_t>();
 
   sycl::range<3> grid(1, 1, num_tokens);
-  sycl::range<3> block(1, 1, std::min<int64_t>(num_heads * rot_dim / 2, 512));
+  sycl::range<3> block(1, 1, std::min<size_t>(num_heads * rot_dim / 2, 512));
 
   at::DeviceGuard device_guard(query.device());
   auto& queue = vllm::xpu::vllmGetQueue();

--- a/csrc/quantization/fp4/mxfp4_quant.cpp
+++ b/csrc/quantization/fp4/mxfp4_quant.cpp
@@ -38,7 +38,7 @@ void per_token_group_quant_mxfp4(
   TORCH_CHECK(
       output_q.scalar_type() == at::ScalarType::Byte, "output_q must be uint8");
 
-  const int num_groups = static_cast<int>(input.numel() / group_size);
+  const size_t num_groups = input.numel() / group_size;
   if (num_groups == 0) {
     // No work to do for empty input; ensure outputs are empty as well.
     TORCH_CHECK(
@@ -52,7 +52,7 @@ void per_token_group_quant_mxfp4(
 
   // Choose how many sub-groups to pack into one work-group.
   constexpr int THREADS_PER_GROUP = 32;
-  int groups_per_block = 1;
+  size_t groups_per_block = 1;
   if (num_groups % 16 == 0)
     groups_per_block = 16;
   else if (num_groups % 8 == 0)
@@ -62,14 +62,14 @@ void per_token_group_quant_mxfp4(
   else if (num_groups % 2 == 0)
     groups_per_block = 2;
 
-  const int num_blocks = num_groups / groups_per_block;
-  const int num_threads = groups_per_block * THREADS_PER_GROUP;
+  const size_t num_blocks = num_groups / groups_per_block;
+  const size_t num_threads = groups_per_block * THREADS_PER_GROUP;
 
   // Detect column-major scale layout.
   const bool is_column_major = output_s.stride(0) < output_s.stride(1);
   // scale_num_cols = number of groups per token row (= N / group_size).
-  const int scale_num_cols = output_s.size(1);
-  const int scale_stride = static_cast<int>(output_s.stride(1));
+  const size_t scale_num_cols = output_s.size(1);
+  const size_t scale_stride = static_cast<size_t>(output_s.stride(1));
 
   sycl::range<1> grid(num_blocks);
   sycl::range<1> block(num_threads);
@@ -83,7 +83,7 @@ void per_token_group_quant_mxfp4(
                   output_q.data_ptr<uint8_t>(),
                   output_s.data_ptr<float>(),
                   input.data_ptr<scalar_t>(),
-                  static_cast<int>(group_size),
+                  static_cast<size_t>(group_size),
                   groups_per_block,
                   static_cast<float>(eps),
                   scale_num_cols,

--- a/csrc/quantization/fp4/mxfp4_quant.h
+++ b/csrc/quantization/fp4/mxfp4_quant.h
@@ -37,11 +37,11 @@ class per_token_group_quant_mxfp4_kernel {
   uint8_t* out;
   float* scale;
   scalar_t const* input;
-  const int group_size;  // = 32 for MX format
-  const int groups_per_block;
+  const size_t group_size;  // = 32 for MX format
+  const size_t groups_per_block;
   float eps;
-  const int scale_num_cols;  // N / group_size  (columns in scale matrix)
-  const int scale_stride;    // stride(1) of scale tensor
+  const size_t scale_num_cols;  // N / group_size  (columns in scale matrix)
+  const size_t scale_stride;    // stride(1) of scale tensor
   bool is_column_major;
 
  public:
@@ -49,11 +49,11 @@ class per_token_group_quant_mxfp4_kernel {
       uint8_t* out_,
       float* scale_,
       scalar_t const* input_,
-      const int group_size_,
-      const int groups_per_block_,
+      const size_t group_size_,
+      const size_t groups_per_block_,
       float eps_,
-      const int scale_num_cols_ = 0,
-      const int scale_stride_ = 0,
+      const size_t scale_num_cols_ = 0,
+      const size_t scale_stride_ = 0,
       bool is_column_major_ = false)
       : out(out_),
         scale(scale_),
@@ -69,12 +69,12 @@ class per_token_group_quant_mxfp4_kernel {
       [[sycl::reqd_sub_group_size(32)]] (sycl::nd_item<1> item) const {
     constexpr int THREADS_PER_GROUP = 32;
 
-    int local_id = item.get_local_id(0);
-    int local_group_id = local_id / THREADS_PER_GROUP;
-    int lane_id = local_id % THREADS_PER_GROUP;
+    size_t local_id = item.get_local_id(0);
+    size_t local_group_id = local_id / THREADS_PER_GROUP;
+    size_t lane_id = local_id % THREADS_PER_GROUP;
 
-    int block_group_id = item.get_group(0) * groups_per_block;
-    int global_group_id = block_group_id + local_group_id;
+    size_t block_group_id = item.get_group(0) * groups_per_block;
+    size_t global_group_id = block_group_id + local_group_id;
 
     int64_t group_offset = static_cast<int64_t>(global_group_id) * group_size;
     scalar_t const* group_input = input + group_offset;
@@ -84,8 +84,8 @@ class per_token_group_quant_mxfp4_kernel {
     // Resolve the scale output pointer for this group.
     float* scale_output;
     if (is_column_major) {
-      const int row_idx = global_group_id / scale_num_cols;
-      const int col_idx = global_group_id % scale_num_cols;
+      const size_t row_idx = global_group_id / scale_num_cols;
+      const size_t col_idx = global_group_id % scale_num_cols;
       scale_output = scale + col_idx * scale_stride + row_idx;
     } else {
       scale_output = scale + global_group_id;

--- a/csrc/quantization/fp8/fp8_quant.cpp
+++ b/csrc/quantization/fp8/fp8_quant.cpp
@@ -24,11 +24,11 @@ class scaled_fp8_quant_kernel_strided_group_shape {
   fp8_type* out;
   const scalar_t* input;
   const float* scale;
-  int hidden_size;
+  size_t hidden_size;
   int64_t in_row_stride;
   int64_t out_row_stride;
-  int group_m;
-  int group_n;
+  size_t group_m;
+  size_t group_n;
   int64_t scale_stride_i;
   int64_t scale_stride_j;
 
@@ -37,11 +37,11 @@ class scaled_fp8_quant_kernel_strided_group_shape {
       fp8_type* out_,
       const scalar_t* input_,
       const float* scale_,
-      int hidden_size,
+      size_t hidden_size,
       int64_t in_row_stride_,
       int64_t out_row_stride_,
-      int group_m_,
-      int group_n_,
+      size_t group_m_,
+      size_t group_n_,
       int64_t scale_stride_i_,
       int64_t scale_stride_j_)
       : out(out_),
@@ -90,9 +90,9 @@ class scaled_fp8_quant_kernel_strided_group_shape {
           token_in, token_out, hidden_size, tid, item.get_local_range(0), op);
     } else if (group_n % VEC_SIZE == 0) {
       // Multiple column groups with vectorization
-      const int num_groups_n = hidden_size / group_n;
+      const size_t num_groups_n = hidden_size / group_n;
 
-      for (int gj = 0; gj < num_groups_n; gj++) {
+      for (size_t gj = 0; gj < num_groups_n; gj++) {
         fp8::ConvertWithScaleOp<true, fp8_type> op{get_inv_scale(gj)};
         fp8::scaled_convert_vec(
             token_in + gj * group_n,
@@ -104,8 +104,8 @@ class scaled_fp8_quant_kernel_strided_group_shape {
       }
     } else {
       // Scalar path for small column groups (group_n < VEC_SIZE)
-      for (int n = tid; n < hidden_size; n += item.get_local_range(0)) {
-        const int gj = n / group_n;
+      for (size_t n = tid; n < hidden_size; n += item.get_local_range(0)) {
+        const size_t gj = n / group_n;
         fp8::ConvertWithScaleOp<true, fp8_type> op{get_inv_scale_cached(gj)};
         op(token_out[n], token_in[n]);
       }
@@ -119,7 +119,7 @@ class scaled_fp8_quant_kernel_strided_dynamic {
   fp8_type* out;
   const scalar_t* input;
   const float* scale;
-  int64_t hidden_size;
+  size_t hidden_size;
   int64_t in_row_stride;
   int64_t out_row_stride;
 
@@ -128,7 +128,7 @@ class scaled_fp8_quant_kernel_strided_dynamic {
       fp8_type* out_,
       const scalar_t* input_,
       const float* scale_,
-      int hidden_size_,
+      size_t hidden_size_,
       int64_t in_row_stride_,
       int64_t out_row_stride_)
       : out(out_),
@@ -158,12 +158,12 @@ class per_token_group_quant_8bit_kernel {
   fp8_type* out;
   float* scale;
   scalar_t const* input;
-  const int group_size;
-  const int groups_per_block;
+  const size_t group_size;
+  const size_t groups_per_block;
   float eps;
   bool scale_ue8m0;
-  const int scale_num_rows;
-  const int scale_stride;
+  const size_t scale_num_rows;
+  const size_t scale_stride;
   bool is_column_major;
 
  public:
@@ -171,12 +171,12 @@ class per_token_group_quant_8bit_kernel {
       fp8_type* out_,
       float* scale_,
       scalar_t const* input_,
-      const int group_size_,
-      const int groups_per_block_,
+      const size_t group_size_,
+      const size_t groups_per_block_,
       float eps_,
       bool scale_ue8m0_,
-      const int scale_num_rows_ = 0,
-      const int scale_stride_ = 0,
+      const size_t scale_num_rows_ = 0,
+      const size_t scale_stride_ = 0,
       bool is_column_major_ = false)
       : out(out_),
         scale(scale_),
@@ -192,13 +192,13 @@ class per_token_group_quant_8bit_kernel {
       [[sycl::reqd_sub_group_size(32)]] (sycl::nd_item<1> item) const {
     constexpr int threads_per_group = 32;
 
-    int local_id = item.get_local_id(0);
-    int local_group_id = local_id / threads_per_group;
-    int lane_id = local_id % threads_per_group;
+    size_t local_id = item.get_local_id(0);
+    size_t local_group_id = local_id / threads_per_group;
+    size_t lane_id = local_id % threads_per_group;
 
     // Global 32-thread group
-    int block_group_id = item.get_group(0) * groups_per_block;
-    int global_group_id = block_group_id + local_group_id;
+    size_t block_group_id = item.get_group(0) * groups_per_block;
+    size_t global_group_id = block_group_id + local_group_id;
 
     // Base offset
     int64_t block_group_offset =
@@ -210,8 +210,8 @@ class per_token_group_quant_8bit_kernel {
     scalar_t const* group_input = &input[block_group_offset];
     fp8_type* group_output = &out[block_group_offset];
     if (is_column_major) {
-      const int row_idx = global_group_id / scale_num_rows;
-      const int col_idx = global_group_id % scale_num_rows;
+      const size_t row_idx = global_group_id / scale_num_rows;
+      const size_t col_idx = global_group_id % scale_num_rows;
       scale_output =
           reinterpret_cast<float*>(scale) + (col_idx * scale_stride + row_idx);
     } else {
@@ -224,7 +224,7 @@ class per_token_group_quant_8bit_kernel {
       local_absmax =
           thread_max_vec(group_input, group_size, lane_id, threads_per_group);
     } else {
-      for (int i = lane_id; i < group_size; i += threads_per_group) {
+      for (size_t i = lane_id; i < group_size; i += threads_per_group) {
         float const x = static_cast<float>(group_input[i]);
         local_absmax = sycl::max(local_absmax, sycl::fabs(x));
       }
@@ -258,7 +258,7 @@ class per_token_group_quant_8bit_kernel {
           item.get_local_range(0),
           op);
     } else {
-      for (int i = lane_id; i < group_size; i += groups_per_block) {
+      for (size_t i = lane_id; i < group_size; i += groups_per_block) {
         fp8::ConvertWithScaleOp<true, fp8_type> op{inverted_scale};
         op(group_output[i], group_input[i]);
       }
@@ -273,7 +273,7 @@ class dynamic_per_token_scaled_fp8_quant_kernel {
   float* scale;
   scalar_t const* input;
   float const* scale_ub;
-  const int hidden_size;
+  const size_t hidden_size;
 
  public:
   dynamic_per_token_scaled_fp8_quant_kernel(
@@ -281,7 +281,7 @@ class dynamic_per_token_scaled_fp8_quant_kernel {
       float* scale_,
       scalar_t const* input_,
       float const* scale_ub_,
-      const int hidden_size_)
+      const size_t hidden_size_)
       : out(out_),
         scale(scale_),
         input(input_),
@@ -306,7 +306,7 @@ class dynamic_per_token_scaled_fp8_quant_kernel {
       absmax_val = thread_max_vec(
           token_input, hidden_size, tid, item.get_local_range(0));
     } else {
-      for (int i = tid; i < hidden_size; i += item.get_local_range(0)) {
+      for (size_t i = tid; i < hidden_size; i += item.get_local_range(0)) {
         float const x = static_cast<float>(token_input[i]);
         absmax_val = sycl::max(absmax_val, sycl::fabs(x));
       }
@@ -344,7 +344,7 @@ class dynamic_per_token_scaled_fp8_quant_kernel {
           item.get_local_range(0),
           op);
     } else {
-      for (int i = tid; i < hidden_size; i += item.get_local_range(0)) {
+      for (size_t i = tid; i < hidden_size; i += item.get_local_range(0)) {
         fp8::ConvertWithScaleOp<true, fp8_type> op{inverted_scale};
         op(token_output[i], token_input[i]);
       }
@@ -366,7 +366,7 @@ void static_scaled_fp8_quant(
   TORCH_CHECK(
       out.stride(-1) == 1, "last dimension of output must be contiguous");
 
-  const int hidden_size = input.size(-1);                  // N (columns)
+  const size_t hidden_size = input.size(-1);                 // N (columns)
   const int64_t num_tokens = input.numel() / hidden_size;  // M (rows)
 
   // Determine group_m, group_n, and scale strides from scale shape
@@ -609,7 +609,7 @@ void per_token_group_quant_fp8(
   TORCH_CHECK(input.is_contiguous());
   TORCH_CHECK(output_q.is_contiguous());
 
-  const int num_groups = input.numel() / group_size;
+  const size_t num_groups = input.numel() / group_size;
 
   TORCH_CHECK(input.numel() % group_size == 0);
   TORCH_CHECK(output_s.dim() == 2);
@@ -618,7 +618,7 @@ void per_token_group_quant_fp8(
 
   constexpr int THREADS_PER_GROUP = 32;
 
-  int groups_per_block = 1;
+  size_t groups_per_block = 1;
 
   if (num_groups % 16 == 0) {
     groups_per_block = 16;
@@ -631,12 +631,12 @@ void per_token_group_quant_fp8(
   }
 
   auto dst_type = output_q.scalar_type();
-  const int num_blocks = num_groups / groups_per_block;
-  const int num_threads = groups_per_block * THREADS_PER_GROUP;
+  const size_t num_blocks = num_groups / groups_per_block;
+  const size_t num_threads = groups_per_block * THREADS_PER_GROUP;
 
   const bool is_column_major = output_s.stride(0) < output_s.stride(1);
-  const int scale_num_rows = output_s.size(1);
-  const int scale_stride = output_s.stride(1);
+  const size_t scale_num_rows = output_s.size(1);
+  const size_t scale_stride = output_s.stride(1);
 
   sycl::range<1> grid(num_blocks);
   sycl::range<1> block(num_threads);
@@ -676,10 +676,10 @@ void dynamic_per_token_scaled_fp8_quant(
   TORCH_CHECK(input.is_contiguous());
   TORCH_CHECK(out.is_contiguous());
 
-  int const hidden_size = input.size(-1);
-  int const num_tokens = input.numel() / hidden_size;
+  size_t const hidden_size = input.size(-1);
+  size_t const num_tokens = input.numel() / hidden_size;
   sycl::range<1> grid(num_tokens);
-  sycl::range<1> block(std::min(hidden_size, 1024));
+  sycl::range<1> block(std::min(hidden_size, static_cast<size_t>(1024)));
 
   const at::DeviceGuard device_guard(input.device());
 

--- a/csrc/quantization/fp8/fp8_quant.cpp
+++ b/csrc/quantization/fp8/fp8_quant.cpp
@@ -366,7 +366,7 @@ void static_scaled_fp8_quant(
   TORCH_CHECK(
       out.stride(-1) == 1, "last dimension of output must be contiguous");
 
-  const size_t hidden_size = input.size(-1);                 // N (columns)
+  const size_t hidden_size = input.size(-1);               // N (columns)
   const int64_t num_tokens = input.numel() / hidden_size;  // M (rows)
 
   // Determine group_m, group_n, and scale strides from scale shape

--- a/csrc/quantization/fp8/fp8_quant.h
+++ b/csrc/quantization/fp8/fp8_quant.h
@@ -93,7 +93,8 @@ class segmented_max_reduction_strided {
     group_barrier(item.get_group());
 
     // parallel reduction to find row max.
-    for (size_t offset = item.get_local_range(0) / 2; offset > 0; offset >>= 1) {
+    for (size_t offset = item.get_local_range(0) / 2; offset > 0;
+         offset >>= 1) {
       if (tid < offset) {
         cache[tid] = sycl::max(cache[tid], cache[tid + offset]);
       }

--- a/csrc/quantization/fp8/fp8_quant.h
+++ b/csrc/quantization/fp8/fp8_quant.h
@@ -85,7 +85,7 @@ class segmented_max_reduction_strided {
 
     // each thread scans elements of the row in a strided fashion.
     float thread_max = 0.0f;
-    for (int e = tid; e < hidden_size; e += item.get_local_range(0)) {
+    for (size_t e = tid; e < hidden_size; e += item.get_local_range(0)) {
       float x = static_cast<float>(row_ptr[e]);
       thread_max = sycl::max(thread_max, sycl::fabs(x));
     }
@@ -93,7 +93,7 @@ class segmented_max_reduction_strided {
     group_barrier(item.get_group());
 
     // parallel reduction to find row max.
-    for (int offset = item.get_local_range(0) / 2; offset > 0; offset >>= 1) {
+    for (size_t offset = item.get_local_range(0) / 2; offset > 0; offset >>= 1) {
       if (tid < offset) {
         cache[tid] = sycl::max(cache[tid], cache[tid + offset]);
       }

--- a/csrc/quantization/fp8/quant_utils.h
+++ b/csrc/quantization/fp8/quant_utils.h
@@ -99,9 +99,9 @@ template <int VEC_SIZE = 4, typename scalar_t, typename dtype_t, typename ScaOp>
 void scaled_convert_vec(
     const scalar_t* src,
     dtype_t* dst,
-    int num_elems,
-    int local_idx,
-    int local_range,
+    size_t num_elems,
+    size_t local_idx,
+    size_t local_range,
     ScaOp&& scalar_op) {
   constexpr int WIDTH = VEC_SIZE * sizeof(scalar_t);
   uintptr_t addr = reinterpret_cast<uintptr_t>(src);
@@ -131,12 +131,12 @@ void scaled_convert_vec(
 
   int misalignment_offset = addr & (WIDTH - 1);
   int alignment_bytes = WIDTH - misalignment_offset;
-  int prefix_elems = alignment_bytes & (WIDTH - 1);
+  size_t prefix_elems = alignment_bytes & (WIDTH - 1);
   prefix_elems /= sizeof(scalar_t);
   prefix_elems = sycl::min(prefix_elems, num_elems);
 
   // 1. prefill elements when it is unsafe to vectorize
-  for (int i = local_idx; i < prefix_elems; i += local_range) {
+  for (size_t i = local_idx; i < prefix_elems; i += local_range) {
     scalar_op(dst[i], src[i]);
   }
 
@@ -144,14 +144,14 @@ void scaled_convert_vec(
   dst += prefix_elems;
   num_elems -= prefix_elems;
 
-  int num_vec = num_elems / VEC_SIZE;
+  size_t num_vec = num_elems / VEC_SIZE;
   using srcx4_t = vec4_t<scalar_t>;
   using distx4_t = dtypex4_t<dtype_t>;
   auto const* vectorized_in = reinterpret_cast<srcx4_t const*>(src);
   auto* vectorized_out = reinterpret_cast<distx4_t*>(dst);
 
   // 2. vectorize the main part
-  for (int i = local_idx; i < num_vec; i += local_range) {
+  for (size_t i = local_idx; i < num_vec; i += local_range) {
     distx4_t tmp;
     // Make a local copy of the entire pack
     srcx4_t in_vec = vectorized_in[i];  // <- encourages a single vector ld
@@ -163,8 +163,8 @@ void scaled_convert_vec(
   }
 
   // 3. handle the tail
-  int tail_start = num_vec * VEC_SIZE;
-  for (int i = local_idx + tail_start; i < num_elems; i += local_range) {
+  size_t tail_start = num_vec * VEC_SIZE;
+  for (size_t i = local_idx + tail_start; i < num_elems; i += local_range) {
     scalar_op(dst[i], src[i]);
   }
 }


### PR DESCRIPTION
* Replace int with size_t for size/count/stride/index variables in cache.cpp

Change local variables assigned from .size() calls, kernel class constructor parameters, kernel class member variables, and loop variables to use size_t instead of int for variables representing sizes, dimensions, counts, strides, indices, block sizes, and head sizes. This avoids signed/unsigned comparison bugs.




* Replace int with size_t for size/dimension/count variables in layernorm kernels

Change variables representing sizes, dimensions, counts, and loop indices from int to size_t in csrc/layernorm.cpp and csrc/layernorm_quant.cpp.

This affects:
- Kernel class constructor parameters and member variables
- Local variables (hidden_size, num_tokens, num_dims, etc.)
- Loop variables iterating over sizes/dimensions
- Fix std::min calls with static_cast<size_t>(1024)
- Fix std::gcd calls with static_cast<size_t>(...)

Preserved: template non-type params (int NUM_DIMS, int VEC_SIZE), int64_t variables, and inner j-loops bounded by VEC_SIZE.





* Replace int with size_t for size/dimension/count variables in pos_encoding and fused_qknorm_rope kernels

- pos_encoding_kernels.cpp: Changed positions_ndim, query_hidden_size, key_hidden_size, num_heads, num_kv_heads, rot_dim, seq_dim_idx, query_ndim, and kernel class member vars (head_size, num_heads, num_kv_heads, rot_dim) from int to size_t. Updated loop/index vars (embed_dim, nq, nk, head_idx, rot_offset, x_index, y_index) and fixed std::min<int64_t> to std::min<size_t>.

- fused_qknorm_rope.cpp: Changed kernel class constructor params and member vars (num_heads_q, num_heads_k, num_heads_v, num_tokens, rotary_dim) from int to size_t. Updated all loop vars, index vars (total_qk_heads, token_idx, local_head_idx, head_idx, num_heads, offset_warp, offset_thread, embed_dim, rotary_lanes, pair_offset, dim_idx, half_dim), and launch function params. Changed static_cast<int> to static_cast<size_t> at call site.

Preserved: int token_idx in rotary_embedding (used with int64_t strides), template non-type params (int head_dim), int64_t variables, and constexpr int constants (block_size, sgs_per_wg, SUB_GROUP_SIZE, NUM_ELEMS_PER_THREAD).





* Replace int with size_t for size/dimension/count variables in moe kernels (partial)

Changed int → size_t for variables representing sizes, dimensions, counts, strides, and indices in 4 files:

- fused_moe_prologue.cpp: experts_per_token
- init_expert_map.cpp: num_experts, ep_rank, ep_size (params, members, launcher)
- moe_gather.cpp: num_experts, num_tokens, hidden_size, topk, loop vars
- remap_hidden_states.cpp: RowsPerExpertCount get_nd_range params (partial)

Note: This is a partial change. The following files still need updates:
- topk.cpp
- moe_align_sum_kernels.cpp
- remap_hidden_states.cpp (remaining changes)
- fused_grouped_topk.cpp
- grouped_topk.cpp
- fused_moe_prologue.hpp





* Replace int with size_t for size/count/stride/index variables across csrc/ to fix signed/unsigned comparison risks

Agent-Logs-Url: https://github.com/jikunshang/vllm-xpu-kernels/sessions/77ac7b1b-2a91-4f87-9031-10fbf67b346f



---------


PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS ABOVE HAVE BEEN CONSIDERED.

## Purpose

## Test Plan

## Test Result

## (Optional) Documentation Update

**BEFORE SUBMITTING, PLEASE READ <https://docs.vllm.ai/en/latest/contributing>** (anything written below this line will be removed by GitHub Actions)
