### PR TITLE
add the roofline analysis metrics for gemm, attention and MoE benchmarks

### DIFF
--- a/benchmark/benchmark_cutlass_flash_attn_decode.py
+++ b/benchmark/benchmark_cutlass_flash_attn_decode.py
@@ -4,6 +4,7 @@
 
 # isort: off
 import gc
+from pathlib import Path
 
 import torch
 import triton
@@ -26,6 +27,9 @@ from benchmark.presets import get_hardware_preset
 # isort: on
 
 DEVICE = "xpu"
+DEFAULT_PEAK_FP8_TFLOPS = 197.0
+DEFAULT_PEAK_BF16_TFLOPS = 98.5
+DEFAULT_PEAK_BW_GBS = 456.0
 
 
 def clear_xpu_cache():
@@ -47,6 +51,127 @@ def calculate_memory_usage(q_len_sum, kv_len_sum, num_heads, head_size,
         torch.tensor([], dtype=output_dtype).element_size()
     # Convert to GB
     return (query_memory + kv_cache_memory + output_memory) / (1000**3)
+
+
+def calculate_flops(num_query_heads, query_lens, kv_lens, head_size):
+    total = 0
+    for sq, sk in zip(query_lens, kv_lens):
+        total += 4 * num_query_heads * sq * sk * head_size
+    return total
+
+
+def calculate_memory_bytes(query_lens, kv_lens, num_query_heads, num_kv_heads,
+                           head_size, output_dtype, q_dtype):
+    q_tensor_dtype = output_dtype if q_dtype is None else q_dtype
+    q_elem = torch.tensor([], dtype=q_tensor_dtype).element_size()
+    kv_elem = q_elem
+    out_elem = torch.tensor([], dtype=output_dtype).element_size()
+
+    q_tokens = sum(query_lens)
+    kv_tokens = sum(kv_lens)
+    q_bytes = q_tokens * num_query_heads * head_size * q_elem
+    kv_bytes = 2 * kv_tokens * num_kv_heads * head_size * kv_elem
+    out_bytes = q_tokens * num_query_heads * head_size * out_elem
+    return q_bytes + kv_bytes + out_bytes
+
+
+def _row_peak_tflops(row):
+    has_fp8 = row.get("q_dtype") is not None
+    return DEFAULT_PEAK_FP8_TFLOPS if has_fp8 else DEFAULT_PEAK_BF16_TFLOPS
+
+
+def _resolve_metric_col(df, preferred, fallback_prefix):
+    if preferred in df.columns:
+        return preferred
+    if fallback_prefix in df.columns:
+        return fallback_prefix
+    matches = [
+        col for col in df.columns
+        if str(col).startswith(fallback_prefix)
+    ]
+    return matches[0] if matches else None
+
+
+def print_roofline_analysis(df):
+    analysis_df = df.copy()
+    for col in ["head_size", "block_size", "num_blocks"]:
+        if col in analysis_df.columns:
+            analysis_df[col] = analysis_df[col].astype(int)
+
+    tflops_col = _resolve_metric_col(
+        analysis_df,
+        "FlashAttention_TFLOPS (value)",
+        "FlashAttention_TFLOPS",
+    )
+    bw_col = _resolve_metric_col(
+        analysis_df,
+        "FlashAttention_memBandwidth(GB/s) (value)",
+        "FlashAttention_memBandwidth(GB/s)",
+    )
+    latency_col = _resolve_metric_col(
+        analysis_df,
+        "FlashAttention_kernelTime(us) (value)",
+        "FlashAttention_kernelTime(us)",
+    )
+
+    required_cols = [tflops_col, bw_col]
+    if any(col is None for col in required_cols):
+        print(
+            "Warning: skip roofline metrics because required columns are "
+            f"missing. columns={list(analysis_df.columns)}"
+        )
+        return analysis_df
+
+    analysis_df["peak_tflops"] = analysis_df.apply(_row_peak_tflops, axis=1)
+    analysis_df["%peak_tflops"] = (
+        analysis_df[tflops_col] / analysis_df["peak_tflops"] * 100.0
+    )
+    analysis_df["%peak_bw"] = (
+        analysis_df[bw_col] / DEFAULT_PEAK_BW_GBS * 100.0
+    )
+    analysis_df["AI(F/B)"] = (
+        analysis_df[tflops_col] * 1000.0 / analysis_df[bw_col]
+    )
+    analysis_df["roofline_tflops"] = (
+        analysis_df["AI(F/B)"] * DEFAULT_PEAK_BW_GBS / 1000.0
+    ).clip(upper=analysis_df["peak_tflops"])
+    analysis_df["eff_vs_roofline(%)"] = (
+        analysis_df[tflops_col] / analysis_df["roofline_tflops"] * 100.0
+    )
+
+    norm_ratio = (
+        analysis_df["%peak_tflops"]
+        / analysis_df["%peak_bw"].clip(lower=1e-6)
+    )
+    analysis_df["bound_hint"] = "mixed"
+    analysis_df.loc[norm_ratio > 1.25, "bound_hint"] = "compute-leaning"
+    analysis_df.loc[norm_ratio < 0.75, "bound_hint"] = "memory-leaning"
+
+    show_cols = [
+        "seq_lens",
+        "num_heads",
+        "head_size",
+        "q_dtype",
+        latency_col,
+        tflops_col,
+        bw_col,
+        "%peak_tflops",
+        "%peak_bw",
+        "AI(F/B)",
+        "roofline_tflops",
+        "eff_vs_roofline(%)",
+        "bound_hint",
+    ]
+    show_cols = [c for c in show_cols if c in analysis_df.columns]
+
+    print("flash_attn_decode_roofline_analysis:")
+    print(
+        analysis_df[show_cols].to_string(
+            index=False,
+            float_format=lambda x: f"{x:.4f}",
+        )
+    )
+    return analysis_df
 
 
 def make_decode_with_paged_kv_input(config):
@@ -168,6 +293,10 @@ def benchmark_decode_with_paged_kv(seq_lens, num_heads, head_size, block_size,
                     num_blocks, fa_versions, q_dtype, is_sink))
 
     num_seqs = int(seq_lens.split(",")[0])
