### PR TITLE
fix the bias missing issue when run fp8/fp4 gemm benchmark

### DIFF
--- a/tests/register_ops.py
+++ b/tests/register_ops.py
@@ -334,7 +334,8 @@ def int4_gemm_w4a8(input: torch.Tensor,
 def fp8_gemm(input: torch.Tensor, weight: torch.Tensor,
              out_dtype: Optional[torch.dtype],
              scale_act: Optional[torch.Tensor],
-             scale_wei: Optional[torch.Tensor], bias: Optional[torch.Tensor]):
+             scale_wei: Optional[torch.Tensor],
+             bias: Optional[torch.Tensor] = None):
     return torch.ops._xpu_C.fp8_gemm(input, weight, out_dtype, scale_act,
                                      scale_wei, bias)
 
@@ -345,7 +346,7 @@ def fp4_gemm(
     scale_act: torch.Tensor,
     scale_wei: torch.Tensor,
     out_dtype: Optional[torch.dtype],
-    bias: Optional[torch.Tensor],
+    bias: Optional[torch.Tensor] = None,
 ):
     return torch.ops._xpu_C.fp4_gemm(input, weight, scale_act, scale_wei,
                                      out_dtype, bias)

--- a/tests/test_fp4_gemm_onednn.py
+++ b/tests/test_fp4_gemm_onednn.py
@@ -68,7 +68,6 @@ def test_mxfp4_gemm(mnk_factors, out_dtype):
         inputs_scale,
         weights_scale,
         out_dtype,
-        torch.Tensor(),
     )
 
     output_ref = torch.matmul(inputs_hp.to(out_dtype),


### PR DESCRIPTION
This PR fixed below error:
"TypeError: fp8_gemm() missing 1 required positional argument: 'bias' "
when run below test case:
"python benchmark_gemm_onednn.py --benchmarks fp8"

Similar issue for fp4 was fixed too.