### PR TITLE
[Refactor] refactor vectorization

### DIFF
--- a/csrc/cache.cpp
+++ b/csrc/cache.cpp
@@ -6,6 +6,7 @@
 
 #include "dispatch_utils.h"
 #include "quantization/fp8/quant_utils.h"
+#include "quantization/utils.h"
 #include "utils.h"
 #include "utils/mem_cpy.h"
 
@@ -162,13 +163,15 @@ class reshape_and_cache_flash_kernel {
     cache_t* __restrict__ value_dst =
         value_cache_ + block_idx * block_stride_ + block_offset * page_stride_;
 
+    constexpr int VEC_SIZE = (sizeof(scalar_t) == 2) ? 8 : 4;
     float k_scale_val = (kv_dt == Fp8KVCacheDataType::kAuto) ? 0.f : *k_scale_;
     float v_scale_val = (kv_dt == Fp8KVCacheDataType::kAuto) ? 0.f : *v_scale_;
 
     fp8::CopyWithScaleOp<cache_t, scalar_t, kv_dt> k_op{k_scale_val};
     fp8::CopyWithScaleOp<cache_t, scalar_t, kv_dt> v_op{v_scale_val};
-    fp8::scaled_convert_vec(key_src, key_dst, n, local_idx, local_range, k_op);
-    fp8::scaled_convert_vec(
+    vectorize_with_alignment<VEC_SIZE>(
+        key_src, key_dst, n, local_idx, local_range, k_op);
+    vectorize_with_alignment<VEC_SIZE>(
         value_src, value_dst, n, local_idx, local_range, v_op);
   }
 

--- a/csrc/quantization/fp8/fp8_quant.cpp
+++ b/csrc/quantization/fp8/fp8_quant.cpp
@@ -86,7 +86,7 @@ class scaled_fp8_quant_kernel_strided_group_shape {
     if (STRIDE_J_ZERO && hidden_size % VEC_SIZE == 0) {
       // Per-tensor or per-token: single scale per row, vectorize full row
       fp8::ConvertWithScaleOp<true, fp8_type> op{get_inv_scale(0)};
-      fp8::scaled_convert_vec(
+      vectorize_with_alignment<VEC_SIZE>(
           token_in, token_out, hidden_size, tid, item.get_local_range(0), op);
     } else if (group_n % VEC_SIZE == 0) {
       // Multiple column groups with vectorization
@@ -94,7 +94,7 @@ class scaled_fp8_quant_kernel_strided_group_shape {
 
       for (int gj = 0; gj < num_groups_n; gj++) {
         fp8::ConvertWithScaleOp<true, fp8_type> op{get_inv_scale(gj)};
-        fp8::scaled_convert_vec(
+        vectorize_with_alignment<VEC_SIZE>(
             token_in + gj * group_n,
             token_out + gj * group_n,
             group_n,
@@ -147,7 +147,8 @@ class scaled_fp8_quant_kernel_strided_dynamic {
     // division.
     const float inverted_scale = 1.0f / (*scale);
     fp8::ConvertWithScaleOp<true, fp8_type> op{inverted_scale};
-    fp8::scaled_convert_vec(
+    constexpr int VEC_SIZE = 4;
+    vectorize_with_alignment<VEC_SIZE>(
         token_in, token_out, hidden_size, tid, item.get_local_range(0), op);
   }
 };
@@ -248,9 +249,10 @@ class per_token_group_quant_8bit_kernel {
     group_barrier(item.get_group());
 
     const float inverted_scale = 1.0f / (y_s);
+    constexpr int VEC_SIZE = 4;
     if (!can_vectorize) {
       fp8::ConvertWithScaleOp<true, fp8_type> op{inverted_scale};
-      fp8::scaled_convert_vec(
+      vectorize_with_alignment<VEC_SIZE>(
           group_input,
           group_output,
           group_size,
@@ -334,9 +336,10 @@ class dynamic_per_token_scaled_fp8_quant_kernel {
 
     // Note that we don't use inverted scales so we can match FBGemm impl.
     const float inverted_scale = 1.0f / (token_scale[0]);
+    constexpr int VEC_SIZE = 4;
     if (can_vectorize) {
       fp8::ConvertWithScaleOp<true, fp8_type> op{inverted_scale};
-      fp8::scaled_convert_vec(
+      vectorize_with_alignment<VEC_SIZE>(
           token_input,
           token_output,
           hidden_size,

--- a/csrc/quantization/fp8/fp8_quant.h
+++ b/csrc/quantization/fp8/fp8_quant.h
@@ -7,6 +7,7 @@
 #include <c10/util/Float8_e5m2.h>
 
 #include "quantization/fp8/quant_utils.h"
+#include "quantization/utils.h"
 
 using namespace at;
 
@@ -19,7 +20,7 @@ inline float thread_max_vec(
     int const tid,
     int const step) {
   // Vectorized input/output to better utilize memory bandwidth.
-  using vec4_t = fp8::vec4_t<scalar_t>;
+  using vec4_t = vec4_t<scalar_t>;
   vec4_t const* vectorized_in = reinterpret_cast<vec4_t const*>(input);
 
   int64_t const num_vec_elems = num_elems >> 2;
@@ -29,13 +30,13 @@ inline float thread_max_vec(
   for (int64_t i = tid; i < num_vec_elems; i += step) {
     vec4_t in_vec = vectorized_in[i];
     absmax_val =
-        sycl::max(absmax_val, sycl::fabs(static_cast<float>(in_vec.x)));
+        sycl::max(absmax_val, sycl::fabs(static_cast<float>(in_vec.val[0])));
     absmax_val =
-        sycl::max(absmax_val, sycl::fabs(static_cast<float>(in_vec.y)));
+        sycl::max(absmax_val, sycl::fabs(static_cast<float>(in_vec.val[1])));
     absmax_val =
-        sycl::max(absmax_val, sycl::fabs(static_cast<float>(in_vec.z)));
+        sycl::max(absmax_val, sycl::fabs(static_cast<float>(in_vec.val[2])));
     absmax_val =
-        sycl::max(absmax_val, sycl::fabs(static_cast<float>(in_vec.w)));
+        sycl::max(absmax_val, sycl::fabs(static_cast<float>(in_vec.val[3])));
   }
 
   // Handle the remaining elements if num_elems is not divisible by 4

--- a/csrc/quantization/fp8/quant_utils.h
+++ b/csrc/quantization/fp8/quant_utils.h
@@ -15,20 +15,6 @@ enum class Fp8KVCacheDataType {
 
 namespace fp8 {
 
-template <typename dtype_t>
-struct alignas(4) dtypex4_t {
-  static_assert(
-      std::is_same_v<dtype_t, float> || std::is_same_v<dtype_t, at::Half> ||
-          std::is_same_v<dtype_t, at::BFloat16> ||
-          std::is_same_v<dtype_t, uint8_t> ||
-          std::is_same_v<dtype_t, at::Float8_e4m3fn> ||
-          std::is_same_v<dtype_t, at::Float8_e5m2>,
-      "Unsupported cache type for dtypex4_t");
-  dtype_t x;
-  dtype_t y;
-  dtype_t z;
-  dtype_t w;
-};
 
 template <
     typename T,

--- a/csrc/quantization/fp8/quant_utils.h
+++ b/csrc/quantization/fp8/quant_utils.h
@@ -15,7 +15,6 @@ enum class Fp8KVCacheDataType {
 
 namespace fp8 {
 
-
 template <
     typename T,
     typename = std::enable_if_t<

--- a/csrc/quantization/fp8/quant_utils.h
+++ b/csrc/quantization/fp8/quant_utils.h
@@ -15,14 +15,6 @@ enum class Fp8KVCacheDataType {
 
 namespace fp8 {
 
-template <typename scalar_t>
-struct alignas(8) vec4_t {
-  scalar_t x;
-  scalar_t y;
-  scalar_t z;
-  scalar_t w;
-};
-
 template <typename dtype_t>
 struct alignas(4) dtypex4_t {
   static_assert(
@@ -92,82 +84,6 @@ struct ConvertWithScaleOp {
     dst = static_cast<fp8_type>(r);
   }
 };
-
-// The vector width is fixed at 4 to avoid excessive branching in the kernel,
-// which could degrade performance.
-template <int VEC_SIZE = 4, typename scalar_t, typename dtype_t, typename ScaOp>
-void scaled_convert_vec(
-    const scalar_t* src,
-    dtype_t* dst,
-    int num_elems,
-    int local_idx,
-    int local_range,
-    ScaOp&& scalar_op) {
-  constexpr int WIDTH = VEC_SIZE * sizeof(scalar_t);
-  uintptr_t addr = reinterpret_cast<uintptr_t>(src);
-
-  bool can_vec =
-      ((addr & (WIDTH - 1)) == 0) && ((num_elems & (VEC_SIZE - 1)) == 0);
-  if (can_vec) {
-    using srcx4_t = vec4_t<scalar_t>;
-    using distx4_t = dtypex4_t<dtype_t>;
-
-    int64_t const num_vec_elems = num_elems / VEC_SIZE;
-
-    auto const* vectorized_in = reinterpret_cast<srcx4_t const*>(src);
-    auto* vectorized_out = reinterpret_cast<distx4_t*>(dst);
-
-    for (int64_t i = local_idx; i < num_vec_elems; i += local_range) {
-      srcx4_t in_vec = vectorized_in[i];
-      distx4_t out_vec;
-      scalar_op(out_vec.x, in_vec.x);
-      scalar_op(out_vec.y, in_vec.y);
-      scalar_op(out_vec.z, in_vec.z);
-      scalar_op(out_vec.w, in_vec.w);
-      vectorized_out[i] = out_vec;
-    }
-    return;
-  }
-
-  int misalignment_offset = addr & (WIDTH - 1);
-  int alignment_bytes = WIDTH - misalignment_offset;
-  int prefix_elems = alignment_bytes & (WIDTH - 1);
-  prefix_elems /= sizeof(scalar_t);
-  prefix_elems = sycl::min(prefix_elems, num_elems);
-
-  // 1. prefill elements when it is unsafe to vectorize
-  for (int i = local_idx; i < prefix_elems; i += local_range) {
-    scalar_op(dst[i], src[i]);
-  }
-
-  src += prefix_elems;
-  dst += prefix_elems;
-  num_elems -= prefix_elems;
-
-  int num_vec = num_elems / VEC_SIZE;
-  using srcx4_t = vec4_t<scalar_t>;
-  using distx4_t = dtypex4_t<dtype_t>;
-  auto const* vectorized_in = reinterpret_cast<srcx4_t const*>(src);
-  auto* vectorized_out = reinterpret_cast<distx4_t*>(dst);
-
-  // 2. vectorize the main part
-  for (int i = local_idx; i < num_vec; i += local_range) {
-    distx4_t tmp;
-    // Make a local copy of the entire pack
-    srcx4_t in_vec = vectorized_in[i];  // <- encourages a single vector ld
-    scalar_op(tmp.x, in_vec.x);
-    scalar_op(tmp.y, in_vec.y);
-    scalar_op(tmp.z, in_vec.z);
-    scalar_op(tmp.w, in_vec.w);
-    vectorized_out[i] = tmp;  // <- encourages a single vector st
-  }
-
-  // 3. handle the tail
-  int tail_start = num_vec * VEC_SIZE;
-  for (int i = local_idx + tail_start; i < num_elems; i += local_range) {
-    scalar_op(dst[i], src[i]);
-  }
-}
 
 }  // namespace fp8
 }  // namespace vllm

--- a/csrc/quantization/utils.h
+++ b/csrc/quantization/utils.h
@@ -1,0 +1,97 @@
+#pragma once
+
+// Vectorization containers
+template <typename scalar_t, size_t vec_size>
+struct alignas(vec_size * sizeof(scalar_t)) vec_n_t {
+  scalar_t val[vec_size];
+};
+
+template <typename scalar_t>
+using vec4_t = vec_n_t<scalar_t, 4>;
+
+template <int VEC_SIZE, typename InT, typename OutT, typename ScaOp>
+struct DefaultVecOp {
+  ScaOp scalar_op;
+
+  inline void operator()(
+      vec_n_t<OutT, VEC_SIZE>& dst, const vec_n_t<InT, VEC_SIZE>& src) const {
+#pragma unroll
+    for (int i = 0; i < VEC_SIZE; ++i) {
+      scalar_op(dst.val[i], src.val[i]);
+    }
+  }
+};
+
+template <int VEC_SIZE, typename InT, typename OutT, typename ScaOp>
+void vectorize_with_alignment(
+    const InT* in,
+    OutT* out,
+    int num_elems,
+    int local_idx,
+    int local_range,
+    ScaOp&& scalar_op) {
+  static_assert(
+      VEC_SIZE > 0 && (VEC_SIZE & (VEC_SIZE - 1)) == 0,
+      "VEC_SIZE must be a positive power-of-two");
+
+  DefaultVecOp<VEC_SIZE, InT, OutT, std::decay_t<ScaOp>> vec_op{scalar_op};
+
+  constexpr int WIDTH = VEC_SIZE * sizeof(InT);
+  uintptr_t addr = reinterpret_cast<uintptr_t>(in);
+
+  bool can_vec =
+      ((addr & (WIDTH - 1)) == 0) && ((num_elems & (VEC_SIZE - 1)) == 0);
+  if (can_vec) {
+    int64_t num_vec = num_elems / VEC_SIZE;
+
+    using vin_t = vec_n_t<InT, VEC_SIZE>;
+    using vout_t = vec_n_t<OutT, VEC_SIZE>;
+    auto const* v_in = reinterpret_cast<const vin_t*>(in);
+    auto* v_out = reinterpret_cast<vout_t*>(out);
+
+    for (int64_t i = local_idx; i < num_vec; i += local_range) {
+      vout_t tmp;
+      // Make a local copy of the entire pack
+      vin_t src = v_in[i];  // <- encourages a single vector ld
+      vec_op(tmp, src);
+      v_out[i] = tmp;  // <- encourages a single vector st
+    }
+    return;
+  }
+
+  int misalignment_offset = addr & (WIDTH - 1);
+  int alignment_bytes = WIDTH - misalignment_offset;
+  int prefix_elems = alignment_bytes & (WIDTH - 1);
+  prefix_elems /= sizeof(InT);
+  prefix_elems = sycl::min(prefix_elems, num_elems);
+
+  // 1. prefill elements when it is unsafe to vectorize
+  for (int i = local_idx; i < prefix_elems; i += local_range) {
+    scalar_op(out[i], in[i]);
+  }
+
+  in += prefix_elems;
+  out += prefix_elems;
+  num_elems -= prefix_elems;
+
+  int num_vec = num_elems / VEC_SIZE;
+  using vin_t = vec_n_t<InT, VEC_SIZE>;
+  using vout_t = vec_n_t<OutT, VEC_SIZE>;
+  auto const* v_in = reinterpret_cast<const vin_t*>(in);
+  auto* v_out = reinterpret_cast<vout_t*>(out);
+
+  // 2. vectorize the main part
+  for (int i = local_idx; i < num_vec; i += local_range) {
+    vout_t tmp;
+    // Make a local copy of the entire pack
+    vin_t src = v_in[i];  // <- encourages a single vector ld
+    vec_op(tmp, src);
+    v_out[i] = tmp;  // <- encourages a single vector st
+  }
+
+  // 3. handle the tail
+  int tail_start = num_vec * VEC_SIZE;
+  for (int i = local_idx + tail_start; i < num_elems; i += local_range) {
+    scalar_op(out[i], in[i]);
+  }
+}


### PR DESCRIPTION
- use dynamic (larger) vectorization in reshape_and_cache_flash kernel

For KPI 4 models shapes, after refactor, this kernel almost all have better performance than before, especially in the decode phase:
<img width="315" height="228" alt="image" src="https://github.com/user-attachments/assets/4376d514-10df-476a-ac2e-f9f8c336ce76" />