+    query_lens = list(map(lambda x: int(x), seq_lens.split(",")[1].split("+")))
+    kv_lens = list(map(lambda x: int(x), seq_lens.split(",")[2].split("+")))
+    num_query_heads = num_heads[0]
+    num_kv_heads = num_heads[1]
     max_num_blocks_per_seq = (max_kv_len + block_size - 1) // block_size
 
     print(f"Running config: {seq_lens, num_heads, head_size, \
@@ -260,7 +389,12 @@ def benchmark_decode_with_paged_kv(seq_lens, num_heads, head_size, block_size,
             for i in range(iterations - 5)
         )
         ms = total_latency / (iterations - 5)
-        if provider == "flash_memBandwidth" or provider == "flash_MBU":
+        if provider in ("flash_memBandwidth", "flash_MBU", "flash_TFLOPS"):
+            if provider == "flash_TFLOPS":
+                flops = calculate_flops(num_query_heads, query_lens, kv_lens,
+                                        head_size)
+                clear_xpu_cache()
+                return flops / (ms / 1000) / 1e12
             memory_load_GB = calculate_memory_usage(cu_query_lens[-1].item(),
                                                     seq_k.sum().item(),
                                                     num_heads, head_size,
@@ -295,13 +429,14 @@ def get_benchmark_decode_with_paged_kv(iterations=20):
             x_vals=[tuple(c) for c in configs],
             line_arg="provider",
             line_vals=["flash", "flash_kernelTime", "flash_memBandwidth",
-                       "flash_MBU"],
+                       "flash_MBU", "flash_TFLOPS"],
             line_names=[
                 "FlashAttention(us)", "FlashAttention_kernelTime(us)",
-                "FlashAttention_memBandwidth(GB/s)", "FlashAttention_MBU (%)"
+                "FlashAttention_memBandwidth(GB/s)", "FlashAttention_MBU (%)",
+                "FlashAttention_TFLOPS"
             ],
             styles=[("blue", "-"), ("green", "-"), ("purple", "-"),
-                    ("red", "-")],
+                    ("red", "-"), ("orange", "-")],
             ylabel="Latency (us)",
             plot_name="flash-attn-decode",
             args={},
@@ -359,4 +494,14 @@ if __name__ == "__main__":
     benchmark = get_benchmark_decode_with_paged_kv(iterations=iterations)
     save_path = ensure_save_path_exists(args.save_path)
     # Run performance benchmark
-    benchmark.run(print_data=True, save_path=save_path)
+    perf_df = benchmark.run(
+        print_data=False,
+        save_path=save_path,
+        return_df=True,
+    )
+    analysis_df = print_roofline_analysis(perf_df)
+    bench_cfg = getattr(benchmark, "benchmarks", None)
+    bench_plot_name = getattr(bench_cfg, "plot_name", None)
+    if bench_plot_name is not None:
+        csv_path = Path(save_path) / f"{bench_plot_name}.csv"
+        analysis_df.to_csv(csv_path, index=False, float_format="%.6f")

