### PR TITLE
benchmark: reduce event recording overhead by using batch timing

### DIFF
--- a/benchmark/benchmark_cutlass_flash_attn_decode.py
+++ b/benchmark/benchmark_cutlass_flash_attn_decode.py
@@ -169,26 +169,18 @@ def benchmark_decode_with_paged_kv(seq_lens, num_heads, head_size, block_size,
           flush=True)
     assert iterations > 5, \
     "Number of iterations should be greater than 5 to account for warmup"
-    total_latency = 0.0
-    ms = 0.0
     queries = [
         torch.rand_like(maybe_quantized_query) for _ in range(iterations)
     ]
 
-    start_events = [
-        torch.xpu.Event(enable_timing=True) for _ in range(iterations - 5)
-    ]
-    end_events = [
-        torch.xpu.Event(enable_timing=True) for _ in range(iterations - 5)
-    ]
     if provider == "flash":
-        for index in range(iterations):
+        start_event = torch.xpu.Event(enable_timing=True)
+        end_event = torch.xpu.Event(enable_timing=True)
+        for index in range(5):
             block_tables = torch.randint(0,
                                          num_blocks,
                                          (num_seqs, max_num_blocks_per_seq),
                                          dtype=torch.int32)
-            if index >= 5:
-                start_events[index - 5].record()
             flash_attn_varlen_func(queries[index],
                                    maybe_quantized_key_cache,
                                    maybe_quantized_value_cache,
@@ -201,9 +193,38 @@ def benchmark_decode_with_paged_kv(seq_lens, num_heads, head_size, block_size,
                                    block_table=block_tables,
                                    window_size=(-1, -1),
                                    s_aux=sink)
-            if index >= 5:
-                end_events[index - 5].record()
+        start_event.record()
+        for index in range(5, iterations):
+            block_tables = torch.randint(0,
+                                         num_blocks,
+                                         (num_seqs, max_num_blocks_per_seq),
+                                         dtype=torch.int32)
+            flash_attn_varlen_func(queries[index],
+                                   maybe_quantized_key_cache,
+                                   maybe_quantized_value_cache,
+                                   max_query_len,
+                                   cu_query_lens,
+                                   max_kv_len,
+                                   seqused_k=seq_k,
+                                   softmax_scale=scale,
+                                   causal=False,
+                                   block_table=block_tables,
+                                   window_size=(-1, -1),
+                                   s_aux=sink)
+        end_event.record()
+        torch.xpu.synchronize()
+        ms = start_event.elapsed_time(end_event) / (iterations - 5)
+        clear_xpu_cache()
+        return 1000 * ms
     else:
+        start_events = [
+            torch.xpu.Event(enable_timing=True)
+            for _ in range(iterations - 5)
+        ]
+        end_events = [
+            torch.xpu.Event(enable_timing=True)
+            for _ in range(iterations - 5)
+        ]
         for index in range(iterations):
             block_tables = torch.randint(0,
                                          num_blocks,
@@ -225,13 +246,13 @@ def benchmark_decode_with_paged_kv(seq_lens, num_heads, head_size, block_size,
                                                  s_aux=sink,
                                                  start_event=se,
                                                  end_event=ee)
+        torch.xpu.synchronize()
+        total_latency = sum(
+            start_events[i].elapsed_time(end_events[i])
+            for i in range(iterations - 5)
+        )
+        ms = total_latency / (iterations - 5)
         if provider == "flash_memBandwidth" or provider == "flash_MBU":
-            torch.xpu.synchronize()
-            total_latency = sum(
-                start_events[i].elapsed_time(end_events[i])
-                for i in range(iterations - 5)
-            )
-            ms = total_latency / (iterations - 5)
             memory_load_GB = calculate_memory_usage(seq_k.sum().item(),
                                                     num_heads[1], head_size,
                                                     output_dtype)
@@ -247,15 +268,8 @@ def benchmark_decode_with_paged_kv(seq_lens, num_heads, head_size, block_size,
                 return (measured_bw / peak_bw) * 100
             clear_xpu_cache()
             return measured_bw
-    torch.xpu.synchronize()
-    total_latency = sum(
-        start_events[i].elapsed_time(end_events[i])
-        for i in range(iterations - 5)
-    )
-    ms = total_latency / (iterations - 5)
-    clear_xpu_cache()
-
-    return 1000 * ms
+        clear_xpu_cache()
+        return 1000 * ms
 
 
 def get_benchmark_decode_with_paged_kv(iterations=20):

--- a/benchmark/benchmark_cutlass_flash_attn_varlen.py
+++ b/benchmark/benchmark_cutlass_flash_attn_varlen.py
@@ -240,28 +240,28 @@ def benchmark_varlen_with_paged_kv(num_seqs,
     assert iterations > 5, \
     "Number of iterations should be greater than 5 to account for warmup"
 
-    total_latency = 0.0
-    ms = 0.0
-
     queries = [
         torch.rand_like(maybe_quantized_query) for _ in range(iterations)
     ]
 
-    start_events = [
-        torch.xpu.Event(enable_timing=True) for _ in range(iterations - 5)
-    ]
-    end_events = [
-        torch.xpu.Event(enable_timing=True) for _ in range(iterations - 5)
-    ]
-    if is_paged:
-        for index in range(iterations):
-            block_tables = torch.randint(0,
-                                         num_blocks,
-                                         (num_seqs, max_num_blocks_per_seq),
-                                         dtype=torch.int32)
-            if provider == "flash_kernel_time" or \
-            provider == "flash_kernel_TFLOPS" or \
-            provider == "flash_kernel_MFU":
+    is_kernel_time_provider = provider in (
+        "flash_kernel_time", "flash_kernel_TFLOPS", "flash_kernel_MFU")
+
+    if is_kernel_time_provider:
+        start_events = [
+            torch.xpu.Event(enable_timing=True)
+            for _ in range(iterations - 5)
+        ]
+        end_events = [
+            torch.xpu.Event(enable_timing=True)
+            for _ in range(iterations - 5)
+        ]
+        if is_paged:
+            for index in range(iterations):
+                block_tables = torch.randint(
+                    0, num_blocks,
+                    (num_seqs, max_num_blocks_per_seq),
+                    dtype=torch.int32)
                 se = start_events[index - 5] if index >= 5 else None
                 ee = end_events[index - 5] if index >= 5 else None
                 flash_attn_varlen_func_CalKernelTime(
@@ -285,34 +285,8 @@ def benchmark_varlen_with_paged_kv(num_seqs,
                     s_aux=sink,
                     start_event=se,
                     end_event=ee)
-            else:
-                if index >= 5:
-                    start_events[index - 5].record()
-                flash_attn_varlen_func(queries[index],
-                                       maybe_quantized_key_cache,
-                                       maybe_quantized_value_cache,
-                                       max_query_len,
-                                       cu_query_lens,
-                                       max_kv_len,
-                                       seqused_k=seq_k,
-                                       q_descale=q_descale.expand(scale_shape)
-                                       if q_descale is not None else None,
-                                       k_descale=k_descale.expand(scale_shape)
-                                       if k_descale is not None else None,
-                                       v_descale=v_descale.expand(scale_shape)
-                                       if v_descale is not None else None,
-                                       softmax_scale=scale,
-                                       causal=is_causal,
-                                       block_table=block_tables,
-                                       window_size=window_size,
-                                       s_aux=sink)
-                if index >= 5:
-                    end_events[index - 5].record()
-    else:
-        for index in range(iterations):
-            if provider == "flash_kernel_time" or \
-            provider == "flash_kernel_TFLOPS" or \
-            provider == "flash_kernel_MFU":
+        else:
+            for index in range(iterations):
                 se = start_events[index - 5] if index >= 5 else None
                 ee = end_events[index - 5] if index >= 5 else None
                 flash_attn_varlen_func_CalKernelTime(
@@ -336,9 +310,83 @@ def benchmark_varlen_with_paged_kv(num_seqs,
                     s_aux=sink,
                     start_event=se,
                     end_event=ee)
-            else:
-                if index >= 5:
-                    start_events[index - 5].record()
+        torch.xpu.synchronize()
+        total_latency = sum(
+            start_events[i].elapsed_time(end_events[i])
+            for i in range(iterations - 5)
+        )
+        ms = total_latency / (iterations - 5)
+        if provider == "flash_kernel_TFLOPS" or provider == "flash_kernel_MFU":
+            flops = calculate_flops(num_query_heads, query_lens, kv_lens,
+                                    head_size, is_causal)
+            tflops = flops / (ms / 1000) / 1e12
+            if provider == "flash_kernel_MFU":
+                hardware_presets = get_hardware_preset(
+                    torch.xpu.get_device_name())
+                if hardware_presets is None:
+                    clear_xpu_cache()
+                    return float("nan")
+                peak_tflops = hardware_presets["tflops"]
+                clear_xpu_cache()
+                return (tflops / peak_tflops) * 100
+            clear_xpu_cache()
+            return tflops
+        clear_xpu_cache()
+        return 1000 * ms
+    else:
+        start_event = torch.xpu.Event(enable_timing=True)
+        end_event = torch.xpu.Event(enable_timing=True)
+        if is_paged:
+            for index in range(5):
+                block_tables = torch.randint(
+                    0, num_blocks,
+                    (num_seqs, max_num_blocks_per_seq),
+                    dtype=torch.int32)
+                flash_attn_varlen_func(queries[index],
+                                       maybe_quantized_key_cache,
+                                       maybe_quantized_value_cache,
+                                       max_query_len,
+                                       cu_query_lens,
+                                       max_kv_len,
+                                       seqused_k=seq_k,
+                                       q_descale=q_descale.expand(scale_shape)
+                                       if q_descale is not None else None,
+                                       k_descale=k_descale.expand(scale_shape)
+                                       if k_descale is not None else None,
+                                       v_descale=v_descale.expand(scale_shape)
+                                       if v_descale is not None else None,
+                                       softmax_scale=scale,
+                                       causal=is_causal,
+                                       block_table=block_tables,
+                                       window_size=window_size,
+                                       s_aux=sink)
+            start_event.record()
+            for index in range(5, iterations):
+                block_tables = torch.randint(
+                    0, num_blocks,
+                    (num_seqs, max_num_blocks_per_seq),
+                    dtype=torch.int32)
+                flash_attn_varlen_func(queries[index],
+                                       maybe_quantized_key_cache,
+                                       maybe_quantized_value_cache,
+                                       max_query_len,
+                                       cu_query_lens,
+                                       max_kv_len,
+                                       seqused_k=seq_k,
+                                       q_descale=q_descale.expand(scale_shape)
+                                       if q_descale is not None else None,
+                                       k_descale=k_descale.expand(scale_shape)
+                                       if k_descale is not None else None,
+                                       v_descale=v_descale.expand(scale_shape)
+                                       if v_descale is not None else None,
+                                       softmax_scale=scale,
+                                       causal=is_causal,
+                                       block_table=block_tables,
+                                       window_size=window_size,
+                                       s_aux=sink)
+            end_event.record()
+        else:
+            for index in range(5):
                 flash_attn_varlen_func(queries[index],
                                        maybe_quantized_key_cache,
                                        maybe_quantized_value_cache,
@@ -357,38 +405,31 @@ def benchmark_varlen_with_paged_kv(num_seqs,
                                        block_table=None,
                                        window_size=window_size,
                                        s_aux=sink)
-                if index >= 5:
-                    end_events[index - 5].record()
-    if provider == "flash_kernel_TFLOPS" or provider == "flash_kernel_MFU":
+            start_event.record()
+            for index in range(5, iterations):
+                flash_attn_varlen_func(queries[index],
+                                       maybe_quantized_key_cache,
+                                       maybe_quantized_value_cache,
+                                       max_query_len,
+                                       cu_query_lens,
+                                       max_kv_len,
+                                       cu_seqlens_k=cu_kv_lens,
+                                       q_descale=q_descale.expand(scale_shape)
+                                       if q_descale is not None else None,
+                                       k_descale=k_descale.expand(scale_shape)
+                                       if k_descale is not None else None,
+                                       v_descale=v_descale.expand(scale_shape)
+                                       if v_descale is not None else None,
+                                       softmax_scale=scale,
+                                       causal=is_causal,
+                                       block_table=None,
+                                       window_size=window_size,
+                                       s_aux=sink)
+            end_event.record()
         torch.xpu.synchronize()
-        total_latency = sum(
-            start_events[i].elapsed_time(end_events[i])
-            for i in range(iterations - 5)
-        )
-        ms = total_latency / (iterations - 5)
-        flops = calculate_flops(num_query_heads, query_lens, kv_lens,
-                                head_size, is_causal)
-        tflops = flops / (ms / 1000) / 1e12
-        if provider == "flash_kernel_MFU":
-            hardware_presets = get_hardware_preset(torch.xpu.get_device_name())
-            if hardware_presets is None:
-                clear_xpu_cache()
-                return float("nan")
-            peak_tflops = hardware_presets["tflops"]
-            clear_xpu_cache()
-            return (tflops / peak_tflops) * 100
+        ms = start_event.elapsed_time(end_event) / (iterations - 5)
         clear_xpu_cache()
-        return tflops
-
-    torch.xpu.synchronize()
-    total_latency = sum(
-        start_events[i].elapsed_time(end_events[i])
-        for i in range(iterations - 5)
-    )
-    ms = total_latency / (iterations - 5)
-    clear_xpu_cache()
-
-    return 1000 * ms
+        return 1000 * ms
 
 
 def get_benchmark_varlen_with_paged_kv(iterations=20):

--- a/benchmark/benchmark_cutlass_fused_moe.py
+++ b/benchmark/benchmark_cutlass_fused_moe.py
@@ -221,17 +221,9 @@ def get_benchmark(iterations):
                             topk, x_dtype, w_dtype, has_bias))
 
         if provider == "vllm":
-            start_events = [
-                torch.xpu.Event(enable_timing=True)
-                for _ in range(iterations - 5)
-            ]
-            end_events = [
-                torch.xpu.Event(enable_timing=True)
-                for _ in range(iterations - 5)
-            ]
-            for index in range(iterations):
-                if index >= 5:
-                    start_events[index - 5].record()
+            start_event = torch.xpu.Event(enable_timing=True)
+            end_event = torch.xpu.Event(enable_timing=True)
+            for index in range(5):
                 xpu_fused_moe(hidden_states=a,
                               w13=w13,
                               w13_scales=w13_scales,
@@ -245,13 +237,24 @@ def get_benchmark(iterations):
                               activation="silu",
                               num_experts=num_experts,
                               is_fp8=(w_dtype is not None))
-                if index >= 5:
-                    end_events[index - 5].record()
+            start_event.record()
+            for index in range(5, iterations):
+                xpu_fused_moe(hidden_states=a,
+                              w13=w13,
+                              w13_scales=w13_scales,
+                              w13_bias=w13_bias,
+                              w2=w2,
+                              w2_scales=w2_scales,
+                              w2_bias=w2_bias,
+                              topk_weights=expert_scores,
+                              topk_ids=expert_indices,
+                              n_experts_per_token=topk,
+                              activation="silu",
+                              num_experts=num_experts,
+                              is_fp8=(w_dtype is not None))
+            end_event.record()
             torch.xpu.synchronize()
-            total_latency = sum(
-                start_events[i].elapsed_time(end_events[i])
-                for i in range(iterations - 5)
-            )
+            total_latency = start_event.elapsed_time(end_event)
         else:
             n_measured = iterations - 5
             remap_se = [

--- a/benchmark/benchmark_gemm_onednn.py
+++ b/benchmark/benchmark_gemm_onednn.py
@@ -527,30 +527,22 @@ def get_bf16_gemm_benchmark(configs, iterations):
         )
     )
     def benchmark(m, n, k, dtype, provider, iterations=iterations):
-        total_latency = 0.0
+
         assert iterations > 5
 
         input = torch.randn([m, k], dtype=dtype, device=DEVICE) / 10.0
         weight = torch.randn([n, k], dtype=dtype, device=DEVICE) / 10.0
 
-        start_event = [
-            torch.xpu.Event(enable_timing=True) for i in range(iterations - 5)
-        ]
-        end_event = [
-            torch.xpu.Event(enable_timing=True) for i in range(iterations - 5)
-        ]
-        for index in range(iterations):
-            if index >= 5:
-                start_event[index - 5].record()
+        start_event = torch.xpu.Event(enable_timing=True)
+        end_event = torch.xpu.Event(enable_timing=True)
+        for index in range(5):
             torch.nn.functional.linear(input, weight)
-            if index >= 5:
-                end_event[index - 5].record()
+        start_event.record()
+        for index in range(iterations - 5):
+            torch.nn.functional.linear(input, weight)
+        end_event.record()
         torch.xpu.synchronize()
-        total_latency = sum(
-            start_event[i].elapsed_time(end_event[i])
-            for i in range(iterations - 5)
-        )
-        ms = total_latency / (iterations - 5)
+        ms = start_event.elapsed_time(end_event) / (iterations - 5)
         clear_xpu_cache()
 
         if provider == "tflops":
@@ -588,7 +580,7 @@ def get_fp8_gemm_benchmark(configs, iterations):
     def benchmark(
         m, n, k, out_dtype, fp8_dtype, provider, iterations=iterations
     ):
-        total_latency = 0.0
+
         assert iterations > 5
 
         input = torch.randn([m, k], dtype=out_dtype, device=DEVICE) / 10.0
@@ -601,15 +593,9 @@ def get_fp8_gemm_benchmark(configs, iterations):
         weight_fp8, _ = scaled_fp8_quant(weight, scale_wei, fp8_dtype=fp8_dtype)
         weight_fp8_t = weight_fp8.transpose(0, 1)
 
-        start_event = [
-            torch.xpu.Event(enable_timing=True) for i in range(iterations - 5)
-        ]
-        end_event = [
-            torch.xpu.Event(enable_timing=True) for i in range(iterations - 5)
-        ]
-        for index in range(iterations):
-            if index >= 5:
-                start_event[index - 5].record()
+        start_event = torch.xpu.Event(enable_timing=True)
+        end_event = torch.xpu.Event(enable_timing=True)
+        for index in range(5):
             fp8_gemm(
                 input_fp8,
                 weight_fp8_t,
@@ -617,15 +603,18 @@ def get_fp8_gemm_benchmark(configs, iterations):
                 scale_src,
                 scale_wei,
             )
-            if index >= 5:
-                end_event[index - 5].record()
-
+        start_event.record()
+        for index in range(iterations - 5):
+            fp8_gemm(
+                input_fp8,
+                weight_fp8_t,
+                out_dtype,
+                scale_src,
+                scale_wei,
+            )
+        end_event.record()
         torch.xpu.synchronize()
-        total_latency = sum(
-            start_event[i].elapsed_time(end_event[i])
-            for i in range(iterations - 5)
-        )
-        ms = total_latency / (iterations - 5)
+        ms = start_event.elapsed_time(end_event) / (iterations - 5)
         clear_xpu_cache()
 
         if provider == "tflops":
@@ -663,7 +652,7 @@ def get_fp8_gemm_w8a16_benchmark(configs, iterations):
     def benchmark(
         m, n, k, out_dtype, fp8_dtype, provider, iterations=iterations
     ):
-        total_latency = 0.0
+
         assert iterations > 5
 
         input = torch.randn([m, k], dtype=out_dtype, device=DEVICE) / 10.0
@@ -675,25 +664,16 @@ def get_fp8_gemm_w8a16_benchmark(configs, iterations):
         )
         weight_fp8_t = weight_fp8.transpose(0, 1)
 
-        start_event = [
-            torch.xpu.Event(enable_timing=True) for i in range(iterations - 5)
-        ]
-        end_event = [
-            torch.xpu.Event(enable_timing=True) for i in range(iterations - 5)
-        ]
-        for index in range(iterations):
-            if index >= 5:
-                start_event[index - 5].record()
+        start_event = torch.xpu.Event(enable_timing=True)
+        end_event = torch.xpu.Event(enable_timing=True)
+        for index in range(5):
             fp8_gemm_w8a16(input, weight_fp8_t, scale_wei, torch.Tensor())
-            if index >= 5:
-                end_event[index - 5].record()
-
+        start_event.record()
+        for index in range(iterations - 5):
+            fp8_gemm_w8a16(input, weight_fp8_t, scale_wei, torch.Tensor())
+        end_event.record()
         torch.xpu.synchronize()
-        total_latency = sum(
-            start_event[i].elapsed_time(end_event[i])
-            for i in range(iterations - 5)
-        )
-        ms = total_latency / (iterations - 5)
+        ms = start_event.elapsed_time(end_event) / (iterations - 5)
         clear_xpu_cache()
 
         if provider == "tflops":
@@ -731,7 +711,7 @@ def get_fp8_gemm_per_channel_benchmark(configs, iterations):
     def benchmark(
         m, n, k, out_dtype, fp8_dtype, provider, iterations=iterations
     ):
-        total_latency = 0.0
+
         assert iterations > 5
 
         input = torch.randn([m, k], dtype=out_dtype, device=DEVICE) / 10.0
@@ -745,15 +725,9 @@ def get_fp8_gemm_per_channel_benchmark(configs, iterations):
         )
         weight_fp8_t = weight_fp8.transpose(0, 1)
 
-        start_event = [
-            torch.xpu.Event(enable_timing=True) for i in range(iterations - 5)
-        ]
-        end_event = [
-            torch.xpu.Event(enable_timing=True) for i in range(iterations - 5)
-        ]
-        for index in range(iterations):
-            if index >= 5:
-                start_event[index - 5].record()
+        start_event = torch.xpu.Event(enable_timing=True)
+        end_event = torch.xpu.Event(enable_timing=True)
+        for index in range(5):
             fp8_gemm(
                 input_fp8,
                 weight_fp8_t,
@@ -761,15 +735,18 @@ def get_fp8_gemm_per_channel_benchmark(configs, iterations):
                 scale_src,
                 scale_wei,
             )
-            if index >= 5:
-                end_event[index - 5].record()
-
+        start_event.record()
+        for index in range(iterations - 5):
+            fp8_gemm(
+                input_fp8,
+                weight_fp8_t,
+                out_dtype,
+                scale_src,
+                scale_wei,
+            )
+        end_event.record()
         torch.xpu.synchronize()
-        total_latency = sum(
-            start_event[i].elapsed_time(end_event[i])
-            for i in range(iterations - 5)
-        )
-        ms = total_latency / (iterations - 5)
+        ms = start_event.elapsed_time(end_event) / (iterations - 5)
         clear_xpu_cache()
 
         if provider == "tflops":
@@ -805,7 +782,7 @@ def get_mxfp8_gemm_benchmark(configs, iterations):
         )
     )
     def benchmark(m, n, k, out_dtype, provider, iterations=iterations):
