### PR TITLE
Add moe dynamic quant kernels

### DIFF
--- a/csrc/moe/dynamic_quant_kernels.cpp
+++ b/csrc/moe/dynamic_quant_kernels.cpp
@@ -11,6 +11,139 @@
 using namespace sycl::ext::intel::esimd;
 using bf16 = sycl::ext::oneapi::bfloat16;
 
+void moe_swiglu_dynamic_quant(
+    torch::Tensor& scatter_tokens,
+    torch::Tensor& smooth_scale,
+    torch::Tensor& experts_token_count,
+    torch::Tensor& experts_token_start,
+    torch::Tensor& quant_tokens,
+    torch::Tensor& per_token_scale,
+    int64_t total_experts_num,
+    int64_t max_token_num) {
+
+    auto& queue = vllm::xpu::vllmGetQueue();
+
+    auto scatter_tokens_ptr = reinterpret_cast<bf16*>(scatter_tokens.data_ptr<at::BFloat16>());
+    auto smooth_scale_ptr = smooth_scale.data_ptr<float>();
+    auto experts_token_count_ptr = experts_token_count.data_ptr<int32_t>();
+    auto experts_token_start_ptr = experts_token_start.data_ptr<int32_t>();
+    auto quant_tokens_ptr = quant_tokens.data_ptr<int8_t>();
+    auto per_token_scale_ptr = per_token_scale.data_ptr<float>();
+
+    int hidden_size = scatter_tokens.size(1) / 2;
+
+    auto launch_swiglu = [&](auto unroll_tag) {
+        constexpr int UNROLL = decltype(unroll_tag)::value;
+        constexpr int CHUNK = 64;
+        constexpr int BS = CHUNK * UNROLL;
+
+        int num_blocks = hidden_size / BS;
+        int wg_size = std::min(num_blocks, 64);
+
+        sycl::range<3> GlobalRange(total_experts_num, max_token_num, wg_size);
+        sycl::range<3> LocalRange(1, 1, wg_size);
+
+        queue.submit([&](sycl::handler& cgh) {
+            cgh.parallel_for(sycl::nd_range<3>(GlobalRange, LocalRange), [=](sycl::nd_item<3> item) SYCL_ESIMD_KERNEL {
+                slm_init(64 * sizeof(float));
+
+                const int loc_id = item.get_local_id(2);
+                if (loc_id == 0) {
+                    slm_block_store<float, 64>(0, simd<float, 64>(0.0f));
+                }
+                barrier();
+
+                const int expert_idx = item.get_global_id(0);
+                const int token_idx = item.get_global_id(1);
+
+                if (token_idx >= experts_token_count_ptr[expert_idx]) {
+                    return;
+                }
+
+                const int token_start = experts_token_start_ptr[expert_idx];
+                bf16* scatter_token_base = scatter_tokens_ptr + (token_start + token_idx) * 2 * hidden_size;
+                int8_t* output_base = quant_tokens_ptr + (token_start + token_idx) * hidden_size;
+
+                float thread_max = 0.0f;
+
+                // Pass 1: Extrema tracking
+                for (int bid = loc_id; bid < num_blocks; bid += wg_size) {
+#pragma unroll
+                    for (int u = 0; u < UNROLL; ++u) {
+                        simd<bf16, CHUNK> x1 = block_load<bf16, CHUNK>(
+                            scatter_token_base + bid * BS + u * CHUNK, properties{cache_hint_L1<cache_hint::cached>, cache_hint_L2<cache_hint::cached>});
+                        simd<bf16, CHUNK> x2 = block_load<bf16, CHUNK>(
+                            scatter_token_base + hidden_size + bid * BS + u * CHUNK, properties{cache_hint_L1<cache_hint::cached>, cache_hint_L2<cache_hint::cached>});
+                        simd<float, CHUNK> scale = block_load<float, CHUNK>(
+                            smooth_scale_ptr + expert_idx * hidden_size + bid * BS + u * CHUNK, properties{cache_hint_L1<cache_hint::cached>, cache_hint_L2<cache_hint::cached>});
+
+                        simd<float, CHUNK> x1_f = x1;
+                        simd<float, CHUNK> x2_f = x2;
+
+                        simd<float, CHUNK> x1_silu = x1_f / (1.0f + sycl::ext::intel::esimd::exp(-x1_f));
+                        simd<float, CHUNK> swiglu_tokens = x1_silu * x2_f;
+
+                        simd<float, CHUNK> scaled_swiglu_tokens = swiglu_tokens * scale;
+                        simd<float, CHUNK> scaled_swiglu_tokens_abs = sycl::ext::intel::esimd::abs(scaled_swiglu_tokens);
+
+                        float max_value = hmax<float, float, CHUNK>(scaled_swiglu_tokens_abs);
+                        thread_max = std::max(thread_max, max_value);
+                    }
+                }
+
+                slm_block_store<float, 1>(loc_id * sizeof(float), thread_max);
+                barrier();
+
+                simd<float, 64> max_value_full = slm_block_load<float, 64>(0);
+                float max_value_final = hmax<float, float, 64>(max_value_full);
+
+                float this_token_scale = max_value_final / 127.0f;
+                float recip_scale = this_token_scale == 0.0f ? 1.0f : (1.0f / this_token_scale);
+
+                // Pass 2: Recompute, quantize, and store
+                for (int bid = loc_id; bid < num_blocks; bid += wg_size) {
+#pragma unroll
+                    for (int u = 0; u < UNROLL; ++u) {
+                        simd<bf16, CHUNK> x1 = block_load<bf16, CHUNK>(
+                            scatter_token_base + bid * BS + u * CHUNK, properties{cache_hint_L1<cache_hint::cached>, cache_hint_L2<cache_hint::cached>});
+                        simd<bf16, CHUNK> x2 = block_load<bf16, CHUNK>(
+                            scatter_token_base + hidden_size + bid * BS + u * CHUNK, properties{cache_hint_L1<cache_hint::cached>, cache_hint_L2<cache_hint::cached>});
+                        simd<float, CHUNK> scale = block_load<float, CHUNK>(
+                            smooth_scale_ptr + expert_idx * hidden_size + bid * BS + u * CHUNK, properties{cache_hint_L1<cache_hint::cached>, cache_hint_L2<cache_hint::cached>});
+
+                        simd<float, CHUNK> x1_f = x1;
+                        simd<float, CHUNK> x2_f = x2;
+
+                        simd<float, CHUNK> x1_silu = x1_f / (1.0f + sycl::ext::intel::esimd::exp(-x1_f));
+                        simd<float, CHUNK> swiglu_tokens = x1_silu * x2_f;
+
+                        simd<float, CHUNK> scaled_swiglu_tokens = swiglu_tokens * scale;
+
+                        simd<int8_t, CHUNK> scaled_swiglu_tokens_quant_out = rnde<float>(scaled_swiglu_tokens * recip_scale);
+
+                        block_store<int8_t, CHUNK>(
+                            output_base + bid * BS + u * CHUNK, scaled_swiglu_tokens_quant_out, properties{cache_hint_L1<cache_hint::write_back>, cache_hint_L2<cache_hint::write_back>});
+                    }
+                }
+
+                if (loc_id == 0) {
+                    block_store<float, 1>(
+                        per_token_scale_ptr + token_start + token_idx, simd<float, 1>(this_token_scale), properties{cache_hint_L1<cache_hint::write_back>, cache_hint_L2<cache_hint::write_back>});
+                }
+            });
+        });
+    };
+
+    if (hidden_size % 512 == 0) {
+        launch_swiglu(std::integral_constant<int, 8>{});
+    } else if (hidden_size % 256 == 0) {
+        launch_swiglu(std::integral_constant<int, 4>{});
+    } else if (hidden_size % 128 == 0) {
+        launch_swiglu(std::integral_constant<int, 2>{});
+    } else {
+        launch_swiglu(std::integral_constant<int, 1>{});
+    }
+}
 
 void moe_scatter_dynamic_quant(
     torch::Tensor& selected_experts,

--- a/csrc/moe/dynamic_quant_kernels.cpp
+++ b/csrc/moe/dynamic_quant_kernels.cpp
@@ -1,0 +1,166 @@
+#include "moe_ops.h"
+#include <sycl/sycl.hpp>
+#include <sycl/ext/intel/esimd.hpp>
+#include <ATen/ATen.h>
+#include <ATen/core/Tensor.h>
+
+#include "../utils.h"
+#include "../dispatch_utils.h"
+#include <sycl/ext/oneapi/bfloat16.hpp>
+
+using namespace sycl::ext::intel::esimd;
+using bf16 = sycl::ext::oneapi::bfloat16;
+
+
+void moe_scatter_dynamic_quant(
+    torch::Tensor& selected_experts,
+    torch::Tensor& moe_weights,
+    torch::Tensor& token_to_scatter_offset,
+    torch::Tensor& experts_token_count,
+    torch::Tensor& experts_token_start,
+    torch::Tensor& hidden_states,
+    torch::Tensor& experts_smooth_scale,
+    torch::Tensor& scatter_tokens,
+    torch::Tensor& scatter_per_token_scale,
+    torch::Tensor& scatter_tokens_offset,
+    int64_t shared_experts_num) {
+
+    auto& queue = vllm::xpu::vllmGetQueue();
+
+    int topk = selected_experts.size(1);
+    int n_tokens = selected_experts.size(0);
+    int n_expert = experts_token_count.size(0);
+    int hd_size = hidden_states.size(1);
+    int n_expert_total = n_expert + shared_experts_num;
+
+    auto selected_experts_ptr = selected_experts.data_ptr<int32_t>();
+    auto ext_tokens_cnt_ptr = experts_token_count.data_ptr<int32_t>();
+    auto ext_tokens_start_ptr = experts_token_start.data_ptr<int32_t>();
+    auto token_to_scatter_offset_ptr = token_to_scatter_offset.data_ptr<int32_t>();
+
+    // Pass 1: Global memory atomic token counting
+    auto e1 = queue.submit([&](sycl::handler& cgh) {
+        cgh.parallel_for(sycl::range<1>(n_tokens), [=](sycl::item<1> item) {
+            int token_idx = item.get_id(0);
+            for (int k = 0; k < topk; ++k) {
+                int expert_id = selected_experts_ptr[token_idx * topk + k];
+                sycl::atomic_ref<int32_t, sycl::memory_order::relaxed, sycl::memory_scope::device, sycl::access::address_space::global_space>
+                    atomic_cnt(ext_tokens_cnt_ptr[expert_id]);
+                token_to_scatter_offset_ptr[token_idx * topk + k] = atomic_cnt.fetch_add(1);
+            }
+        });
+    });
+
+    // Pass 2: Prefix sum for expert start indices
+    auto e2 = queue.submit([&](sycl::handler& cgh) {
+        cgh.depends_on(e1);
+        cgh.single_task([=]() {
+            int32_t sum = 0;
+            for(int i = 0; i < n_expert_total; ++i) {
+                ext_tokens_start_ptr[i] = sum;
+                sum += ext_tokens_cnt_ptr[i];
+            }
+        });
+    });
+
+    auto hidden_states_ptr = reinterpret_cast<bf16*>(hidden_states.data_ptr<at::BFloat16>());
+    auto smooth_scale_ptr = experts_smooth_scale.data_ptr<float>();
+    auto moe_weights_ptr = moe_weights.data_ptr<float>();
+    auto scatter_tokens_ptr = scatter_tokens.data_ptr<int8_t>();
+    auto scatter_per_token_scale_ptr = scatter_per_token_scale.data_ptr<float>();
+    auto scatter_tokens_offset_ptr = scatter_tokens_offset.data_ptr<int32_t>();
+
+    // Pass 3: Gather, quantize, and scatter
+    auto launch_step3 = [&](auto unroll_tag) {
+        constexpr int UNROLL = decltype(unroll_tag)::value;
+        constexpr int CHUNK = 64;
+        constexpr int BS = CHUNK * UNROLL;
+
+        int num_blocks = hd_size / BS;
+        int wg_size = std::min(num_blocks, 64);
+
+        queue.submit([&](sycl::handler& cgh) {
+            cgh.depends_on(e2);
+            cgh.parallel_for(sycl::nd_range<2>(sycl::range<2>(n_tokens * topk, wg_size), sycl::range<2>(1, wg_size)),
+            [=](sycl::nd_item<2> item) SYCL_ESIMD_KERNEL {
+                slm_init(64 * sizeof(float));
+
+                const int loc_id = item.get_local_id(1);
+
+                if (loc_id == 0) {
+                    simd<float, 64> zeros = 0.0f;
+                    slm_block_store<float, 64>(0, zeros);
+                }
+                barrier();
+
+                const int token_k_idx = item.get_group(0);
+                const int token_idx = token_k_idx / topk;
+
+                const int expert_id = selected_experts_ptr[token_k_idx];
+                const int offset = token_to_scatter_offset_ptr[token_k_idx];
+                const int expert_start = ext_tokens_start_ptr[expert_id];
+
+                const int target_idx = expert_start + offset;
+                const float weight = moe_weights_ptr[token_k_idx];
+
+                float thread_max = 0.0f;
+
+                for (int hd_bid = loc_id; hd_bid < num_blocks; hd_bid += wg_size) {
+#pragma unroll
+                    for (int u = 0; u < UNROLL; ++u) {
+                        simd<bf16, CHUNK> hidden = block_load<bf16, CHUNK>(
+                            hidden_states_ptr + token_idx * hd_size + hd_bid * BS + u * CHUNK, properties{cache_hint_L1<cache_hint::cached>, cache_hint_L2<cache_hint::cached>});
+                        simd<float, CHUNK> scale = block_load<float, CHUNK>(
+                            smooth_scale_ptr + expert_id * hd_size + hd_bid * BS + u * CHUNK, properties{cache_hint_L1<cache_hint::cached>, cache_hint_L2<cache_hint::cached>});
+
+                        simd<float, CHUNK> smoothed = simd<float, CHUNK>(hidden) * scale * weight;
+                        simd<float, CHUNK> smoothed_abs = sycl::ext::intel::esimd::abs(smoothed);
+
+                        float max_val = hmax<float, float, CHUNK>(smoothed_abs);
+                        thread_max = std::max(thread_max, max_val);
+                    }
+                }
+
+                slm_block_store<float, 1>(loc_id * sizeof(float), thread_max);
+                barrier();
+
+                simd<float, 64> max_value_full = slm_block_load<float, 64>(0);
+                float max_value_final = hmax<float, float, 64>(max_value_full);
+                float this_token_scale = max_value_final / 127.0f;
+                float recip_scale = this_token_scale == 0.0f ? 1.0f : (1.0f / this_token_scale);
+
+                for (int hd_bid = loc_id; hd_bid < num_blocks; hd_bid += wg_size) {
+#pragma unroll
+                    for (int u = 0; u < UNROLL; ++u) {
+                        simd<bf16, CHUNK> hidden = block_load<bf16, CHUNK>(
+                            hidden_states_ptr + token_idx * hd_size + hd_bid * BS + u * CHUNK, properties{cache_hint_L1<cache_hint::cached>, cache_hint_L2<cache_hint::cached>});
+                        simd<float, CHUNK> scale = block_load<float, CHUNK>(
+                            smooth_scale_ptr + expert_id * hd_size + hd_bid * BS + u * CHUNK, properties{cache_hint_L1<cache_hint::cached>, cache_hint_L2<cache_hint::cached>});
+
+                        simd<float, CHUNK> smoothed = simd<float, CHUNK>(hidden) * scale * weight;
+                        simd<int8_t, CHUNK> quantized = rnde<float>(smoothed * recip_scale);
+
+                        block_store<int8_t, CHUNK>(
+                            scatter_tokens_ptr + target_idx * hd_size + hd_bid * BS + u * CHUNK, quantized, properties{cache_hint_L1<cache_hint::write_back>, cache_hint_L2<cache_hint::write_back>});
+                    }
+                }
+
+                if (loc_id == 0) {
+                    block_store<float, 1>(scatter_per_token_scale_ptr + target_idx, simd<float, 1>(this_token_scale), properties{cache_hint_L1<cache_hint::write_back>, cache_hint_L2<cache_hint::write_back>});
+                    block_store<int32_t, 1>(scatter_tokens_offset_ptr + target_idx, simd<int32_t, 1>(token_idx), properties{cache_hint_L1<cache_hint::write_back>, cache_hint_L2<cache_hint::write_back>});
+                }
+            });
+        });
+    };
+
+    // Dispatch based on hidden size divisibility mapping to max stable unroll bounds
+    if (hd_size % 512 == 0) {
+        launch_step3(std::integral_constant<int, 8>{});
+    } else if (hd_size % 256 == 0) {
+        launch_step3(std::integral_constant<int, 4>{});
+    } else if (hd_size % 128 == 0) {
+        launch_step3(std::integral_constant<int, 2>{});
+    } else {
+        launch_step3(std::integral_constant<int, 1>{});
+    }
+}

--- a/csrc/moe/dynamic_quant_kernels.cpp
+++ b/csrc/moe/dynamic_quant_kernels.cpp
@@ -7,11 +7,45 @@
 #include "../utils.h"
 #include "../dispatch_utils.h"
 #include <sycl/ext/oneapi/bfloat16.hpp>
+#include <c10/core/DeviceGuard.h>
 
 using namespace sycl::ext::intel::esimd;
 using bf16 = sycl::ext::oneapi::bfloat16;
+using fp16 = sycl::half;
 
-void moe_swiglu_dynamic_quant(
+template <typename decl_tag> struct QuantMax;
+template <> struct QuantMax<int8_t> { static constexpr float value = 127.0f; };
+template <> struct QuantMax<uint8_t> { static constexpr float value = 448.0f; }; // e4m3fn max value
+
+// Vectorized software emulation for float32 -> float8_e4m3fn conversion
+template <int N>
+inline simd<uint8_t, N> fast_cvt_float_to_e4m3fn(simd<float, N> x) {
+    simd<uint32_t, N> bits = x.template bit_cast_view<uint32_t>();
+    simd<uint32_t, N> sign = (bits >> 24) & 0x80;
+    simd<uint32_t, N> abs_bits = bits & 0x7FFFFFFF;
+
+    // Rounding tie-to-even approximation (add half of the 20-bit shifted fractional part)
+    simd<uint32_t, N> rounded = abs_bits + 0x00080000;
+    
+    simd<int32_t, N> exp = (rounded >> 23) - 127 + 7;
+    simd<uint32_t, N> mantissa = (rounded & 0x7FFFFF) >> 20;
+
+    simd<uint8_t, N> res = 0;
+    
+    auto is_normal = (exp > 0) & (exp < 16);
+    auto is_overflow = exp >= 16;
+    auto is_underflow = exp <= 0;
+
+    res.merge(sign | (exp << 3) | mantissa, is_normal);
+    res.merge(sign | 0x7E, is_overflow); // 0x7E is 448.0 (Maximum e4m3fn value)
+    res.merge(sign, is_underflow);       // Fast fallback: flush subnormals to 0
+
+    return res;
+}
+
+
+template <typename T_in, typename T_out>
+void moe_swiglu_dynamic_quant_impl(
     torch::Tensor& scatter_tokens,
     torch::Tensor& smooth_scale,
     torch::Tensor& experts_token_count,
@@ -23,14 +57,15 @@ void moe_swiglu_dynamic_quant(
 
     auto& queue = vllm::xpu::vllmGetQueue();
 
-    auto scatter_tokens_ptr = reinterpret_cast<bf16*>(scatter_tokens.data_ptr<at::BFloat16>());
+    auto scatter_tokens_ptr = reinterpret_cast<T_in*>(scatter_tokens.data_ptr());
     auto smooth_scale_ptr = smooth_scale.data_ptr<float>();
     auto experts_token_count_ptr = experts_token_count.data_ptr<int32_t>();
     auto experts_token_start_ptr = experts_token_start.data_ptr<int32_t>();
-    auto quant_tokens_ptr = quant_tokens.data_ptr<int8_t>();
+    auto quant_tokens_ptr = reinterpret_cast<T_out*>(quant_tokens.data_ptr());
     auto per_token_scale_ptr = per_token_scale.data_ptr<float>();
 
     int hidden_size = scatter_tokens.size(1) / 2;
+    constexpr float quant_max = QuantMax<T_out>::value;
 
     auto launch_swiglu = [&](auto unroll_tag) {
         constexpr int UNROLL = decltype(unroll_tag)::value;
@@ -61,8 +96,8 @@ void moe_swiglu_dynamic_quant(
                 }
 
                 const int token_start = experts_token_start_ptr[expert_idx];
-                bf16* scatter_token_base = scatter_tokens_ptr + (token_start + token_idx) * 2 * hidden_size;
-                int8_t* output_base = quant_tokens_ptr + (token_start + token_idx) * hidden_size;
+                T_in* scatter_token_base = scatter_tokens_ptr + (token_start + token_idx) * 2 * hidden_size;
+                T_out* output_base = quant_tokens_ptr + (token_start + token_idx) * hidden_size;
 
                 float thread_max = 0.0f;
 
@@ -70,9 +105,9 @@ void moe_swiglu_dynamic_quant(
                 for (int bid = loc_id; bid < num_blocks; bid += wg_size) {
 #pragma unroll
                     for (int u = 0; u < UNROLL; ++u) {
-                        simd<bf16, CHUNK> x1 = block_load<bf16, CHUNK>(
+                        simd<T_in, CHUNK> x1 = block_load<T_in, CHUNK>(
                             scatter_token_base + bid * BS + u * CHUNK, properties{cache_hint_L1<cache_hint::cached>, cache_hint_L2<cache_hint::cached>});
-                        simd<bf16, CHUNK> x2 = block_load<bf16, CHUNK>(
+                        simd<T_in, CHUNK> x2 = block_load<T_in, CHUNK>(
                             scatter_token_base + hidden_size + bid * BS + u * CHUNK, properties{cache_hint_L1<cache_hint::cached>, cache_hint_L2<cache_hint::cached>});
                         simd<float, CHUNK> scale = block_load<float, CHUNK>(
                             smooth_scale_ptr + expert_idx * hidden_size + bid * BS + u * CHUNK, properties{cache_hint_L1<cache_hint::cached>, cache_hint_L2<cache_hint::cached>});
@@ -97,16 +132,17 @@ void moe_swiglu_dynamic_quant(
                 simd<float, 64> max_value_full = slm_block_load<float, 64>(0);
                 float max_value_final = hmax<float, float, 64>(max_value_full);
 
-                float this_token_scale = max_value_final / 127.0f;
-                float recip_scale = this_token_scale == 0.0f ? 1.0f : (1.0f / this_token_scale);
+                float raw_token_scale = max_value_final / quant_max;
+                float this_token_scale = raw_token_scale == 0.0f ? 1.0f : raw_token_scale;
+                float recip_scale = 1.0f / this_token_scale;
 
                 // Pass 2: Recompute, quantize, and store
                 for (int bid = loc_id; bid < num_blocks; bid += wg_size) {
 #pragma unroll
                     for (int u = 0; u < UNROLL; ++u) {
-                        simd<bf16, CHUNK> x1 = block_load<bf16, CHUNK>(
+                        simd<T_in, CHUNK> x1 = block_load<T_in, CHUNK>(
                             scatter_token_base + bid * BS + u * CHUNK, properties{cache_hint_L1<cache_hint::cached>, cache_hint_L2<cache_hint::cached>});
-                        simd<bf16, CHUNK> x2 = block_load<bf16, CHUNK>(
+                        simd<T_in, CHUNK> x2 = block_load<T_in, CHUNK>(
                             scatter_token_base + hidden_size + bid * BS + u * CHUNK, properties{cache_hint_L1<cache_hint::cached>, cache_hint_L2<cache_hint::cached>});
                         simd<float, CHUNK> scale = block_load<float, CHUNK>(
                             smooth_scale_ptr + expert_idx * hidden_size + bid * BS + u * CHUNK, properties{cache_hint_L1<cache_hint::cached>, cache_hint_L2<cache_hint::cached>});
@@ -119,9 +155,14 @@ void moe_swiglu_dynamic_quant(
 
                         simd<float, CHUNK> scaled_swiglu_tokens = swiglu_tokens * scale;
 
-                        simd<int8_t, CHUNK> scaled_swiglu_tokens_quant_out = rnde<float>(scaled_swiglu_tokens * recip_scale);
+                        simd<T_out, CHUNK> scaled_swiglu_tokens_quant_out;
+                        if constexpr (std::is_same_v<T_out, int8_t>) {
+                            scaled_swiglu_tokens_quant_out = rnde<float>(scaled_swiglu_tokens * recip_scale);
+                        } else {
+                            scaled_swiglu_tokens_quant_out = fast_cvt_float_to_e4m3fn<CHUNK>(scaled_swiglu_tokens * recip_scale);
+                        }
 
-                        block_store<int8_t, CHUNK>(
+                        block_store<T_out, CHUNK>(
                             output_base + bid * BS + u * CHUNK, scaled_swiglu_tokens_quant_out, properties{cache_hint_L1<cache_hint::write_back>, cache_hint_L2<cache_hint::write_back>});
                     }
                 }
@@ -145,7 +186,8 @@ void moe_swiglu_dynamic_quant(
     }
 }
 
-void moe_scatter_dynamic_quant(
+template <typename T_in, typename T_out>
+void moe_scatter_dynamic_quant_impl(
     torch::Tensor& selected_experts,
     torch::Tensor& moe_weights,
     torch::Tensor& token_to_scatter_offset,
@@ -164,7 +206,9 @@ void moe_scatter_dynamic_quant(
     int n_tokens = selected_experts.size(0);
     int n_expert = experts_token_count.size(0);
     int hd_size = hidden_states.size(1);
-    int n_expert_total = n_expert + shared_experts_num;
+    int n_expert_total = n_expert;
+    
+    constexpr float quant_max = QuantMax<T_out>::value;
 
     auto selected_experts_ptr = selected_experts.data_ptr<int32_t>();
     auto ext_tokens_cnt_ptr = experts_token_count.data_ptr<int32_t>();
@@ -196,10 +240,10 @@ void moe_scatter_dynamic_quant(
         });
     });
 
-    auto hidden_states_ptr = reinterpret_cast<bf16*>(hidden_states.data_ptr<at::BFloat16>());
+    auto hidden_states_ptr = reinterpret_cast<T_in*>(hidden_states.data_ptr());
     auto smooth_scale_ptr = experts_smooth_scale.data_ptr<float>();
     auto moe_weights_ptr = moe_weights.data_ptr<float>();
-    auto scatter_tokens_ptr = scatter_tokens.data_ptr<int8_t>();
+    auto scatter_tokens_ptr = reinterpret_cast<T_out*>(scatter_tokens.data_ptr());
     auto scatter_per_token_scale_ptr = scatter_per_token_scale.data_ptr<float>();
     auto scatter_tokens_offset_ptr = scatter_tokens_offset.data_ptr<int32_t>();
 
@@ -241,7 +285,7 @@ void moe_scatter_dynamic_quant(
                 for (int hd_bid = loc_id; hd_bid < num_blocks; hd_bid += wg_size) {
 #pragma unroll
                     for (int u = 0; u < UNROLL; ++u) {
-                        simd<bf16, CHUNK> hidden = block_load<bf16, CHUNK>(
+                        simd<T_in, CHUNK> hidden = block_load<T_in, CHUNK>(
                             hidden_states_ptr + token_idx * hd_size + hd_bid * BS + u * CHUNK, properties{cache_hint_L1<cache_hint::cached>, cache_hint_L2<cache_hint::cached>});
                         simd<float, CHUNK> scale = block_load<float, CHUNK>(
                             smooth_scale_ptr + expert_id * hd_size + hd_bid * BS + u * CHUNK, properties{cache_hint_L1<cache_hint::cached>, cache_hint_L2<cache_hint::cached>});
@@ -259,21 +303,28 @@ void moe_scatter_dynamic_quant(
 
                 simd<float, 64> max_value_full = slm_block_load<float, 64>(0);
                 float max_value_final = hmax<float, float, 64>(max_value_full);
-                float this_token_scale = max_value_final / 127.0f;
-                float recip_scale = this_token_scale == 0.0f ? 1.0f : (1.0f / this_token_scale);
+                float raw_token_scale = max_value_final / quant_max;
+                float this_token_scale = raw_token_scale == 0.0f ? 1.0f : raw_token_scale;
+                float recip_scale = 1.0f / this_token_scale;
 
                 for (int hd_bid = loc_id; hd_bid < num_blocks; hd_bid += wg_size) {
 #pragma unroll
                     for (int u = 0; u < UNROLL; ++u) {
-                        simd<bf16, CHUNK> hidden = block_load<bf16, CHUNK>(
+                        simd<T_in, CHUNK> hidden = block_load<T_in, CHUNK>(
                             hidden_states_ptr + token_idx * hd_size + hd_bid * BS + u * CHUNK, properties{cache_hint_L1<cache_hint::cached>, cache_hint_L2<cache_hint::cached>});
                         simd<float, CHUNK> scale = block_load<float, CHUNK>(
                             smooth_scale_ptr + expert_id * hd_size + hd_bid * BS + u * CHUNK, properties{cache_hint_L1<cache_hint::cached>, cache_hint_L2<cache_hint::cached>});
 
                         simd<float, CHUNK> smoothed = simd<float, CHUNK>(hidden) * scale * weight;
-                        simd<int8_t, CHUNK> quantized = rnde<float>(smoothed * recip_scale);
 
-                        block_store<int8_t, CHUNK>(
+                        simd<T_out, CHUNK> quantized;
+                        if constexpr (std::is_same_v<T_out, int8_t>) {
+                            quantized = rnde<float>(smoothed * recip_scale);
+                        } else {
+                            quantized = fast_cvt_float_to_e4m3fn<CHUNK>(smoothed * recip_scale);
+                        }
+
+                        block_store<T_out, CHUNK>(
                             scatter_tokens_ptr + target_idx * hd_size + hd_bid * BS + u * CHUNK, quantized, properties{cache_hint_L1<cache_hint::write_back>, cache_hint_L2<cache_hint::write_back>});
                     }
                 }
@@ -286,7 +337,6 @@ void moe_scatter_dynamic_quant(
         });
     };
 
-    // Dispatch based on hidden size divisibility mapping to max stable unroll bounds
     if (hd_size % 512 == 0) {
         launch_step3(std::integral_constant<int, 8>{});
     } else if (hd_size % 256 == 0) {
@@ -296,4 +346,74 @@ void moe_scatter_dynamic_quant(
     } else {
         launch_step3(std::integral_constant<int, 1>{});
     }
+}
+
+// Outer dispatch macros to select implementation
+#define DISPATCH_MOE_QUANT_IMPL(FUNC_NAME, ...) \
+    if (in_dtype == at::ScalarType::BFloat16 && out_dtype == at::ScalarType::Char) { \
+        FUNC_NAME<bf16, int8_t>(__VA_ARGS__); \
+    } else if (in_dtype == at::ScalarType::Half && out_dtype == at::ScalarType::Char) { \
+        FUNC_NAME<fp16, int8_t>(__VA_ARGS__); \
+    } else if (in_dtype == at::ScalarType::BFloat16 && out_dtype == at::ScalarType::Float8_e4m3fn) { \
+        FUNC_NAME<bf16, uint8_t>(__VA_ARGS__); \
+    } else if (in_dtype == at::ScalarType::Half && out_dtype == at::ScalarType::Float8_e4m3fn) { \
+        FUNC_NAME<fp16, uint8_t>(__VA_ARGS__); \
+    } else { \
+        TORCH_CHECK(false, "Unsupported in_dtype/out_dtype combination for dynamic quant."); \
+    }
+
+void moe_swiglu_dynamic_quant(
+    torch::Tensor& scatter_tokens,
+    torch::Tensor& smooth_scale,
+    torch::Tensor& experts_token_count,
+    torch::Tensor& experts_token_start,
+    torch::Tensor& quant_tokens,
+    torch::Tensor& per_token_scale,
+    int64_t total_experts_num,
+    int64_t max_token_num) {
+
+    at::DeviceGuard guard(scatter_tokens.device());
+
+    TORCH_CHECK(scatter_tokens.is_contiguous(), "scatter_tokens must be contiguous");
+    TORCH_CHECK(smooth_scale.is_contiguous(), "smooth_scale must be contiguous");
+    TORCH_CHECK(quant_tokens.is_contiguous(), "quant_tokens must be contiguous");
+
+    TORCH_CHECK(smooth_scale.scalar_type() == at::ScalarType::Float, "smooth_scale must be Float32");
+
+    auto in_dtype = scatter_tokens.scalar_type();
+    auto out_dtype = quant_tokens.scalar_type();
+
+    DISPATCH_MOE_QUANT_IMPL(moe_swiglu_dynamic_quant_impl, 
+                            scatter_tokens, smooth_scale, experts_token_count, 
+                            experts_token_start, quant_tokens, per_token_scale, 
+                            total_experts_num, max_token_num);
+}
+
+void moe_scatter_dynamic_quant(
+    torch::Tensor& selected_experts,
+    torch::Tensor& moe_weights,
+    torch::Tensor& token_to_scatter_offset,
+    torch::Tensor& experts_token_count,
+    torch::Tensor& experts_token_start,
+    torch::Tensor& hidden_states,
+    torch::Tensor& experts_smooth_scale,
+    torch::Tensor& scatter_tokens,
+    torch::Tensor& scatter_per_token_scale,
+    torch::Tensor& scatter_tokens_offset,
+    int64_t shared_experts_num) {
+
+    at::DeviceGuard guard(hidden_states.device());
+
+    TORCH_CHECK(hidden_states.is_contiguous() && scatter_tokens.is_contiguous(), "Tensors must be contiguous");
+    TORCH_CHECK(experts_smooth_scale.scalar_type() == at::ScalarType::Float, "experts_smooth_scale must be Float32");
+    TORCH_CHECK(experts_token_count.size(0) == experts_token_start.size(0), "Token count and start tensors must match in size");
+
+    auto in_dtype = hidden_states.scalar_type();
+    auto out_dtype = scatter_tokens.scalar_type();
+
+    DISPATCH_MOE_QUANT_IMPL(moe_scatter_dynamic_quant_impl,
+                            selected_experts, moe_weights, token_to_scatter_offset, 
+                            experts_token_count, experts_token_start, hidden_states, 
+                            experts_smooth_scale, scatter_tokens, scatter_per_token_scale, 
+                            scatter_tokens_offset, shared_experts_num);
 }

--- a/csrc/moe/moe_ops.h
+++ b/csrc/moe/moe_ops.h
@@ -123,3 +123,14 @@ void moe_scatter_dynamic_quant(
     torch::Tensor& scatter_per_token_scale,
     torch::Tensor& scatter_tokens_offset,
     int64_t shared_experts_num);
+
+void moe_swiglu_dynamic_quant(
+    torch::Tensor& scatter_tokens,
+    torch::Tensor& smooth_scale,
+    torch::Tensor& experts_token_count,
+    torch::Tensor& experts_token_start,
+    torch::Tensor& quant_tokens,
+    torch::Tensor& per_token_scale,
+    int64_t total_experts_num,
+    int64_t max_token_num);
+

--- a/csrc/moe/moe_ops.h
+++ b/csrc/moe/moe_ops.h
@@ -110,3 +110,16 @@ void remap_hidden_states(
     torch::Tensor& topk_ids,
     int64_t total_experts_num,
     int64_t local_experts_num);
+
+void moe_scatter_dynamic_quant(
+    torch::Tensor& selected_experts,
+    torch::Tensor& moe_weights,
+    torch::Tensor& token_to_scatter_offset,
+    torch::Tensor& experts_token_count,
+    torch::Tensor& experts_token_start,
+    torch::Tensor& hidden_states,
+    torch::Tensor& experts_smooth_scale,
+    torch::Tensor& scatter_tokens,
+    torch::Tensor& scatter_per_token_scale,
+    torch::Tensor& scatter_tokens_offset,
+    int64_t shared_experts_num);

--- a/csrc/moe/torch_bindings.cpp
+++ b/csrc/moe/torch_bindings.cpp
@@ -108,18 +108,18 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, m) {
   m.impl("remap_hidden_states", torch::kXPU, &remap_hidden_states);
 
   m.def(
-      "moe_scatter_dynamic_quant(Tensor! selected_experts, Tensor! moe_weights, "
+      "moe_scatter_dynamic_quant(Tensor selected_experts, Tensor moe_weights, "
       "Tensor! token_to_scatter_offset, Tensor! experts_token_count, "
-      "Tensor! experts_token_start, Tensor! hidden_states, "
-      "Tensor! experts_smooth_scale, Tensor! scatter_tokens, "
+      "Tensor! experts_token_start, Tensor hidden_states, "
+      "Tensor experts_smooth_scale, Tensor! scatter_tokens, "
       "Tensor! scatter_per_token_scale, Tensor! scatter_tokens_offset, "
       "int shared_experts_num) -> ()");
   m.impl(
       "moe_scatter_dynamic_quant", torch::kXPU, &moe_scatter_dynamic_quant);
 
   m.def(
-      "moe_swiglu_dynamic_quant(Tensor! scatter_tokens, Tensor! smooth_scale, "
-      "Tensor! experts_token_count, Tensor! experts_token_start, "
+      "moe_swiglu_dynamic_quant(Tensor scatter_tokens, Tensor smooth_scale, "
+      "Tensor experts_token_count, Tensor experts_token_start, "
       "Tensor! quant_tokens, Tensor! per_token_scale, "
       "int total_experts_num, int max_token_num) -> ()");
   m.impl(

--- a/csrc/moe/torch_bindings.cpp
+++ b/csrc/moe/torch_bindings.cpp
@@ -106,6 +106,24 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, m) {
       "local_experts_num) -> "
       "()");
   m.impl("remap_hidden_states", torch::kXPU, &remap_hidden_states);
+
+  m.def(
+      "moe_scatter_dynamic_quant(Tensor! selected_experts, Tensor! moe_weights, "
+      "Tensor! token_to_scatter_offset, Tensor! experts_token_count, "
+      "Tensor! experts_token_start, Tensor! hidden_states, "
+      "Tensor! experts_smooth_scale, Tensor! scatter_tokens, "
+      "Tensor! scatter_per_token_scale, Tensor! scatter_tokens_offset, "
+      "int shared_experts_num) -> ()");
+  m.impl(
+      "moe_scatter_dynamic_quant", torch::kXPU, &moe_scatter_dynamic_quant);
+
+  m.def(
+      "moe_swiglu_dynamic_quant(Tensor! scatter_tokens, Tensor! smooth_scale, "
+      "Tensor! experts_token_count, Tensor! experts_token_start, "
+      "Tensor! quant_tokens, Tensor! per_token_scale, "
+      "int total_experts_num, int max_token_num) -> ()");
+  m.impl(
+      "moe_swiglu_dynamic_quant", torch::kXPU, &moe_swiglu_dynamic_quant);
 }
 
 REGISTER_EXTENSION(TORCH_EXTENSION_NAME)

--- a/tests/register_ops.py
+++ b/tests/register_ops.py
@@ -21,6 +21,7 @@ def fused_add_rms_norm(input: torch.Tensor, residual: torch.Tensor,
                        weight: torch.Tensor, epsilon: float) -> None:
     torch.ops._C.fused_add_rms_norm(input, residual, weight, epsilon)
 
+
 def silu_and_mul(out: torch.Tensor, input: torch.Tensor) -> None:
     torch.ops._C.silu_and_mul(out, input)
 
@@ -483,6 +484,23 @@ def moe_scatter_dynamic_quant(
         experts_token_count, experts_token_start, hidden_states,
         experts_smooth_scale, scatter_tokens, scatter_per_token_scale,
         scatter_tokens_offset, shared_experts_num
+    )
+
+
+def moe_swiglu_dynamic_quant(
+    scatter_tokens: torch.Tensor,
+    smooth_scale: torch.Tensor,
+    experts_token_count: torch.Tensor,
+    experts_token_start: torch.Tensor,
+    quant_tokens: torch.Tensor,
+    per_token_scale: torch.Tensor,
+    total_experts_num: int,
+    max_token_num: int
+) -> None:
+    torch.ops._moe_C.moe_swiglu_dynamic_quant(
+        scatter_tokens, smooth_scale, experts_token_count,
+        experts_token_start, quant_tokens, per_token_scale,
+        total_experts_num, max_token_num
     )
 
 

--- a/tests/register_ops.py
+++ b/tests/register_ops.py
@@ -21,7 +21,6 @@ def fused_add_rms_norm(input: torch.Tensor, residual: torch.Tensor,
                        weight: torch.Tensor, epsilon: float) -> None:
     torch.ops._C.fused_add_rms_norm(input, residual, weight, epsilon)
 
-
 def silu_and_mul(out: torch.Tensor, input: torch.Tensor) -> None:
     torch.ops._C.silu_and_mul(out, input)
 
@@ -465,6 +464,26 @@ def topk_softmax(topk_weights: torch.Tensor, topk_ids: torch.Tensor,
                  bias: Optional[torch.Tensor]) -> None:
     torch.ops._moe_C.topk_softmax(topk_weights, topk_ids, token_expert_indices,
                                   gating_output, renormalize, bias)
+
+def moe_scatter_dynamic_quant(
+    selected_experts: torch.Tensor,
+    moe_weights: torch.Tensor,
+    token_to_scatter_offset: torch.Tensor,
+    experts_token_count: torch.Tensor,
+    experts_token_start: torch.Tensor,
+    hidden_states: torch.Tensor,
+    experts_smooth_scale: torch.Tensor,
+    scatter_tokens: torch.Tensor,
+    scatter_per_token_scale: torch.Tensor,
+    scatter_tokens_offset: torch.Tensor,
+    shared_experts_num: int
+) -> None:
+    torch.ops._moe_C.moe_scatter_dynamic_quant(
+        selected_experts, moe_weights, token_to_scatter_offset,
+        experts_token_count, experts_token_start, hidden_states,
+        experts_smooth_scale, scatter_tokens, scatter_per_token_scale,
+        scatter_tokens_offset, shared_experts_num
+    )
 
 
 def swap_blocks(

--- a/tests/test_moe_scatter_dynamic_quant.py
+++ b/tests/test_moe_scatter_dynamic_quant.py
@@ -1,0 +1,336 @@
+import os
+import csv
+import time
+import pytest
+import torch
+import statistics
+from collections import defaultdict
+
+import tests.register_ops as ops  # noqa: F401
+
+torch.manual_seed(42)
+
+CSV_FILENAME = "test_moe_scatter_quant.csv"
+_CACHE_FLUSH_TENSOR = None
+
+
+def _flush_cache(device: str):
+    global _CACHE_FLUSH_TENSOR
+    if _CACHE_FLUSH_TENSOR is None or _CACHE_FLUSH_TENSOR.device.type != device:
+        _CACHE_FLUSH_TENSOR = torch.empty(int(256 * 1024 * 1024 // 4), dtype=torch.int32, device=device)
+    _CACHE_FLUSH_TENSOR.zero_()
+
+
+@pytest.fixture(scope="session", autouse=True)
+def setup_csv():
+    categories = ["dtype", "num_tokens", "hidden_size", "topk", "num_experts"]
+
+    with open(CSV_FILENAME, "w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(categories + ["status", "custom_time_us", "custom_bw_gbps", "custom_tflops"])
+
+    yield
+
+    if not os.path.exists(CSV_FILENAME):
+        return
+
+    global_bw, global_tf, global_c_lat = [], [], []
+    global_pass = global_total = 0
+    grouped = defaultdict(lambda: defaultdict(lambda: {"bw": [], "tf": [], "c_lat": [], "passes": 0, "total": 0}))
+
+    with open(CSV_FILENAME, "r") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            status = row["status"]
+            global_total += 1
+            is_pass = (status == "PASS")
+
+            if is_pass:
+                global_pass += 1
+                try:
+                    bw, tf = float(row["custom_bw_gbps"]), float(row["custom_tflops"])
+                    c_lat = float(row["custom_time_us"])
+                    global_bw.append(bw)
+                    global_tf.append(tf)
+                    global_c_lat.append(c_lat)
+                except ValueError:
+                    is_pass = False
+
+            for cat in categories:
+                val = row[cat]
+                grouped[cat][val]["total"] += 1
+                if is_pass:
+                    grouped[cat][val]["passes"] += 1
+                    grouped[cat][val]["bw"].append(bw)
+                    grouped[cat][val]["tf"].append(tf)
+                    grouped[cat][val]["c_lat"].append(c_lat)
+
+    if global_total == 0:
+        return
+
+    g_pass_pct = (global_pass / global_total) * 100
+    g_mu_bw = sum(global_bw) / len(global_bw) if global_bw else 0
+    g_min_bw = min(global_bw) if global_bw else 0
+    g_max_bw = max(global_bw) if global_bw else 0
+
+    g_mu_tf = sum(global_tf) / len(global_tf) if global_tf else 0
+    g_min_tf = min(global_tf) if global_tf else 0
+    g_max_tf = max(global_tf) if global_tf else 0
+
+    g_mu_c_lat = sum(global_c_lat) / len(global_c_lat) if global_c_lat else 0
+
+    print("\n\n" + "=" * 120)
+    print(f"{'PARAMETER':<23} {'VALUE':<12} {'PASS%':<7} {'LATENCY (us)':<15} | {'BW (GB/s) [Mean / Min / Max]':<28} | {'TFLOPS [Mean / Min / Max]'}")
+    print("-" * 120)
+    print(f"{'Global Average':<23} {'-':<12} {g_pass_pct:<6.1f}% {g_mu_c_lat:<15.1f} | {g_mu_bw:<6.1f} / {g_min_bw:<6.1f} / {g_max_bw:<6.1f}       | {g_mu_tf:<6.3f} / {g_min_tf:<6.3f} / {g_max_tf:<6.3f}")
+    print("-" * 120)
+
+    for cat in categories:
+        print(f"{cat.upper().replace('_', ' ')}")
+        for val, data in grouped[cat].items():
+            pass_pct = (data["passes"] / data["total"]) * 100
+            valid = len(data["c_lat"]) > 0
+
+            grp_c_lat = sum(data["c_lat"]) / len(data["c_lat"]) if valid else 0.0
+            lat_str = f"{grp_c_lat:<15.1f}" if valid else "N/A"
+
+            mean_bw = sum(data['bw']) / len(data['bw']) if valid else 0
+            min_bw = min(data['bw']) if valid else 0
+            max_bw = max(data['bw']) if valid else 0
+
+            mean_tf = sum(data['tf']) / len(data['tf']) if valid else 0
+            min_tf = min(data['tf']) if valid else 0
+            max_tf = max(data['tf']) if valid else 0
+
+            print(f"{'':<23} {val:<12} {pass_pct:<6.1f}% {lat_str:<15} | "
+                  f"{mean_bw:<6.1f} / {min_bw:<6.1f} / {max_bw:<6.1f}       | "
+                  f"{mean_tf:<6.3f} / {min_tf:<6.3f} / {max_tf:<6.3f}")
+    print("=" * 120 + "\n")
+
+
+def baseline_moe_scatter(selected_experts, moe_weights, hidden_states, experts_smooth_scale, total_experts):
+    """Pure PyTorch vectorized baseline for MoE Scatter + Dynamic Quantization."""
+    num_tokens, topk = selected_experts.shape
+    hidden_size = hidden_states.shape[1]
+    device = hidden_states.device
+
+    out_tokens_count = torch.zeros(total_experts, dtype=torch.int32, device=device)
+    out_token_to_scatter_offset = torch.zeros_like(selected_experts, dtype=torch.int32)
+
+    # 1. Count and offsets
+    for t in range(num_tokens):
+        for k in range(topk):
+            exp = selected_experts[t, k].item()
+            out_token_to_scatter_offset[t, k] = out_tokens_count[exp].item()
+            out_tokens_count[exp] += 1
+
+    # 2. Prefix sum
+    out_tokens_start = torch.zeros_like(out_tokens_count)
+    out_tokens_start[1:] = torch.cumsum(out_tokens_count[:-1], dim=0)
+
+    # 3. Target mapping
+    flat_experts = selected_experts.flatten().long()
+    flat_offsets = out_token_to_scatter_offset.flatten()
+    target_idx = out_tokens_start[flat_experts] + flat_offsets
+
+    # 4. Gather & compute
+    h_expanded = hidden_states.float().repeat_interleave(topk, dim=0)
+    w_expanded = moe_weights.float().flatten().unsqueeze(-1)
+    s_extracted = experts_smooth_scale.float()[flat_experts]
+
+    smoothed = h_expanded * s_extracted * w_expanded
+
+    # 5. Quantize
+    max_vals = smoothed.abs().max(dim=-1).values
+    scale = max_vals / 127.0
+    scale = torch.where(scale == 0, torch.tensor(1.0, device=device), scale)
+    quantized = torch.round(smoothed / scale.unsqueeze(-1)).to(torch.int8)
+
+    # 6. Scatter outputs
+    total_scattered = num_tokens * topk
+    scatter_tokens = torch.zeros((total_scattered, hidden_size), dtype=torch.int8, device=device)
+    scatter_tokens[target_idx] = quantized
+
+    per_token_scale = torch.zeros(total_scattered, dtype=torch.float32, device=device)
+    per_token_scale[target_idx] = scale
+
+    tokens_offset = torch.zeros(total_scattered, dtype=torch.int32, device=device)
+    flat_t = torch.arange(num_tokens, device=device).repeat_interleave(topk).int()
+    tokens_offset[target_idx] = flat_t
+
+    unquantized_math = torch.zeros((total_scattered, hidden_size), dtype=torch.float32, device=device)
+    unquantized_math[target_idx] = smoothed
+
+    return (out_token_to_scatter_offset, out_tokens_count, out_tokens_start,
+            scatter_tokens, per_token_scale, tokens_offset, unquantized_math)
+
+
+#override pytest parameters when enable mini pytest
+MINI_PYTEST_PARAMS = {
+    "default": {
+        "num_tokens": [40, 80],
+        "hidden_size": [64, 256],
+        "topk": [5],
+        "num_experts": [64],
+    },
+}
+
+@pytest.mark.parametrize("num_tokens", [40, 80, 256, 4096])
+@pytest.mark.parametrize("hidden_size", [64, 256, 1024, 7168])
+@pytest.mark.parametrize("topk", [5, 8])
+@pytest.mark.parametrize("num_experts", [64, 256])
+def test_moe_scatter_dynamic_quant(num_tokens, hidden_size, topk, num_experts):
+    device = "xpu"
+    dtype = torch.bfloat16
+    shared_experts_num = 0
+
+    selected_experts = torch.rand((num_tokens, num_experts), device=device).topk(topk, dim=-1).indices.to(torch.int32)
+    moe_weights = torch.rand((num_tokens, topk), dtype=torch.float32, device=device)
+    hidden_states = torch.randn((num_tokens, hidden_size), dtype=dtype, device=device)
+    experts_smooth_scale = torch.rand((num_experts, hidden_size), dtype=torch.float32, device=device)
+
+    out_t_offset = torch.zeros_like(selected_experts)
+    out_t_count = torch.zeros(num_experts, dtype=torch.int32, device=device)
+    out_t_start = torch.zeros(num_experts, dtype=torch.int32, device=device)
+    out_scatter_tokens = torch.zeros((num_tokens * topk, hidden_size), dtype=torch.int8, device=device)
+    out_per_scale = torch.zeros(num_tokens * topk, dtype=torch.float32, device=device)
+    out_tokens_offset = torch.zeros(num_tokens * topk, dtype=torch.int32, device=device)
+
+    status = "FAIL"
+    custom_time_s = custom_bw = custom_tflops = 0.0
+    accuracy_check_total_time = prep_time = bench_time = bench_iters = 0.0
+
+    try:
+        accuracy_check_start_time = time.perf_counter()
+
+        # 1. Base Accuracy Reference
+        (ref_t_offset, ref_t_count, ref_t_start, ref_scatter_tokens,
+         ref_per_scale, ref_tokens_offset, ref_unquantized_tokens) = baseline_moe_scatter(
+             selected_experts, moe_weights, hidden_states, experts_smooth_scale, num_experts
+        )
+
+        # 2. XPU Kernel Output
+        torch.ops._moe_C.moe_scatter_dynamic_quant(
+            selected_experts, moe_weights, out_t_offset, out_t_count, out_t_start,
+            hidden_states, experts_smooth_scale, out_scatter_tokens, out_per_scale,
+            out_tokens_offset, shared_experts_num
+        )
+        torch.xpu.synchronize()
+
+        # 3. Accuracy Verifications
+        torch.testing.assert_close(out_t_count, ref_t_count)
+        torch.testing.assert_close(out_t_start, ref_t_start)
+
+        expert_ids = torch.zeros(num_tokens * topk, dtype=torch.int64, device=device)
+        for i in range(num_experts):
+            start, count = ref_t_start[i].item(), ref_t_count[i].item()
+            if count > 0:
+                expert_ids[start:start+count] = i
+
+        sort_key_custom = (expert_ids * num_tokens) + out_tokens_offset
+        sort_key_ref = (expert_ids * num_tokens) + ref_tokens_offset
+
+        sort_idx_custom = torch.argsort(sort_key_custom)
+        sort_idx_ref = torch.argsort(sort_key_ref)
+
+        torch.testing.assert_close(out_tokens_offset[sort_idx_custom], ref_tokens_offset[sort_idx_ref])
+        torch.testing.assert_close(out_per_scale[sort_idx_custom], ref_per_scale[sort_idx_ref], atol=1e-5, rtol=1e-5)
+
+        diff = (out_scatter_tokens[sort_idx_custom].int() - ref_scatter_tokens[sort_idx_ref].int()).abs()
+        assert diff.max().item() <= 1, "Quantized values diverge completely!"
+
+        custom_dequantized = out_scatter_tokens.float() * out_per_scale.unsqueeze(1)
+        flat_experts = selected_experts.long()
+
+        ref_indices = ref_t_start[flat_experts] + ref_t_offset
+        custom_indices = out_t_start[flat_experts] + out_t_offset
+
+        float_diff = (custom_dequantized[custom_indices] - ref_unquantized_tokens[ref_indices]).abs()
+        max_float_error = float_diff.max().item()
+        assert max_float_error < 0.5, f"Dequantized mathematical outputs diverge! Max float error: {max_float_error}"
+
+        accuracy_check_total_time = time.perf_counter() - accuracy_check_start_time
+
+        # 4. Performance Benchmarks
+        def bench_fn(warmup=2, profile=4, min_test_iters=25, max_test_iters=float("inf"), max_test_time=0.5, sleep_duration=0.05):
+            bench_prep_start_time = time.perf_counter()
+            # Warmup
+            for _ in range(warmup):
+                out_t_count.zero_()
+                torch.ops._moe_C.moe_scatter_dynamic_quant(
+                    selected_experts, moe_weights, out_t_offset, out_t_count, out_t_start,
+                    hidden_states, experts_smooth_scale, out_scatter_tokens, out_per_scale,
+                    out_tokens_offset, shared_experts_num
+                )
+            torch.xpu.synchronize()
+
+            # Profile
+            start_time = time.perf_counter()
+            for _ in range(profile):
+                out_t_count.zero_()
+                torch.ops._moe_C.moe_scatter_dynamic_quant(
+                    selected_experts, moe_weights, out_t_offset, out_t_count, out_t_start,
+                    hidden_states, experts_smooth_scale, out_scatter_tokens, out_per_scale,
+                    out_tokens_offset, shared_experts_num
+                )
+            torch.xpu.synchronize()
+            profile_latency = (time.perf_counter() - start_time) / profile
+
+            prefer_iters = int(max_test_time / profile_latency) if profile_latency > 0 else min_test_iters
+            prefer_iters = max(min_test_iters, min(prefer_iters, int(max_test_iters) if max_test_iters != float("inf") else prefer_iters))
+
+            time.sleep(sleep_duration)
+
+            # Warmup
+            for _ in range(warmup):
+                out_t_count.zero_()
+                torch.ops._moe_C.moe_scatter_dynamic_quant(
+                    selected_experts, moe_weights, out_t_offset, out_t_count, out_t_start,
+                    hidden_states, experts_smooth_scale, out_scatter_tokens, out_per_scale,
+                    out_tokens_offset, shared_experts_num
+                )
+            torch.xpu.synchronize()
+
+            bench_prep_total_time = time.perf_counter() - bench_prep_start_time
+
+            # Benchmark
+            start_time = time.perf_counter()
+            for _ in range(prefer_iters):
+                out_t_count.zero_()
+                torch.ops._moe_C.moe_scatter_dynamic_quant(
+                    selected_experts, moe_weights, out_t_offset, out_t_count, out_t_start,
+                    hidden_states, experts_smooth_scale, out_scatter_tokens, out_per_scale,
+                    out_tokens_offset, shared_experts_num
+                )
+            torch.xpu.synchronize()
+            total_time = time.perf_counter() - start_time
+
+            return total_time / prefer_iters, bench_prep_total_time, total_time, prefer_iters
+
+        custom_time_s, prep_time, bench_time, bench_iters = bench_fn()
+
+        # 5. Calculate Metrics
+        total_bytes = (num_tokens * hidden_size * 2) + \
+                      (num_experts * hidden_size * 4) + \
+                      (num_tokens * topk * 4) + \
+                      (num_tokens * topk * hidden_size * 1)
+        total_flops = num_tokens * topk * hidden_size * 2
+
+        custom_bw = (total_bytes / 1e9) / custom_time_s
+        custom_tflops = (total_flops / 1e12) / custom_time_s
+        status = "PASS"
+
+    except Exception as e:
+        status = "FAIL"
+        raise e
+    finally:
+        print(f"\n[Scatter Quant] Tok={num_tokens} Hid={hidden_size} TopK={topk} Exp={num_experts} | "
+              f"{status} | Custom: {custom_time_s*1e6:.2f} us ({custom_bw:.2f} GB/s) | "
+              f"Accuracy Time: {accuracy_check_total_time:.4f} s | Prep Time: {prep_time:.4f} s | "
+              f"Bench Time: {bench_time:.4f} s | Bench Iters: {int(bench_iters)}")
+
+        with open(CSV_FILENAME, "a", newline="") as f:
+            csv.writer(f).writerow([
+                "bfloat16", num_tokens, hidden_size, topk, num_experts, status,
+                custom_time_s * 1e6, custom_bw, custom_tflops
+            ])

--- a/tests/test_moe_scatter_dynamic_quant.py
+++ b/tests/test_moe_scatter_dynamic_quant.py
@@ -1,114 +1,11 @@
-import os
-import csv
-import time
 import pytest
 import torch
-import statistics
-from collections import defaultdict
 
 import tests.register_ops as ops  # noqa: F401
 
 torch.manual_seed(42)
 
-CSV_FILENAME = "test_moe_scatter_quant.csv"
-_CACHE_FLUSH_TENSOR = None
-
-
-def _flush_cache(device: str):
-    global _CACHE_FLUSH_TENSOR
-    if _CACHE_FLUSH_TENSOR is None or _CACHE_FLUSH_TENSOR.device.type != device:
-        _CACHE_FLUSH_TENSOR = torch.empty(int(256 * 1024 * 1024 // 4), dtype=torch.int32, device=device)
-    _CACHE_FLUSH_TENSOR.zero_()
-
-
-@pytest.fixture(scope="session", autouse=True)
-def setup_csv():
-    categories = ["dtype", "num_tokens", "hidden_size", "topk", "num_experts"]
-
-    with open(CSV_FILENAME, "w", newline="") as f:
-        writer = csv.writer(f)
-        writer.writerow(categories + ["status", "custom_time_us", "custom_bw_gbps", "custom_tflops"])
-
-    yield
-
-    if not os.path.exists(CSV_FILENAME):
-        return
-
-    global_bw, global_tf, global_c_lat = [], [], []
-    global_pass = global_total = 0
-    grouped = defaultdict(lambda: defaultdict(lambda: {"bw": [], "tf": [], "c_lat": [], "passes": 0, "total": 0}))
-
-    with open(CSV_FILENAME, "r") as f:
-        reader = csv.DictReader(f)
-        for row in reader:
-            status = row["status"]
-            global_total += 1
-            is_pass = (status == "PASS")
-
-            if is_pass:
-                global_pass += 1
-                try:
-                    bw, tf = float(row["custom_bw_gbps"]), float(row["custom_tflops"])
-                    c_lat = float(row["custom_time_us"])
-                    global_bw.append(bw)
-                    global_tf.append(tf)
-                    global_c_lat.append(c_lat)
-                except ValueError:
-                    is_pass = False
-
-            for cat in categories:
-                val = row[cat]
-                grouped[cat][val]["total"] += 1
-                if is_pass:
-                    grouped[cat][val]["passes"] += 1
-                    grouped[cat][val]["bw"].append(bw)
-                    grouped[cat][val]["tf"].append(tf)
-                    grouped[cat][val]["c_lat"].append(c_lat)
-
-    if global_total == 0:
-        return
-
-    g_pass_pct = (global_pass / global_total) * 100
-    g_mu_bw = sum(global_bw) / len(global_bw) if global_bw else 0
-    g_min_bw = min(global_bw) if global_bw else 0
-    g_max_bw = max(global_bw) if global_bw else 0
-
-    g_mu_tf = sum(global_tf) / len(global_tf) if global_tf else 0
-    g_min_tf = min(global_tf) if global_tf else 0
-    g_max_tf = max(global_tf) if global_tf else 0
-
-    g_mu_c_lat = sum(global_c_lat) / len(global_c_lat) if global_c_lat else 0
-
-    print("\n\n" + "=" * 120)
-    print(f"{'PARAMETER':<23} {'VALUE':<12} {'PASS%':<7} {'LATENCY (us)':<15} | {'BW (GB/s) [Mean / Min / Max]':<28} | {'TFLOPS [Mean / Min / Max]'}")
-    print("-" * 120)
-    print(f"{'Global Average':<23} {'-':<12} {g_pass_pct:<6.1f}% {g_mu_c_lat:<15.1f} | {g_mu_bw:<6.1f} / {g_min_bw:<6.1f} / {g_max_bw:<6.1f}       | {g_mu_tf:<6.3f} / {g_min_tf:<6.3f} / {g_max_tf:<6.3f}")
-    print("-" * 120)
-
-    for cat in categories:
-        print(f"{cat.upper().replace('_', ' ')}")
-        for val, data in grouped[cat].items():
-            pass_pct = (data["passes"] / data["total"]) * 100
-            valid = len(data["c_lat"]) > 0
-
-            grp_c_lat = sum(data["c_lat"]) / len(data["c_lat"]) if valid else 0.0
-            lat_str = f"{grp_c_lat:<15.1f}" if valid else "N/A"
-
-            mean_bw = sum(data['bw']) / len(data['bw']) if valid else 0
-            min_bw = min(data['bw']) if valid else 0
-            max_bw = max(data['bw']) if valid else 0
-
-            mean_tf = sum(data['tf']) / len(data['tf']) if valid else 0
-            min_tf = min(data['tf']) if valid else 0
-            max_tf = max(data['tf']) if valid else 0
-
-            print(f"{'':<23} {val:<12} {pass_pct:<6.1f}% {lat_str:<15} | "
-                  f"{mean_bw:<6.1f} / {min_bw:<6.1f} / {max_bw:<6.1f}       | "
-                  f"{mean_tf:<6.3f} / {min_tf:<6.3f} / {max_tf:<6.3f}")
-    print("=" * 120 + "\n")
-
-
-def baseline_moe_scatter(selected_experts, moe_weights, hidden_states, experts_smooth_scale, total_experts):
+def baseline_moe_scatter(selected_experts, moe_weights, hidden_states, experts_smooth_scale, total_experts, dst_dtype):
     """Pure PyTorch vectorized baseline for MoE Scatter + Dynamic Quantization."""
     num_tokens, topk = selected_experts.shape
     hidden_size = hidden_states.shape[1]
@@ -141,14 +38,19 @@ def baseline_moe_scatter(selected_experts, moe_weights, hidden_states, experts_s
     smoothed = h_expanded * s_extracted * w_expanded
 
     # 5. Quantize
+    quant_max = 448.0 if dst_dtype == torch.float8_e4m3fn else 127.0
     max_vals = smoothed.abs().max(dim=-1).values
-    scale = max_vals / 127.0
+    scale = max_vals / quant_max
     scale = torch.where(scale == 0, torch.tensor(1.0, device=device), scale)
-    quantized = torch.round(smoothed / scale.unsqueeze(-1)).to(torch.int8)
+    
+    if dst_dtype == torch.int8:
+        quantized = torch.round(smoothed / scale.unsqueeze(-1)).to(torch.int8)
+    else:
+        quantized = (smoothed / scale.unsqueeze(-1)).to(torch.float8_e4m3fn)
 
     # 6. Scatter outputs
     total_scattered = num_tokens * topk
-    scatter_tokens = torch.zeros((total_scattered, hidden_size), dtype=torch.int8, device=device)
+    scatter_tokens = torch.zeros((total_scattered, hidden_size), dtype=dst_dtype, device=device)
     scatter_tokens[target_idx] = quantized
 
     per_token_scale = torch.zeros(total_scattered, dtype=torch.float32, device=device)
@@ -168,169 +70,91 @@ def baseline_moe_scatter(selected_experts, moe_weights, hidden_states, experts_s
 #override pytest parameters when enable mini pytest
 MINI_PYTEST_PARAMS = {
     "default": {
-        "num_tokens": [40, 80],
-        "hidden_size": [64, 256],
+        "num_tokens": [256],
+        "hidden_size": [64],
         "topk": [5],
         "num_experts": [64],
     },
 }
 
-@pytest.mark.parametrize("num_tokens", [40, 80, 256, 4096])
-@pytest.mark.parametrize("hidden_size", [64, 256, 1024, 7168])
+@pytest.mark.parametrize("num_tokens", [64, 256])
+@pytest.mark.parametrize("hidden_size", [64, 256, 1024])
 @pytest.mark.parametrize("topk", [5, 8])
-@pytest.mark.parametrize("num_experts", [64, 256])
-def test_moe_scatter_dynamic_quant(num_tokens, hidden_size, topk, num_experts):
+@pytest.mark.parametrize("num_experts", [64])
+@pytest.mark.parametrize("shared_experts_num", [1])
+@pytest.mark.parametrize("src_dtype", [torch.bfloat16, torch.float16])
+@pytest.mark.parametrize("dst_dtype", [torch.int8, torch.float8_e4m3fn])
+def test_moe_scatter_dynamic_quant(num_tokens, hidden_size, topk, num_experts, shared_experts_num, src_dtype, dst_dtype):
     device = "xpu"
-    dtype = torch.bfloat16
-    shared_experts_num = 0
+    
+    total_experts = num_experts + shared_experts_num
+    total_topk = topk + shared_experts_num
 
-    selected_experts = torch.rand((num_tokens, num_experts), device=device).topk(topk, dim=-1).indices.to(torch.int32)
-    moe_weights = torch.rand((num_tokens, topk), dtype=torch.float32, device=device)
-    hidden_states = torch.randn((num_tokens, hidden_size), dtype=dtype, device=device)
-    experts_smooth_scale = torch.rand((num_experts, hidden_size), dtype=torch.float32, device=device)
+    # Base routing for normal experts
+    routed_experts = torch.rand((num_tokens, num_experts), device=device).topk(topk, dim=-1).indices.to(torch.int32)
+    
+    # Append shared experts (they always process every token, usually placed at the end of expert list)
+    if shared_experts_num > 0:
+        shared_ids = torch.arange(num_experts, total_experts, dtype=torch.int32, device=device).unsqueeze(0).expand(num_tokens, shared_experts_num)
+        selected_experts = torch.cat([routed_experts, shared_ids], dim=-1)
+    else:
+        selected_experts = routed_experts
+
+    moe_weights = torch.rand((num_tokens, total_topk), dtype=torch.float32, device=device)
+    hidden_states = torch.randn((num_tokens, hidden_size), dtype=src_dtype, device=device)
+    experts_smooth_scale = torch.rand((total_experts, hidden_size), dtype=torch.float32, device=device)
 
     out_t_offset = torch.zeros_like(selected_experts)
-    out_t_count = torch.zeros(num_experts, dtype=torch.int32, device=device)
-    out_t_start = torch.zeros(num_experts, dtype=torch.int32, device=device)
-    out_scatter_tokens = torch.zeros((num_tokens * topk, hidden_size), dtype=torch.int8, device=device)
-    out_per_scale = torch.zeros(num_tokens * topk, dtype=torch.float32, device=device)
-    out_tokens_offset = torch.zeros(num_tokens * topk, dtype=torch.int32, device=device)
+    out_t_count = torch.zeros(total_experts, dtype=torch.int32, device=device)
+    out_t_start = torch.zeros(total_experts, dtype=torch.int32, device=device)
+    out_scatter_tokens = torch.zeros((num_tokens * total_topk, hidden_size), dtype=dst_dtype, device=device)
+    out_per_scale = torch.zeros(num_tokens * total_topk, dtype=torch.float32, device=device)
+    out_tokens_offset = torch.zeros(num_tokens * total_topk, dtype=torch.int32, device=device)
 
-    status = "FAIL"
-    custom_time_s = custom_bw = custom_tflops = 0.0
-    accuracy_check_total_time = prep_time = bench_time = bench_iters = 0.0
+    # 1. Base Accuracy Reference
+    (ref_t_offset, ref_t_count, ref_t_start, ref_scatter_tokens,
+     ref_per_scale, ref_tokens_offset, ref_unquantized_tokens) = baseline_moe_scatter(
+         selected_experts, moe_weights, hidden_states, experts_smooth_scale, total_experts, dst_dtype
+    )
 
-    try:
-        accuracy_check_start_time = time.perf_counter()
+    # 2. XPU Kernel Output
+    torch.ops._moe_C.moe_scatter_dynamic_quant(
+        selected_experts, moe_weights, out_t_offset, out_t_count, out_t_start,
+        hidden_states, experts_smooth_scale, out_scatter_tokens, out_per_scale,
+        out_tokens_offset, shared_experts_num
+    )
+    torch.xpu.synchronize()
 
-        # 1. Base Accuracy Reference
-        (ref_t_offset, ref_t_count, ref_t_start, ref_scatter_tokens,
-         ref_per_scale, ref_tokens_offset, ref_unquantized_tokens) = baseline_moe_scatter(
-             selected_experts, moe_weights, hidden_states, experts_smooth_scale, num_experts
-        )
+    # 3. Accuracy Verifications
+    torch.testing.assert_close(out_t_count, ref_t_count)
+    torch.testing.assert_close(out_t_start, ref_t_start)
 
-        # 2. XPU Kernel Output
-        torch.ops._moe_C.moe_scatter_dynamic_quant(
-            selected_experts, moe_weights, out_t_offset, out_t_count, out_t_start,
-            hidden_states, experts_smooth_scale, out_scatter_tokens, out_per_scale,
-            out_tokens_offset, shared_experts_num
-        )
-        torch.xpu.synchronize()
+    expert_ids = torch.zeros(num_tokens * total_topk, dtype=torch.int64, device=device)
+    for i in range(total_experts):
+        start, count = ref_t_start[i].item(), ref_t_count[i].item()
+        if count > 0:
+            expert_ids[start:start+count] = i
 
-        # 3. Accuracy Verifications
-        torch.testing.assert_close(out_t_count, ref_t_count)
-        torch.testing.assert_close(out_t_start, ref_t_start)
+    sort_key_custom = (expert_ids * num_tokens) + out_tokens_offset
+    sort_key_ref = (expert_ids * num_tokens) + ref_tokens_offset
 
-        expert_ids = torch.zeros(num_tokens * topk, dtype=torch.int64, device=device)
-        for i in range(num_experts):
-            start, count = ref_t_start[i].item(), ref_t_count[i].item()
-            if count > 0:
-                expert_ids[start:start+count] = i
+    sort_idx_custom = torch.argsort(sort_key_custom)
+    sort_idx_ref = torch.argsort(sort_key_ref)
 
-        sort_key_custom = (expert_ids * num_tokens) + out_tokens_offset
-        sort_key_ref = (expert_ids * num_tokens) + ref_tokens_offset
+    torch.testing.assert_close(out_tokens_offset[sort_idx_custom], ref_tokens_offset[sort_idx_ref])
+    torch.testing.assert_close(out_per_scale[sort_idx_custom], ref_per_scale[sort_idx_ref], atol=1e-5, rtol=1e-5)
 
-        sort_idx_custom = torch.argsort(sort_key_custom)
-        sort_idx_ref = torch.argsort(sort_key_ref)
-
-        torch.testing.assert_close(out_tokens_offset[sort_idx_custom], ref_tokens_offset[sort_idx_ref])
-        torch.testing.assert_close(out_per_scale[sort_idx_custom], ref_per_scale[sort_idx_ref], atol=1e-5, rtol=1e-5)
-
+    if dst_dtype == torch.int8:
         diff = (out_scatter_tokens[sort_idx_custom].int() - ref_scatter_tokens[sort_idx_ref].int()).abs()
         assert diff.max().item() <= 1, "Quantized values diverge completely!"
 
-        custom_dequantized = out_scatter_tokens.float() * out_per_scale.unsqueeze(1)
-        flat_experts = selected_experts.long()
-
-        ref_indices = ref_t_start[flat_experts] + ref_t_offset
-        custom_indices = out_t_start[flat_experts] + out_t_offset
-
-        float_diff = (custom_dequantized[custom_indices] - ref_unquantized_tokens[ref_indices]).abs()
-        max_float_error = float_diff.max().item()
-        assert max_float_error < 0.5, f"Dequantized mathematical outputs diverge! Max float error: {max_float_error}"
-
-        accuracy_check_total_time = time.perf_counter() - accuracy_check_start_time
-
-        # 4. Performance Benchmarks
-        def bench_fn(warmup=2, profile=4, min_test_iters=25, max_test_iters=float("inf"), max_test_time=0.5, sleep_duration=0.05):
-            bench_prep_start_time = time.perf_counter()
-            # Warmup
-            for _ in range(warmup):
-                out_t_count.zero_()
-                torch.ops._moe_C.moe_scatter_dynamic_quant(
-                    selected_experts, moe_weights, out_t_offset, out_t_count, out_t_start,
-                    hidden_states, experts_smooth_scale, out_scatter_tokens, out_per_scale,
-                    out_tokens_offset, shared_experts_num
-                )
-            torch.xpu.synchronize()
-
-            # Profile
-            start_time = time.perf_counter()
-            for _ in range(profile):
-                out_t_count.zero_()
-                torch.ops._moe_C.moe_scatter_dynamic_quant(
-                    selected_experts, moe_weights, out_t_offset, out_t_count, out_t_start,
-                    hidden_states, experts_smooth_scale, out_scatter_tokens, out_per_scale,
-                    out_tokens_offset, shared_experts_num
-                )
-            torch.xpu.synchronize()
-            profile_latency = (time.perf_counter() - start_time) / profile
-
-            prefer_iters = int(max_test_time / profile_latency) if profile_latency > 0 else min_test_iters
-            prefer_iters = max(min_test_iters, min(prefer_iters, int(max_test_iters) if max_test_iters != float("inf") else prefer_iters))
-
-            time.sleep(sleep_duration)
-
-            # Warmup
-            for _ in range(warmup):
-                out_t_count.zero_()
-                torch.ops._moe_C.moe_scatter_dynamic_quant(
-                    selected_experts, moe_weights, out_t_offset, out_t_count, out_t_start,
-                    hidden_states, experts_smooth_scale, out_scatter_tokens, out_per_scale,
-                    out_tokens_offset, shared_experts_num
-                )
-            torch.xpu.synchronize()
-
-            bench_prep_total_time = time.perf_counter() - bench_prep_start_time
-
-            # Benchmark
-            start_time = time.perf_counter()
-            for _ in range(prefer_iters):
-                out_t_count.zero_()
-                torch.ops._moe_C.moe_scatter_dynamic_quant(
-                    selected_experts, moe_weights, out_t_offset, out_t_count, out_t_start,
-                    hidden_states, experts_smooth_scale, out_scatter_tokens, out_per_scale,
-                    out_tokens_offset, shared_experts_num
-                )
-            torch.xpu.synchronize()
-            total_time = time.perf_counter() - start_time
-
-            return total_time / prefer_iters, bench_prep_total_time, total_time, prefer_iters
-
-        custom_time_s, prep_time, bench_time, bench_iters = bench_fn()
-
-        # 5. Calculate Metrics
-        total_bytes = (num_tokens * hidden_size * 2) + \
-                      (num_experts * hidden_size * 4) + \
-                      (num_tokens * topk * 4) + \
-                      (num_tokens * topk * hidden_size * 1)
-        total_flops = num_tokens * topk * hidden_size * 2
-
-        custom_bw = (total_bytes / 1e9) / custom_time_s
-        custom_tflops = (total_flops / 1e12) / custom_time_s
-        status = "PASS"
-
-    except Exception as e:
-        status = "FAIL"
-        raise e
-    finally:
-        print(f"\n[Scatter Quant] Tok={num_tokens} Hid={hidden_size} TopK={topk} Exp={num_experts} | "
-              f"{status} | Custom: {custom_time_s*1e6:.2f} us ({custom_bw:.2f} GB/s) | "
-              f"Accuracy Time: {accuracy_check_total_time:.4f} s | Prep Time: {prep_time:.4f} s | "
-              f"Bench Time: {bench_time:.4f} s | Bench Iters: {int(bench_iters)}")
-
-        with open(CSV_FILENAME, "a", newline="") as f:
-            csv.writer(f).writerow([
-                "bfloat16", num_tokens, hidden_size, topk, num_experts, status,
-                custom_time_s * 1e6, custom_bw, custom_tflops
-            ])
+    custom_dequantized = out_scatter_tokens[sort_idx_custom].float() * out_per_scale[sort_idx_custom].unsqueeze(1)
+    ref_dequantized = ref_scatter_tokens[sort_idx_ref].float() * ref_per_scale[sort_idx_ref].unsqueeze(1)
+    
+    float_diff = (custom_dequantized - ref_dequantized).abs()
+        
+    if dst_dtype == torch.int8:
+        assert float_diff.max().item() < 0.5, f"INT8 dequantized math outputs diverge! Error: {float_diff.max().item()}"
+    else:
+        max_expected_error = 16.0 * out_per_scale.max().item() + 1e-3
+        assert float_diff.max().item() <= max_expected_error, f"FP8 dequantized math outputs diverge too broadly. Max error: {float_diff.max().item()} > Allowed: {max_expected_error}"

--- a/tests/test_moe_swiglu_dynamic_quant.py
+++ b/tests/test_moe_swiglu_dynamic_quant.py
@@ -1,0 +1,288 @@
+import os
+import csv
+import time
+import pytest
+import torch
+from collections import defaultdict
+
+import tests.register_ops as ops  # noqa: F401
+
+torch.manual_seed(42)
+
+CSV_FILENAME = "test_moe_swiglu_quant.csv"
+_CACHE_FLUSH_TENSOR = None
+
+
+def _flush_cache(device: str):
+    global _CACHE_FLUSH_TENSOR
+    if _CACHE_FLUSH_TENSOR is None or _CACHE_FLUSH_TENSOR.device.type != device:
+        _CACHE_FLUSH_TENSOR = torch.empty(int(256 * 1024 * 1024 // 4), dtype=torch.int32, device=device)
+    _CACHE_FLUSH_TENSOR.zero_()
+
+
+@pytest.fixture(scope="session", autouse=True)
+def setup_csv():
+    categories = ["dtype", "num_scattered", "hidden_size", "num_experts"]
+
+    with open(CSV_FILENAME, "w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(categories + ["status", "custom_time_us", "custom_bw_gbps", "custom_tflops"])
+
+    yield
+
+    if not os.path.exists(CSV_FILENAME):
+        return
+
+    global_bw, global_tf, global_c_lat = [], [], []
+    global_pass = global_total = 0
+    grouped = defaultdict(lambda: defaultdict(lambda: {"bw": [], "tf": [], "c_lat": [], "passes": 0, "total": 0}))
+
+    with open(CSV_FILENAME, "r") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            status = row["status"]
+            global_total += 1
+            is_pass = (status == "PASS")
+
+            if is_pass:
+                global_pass += 1
+                try:
+                    bw, tf = float(row["custom_bw_gbps"]), float(row["custom_tflops"])
+                    c_lat = float(row["custom_time_us"])
+                    global_bw.append(bw)
+                    global_tf.append(tf)
+                    global_c_lat.append(c_lat)
+                except ValueError:
+                    is_pass = False
+
+            for cat in categories:
+                val = row[cat]
+                grouped[cat][val]["total"] += 1
+                if is_pass:
+                    grouped[cat][val]["passes"] += 1
+                    grouped[cat][val]["bw"].append(bw)
+                    grouped[cat][val]["tf"].append(tf)
+                    grouped[cat][val]["c_lat"].append(c_lat)
+
+    if global_total == 0:
+        return
+
+    g_pass_pct = (global_pass / global_total) * 100
+    g_mu_bw = sum(global_bw) / len(global_bw) if global_bw else 0
+    g_min_bw = min(global_bw) if global_bw else 0
+    g_max_bw = max(global_bw) if global_bw else 0
+
+    g_mu_tf = sum(global_tf) / len(global_tf) if global_tf else 0
+    g_min_tf = min(global_tf) if global_tf else 0
+    g_max_tf = max(global_tf) if global_tf else 0
+
+    g_mu_c_lat = sum(global_c_lat) / len(global_c_lat) if global_c_lat else 0
+
+    print("\n\n" + "=" * 120)
+    print(f"{'PARAMETER':<23} {'VALUE':<12} {'PASS%':<7} {'LATENCY (us)':<15} | {'BW (GB/s) [Mean / Min / Max]':<28} | {'TFLOPS [Mean / Min / Max]'}")
+    print("-" * 120)
+    print(f"{'Global Average':<23} {'-':<12} {g_pass_pct:<6.1f}% {g_mu_c_lat:<15.1f} | {g_mu_bw:<6.1f} / {g_min_bw:<6.1f} / {g_max_bw:<6.1f}       | {g_mu_tf:<6.3f} / {g_min_tf:<6.3f} / {g_max_tf:<6.3f}")
+    print("-" * 120)
+
+    for cat in categories:
+        print(f"{cat.upper().replace('_', ' ')}")
+        for val, data in grouped[cat].items():
+            pass_pct = (data["passes"] / data["total"]) * 100
+            valid = len(data["c_lat"]) > 0
+
+            grp_c_lat = sum(data["c_lat"]) / len(data["c_lat"]) if valid else 0.0
+            lat_str = f"{grp_c_lat:<15.1f}" if valid else "N/A"
+
+            mean_bw = sum(data['bw']) / len(data['bw']) if valid else 0
+            min_bw = min(data['bw']) if valid else 0
+            max_bw = max(data['bw']) if valid else 0
+
+            mean_tf = sum(data['tf']) / len(data['tf']) if valid else 0
+            min_tf = min(data['tf']) if valid else 0
+            max_tf = max(data['tf']) if valid else 0
+
+            print(f"{'':<23} {val:<12} {pass_pct:<6.1f}% {lat_str:<15} | "
+                  f"{mean_bw:<6.1f} / {min_bw:<6.1f} / {max_bw:<6.1f}       | "
+                  f"{mean_tf:<6.3f} / {min_tf:<6.3f} / {max_tf:<6.3f}")
+    print("=" * 120 + "\n")
+
+
+def baseline_moe_swiglu(scatter_tokens, smooth_scale, experts_token_count, experts_token_start):
+    """Pure PyTorch vectorized baseline for MoE SwiGLU + Dynamic Quantization."""
+    num_experts = experts_token_count.shape[0]
+    hidden_size = scatter_tokens.shape[1] // 2
+    device = scatter_tokens.device
+
+    expert_ids = torch.arange(num_experts, device=device).repeat_interleave(experts_token_count)
+    token_scales = smooth_scale[expert_ids].float()
+
+    x1 = scatter_tokens[:, :hidden_size].float()
+    x2 = scatter_tokens[:, hidden_size:].float()
+
+    x1_silu = torch.nn.functional.silu(x1)
+    swiglu = x1_silu * x2
+    scaled = swiglu * token_scales
+
+    unquantized_math = scaled
+
+    max_vals = scaled.abs().max(dim=-1).values
+    scale = max_vals / 127.0
+    scale = torch.where(scale == 0, torch.tensor(1.0, device=device), scale)
+
+    quant_tokens = torch.round(scaled / scale.unsqueeze(-1)).to(torch.int8)
+    per_token_scale = scale
+
+    return quant_tokens, per_token_scale, unquantized_math
+
+#override pytest parameters when enable mini pytest
+MINI_PYTEST_PARAMS = {
+    "default": {
+        "num_scattered": [40, 80, 256],
+        "hidden_size": [64, 128, 256],
+        "num_experts": [64],
+    },
+}
+
+@pytest.mark.parametrize("num_scattered", [40, 80, 256, 1024, 4096])
+@pytest.mark.parametrize("hidden_size", [64, 128, 256, 1024, 2048, 4096, 7168])
+@pytest.mark.parametrize("num_experts", [64, 256])
+def test_moe_swiglu_dynamic_quant(num_scattered, hidden_size, num_experts):
+    device = "xpu"
+    dtype = torch.bfloat16
+
+    experts_token_count = torch.zeros(num_experts, dtype=torch.int32, device=device)
+    experts_token_start = torch.zeros(num_experts, dtype=torch.int32, device=device)
+
+    tokens_per_expert = num_scattered // num_experts
+    experts_token_count[:] = tokens_per_expert
+    experts_token_count[-1] = num_scattered - (tokens_per_expert * (num_experts - 1))
+
+    start = 0
+    max_token_num = 0
+    for i in range(num_experts):
+        experts_token_start[i] = start
+        start += experts_token_count[i].item()
+        if experts_token_count[i].item() > max_token_num:
+            max_token_num = experts_token_count[i].item()
+
+    scatter_tokens = torch.randn((num_scattered, hidden_size * 2), dtype=dtype, device=device)
+    smooth_scale = torch.rand((num_experts, hidden_size), dtype=torch.float32, device=device)
+
+    out_quant_tokens = torch.zeros((num_scattered, hidden_size), dtype=torch.int8, device=device)
+    out_per_scale = torch.zeros(num_scattered, dtype=torch.float32, device=device)
+
+    status = "FAIL"
+    custom_time_s = custom_bw = custom_tflops = 0.0
+    accuracy_check_total_time = prep_time = bench_time = bench_iters = 0.0
+
+    try:
+        accuracy_check_start_time = time.perf_counter()
+
+        # 1. Base Accuracy Reference
+        ref_quant_tokens, ref_per_scale, ref_unquantized_tokens = baseline_moe_swiglu(
+            scatter_tokens, smooth_scale, experts_token_count, experts_token_start
+        )
+
+        out_quant_tokens.zero_()
+        out_per_scale.zero_()
+
+        # 2. XPU Kernel Output
+        torch.ops._moe_C.moe_swiglu_dynamic_quant(
+            scatter_tokens, smooth_scale, experts_token_count, experts_token_start,
+            out_quant_tokens, out_per_scale, num_experts, max_token_num
+        )
+        torch.xpu.synchronize()
+
+        # 3. Accuracy Verifications
+        custom_dequantized = out_quant_tokens.float() * out_per_scale.unsqueeze(1)
+        float_diff = (custom_dequantized - ref_unquantized_tokens).abs()
+        max_float_error = float_diff.max().item()
+
+        torch.testing.assert_close(out_per_scale, ref_per_scale, atol=1e-5, rtol=1e-5)
+
+        diff = (out_quant_tokens.int() - ref_quant_tokens.int()).abs()
+        assert diff.max().item() <= 1, "Quantized values diverge completely!"
+        assert max_float_error < 0.5, f"Dequantized mathematical outputs diverge! Max float error: {max_float_error}"
+
+        accuracy_check_total_time = time.perf_counter() - accuracy_check_start_time
+
+        # 4. Benchmarks
+        def bench_fn(warmup=2, profile=4, min_test_iters=25, max_test_iters=float("inf"), max_test_time=0.3, sleep_duration=0.05):
+            bench_prep_start_time = time.perf_counter()
+            # Warmup
+            for _ in range(warmup):
+                torch.ops._moe_C.moe_swiglu_dynamic_quant(
+                    scatter_tokens, smooth_scale, experts_token_count, experts_token_start,
+                    out_quant_tokens, out_per_scale, num_experts, max_token_num
+                )
+            torch.xpu.synchronize()
+
+            # Profile
+            start_time = time.perf_counter()
+            for _ in range(profile):
+                torch.ops._moe_C.moe_swiglu_dynamic_quant(
+                    scatter_tokens, smooth_scale, experts_token_count, experts_token_start,
+                    out_quant_tokens, out_per_scale, num_experts, max_token_num
+                )
+            torch.xpu.synchronize()
+
+            profile_latency = (time.perf_counter() - start_time) / profile
+
+            prefer_iters = int(max_test_time / profile_latency) if profile_latency > 0 else min_test_iters
+            prefer_iters = max(min_test_iters, min(prefer_iters, int(max_test_iters) if max_test_iters != float("inf") else prefer_iters))
+
+            time.sleep(sleep_duration)
+
+            # Warmup
+            for _ in range(warmup):
+                torch.ops._moe_C.moe_swiglu_dynamic_quant(
+                    scatter_tokens, smooth_scale, experts_token_count, experts_token_start,
+                    out_quant_tokens, out_per_scale, num_experts, max_token_num
+                )
+            torch.xpu.synchronize()
+
+            bench_prep_total_time = time.perf_counter() - bench_prep_start_time
+
+            # Benchmark
+            start_time = time.perf_counter()
+            for _ in range(prefer_iters):
+                torch.ops._moe_C.moe_swiglu_dynamic_quant(
+                    scatter_tokens, smooth_scale, experts_token_count, experts_token_start,
+                    out_quant_tokens, out_per_scale, num_experts, max_token_num
+                )
+            torch.xpu.synchronize()
+            total_time = time.perf_counter() - start_time
+
+            return total_time / prefer_iters, bench_prep_total_time, total_time, prefer_iters
+
+        custom_time_s, prep_time, bench_time, bench_iters = bench_fn()
+
+        # 5. Metrics
+        # Bytes = Read Scatter 2*H (bf16), Read Scale H (f32), Write Quant H (int8), Write per_token 1 (f32)
+        total_bytes = (num_scattered * hidden_size * 2 * 2) + \
+                      (num_scattered * hidden_size * 4) + \
+                      (num_scattered * hidden_size * 1) + \
+                      (num_scattered * 4)
+
+        # Flops approx: silu + mul + scale + quant (rating at roughly 6 operations per element)
+        total_flops = num_scattered * hidden_size * 6
+
+        custom_bw = (total_bytes / 1e9) / custom_time_s
+        custom_tflops = (total_flops / 1e12) / custom_time_s
+        status = "PASS"
+
+    except Exception as e:
+        status = "FAIL"
+        raise e
+
+    finally:
+        print(f"\n[SwiGLU Quant] N={num_scattered} Hid={hidden_size} Exp={num_experts} | "
+              f"{status} | Custom: {custom_time_s*1e6:.2f} us ({custom_bw:.2f} GB/s) | "
+              f"Accuracy Time: {accuracy_check_total_time:.4f} s | Prep Time: {prep_time:.4f} s | "
+              f"Bench Time: {bench_time:.4f} s | Bench Iters: {int(bench_iters)}")
+
+        with open(CSV_FILENAME, "a", newline="") as f:
+            csv.writer(f).writerow([
+                "bfloat16", num_scattered, hidden_size, num_experts, status,
+                custom_time_s * 1e6, custom_bw, custom_tflops
+            ])

--- a/tests/test_moe_swiglu_dynamic_quant.py
+++ b/tests/test_moe_swiglu_dynamic_quant.py
@@ -1,113 +1,11 @@
-import os
-import csv
-import time
 import pytest
 import torch
-from collections import defaultdict
 
 import tests.register_ops as ops  # noqa: F401
 
 torch.manual_seed(42)
 
-CSV_FILENAME = "test_moe_swiglu_quant.csv"
-_CACHE_FLUSH_TENSOR = None
-
-
-def _flush_cache(device: str):
-    global _CACHE_FLUSH_TENSOR
-    if _CACHE_FLUSH_TENSOR is None or _CACHE_FLUSH_TENSOR.device.type != device:
-        _CACHE_FLUSH_TENSOR = torch.empty(int(256 * 1024 * 1024 // 4), dtype=torch.int32, device=device)
-    _CACHE_FLUSH_TENSOR.zero_()
-
-
-@pytest.fixture(scope="session", autouse=True)
-def setup_csv():
-    categories = ["dtype", "num_scattered", "hidden_size", "num_experts"]
-
-    with open(CSV_FILENAME, "w", newline="") as f:
-        writer = csv.writer(f)
-        writer.writerow(categories + ["status", "custom_time_us", "custom_bw_gbps", "custom_tflops"])
-
-    yield
-
-    if not os.path.exists(CSV_FILENAME):
-        return
-
-    global_bw, global_tf, global_c_lat = [], [], []
-    global_pass = global_total = 0
-    grouped = defaultdict(lambda: defaultdict(lambda: {"bw": [], "tf": [], "c_lat": [], "passes": 0, "total": 0}))
-
-    with open(CSV_FILENAME, "r") as f:
-        reader = csv.DictReader(f)
-        for row in reader:
-            status = row["status"]
-            global_total += 1
-            is_pass = (status == "PASS")
-
-            if is_pass:
-                global_pass += 1
-                try:
-                    bw, tf = float(row["custom_bw_gbps"]), float(row["custom_tflops"])
-                    c_lat = float(row["custom_time_us"])
-                    global_bw.append(bw)
-                    global_tf.append(tf)
-                    global_c_lat.append(c_lat)
-                except ValueError:
-                    is_pass = False
-
-            for cat in categories:
-                val = row[cat]
-                grouped[cat][val]["total"] += 1
-                if is_pass:
-                    grouped[cat][val]["passes"] += 1
-                    grouped[cat][val]["bw"].append(bw)
-                    grouped[cat][val]["tf"].append(tf)
-                    grouped[cat][val]["c_lat"].append(c_lat)
-
-    if global_total == 0:
-        return
-
-    g_pass_pct = (global_pass / global_total) * 100
-    g_mu_bw = sum(global_bw) / len(global_bw) if global_bw else 0
-    g_min_bw = min(global_bw) if global_bw else 0
-    g_max_bw = max(global_bw) if global_bw else 0
-
-    g_mu_tf = sum(global_tf) / len(global_tf) if global_tf else 0
-    g_min_tf = min(global_tf) if global_tf else 0
-    g_max_tf = max(global_tf) if global_tf else 0
-
-    g_mu_c_lat = sum(global_c_lat) / len(global_c_lat) if global_c_lat else 0
-
-    print("\n\n" + "=" * 120)
-    print(f"{'PARAMETER':<23} {'VALUE':<12} {'PASS%':<7} {'LATENCY (us)':<15} | {'BW (GB/s) [Mean / Min / Max]':<28} | {'TFLOPS [Mean / Min / Max]'}")
-    print("-" * 120)
-    print(f"{'Global Average':<23} {'-':<12} {g_pass_pct:<6.1f}% {g_mu_c_lat:<15.1f} | {g_mu_bw:<6.1f} / {g_min_bw:<6.1f} / {g_max_bw:<6.1f}       | {g_mu_tf:<6.3f} / {g_min_tf:<6.3f} / {g_max_tf:<6.3f}")
-    print("-" * 120)
-
-    for cat in categories:
-        print(f"{cat.upper().replace('_', ' ')}")
-        for val, data in grouped[cat].items():
-            pass_pct = (data["passes"] / data["total"]) * 100
-            valid = len(data["c_lat"]) > 0
-
-            grp_c_lat = sum(data["c_lat"]) / len(data["c_lat"]) if valid else 0.0
-            lat_str = f"{grp_c_lat:<15.1f}" if valid else "N/A"
-
-            mean_bw = sum(data['bw']) / len(data['bw']) if valid else 0
-            min_bw = min(data['bw']) if valid else 0
-            max_bw = max(data['bw']) if valid else 0
-
-            mean_tf = sum(data['tf']) / len(data['tf']) if valid else 0
-            min_tf = min(data['tf']) if valid else 0
-            max_tf = max(data['tf']) if valid else 0
-
-            print(f"{'':<23} {val:<12} {pass_pct:<6.1f}% {lat_str:<15} | "
-                  f"{mean_bw:<6.1f} / {min_bw:<6.1f} / {max_bw:<6.1f}       | "
-                  f"{mean_tf:<6.3f} / {min_tf:<6.3f} / {max_tf:<6.3f}")
-    print("=" * 120 + "\n")
-
-
-def baseline_moe_swiglu(scatter_tokens, smooth_scale, experts_token_count, experts_token_start):
+def baseline_moe_swiglu(scatter_tokens, smooth_scale, experts_token_count, experts_token_start, dst_dtype):
     """Pure PyTorch vectorized baseline for MoE SwiGLU + Dynamic Quantization."""
     num_experts = experts_token_count.shape[0]
     hidden_size = scatter_tokens.shape[1] // 2
@@ -125,11 +23,16 @@ def baseline_moe_swiglu(scatter_tokens, smooth_scale, experts_token_count, exper
 
     unquantized_math = scaled
 
+    quant_max = 448.0 if dst_dtype == torch.float8_e4m3fn else 127.0
     max_vals = scaled.abs().max(dim=-1).values
-    scale = max_vals / 127.0
+    scale = max_vals / quant_max
     scale = torch.where(scale == 0, torch.tensor(1.0, device=device), scale)
 
-    quant_tokens = torch.round(scaled / scale.unsqueeze(-1)).to(torch.int8)
+    if dst_dtype == torch.int8:
+        quant_tokens = torch.round(scaled / scale.unsqueeze(-1)).to(torch.int8)
+    else:
+        quant_tokens = (scaled / scale.unsqueeze(-1)).to(torch.float8_e4m3fn)
+        
     per_token_scale = scale
 
     return quant_tokens, per_token_scale, unquantized_math
@@ -137,18 +40,19 @@ def baseline_moe_swiglu(scatter_tokens, smooth_scale, experts_token_count, exper
 #override pytest parameters when enable mini pytest
 MINI_PYTEST_PARAMS = {
     "default": {
-        "num_scattered": [40, 80, 256],
+        "num_scattered": [64, 256],
         "hidden_size": [64, 128, 256],
         "num_experts": [64],
     },
 }
 
-@pytest.mark.parametrize("num_scattered", [40, 80, 256, 1024, 4096])
-@pytest.mark.parametrize("hidden_size", [64, 128, 256, 1024, 2048, 4096, 7168])
+@pytest.mark.parametrize("num_scattered", [64, 256, 1024, 4096])
+@pytest.mark.parametrize("hidden_size", [64, 128, 256, 1024, 4096])
 @pytest.mark.parametrize("num_experts", [64, 256])
-def test_moe_swiglu_dynamic_quant(num_scattered, hidden_size, num_experts):
+@pytest.mark.parametrize("src_dtype", [torch.bfloat16, torch.float16])
+@pytest.mark.parametrize("dst_dtype", [torch.int8, torch.float8_e4m3fn])
+def test_moe_swiglu_dynamic_quant(num_scattered, hidden_size, num_experts, src_dtype, dst_dtype):
     device = "xpu"
-    dtype = torch.bfloat16
 
     experts_token_count = torch.zeros(num_experts, dtype=torch.int32, device=device)
     experts_token_start = torch.zeros(num_experts, dtype=torch.int32, device=device)
@@ -165,124 +69,47 @@ def test_moe_swiglu_dynamic_quant(num_scattered, hidden_size, num_experts):
         if experts_token_count[i].item() > max_token_num:
             max_token_num = experts_token_count[i].item()
 
-    scatter_tokens = torch.randn((num_scattered, hidden_size * 2), dtype=dtype, device=device)
+    scatter_tokens = torch.randn((num_scattered, hidden_size * 2), dtype=src_dtype, device=device)
     smooth_scale = torch.rand((num_experts, hidden_size), dtype=torch.float32, device=device)
 
-    out_quant_tokens = torch.zeros((num_scattered, hidden_size), dtype=torch.int8, device=device)
+    out_quant_tokens = torch.zeros((num_scattered, hidden_size), dtype=dst_dtype, device=device)
     out_per_scale = torch.zeros(num_scattered, dtype=torch.float32, device=device)
 
-    status = "FAIL"
-    custom_time_s = custom_bw = custom_tflops = 0.0
-    accuracy_check_total_time = prep_time = bench_time = bench_iters = 0.0
+    # 1. Base Accuracy Reference
+    ref_quant_tokens, ref_per_scale, ref_unquantized_tokens = baseline_moe_swiglu(
+        scatter_tokens, smooth_scale, experts_token_count, experts_token_start, dst_dtype
+    )
 
-    try:
-        accuracy_check_start_time = time.perf_counter()
+    out_quant_tokens.zero_()
+    out_per_scale.zero_()
 
-        # 1. Base Accuracy Reference
-        ref_quant_tokens, ref_per_scale, ref_unquantized_tokens = baseline_moe_swiglu(
-            scatter_tokens, smooth_scale, experts_token_count, experts_token_start
-        )
+    # 2. XPU Kernel Output
+    torch.ops._moe_C.moe_swiglu_dynamic_quant(
+        scatter_tokens, smooth_scale, experts_token_count, experts_token_start,
+        out_quant_tokens, out_per_scale, num_experts, max_token_num
+    )
+    torch.xpu.synchronize()
 
-        out_quant_tokens.zero_()
-        out_per_scale.zero_()
+    # 3. Accuracy Verifications
+    assert out_quant_tokens.shape == ref_quant_tokens.shape, "Output quant shape mismatch!"
+    assert out_per_scale.shape == ref_per_scale.shape, "Output scale shape mismatch!"
 
-        # 2. XPU Kernel Output
-        torch.ops._moe_C.moe_swiglu_dynamic_quant(
-            scatter_tokens, smooth_scale, experts_token_count, experts_token_start,
-            out_quant_tokens, out_per_scale, num_experts, max_token_num
-        )
-        torch.xpu.synchronize()
+    torch.testing.assert_close(out_per_scale, ref_per_scale, atol=1e-5, rtol=1e-5)
 
-        # 3. Accuracy Verifications
-        custom_dequantized = out_quant_tokens.float() * out_per_scale.unsqueeze(1)
-        float_diff = (custom_dequantized - ref_unquantized_tokens).abs()
-        max_float_error = float_diff.max().item()
-
-        torch.testing.assert_close(out_per_scale, ref_per_scale, atol=1e-5, rtol=1e-5)
-
+    if dst_dtype == torch.int8:
         diff = (out_quant_tokens.int() - ref_quant_tokens.int()).abs()
         assert diff.max().item() <= 1, "Quantized values diverge completely!"
-        assert max_float_error < 0.5, f"Dequantized mathematical outputs diverge! Max float error: {max_float_error}"
-
-        accuracy_check_total_time = time.perf_counter() - accuracy_check_start_time
-
-        # 4. Benchmarks
-        def bench_fn(warmup=2, profile=4, min_test_iters=25, max_test_iters=float("inf"), max_test_time=0.3, sleep_duration=0.05):
-            bench_prep_start_time = time.perf_counter()
-            # Warmup
-            for _ in range(warmup):
-                torch.ops._moe_C.moe_swiglu_dynamic_quant(
-                    scatter_tokens, smooth_scale, experts_token_count, experts_token_start,
-                    out_quant_tokens, out_per_scale, num_experts, max_token_num
-                )
-            torch.xpu.synchronize()
-
-            # Profile
-            start_time = time.perf_counter()
-            for _ in range(profile):
-                torch.ops._moe_C.moe_swiglu_dynamic_quant(
-                    scatter_tokens, smooth_scale, experts_token_count, experts_token_start,
-                    out_quant_tokens, out_per_scale, num_experts, max_token_num
-                )
-            torch.xpu.synchronize()
-
-            profile_latency = (time.perf_counter() - start_time) / profile
-
-            prefer_iters = int(max_test_time / profile_latency) if profile_latency > 0 else min_test_iters
-            prefer_iters = max(min_test_iters, min(prefer_iters, int(max_test_iters) if max_test_iters != float("inf") else prefer_iters))
-
-            time.sleep(sleep_duration)
-
-            # Warmup
-            for _ in range(warmup):
-                torch.ops._moe_C.moe_swiglu_dynamic_quant(
-                    scatter_tokens, smooth_scale, experts_token_count, experts_token_start,
-                    out_quant_tokens, out_per_scale, num_experts, max_token_num
-                )
-            torch.xpu.synchronize()
-
-            bench_prep_total_time = time.perf_counter() - bench_prep_start_time
-
-            # Benchmark
-            start_time = time.perf_counter()
-            for _ in range(prefer_iters):
-                torch.ops._moe_C.moe_swiglu_dynamic_quant(
-                    scatter_tokens, smooth_scale, experts_token_count, experts_token_start,
-                    out_quant_tokens, out_per_scale, num_experts, max_token_num
-                )
-            torch.xpu.synchronize()
-            total_time = time.perf_counter() - start_time
-
-            return total_time / prefer_iters, bench_prep_total_time, total_time, prefer_iters
-
-        custom_time_s, prep_time, bench_time, bench_iters = bench_fn()
-
-        # 5. Metrics
-        # Bytes = Read Scatter 2*H (bf16), Read Scale H (f32), Write Quant H (int8), Write per_token 1 (f32)
-        total_bytes = (num_scattered * hidden_size * 2 * 2) + \
-                      (num_scattered * hidden_size * 4) + \
-                      (num_scattered * hidden_size * 1) + \
-                      (num_scattered * 4)
-
-        # Flops approx: silu + mul + scale + quant (rating at roughly 6 operations per element)
-        total_flops = num_scattered * hidden_size * 6
-
-        custom_bw = (total_bytes / 1e9) / custom_time_s
-        custom_tflops = (total_flops / 1e12) / custom_time_s
-        status = "PASS"
-
-    except Exception as e:
-        status = "FAIL"
-        raise e
-
-    finally:
-        print(f"\n[SwiGLU Quant] N={num_scattered} Hid={hidden_size} Exp={num_experts} | "
-              f"{status} | Custom: {custom_time_s*1e6:.2f} us ({custom_bw:.2f} GB/s) | "
-              f"Accuracy Time: {accuracy_check_total_time:.4f} s | Prep Time: {prep_time:.4f} s | "
-              f"Bench Time: {bench_time:.4f} s | Bench Iters: {int(bench_iters)}")
-
-        with open(CSV_FILENAME, "a", newline="") as f:
-            csv.writer(f).writerow([
-                "bfloat16", num_scattered, hidden_size, num_experts, status,
-                custom_time_s * 1e6, custom_bw, custom_tflops
-            ])
+        
+    custom_dequantized = out_quant_tokens.float() * out_per_scale.unsqueeze(1)
+    ref_dequantized = ref_quant_tokens.float() * ref_per_scale.unsqueeze(1)
+    
+    float_diff = (custom_dequantized - ref_dequantized).abs()
+        
+    if dst_dtype == torch.int8:
+        # INT8 has perfect correlation
+        assert float_diff.max().item() < 0.5, f"INT8 dequantized math outputs diverge! Error: {float_diff.max().item()}"
+    else:
+        # FP8 has massive steps between values at the top of its range (step size between 448 and 416 is 32)
+        # An absolute ULP rounding disagreement can manifest as a ~16.0 difference before applying the scale
+        max_expected_error = 16.0 * out_per_scale.max().item() + 1e-3
+        assert float_diff.max().item() <= max_expected_error, f"FP8 dequantized math outputs diverge too broadly. Max error: {float_diff.max().item()} > Allowed: {max_expected_error}"


### PR DESCRIPTION
This kernel adds optimized ops for moe_scatter_dynamic_quant and moe_swiglu_dynamic_quant, following the request by ByteDance for support for these ops. In performance measurements, these ops were within a few percent of the same kernels on IPEX, and in most cases exceeded IPEX's bandwidth.