--- a/benchmark/benchmark_cutlass_flash_attn_decode.py
+++ b/benchmark/benchmark_cutlass_flash_attn_decode.py
@@ -296,7 +296,6 @@ def benchmark_decode_with_paged_kv(seq_lens, num_heads, head_size, block_size,
     query_lens = list(map(lambda x: int(x), seq_lens.split(",")[1].split("+")))
     kv_lens = list(map(lambda x: int(x), seq_lens.split(",")[2].split("+")))
     num_query_heads = num_heads[0]
-    num_kv_heads = num_heads[1]
     max_num_blocks_per_seq = (max_kv_len + block_size - 1) // block_size
 
     print(f"Running config: {seq_lens, num_heads, head_size, \

--- a/benchmark/benchmark_cutlass_flash_attn_varlen.py
+++ b/benchmark/benchmark_cutlass_flash_attn_varlen.py
@@ -16,6 +16,9 @@ bootstrap_benchmark_env(__file__)
 from benchmark.src.flash_attn_interface_ import (
     flash_attn_varlen_func_CalKernelTime)
 from benchmark.src.get_model_config import (
+    gen_cutlass_flash_attn_varlen_correctness_configs as
+    gen_correctness_config)
+from benchmark.src.get_model_config import (
     gen_cutlass_flash_attn_varlen_perf_configs as gen_perf_configs)
 from tests.flash_attn.test_flash_attn_varlen_func import ref_paged_attn
 from tests.utils import parse_args, seed_everything
@@ -597,15 +600,15 @@ if __name__ == "__main__":
     torch.set_default_device("xpu")
     torch.xpu.set_device("xpu:0")
 
-    # configs = gen_correctness_config()
-    # configs = filter_configs(configs)
+    configs = gen_correctness_config()
+    configs = filter_configs(configs)
 
-    # for config in configs:
-    #     try:
-    #         calculate_diff_varlen_paged_kv(config)
-    #     except Exception as e:
-    #         print("Error in config: ", config, " error: ", e)
-    #     clear_xpu_cache()
+    for config in configs:
+        try:
+            calculate_diff_varlen_paged_kv(config)
+        except Exception as e:
+            print("Error in config: ", config, " error: ", e)
+        clear_xpu_cache()
 
     configs = gen_perf_configs()
     configs = filter_configs(configs)

--- a/benchmark/benchmark_cutlass_flash_attn_varlen.py
+++ b/benchmark/benchmark_cutlass_flash_attn_varlen.py
@@ -4,6 +4,7 @@
 
 # isort: off
 import gc
+from pathlib import Path
 
 import torch
 import triton
@@ -15,9 +16,6 @@ bootstrap_benchmark_env(__file__)
 from benchmark.src.flash_attn_interface_ import (
     flash_attn_varlen_func_CalKernelTime)
 from benchmark.src.get_model_config import (
-    gen_cutlass_flash_attn_varlen_correctness_configs as
-    gen_correctness_config)
-from benchmark.src.get_model_config import (
     gen_cutlass_flash_attn_varlen_perf_configs as gen_perf_configs)
 from tests.flash_attn.test_flash_attn_varlen_func import ref_paged_attn
 from tests.utils import parse_args, seed_everything
@@ -26,6 +24,9 @@ from benchmark.presets import get_hardware_preset
 # isort: on
 
 DEVICE = "xpu"
+DEFAULT_PEAK_FP8_TFLOPS = 197.0
+DEFAULT_PEAK_BF16_TFLOPS = 98.5
+DEFAULT_PEAK_BW_GBS = 456.0
 
 
 def clear_xpu_cache():
@@ -41,6 +42,130 @@ def calculate_flops(num_query_heads, query_lens, kv_lens, head_size,
         effective_sk = sk * 0.5 if is_causal else sk
         total += 4 * num_query_heads * sq * effective_sk * head_size
     return total
+
+
+def calculate_memory_bytes(query_lens, kv_lens, num_query_heads,
+                           num_kv_heads, head_size, output_dtype,
+                           q_dtype, kv_dtype):
+    q_tensor_dtype = output_dtype if q_dtype is None else q_dtype
+    kv_tensor_dtype = output_dtype if kv_dtype is None else kv_dtype
+    q_elem = torch.tensor([], dtype=q_tensor_dtype).element_size()
+    kv_elem = torch.tensor([], dtype=kv_tensor_dtype).element_size()
+    out_elem = torch.tensor([], dtype=output_dtype).element_size()
+
+    q_tokens = sum(query_lens)
+    kv_tokens = sum(kv_lens)
+    q_bytes = q_tokens * num_query_heads * head_size * q_elem
+    kv_bytes = 2 * kv_tokens * num_kv_heads * head_size * kv_elem
+    out_bytes = q_tokens * num_query_heads * head_size * out_elem
+    return q_bytes + kv_bytes + out_bytes
+
+
+def _row_peak_tflops(row):
+    has_fp8 = row.get("q_dtype") is not None or row.get("kv_dtype") is not None
+    return DEFAULT_PEAK_FP8_TFLOPS if has_fp8 else DEFAULT_PEAK_BF16_TFLOPS
+
+
+def _resolve_metric_col(df, candidates):
+    for col in candidates:
+        if col in df.columns:
+            return col
+    for candidate in candidates:
+        for col in df.columns:
+            if col.startswith(candidate):
+                return col
+    return None
+
+
+def print_roofline_analysis(df):
+    analysis_df = df.copy()
+    for col in ["num_seqs", "head_size", "block_size", "num_blocks"]:
+        if col in analysis_df.columns:
+            analysis_df[col] = analysis_df[col].astype(int)
+
+    tflops_col = _resolve_metric_col(
+        analysis_df,
+        [
+            "FlashAttention_TFLOPS (value)",
+            "FlashAttention_TFLOPS",
+        ],
+    )
+    bw_col = _resolve_metric_col(
+        analysis_df,
+        [
+            "FlashAttention_Kernel_Bandwidth(GB/s) (value)",
+            "FlashAttention_Kernel_Bandwidth(GB/s)",
+        ],
+    )
+    latency_col = _resolve_metric_col(
+        analysis_df,
+        [
+            "FlashAttention_Kernel_Time(us) (value)",
+            "FlashAttention_Kernel_Time(us)",
+            "FlashAttention(us) (value)",
+            "FlashAttention(us)",
+        ],
+    )
+
+    if tflops_col is None or bw_col is None:
+        print("Warning: roofline analysis skipped due to missing columns")
+        print(f"  available columns: {list(analysis_df.columns)}")
+        return analysis_df
+
+    analysis_df["peak_tflops"] = analysis_df.apply(_row_peak_tflops, axis=1)
+    analysis_df["%peak_tflops"] = (
+        analysis_df[tflops_col] / analysis_df["peak_tflops"] * 100.0
+    )
+    analysis_df["%peak_bw"] = (
+        analysis_df[bw_col] / DEFAULT_PEAK_BW_GBS * 100.0
+    )
+    analysis_df["AI(F/B)"] = (
+        analysis_df[tflops_col] * 1000.0 / analysis_df[bw_col]
+    )
+    analysis_df["roofline_tflops"] = (
+        analysis_df["AI(F/B)"] * DEFAULT_PEAK_BW_GBS / 1000.0
+    ).clip(upper=analysis_df["peak_tflops"])
+    analysis_df["eff_vs_roofline(%)"] = (
+        analysis_df[tflops_col] / analysis_df["roofline_tflops"] * 100.0
+    )
+    norm_ratio = (
+        analysis_df["%peak_tflops"]
+        / analysis_df["%peak_bw"].clip(lower=1e-6)
+    )
+    analysis_df["bound_hint"] = "mixed"
+    analysis_df.loc[norm_ratio > 1.25, "bound_hint"] = "compute-leaning"
+    analysis_df.loc[norm_ratio < 0.75, "bound_hint"] = "memory-leaning"
+
+    show_cols = [
+        "num_seqs",
+        "query_lens",
+        "kv_lens",
+        "num_heads",
+        "head_size",
+        "q_dtype",
+        "kv_dtype",
+        latency_col,
+        tflops_col,
+        bw_col,
+        "%peak_tflops",
+        "%peak_bw",
+        "AI(F/B)",
+        "roofline_tflops",
+        "eff_vs_roofline(%)",
+        "bound_hint",
+    ]
+    show_cols = [
+        c for c in show_cols if c is not None and c in analysis_df.columns
+    ]
+
+    print("flash_attn_varlen_roofline_analysis:")
+    print(
+        analysis_df[show_cols].to_string(
+            index=False,
+            float_format=lambda x: f"{x:.4f}",
+        )
+    )
+    return analysis_df
 
 
 def make_varlen_with_paged_kv_input(config):
@@ -230,6 +355,7 @@ def benchmark_varlen_with_paged_kv(num_seqs,
                 num_blocks, fa_versions, q_dtype, is_sink,
                 is_causal, is_paged, kv_dtype))
     num_query_heads = num_heads[0]
+    num_kv_heads = num_heads[1]
 
     print(f"Running config: {num_seqs, query_lens, kv_lens, \
                               num_heads, head_size, block_size, \
@@ -245,25 +371,26 @@ def benchmark_varlen_with_paged_kv(num_seqs,
     ]
 
     is_kernel_time_provider = provider in (
-        "flash_kernel_time", "flash_kernel_TFLOPS", "flash_kernel_MFU")
+        "flash_kernel_time", "flash_kernel_TFLOPS", "flash_kernel_MFU",
+        "flash_kernel_Bandwidth")
 
-    if is_kernel_time_provider:
-        start_events = [
-            torch.xpu.Event(enable_timing=True)
-            for _ in range(iterations - 5)
-        ]
-        end_events = [
-            torch.xpu.Event(enable_timing=True)
-            for _ in range(iterations - 5)
-        ]
+    start_events = [
+        torch.xpu.Event(enable_timing=True) for _ in range(iterations - 5)
+    ]
+    end_events = [
+        torch.xpu.Event(enable_timing=True) for _ in range(iterations - 5)
+    ]
+
+    for index in range(iterations):
+        se = start_events[index - 5] if index >= 5 else None
+        ee = end_events[index - 5] if index >= 5 else None
+
         if is_paged:
-            for index in range(iterations):
-                block_tables = torch.randint(
-                    0, num_blocks,
-                    (num_seqs, max_num_blocks_per_seq),
-                    dtype=torch.int32)
-                se = start_events[index - 5] if index >= 5 else None
-                ee = end_events[index - 5] if index >= 5 else None
+            block_tables = torch.randint(0,
+                                         num_blocks,
+                                         (num_seqs, max_num_blocks_per_seq),
+                                         dtype=torch.int32)
+            if is_kernel_time_provider:
                 flash_attn_varlen_func_CalKernelTime(
                     queries[index],
                     maybe_quantized_key_cache,
@@ -285,10 +412,31 @@ def benchmark_varlen_with_paged_kv(num_seqs,
                     s_aux=sink,
                     start_event=se,
                     end_event=ee)
+            else:
+                if index >= 5:
+                    start_events[index - 5].record()
+                flash_attn_varlen_func(queries[index],
+                                       maybe_quantized_key_cache,
+                                       maybe_quantized_value_cache,
+                                       max_query_len,
+                                       cu_query_lens,
+                                       max_kv_len,
+                                       seqused_k=seq_k,
+                                       q_descale=q_descale.expand(scale_shape)
+                                       if q_descale is not None else None,
+                                       k_descale=k_descale.expand(scale_shape)
+                                       if k_descale is not None else None,
+                                       v_descale=v_descale.expand(scale_shape)
+                                       if v_descale is not None else None,
+                                       softmax_scale=scale,
+                                       causal=is_causal,
+                                       block_table=block_tables,
+                                       window_size=window_size,
+                                       s_aux=sink)
+                if index >= 5:
+                    end_events[index - 5].record()
         else:
-            for index in range(iterations):
-                se = start_events[index - 5] if index >= 5 else None
-                ee = end_events[index - 5] if index >= 5 else None
+            if is_kernel_time_provider:
                 flash_attn_varlen_func_CalKernelTime(
                     queries[index],
                     maybe_quantized_key_cache,
@@ -310,126 +458,70 @@ def benchmark_varlen_with_paged_kv(num_seqs,
                     s_aux=sink,
                     start_event=se,
                     end_event=ee)
-        torch.xpu.synchronize()
-        total_latency = sum(
-            start_events[i].elapsed_time(end_events[i])
-            for i in range(iterations - 5)
-        )
-        ms = total_latency / (iterations - 5)
-        if provider == "flash_kernel_TFLOPS" or provider == "flash_kernel_MFU":
-            flops = calculate_flops(num_query_heads, query_lens, kv_lens,
-                                    head_size, is_causal)
-            tflops = flops / (ms / 1000) / 1e12
-            if provider == "flash_kernel_MFU":
-                hardware_presets = get_hardware_preset(
-                    torch.xpu.get_device_name())
-                if hardware_presets is None:
-                    clear_xpu_cache()
-                    return float("nan")
-                peak_tflops = hardware_presets["tflops"]
+            else:
+                if index >= 5:
+                    start_events[index - 5].record()
+                flash_attn_varlen_func(queries[index],
+                                       maybe_quantized_key_cache,
+                                       maybe_quantized_value_cache,
+                                       max_query_len,
+                                       cu_query_lens,
+                                       max_kv_len,
+                                       cu_seqlens_k=cu_kv_lens,
+                                       q_descale=q_descale.expand(scale_shape)
+                                       if q_descale is not None else None,
+                                       k_descale=k_descale.expand(scale_shape)
+                                       if k_descale is not None else None,
+                                       v_descale=v_descale.expand(scale_shape)
+                                       if v_descale is not None else None,
+                                       softmax_scale=scale,
+                                       causal=is_causal,
+                                       block_table=None,
+                                       window_size=window_size,
+                                       s_aux=sink)
+                if index >= 5:
+                    end_events[index - 5].record()
+
+    torch.xpu.synchronize()
+    total_latency = sum(
+        start_events[i].elapsed_time(end_events[i])
+        for i in range(iterations - 5)
+    )
+    ms = total_latency / (iterations - 5)
+
+    if provider in ("flash_kernel_TFLOPS", "flash_kernel_MFU"):
+        flops = calculate_flops(num_query_heads, query_lens, kv_lens,
+                                head_size, is_causal)
+        tflops = flops / (ms / 1000) / 1e12
+        if provider == "flash_kernel_MFU":
+            hardware_presets = get_hardware_preset(
+                torch.xpu.get_device_name())
+            if hardware_presets is None:
                 clear_xpu_cache()
-                return (tflops / peak_tflops) * 100
+                return float("nan")
+            peak_tflops = hardware_presets["tflops"]
             clear_xpu_cache()
-            return tflops
+            return (tflops / peak_tflops) * 100
         clear_xpu_cache()
-        return 1000 * ms
-    else:
-        start_event = torch.xpu.Event(enable_timing=True)
-        end_event = torch.xpu.Event(enable_timing=True)
-        if is_paged:
-            for index in range(5):
-                block_tables = torch.randint(
-                    0, num_blocks,
-                    (num_seqs, max_num_blocks_per_seq),
-                    dtype=torch.int32)
-                flash_attn_varlen_func(queries[index],
-                                       maybe_quantized_key_cache,
-                                       maybe_quantized_value_cache,
-                                       max_query_len,
-                                       cu_query_lens,
-                                       max_kv_len,
-                                       seqused_k=seq_k,
-                                       q_descale=q_descale.expand(scale_shape)
-                                       if q_descale is not None else None,
-                                       k_descale=k_descale.expand(scale_shape)
-                                       if k_descale is not None else None,
-                                       v_descale=v_descale.expand(scale_shape)
-                                       if v_descale is not None else None,
-                                       softmax_scale=scale,
-                                       causal=is_causal,
-                                       block_table=block_tables,
-                                       window_size=window_size,
-                                       s_aux=sink)
-            start_event.record()
-            for index in range(5, iterations):
-                block_tables = torch.randint(
-                    0, num_blocks,
-                    (num_seqs, max_num_blocks_per_seq),
-                    dtype=torch.int32)
-                flash_attn_varlen_func(queries[index],
-                                       maybe_quantized_key_cache,
-                                       maybe_quantized_value_cache,
-                                       max_query_len,
-                                       cu_query_lens,
-                                       max_kv_len,
-                                       seqused_k=seq_k,
-                                       q_descale=q_descale.expand(scale_shape)
-                                       if q_descale is not None else None,
-                                       k_descale=k_descale.expand(scale_shape)
-                                       if k_descale is not None else None,
-                                       v_descale=v_descale.expand(scale_shape)
-                                       if v_descale is not None else None,
-                                       softmax_scale=scale,
-                                       causal=is_causal,
-                                       block_table=block_tables,
-                                       window_size=window_size,
-                                       s_aux=sink)
-            end_event.record()
-        else:
-            for index in range(5):
-                flash_attn_varlen_func(queries[index],
-                                       maybe_quantized_key_cache,
-                                       maybe_quantized_value_cache,
-                                       max_query_len,
-                                       cu_query_lens,
-                                       max_kv_len,
-                                       cu_seqlens_k=cu_kv_lens,
-                                       q_descale=q_descale.expand(scale_shape)
-                                       if q_descale is not None else None,
-                                       k_descale=k_descale.expand(scale_shape)
-                                       if k_descale is not None else None,
-                                       v_descale=v_descale.expand(scale_shape)
-                                       if v_descale is not None else None,
-                                       softmax_scale=scale,
-                                       causal=is_causal,
-                                       block_table=None,
-                                       window_size=window_size,
-                                       s_aux=sink)
-            start_event.record()
-            for index in range(5, iterations):
-                flash_attn_varlen_func(queries[index],
-                                       maybe_quantized_key_cache,
-                                       maybe_quantized_value_cache,
-                                       max_query_len,
-                                       cu_query_lens,
-                                       max_kv_len,
-                                       cu_seqlens_k=cu_kv_lens,
-                                       q_descale=q_descale.expand(scale_shape)
-                                       if q_descale is not None else None,
-                                       k_descale=k_descale.expand(scale_shape)
-                                       if k_descale is not None else None,
-                                       v_descale=v_descale.expand(scale_shape)
-                                       if v_descale is not None else None,
-                                       softmax_scale=scale,
-                                       causal=is_causal,
-                                       block_table=None,
-                                       window_size=window_size,
-                                       s_aux=sink)
-            end_event.record()
-        torch.xpu.synchronize()
-        ms = start_event.elapsed_time(end_event) / (iterations - 5)
+        return tflops
+
+    if provider == "flash_kernel_Bandwidth":
+        memory_bytes = calculate_memory_bytes(
+            query_lens,
+            kv_lens,
+            num_query_heads,
+            num_kv_heads,
+            head_size,
+            output_dtype,
+            q_dtype,
+            kv_dtype,
+        )
+        bandwidth_gbs = memory_bytes / (ms / 1000) / 1e9
         clear_xpu_cache()
-        return 1000 * ms
+        return bandwidth_gbs
+
+    clear_xpu_cache()
+    return 1000 * ms
 
 
 def get_benchmark_varlen_with_paged_kv(iterations=20):
@@ -445,13 +537,14 @@ def get_benchmark_varlen_with_paged_kv(iterations=20):
             x_vals=[tuple(c) for c in configs],
             line_arg="provider",
             line_vals=["flash", "flash_kernel_time", "flash_kernel_TFLOPS",
-                       "flash_kernel_MFU"],
+                       "flash_kernel_MFU", "flash_kernel_Bandwidth"],
             line_names=[
                 "FlashAttention(us)", "FlashAttention_Kernel_Time(us)",
-                "FlashAttention_TFLOPS", "FlashAttention_MFU (%)"
+                "FlashAttention_TFLOPS", "FlashAttention_MFU (%)",
+                "FlashAttention_Kernel_Bandwidth(GB/s)"
             ],
             styles=[("blue", "-"), ("green", "-"), ("purple", "-"),
-                    ("red", "-")],
+                    ("red", "-"), ("orange", "-")],
             ylabel="Latency (us)",
             plot_name="flash-attn-varlen",
             args={},
@@ -504,19 +597,29 @@ if __name__ == "__main__":
     torch.set_default_device("xpu")
     torch.xpu.set_device("xpu:0")
 
-    configs = gen_correctness_config()
-    configs = filter_configs(configs)
+    # configs = gen_correctness_config()
+    # configs = filter_configs(configs)
 
-    for config in configs:
-        try:
-            calculate_diff_varlen_paged_kv(config)
-        except Exception as e:
-            print("Error in config: ", config, " error: ", e)
-        clear_xpu_cache()
+    # for config in configs:
+    #     try:
+    #         calculate_diff_varlen_paged_kv(config)
+    #     except Exception as e:
+    #         print("Error in config: ", config, " error: ", e)
+    #     clear_xpu_cache()
 
     configs = gen_perf_configs()
     configs = filter_configs(configs)
     benchmark = get_benchmark_varlen_with_paged_kv(iterations=iterations)
     save_path = ensure_save_path_exists(args.save_path)
     # Run performance benchmark
-    benchmark.run(print_data=True, save_path=save_path)
+    perf_df = benchmark.run(
+        print_data=False,
+        save_path=save_path,
+        return_df=True,
+    )
+    analysis_df = print_roofline_analysis(perf_df)
+    bench_cfg = getattr(benchmark, "benchmarks", None)
+    bench_plot_name = getattr(bench_cfg, "plot_name", None)
+    if bench_plot_name is not None:
+        csv_path = Path(save_path) / f"{bench_plot_name}.csv"
+        analysis_df.to_csv(csv_path, index=False, float_format="%.6f")

--- a/benchmark/benchmark_cutlass_fused_moe.py
+++ b/benchmark/benchmark_cutlass_fused_moe.py
@@ -4,6 +4,7 @@
 
 # isort: off
 import gc
+from pathlib import Path
 
 import torch
 import triton
@@ -24,6 +25,9 @@ from vllm_xpu_kernels.fused_moe_interface import xpu_fused_moe
 # isort: on
 
 DEVICE = "xpu"
+DEFAULT_PEAK_FP8_TFLOPS = 197.0
+DEFAULT_PEAK_BF16_TFLOPS = 98.5
+DEFAULT_PEAK_BW_GBS = 456.0
 
 def clear_xpu_cache():
     torch.xpu.empty_cache()
@@ -42,6 +46,129 @@ def calculate_memory_usage(m, n, k, num_experts, x_dtype, w_dtype=None):
         [], dtype=x_dtype if w_dtype is None else w_dtype).element_size() / (
             1000**3)  # in GB
     return io_memory + weight_memory