-        total_latency = 0.0
+
         assert iterations > 5
 
         inputs = torch.randn((m, k), dtype=out_dtype, device=DEVICE) * 0.01
@@ -818,15 +795,9 @@ def get_mxfp8_gemm_benchmark(configs, iterations):
         _, inputs_lp, inputs_scale = _convert_to_mxfp8(inputs)
         _, weights_lp, weights_scale = _convert_to_mxfp8(weights)
 
-        start_event = [
-            torch.xpu.Event(enable_timing=True) for i in range(iterations - 5)
-        ]
-        end_event = [
-            torch.xpu.Event(enable_timing=True) for i in range(iterations - 5)
-        ]
-        for index in range(iterations):
-            if index >= 5:
-                start_event[index - 5].record()
+        start_event = torch.xpu.Event(enable_timing=True)
+        end_event = torch.xpu.Event(enable_timing=True)
+        for index in range(5):
             fp8_gemm(
                 inputs_lp,
                 weights_lp.transpose(0, 1),
@@ -834,15 +805,18 @@ def get_mxfp8_gemm_benchmark(configs, iterations):
                 inputs_scale,
                 weights_scale,
             )
-            if index >= 5:
-                end_event[index - 5].record()
-
+        start_event.record()
+        for index in range(iterations - 5):
+            fp8_gemm(
+                inputs_lp,
+                weights_lp.transpose(0, 1),
+                out_dtype,
+                inputs_scale,
+                weights_scale,
+            )
+        end_event.record()
         torch.xpu.synchronize()
