### PR TITLE
upgrade fp8 moe gemm policy

### DIFF
--- a/csrc/xpu/grouped_gemm/xe_2/gemm_xe2_policy.hpp
+++ b/csrc/xpu/grouped_gemm/xe_2/gemm_xe2_policy.hpp
@@ -51,8 +51,8 @@ class w16a16_policy_m_32 : public xe_gemm_policy_base {
 
 class w8a16_policy : public xe_gemm_policy_base {
  public:
-  using WGTile = Shape<_128, _256, _32>;
-  using SGLayout = Layout<Shape<_4, _8, _1>, Stride<_8, _1, _0>>;
+  using WGTile = Shape<_128, _128, _16>;
+  using SGLayout = Layout<Shape<_4, _2, _1>, Stride<_2, _1, _0>>;
 };
 
 class w8a16_policy_m_8 : public xe_gemm_policy_base {


### PR DESCRIPTION
FUSED_MOE_MNK_FACTORS = [
    (8192, 5120, 8192),
]
NUM_EXPERTS = [16]
TOP_KS = [1]
Kernel time reduces from 11.571ms to 8.747ms

FUSED_MOE_MNK_FACTORS = [
    (8192, 384, 2048),
]
Kernel time reduce from 2.5ms to 1.436ms
TTFT of Qwen3-30b-a3b,tp=4, 1k, bs=125 reduces from 6300+  to 5823.29