+
+
+def _row_peak_tflops(row):
+    return (
+        DEFAULT_PEAK_FP8_TFLOPS
+        if row.get("w_dtype") is not None
+        else DEFAULT_PEAK_BF16_TFLOPS
+    )
+
+
+def _resolve_metric_col(df, preferred, fallback_prefix):
+    if preferred in df.columns:
+        return preferred
+    if fallback_prefix in df.columns:
+        return fallback_prefix
+    matches = [
+        col for col in df.columns
+        if str(col).startswith(fallback_prefix)
+    ]
+    return matches[0] if matches else None
+
+
+def _append_roofline_metrics(df, tflops_col, bw_col, suffix):
+    peak_tflops_col = f"peak_tflops_{suffix}"
+    df[peak_tflops_col] = df.apply(_row_peak_tflops, axis=1)
+    df[f"%peak_tflops_{suffix}"] = df[tflops_col] / df[peak_tflops_col] * 100.0
+    df[f"%peak_bw_{suffix}"] = df[bw_col] / DEFAULT_PEAK_BW_GBS * 100.0
+    df[f"AI(F/B)_{suffix}"] = df[tflops_col] * 1000.0 / df[bw_col]
+    df[f"roofline_tflops_{suffix}"] = (
+        df[f"AI(F/B)_{suffix}"] * DEFAULT_PEAK_BW_GBS / 1000.0
+    ).clip(upper=df[peak_tflops_col])
+    df[f"eff_vs_roofline(%)_{suffix}"] = (
+        df[tflops_col] / df[f"roofline_tflops_{suffix}"] * 100.0
+    )
+
+    norm_ratio = (
+        df[f"%peak_tflops_{suffix}"]
+        / df[f"%peak_bw_{suffix}"].clip(lower=1e-6)
+    )
+    df[f"bound_hint_{suffix}"] = "mixed"
+    df.loc[norm_ratio > 1.25, f"bound_hint_{suffix}"] = "compute-leaning"
+    df.loc[norm_ratio < 0.75, f"bound_hint_{suffix}"] = "memory-leaning"
+
+
+def print_roofline_analysis(df):
+    analysis_df = df.copy()
+    for col in ["m", "n", "k", "num_experts", "topk"]:
+        if col in analysis_df.columns:
+            analysis_df[col] = analysis_df[col].astype(int)
+
+    gemm1_tflops_col = _resolve_metric_col(
+        analysis_df,
+        "vllm_kernel_gemm1_tflops (value)",
+        "vllm_kernel_gemm1_tflops",
+    )
+    gemm2_tflops_col = _resolve_metric_col(
+        analysis_df,
+        "vllm_kernel_gemm2_tflops (value)",
+        "vllm_kernel_gemm2_tflops",
+    )
+    gemm1_bw_col = _resolve_metric_col(
+        analysis_df,
+        "vllm_kernel_gemm1_memory(GB/s) (value)",
+        "vllm_kernel_gemm1_memory(GB/s)",
+    )
+    gemm2_bw_col = _resolve_metric_col(
+        analysis_df,
+        "vllm_kernel_gemm2_memory(GB/s) (value)",
+        "vllm_kernel_gemm2_memory(GB/s)",
+    )
+
+    required_cols = [
+        gemm1_tflops_col,
+        gemm2_tflops_col,
+        gemm1_bw_col,
+        gemm2_bw_col,
+    ]
+    if any(col is None for col in required_cols):
+        print(
+            "Warning: skip roofline metrics because required columns are "
+            f"missing. columns={list(analysis_df.columns)}"
+        )
+        return analysis_df
+
+    _append_roofline_metrics(analysis_df, gemm1_tflops_col, gemm1_bw_col,
+                             "gemm1")
+    _append_roofline_metrics(analysis_df, gemm2_tflops_col, gemm2_bw_col,
+                             "gemm2")
+
+    show_cols = [
+        "m",
+        "n",
+        "k",
+        "num_experts",
+        "topk",
+        "x_dtype",
+        "w_dtype",
+        gemm1_tflops_col,
+        gemm1_bw_col,
+        "%peak_tflops_gemm1",
+        "%peak_bw_gemm1",
+        "AI(F/B)_gemm1",
+        "roofline_tflops_gemm1",
+        "eff_vs_roofline(%)_gemm1",
+        "bound_hint_gemm1",
+        gemm2_tflops_col,
+        gemm2_bw_col,
+        "%peak_tflops_gemm2",
+        "%peak_bw_gemm2",
+        "AI(F/B)_gemm2",
+        "roofline_tflops_gemm2",
+        "eff_vs_roofline(%)_gemm2",
+        "bound_hint_gemm2",
+    ]
+    show_cols = [c for c in show_cols if c in analysis_df.columns]
+    print("fused_moe_roofline_analysis:")
+    print(
+        analysis_df[show_cols].to_string(
+            index=False,
+            float_format=lambda x: f"{x:.4f}",
+        )
+    )
+    return analysis_df
 
 
 def make_fused_moe_input(config):