-        total_latency = sum(
-            start_event[i].elapsed_time(end_event[i])
-            for i in range(iterations - 5)
-        )
-        ms = total_latency / (iterations - 5)
+        ms = start_event.elapsed_time(end_event) / (iterations - 5)
         clear_xpu_cache()
 
         if provider == "tflops":
@@ -896,7 +870,7 @@ def get_mxfp4_gemm_benchmark(configs, iterations):
         )
     )
     def benchmark(m, n, k, out_dtype, provider, iterations=iterations):
-        total_latency = 0.0
+
         assert iterations > 5
 
         inputs = torch.randn((m, k), dtype=out_dtype, device=DEVICE) * 0.01
@@ -909,15 +883,9 @@ def get_mxfp4_gemm_benchmark(configs, iterations):
         _, inputs_lp, inputs_scale = _convert_to_mxfp4(inputs)
         _, weights_lp, weights_scale = _convert_to_mxfp4(weights)
 
-        start_event = [
-            torch.xpu.Event(enable_timing=True) for i in range(iterations - 5)
-        ]
-        end_event = [
-            torch.xpu.Event(enable_timing=True) for i in range(iterations - 5)
-        ]
-        for index in range(iterations):
-            if index >= 5:
-                start_event[index - 5].record()
+        start_event = torch.xpu.Event(enable_timing=True)
+        end_event = torch.xpu.Event(enable_timing=True)
+        for index in range(5):
             fp4_gemm(
                 inputs_lp,
                 weights_lp.transpose(0, 1),
@@ -925,15 +893,18 @@ def get_mxfp4_gemm_benchmark(configs, iterations):
                 weights_scale,
                 out_dtype,
             )