@@ -385,4 +512,14 @@ if __name__ == "__main__":
     benchmark = get_benchmark(iterations=iterations)
     save_path = ensure_save_path_exists(args.save_path)
     # Run performance benchmark
-    benchmark.run(print_data=True, save_path=save_path)
+    perf_df = benchmark.run(
+        print_data=False,
+        save_path=save_path,
+        return_df=True,
+    )
+    analysis_df = print_roofline_analysis(perf_df)
+    bench_cfg = getattr(benchmark, "benchmarks", None)
+    bench_plot_name = getattr(bench_cfg, "plot_name", None)
+    if bench_plot_name is not None:
+        csv_path = Path(save_path) / f"{bench_plot_name}.csv"
+        analysis_df.to_csv(csv_path, index=False, float_format="%.6f")

--- a/benchmark/benchmark_gemm_onednn.py
+++ b/benchmark/benchmark_gemm_onednn.py
@@ -6,6 +6,7 @@
 import argparse
 import gc
 import itertools
+from pathlib import Path
 
 import torch
 import triton
@@ -39,6 +40,9 @@ ALL_BENCHMARKS = [
 ]
 
 DEVICE = "xpu"
+DEFAULT_PEAK_FP8_TFLOPS = 197.0
+DEFAULT_PEAK_BF16_TFLOPS = 98.5
+DEFAULT_PEAK_BW_GBS = 456.0
 
 
 def clear_xpu_cache():
@@ -60,6 +64,69 @@ def calculate_memory_bytes(m, n, k, x_dtype, w_dtype=None):
     out_elem = torch.tensor([], dtype=x_dtype).element_size()
     # input + weight + output
     return m * k * x_elem + k * n * w_elem + m * n * out_elem
+
+
+def _add_roofline_metrics(df, peak_tflops, peak_bw_gbs):
+    analysis_df = df.copy()
+    for col in ("m", "n", "k"):
+        if col in analysis_df.columns:
+            analysis_df[col] = analysis_df[col].astype(int)
+
+    tflops_col = "TFLOPS (value)"
+    bw_col = "Bandwidth (GB/s) (value)"
+
+    analysis_df["%peak_tflops"] = analysis_df[tflops_col] / peak_tflops * 100.0
+    analysis_df["%peak_bw"] = analysis_df[bw_col] / peak_bw_gbs * 100.0
+    analysis_df["AI(F/B)"] = (
+        analysis_df[tflops_col] * 1000.0 / analysis_df[bw_col]
+    )
+    analysis_df["roofline_tflops"] = (
+        analysis_df["AI(F/B)"] * peak_bw_gbs / 1000.0
+    ).clip(upper=peak_tflops)
+    analysis_df["eff_vs_roofline(%)"] = (
+        analysis_df[tflops_col] / analysis_df["roofline_tflops"] * 100.0
+    )
+
+    norm_ratio = analysis_df["%peak_tflops"] / analysis_df["%peak_bw"].clip(
+        lower=1e-6
+    )
+    analysis_df["bound_hint"] = "mixed"
+    analysis_df.loc[norm_ratio > 1.25, "bound_hint"] = "compute-leaning"
+    analysis_df.loc[norm_ratio < 0.75, "bound_hint"] = "memory-leaning"
+    return analysis_df
+
+
+def _print_roofline_analysis(plot_name, df, peak_tflops, peak_bw_gbs):
+    analysis_df = _add_roofline_metrics(df, peak_tflops, peak_bw_gbs)
+    latency_col = "Latency (us) (value)"
+    tflops_col = "TFLOPS (value)"
+    bw_col = "Bandwidth (GB/s) (value)"
+
+    prefix_cols = [
+        col
+        for col in ["m", "n", "k", "dtype", "out_dtype", "fp8_dtype"]
+        if col in analysis_df.columns
+    ]
+    show_cols = prefix_cols + [
+        latency_col,
+        tflops_col,
+        bw_col,
+        "%peak_tflops",
+        "%peak_bw",
+        "AI(F/B)",
+        "roofline_tflops",
+        "eff_vs_roofline(%)",
+        "bound_hint",
+    ]
+
+    print(f"{plot_name}_analysis:")
+    print(
+        analysis_df[show_cols].to_string(
+            index=False,
+            float_format=lambda x: f"{x:.4f}",
+        )
+    )
+    return analysis_df
 
 
 # ---------------------------------------------------------------------------