-            if index >= 5:
-                end_event[index - 5].record()
-
+        start_event.record()
+        for index in range(iterations - 5):
+            fp4_gemm(
+                inputs_lp,
+                weights_lp.transpose(0, 1),
+                inputs_scale,
+                weights_scale,
+                out_dtype,
+            )
+        end_event.record()
         torch.xpu.synchronize()
-        total_latency = sum(
-            start_event[i].elapsed_time(end_event[i])
-            for i in range(iterations - 5)
-        )
-        ms = total_latency / (iterations - 5)
+        ms = start_event.elapsed_time(end_event) / (iterations - 5)
         clear_xpu_cache()
 
         if provider == "tflops":


### PR DESCRIPTION
## Summary
- Switch standard (e2e) timing from per-iteration event pairs to a single start/end event wrapping the entire measured loop
- Eliminates 2*(N-5) `event.record()` calls from the hot path, removing significant overhead for fast kernels (<50us)
- CalKernelTime providers retain per-iteration events since they pass events into the kernel for sub-kernel measurement

## Test plan
- [x] Verified syntax with `ast.parse` for all modified files
- [x] All pre-commit hooks pass (ruff, codespell, isort, mypy)
- [x] Tested bf16 GEMM benchmark in container — results consistent with expected kernel throughput