@@ -947,6 +1014,24 @@ def gemm_parse_args():
         default="./configs/gemm/",
         help="Path to save benchmark results",
     )
+    parser.add_argument(
+        "--peak-fp8-tflops",
+        type=float,
+        default=DEFAULT_PEAK_FP8_TFLOPS,
+        help="Peak FP8 TFLOPS for roofline analysis",
+    )
+    parser.add_argument(
+        "--peak-bf16-tflops",
+        type=float,
+        default=DEFAULT_PEAK_BF16_TFLOPS,
+        help="Peak BF16 TFLOPS for roofline analysis",
+    )
+    parser.add_argument(
+        "--peak-bw-gbs",
+        type=float,
+        default=DEFAULT_PEAK_BW_GBS,
+        help="Peak memory bandwidth (GB/s) for roofline analysis",
+    )
     args = parser.parse_args()
     if "all" in args.benchmarks:
         args.benchmarks = ALL_BENCHMARKS
@@ -1043,4 +1128,23 @@ if __name__ == "__main__":
         print(f"Performance: {label}{suffix}")
         print("=" * 60)
         bench = get_bench(configs, iterations)
-        bench.run(print_data=True, save_path=args.save_path)
+        perf_df = bench.run(
+            print_data=False,
+            save_path=args.save_path,
+            return_df=True,
+        )
+        peak_tflops = (
+            args.peak_bf16_tflops if name == "bf16" else args.peak_fp8_tflops
+        )
+        plot_name = label.replace(" ", "_").replace("(", "").replace(")", "")
+        analysis_df = _print_roofline_analysis(
+            plot_name=plot_name,
+            df=perf_df,
+            peak_tflops=peak_tflops,
+            peak_bw_gbs=args.peak_bw_gbs,
+        )
+        bench_cfg = getattr(bench, "benchmarks", None)
+        bench_plot_name = getattr(bench_cfg, "plot_name", None)
+        if bench_plot_name is not None:
+            csv_path = Path(args.save_path) / f"{bench_plot_name}.csv"
+            analysis_df.to_csv(csv_path, index=False, float_format="%.6f")

--- a/benchmark/src/get_model_config.py
+++ b/benchmark/src/get_model_config.py
@@ -14,6 +14,17 @@ model_lists = [
 ]
 
 
+def _safe_get_model_config(model: str, tp_size: int = 1):
+    try:
+        return get_model_config(model, tp_size=tp_size)
+    except Exception as error:
+        print(
+            "Warning: skip model config load failure: "
+            f"model={model}, error={error}"
+        )
+        return None
+
+
 def gen_cutlass_fused_moe_correctness_configs():
     mnk = [
         (1, 5120, 8192),
@@ -41,7 +52,9 @@ def gen_cutlass_fused_moe_perf_configs():
     input_lens = [1, 4, 16, 1024, 8192]
 
     for model in model_lists:
-        model_config = get_model_config(model, tp_size=1)
+        model_config = _safe_get_model_config(model, tp_size=1)
+        if model_config is None:
+            continue
         if not model_config["is_moe"]:
             continue
 
@@ -145,8 +158,8 @@ def gen_cutlass_flash_attn_varlen_correctness_configs():
 
 def gen_cutlass_flash_attn_varlen_perf_configs():
     num_seqs = [4]
-    query_lens = ["1024,2048,2048,8192"]
-    kv_lens = ["1024,1024,2048,8192"]
+    query_lens = ["1024,2048,2048"]
+    kv_lens = ["1024,1024,2048"]
 
     block_size = [64, 128]
     window_size = [(-1, -1)]
@@ -172,7 +185,9 @@ def gen_cutlass_flash_attn_varlen_perf_configs():
     def get_configs_from_models():
         configs = []
         for model in model_lists:
-            model_config = get_model_config(model, tp_size=1)
+            model_config = _safe_get_model_config(model, tp_size=1)
+            if model_config is None:
+                continue
             head_size = [model_config["head_dim"]]
             num_heads = [(model_config["num_attention_heads"],
                           model_config["num_key_value_heads"])]
@@ -274,7 +289,9 @@ def gen_cutlass_flash_attn_decode_perf_configs():
 
     configs = []
     for model in model_lists:
-        model_config = get_model_config(model, tp_size=1)
+        model_config = _safe_get_model_config(model, tp_size=1)
+        if model_config is None:
+            continue
         head_size = [model_config["head_dim"]]
         num_heads = [(model_config["num_attention_heads"],
                       model_config["num_key_value_heads"])]

--- a/benchmark/src/get_model_config.py
+++ b/benchmark/src/get_model_config.py
@@ -158,8 +158,8 @@ def gen_cutlass_flash_attn_varlen_correctness_configs():
 
 def gen_cutlass_flash_attn_varlen_perf_configs():
     num_seqs = [4]
-    query_lens = ["1024,2048,2048"]
-    kv_lens = ["1024,1024,2048"]
+    query_lens = ["1024,2048,2048,8192"]
+    kv_lens = ["1024,1024,2048,8192"]
 
     block_size = [64, 128]
     window_size = [(-1, -1)]


### PR DESCRIPTION
Below metrics were added.
- Arithmetic Intensity (AI): 
  AI(F/B) = TFLOPS * 1000 / Bandwidth(GB/s)
- roofline_tflops. 
  The best perf it can achieve. 
  roofline_tflops = min(peak_tflops, AI(F/B) * peak_bw_gbs / 1000)
- eff_vs_roofline(%). 
  The percentage of current TFLOPS vs roofline.
  eff_vs_roofline(%) = TFLOPS / roofline_tflops * 100
- bound_hint.
  Whether it is memory bound or compute bound.
  How to measure the bound hit?
  1, first to calculate norm_ratio = %peak_tflops / %peak_bw.
  2, if norm_ratio > 1.25 → compute-leaning 
      elif norm_ratio < 0.75 → memory-leaning 
      else mixed

Verified with below commands.
"
GEMM:
python benchmark_gemm_onednn.py --benchmarks bf16 --save-path ./roofline_analysis/

Attention Prefill:
python benchmark_cutlass_flash_attn_varlen.py --save-path ./roofline_analysis/

Attention Decode:
python benchmark_cutlass_flash_attn_decode.py --save-path ./roofline_analysis/

MoE:
python benchmark_cutlass_fused_moe.py --save-path ./roofline_analysis/

An example out looks like below:
============================================================ Performance: bf16 gemm (F.linear)
============================================================ bf16_gemm_F.linear_analysis:
   m     n    k          dtype  Latency (us) (value)  TFLOPS (value)  Bandwidth (GB/s) (value)  %peak_tflops  %peak_bw   AI(F/B)  roofline_tflops  eff_vs_roofline(%)      bound_hint
   1  1024 2048  torch.float16               86.5392          0.0464                   49.4136        0.0471   10.8363    0.9396           0.4285             10.8363  memory-leaning
   1  1024 2048 torch.bfloat16               90.4317          0.0497                   49.4122        0.0505   10.8360    1.0065           0.4590             10.8360  memory-leaning
   2  1024 2048  torch.float16               89.5619          0.0925                   47.3986        0.0939   10.3944    1.9519           0.8901             10.3944  memory-leaning
   2  1024 2048 torch.bfloat16               84.2387          0.0973                   50.0902        0.0988   10.9847    1.9434           0.8862             10.9847  memory-leaning
   4  1024 2048  torch.float16               86.3587          0.1816                   48.7472        0.1843   10.6902    3.7247           1.6985             10.6902  memory-leaning
...
"
