### PR TITLE
[GDN] Spec-decoding-aware attention kernel

### DIFF
--- a/csrc/xpu/gdn_attn/causal_conv1d.hpp
+++ b/csrc/xpu/gdn_attn/causal_conv1d.hpp
@@ -7,7 +7,7 @@
 
 namespace gdn {
 
-template <typename T, int Width, bool ReorderInput>
+template <typename T, int Width, bool ReorderInput, bool IS_SPEC = false>
 struct causal_conv1d_kernel {
  public:
   static constexpr int sub_group_size = 32;
@@ -41,7 +41,15 @@ struct causal_conv1d_kernel {
       const int& num_v_heads,
       const int& head_v_dim,
       const int& qkvz_elems,
-      const int& conv_elems)
+      const int& conv_elems,
+      // Spec-decoding (only consulted when IS_SPEC=true). Per-token store
+      // slot comes from spec_state_indices[batch_id, t - seq_start]; the
+      // load slot for the partial-window branch comes from
+      // spec_state_indices[batch_id, num_accepted_tokens[batch_id]-1].
+      const int* spec_state_indices = nullptr,
+      const int* num_accepted_tokens = nullptr,
+      const int spec_stride = 0,
+      const int state_len = 0)
       : q_out(q_out),
         k_out(k_out),
         v_out(v_out),
@@ -67,7 +75,11 @@ struct causal_conv1d_kernel {
         num_v_heads(num_v_heads),
         head_v_dim(head_v_dim),
         qkvz_elems(qkvz_elems),
-        conv_elems(conv_elems) {}
+        conv_elems(conv_elems),
+        spec_state_indices(spec_state_indices),
+        num_accepted_tokens(num_accepted_tokens),
+        spec_stride(spec_stride),
+        state_len(state_len) {}
 
   static inline sycl::nd_range<2>
   get_nd_range(const int total_seqlen, const int qkvz_elems) {
@@ -144,11 +156,38 @@ struct causal_conv1d_kernel {
       }
     }
 
-    // get states cache location
-    int states_id = cache_indices[batch_id];
+    // get states cache location. For spec-decoding (FLA-aligned, tick 40):
+    // ALL spec tokens read/write the single slot at cache_indices[batch_id]
+    // (= spec_state_indices[batch_id, 0] per the dispatcher), with a rolling
+    // history of state_len positions inside it. The history starting offset
+    // within the slot is (num_accepted_tokens - 1).
+    int states_id;
+    int spec_store_slot = pad_slot_id;
+    bool spec_skip_init_load = false;
+    if constexpr (IS_SPEC) {
+      const int n_acc = num_accepted_tokens[batch_id];
+      if (n_acc <= 0) {
+        // (Rung 6) num_accepted=0: no valid prior state to load.
+        states_id = 0;
+        spec_skip_init_load = true;
+      } else {
+        states_id = cache_indices[batch_id];
+        if (states_id <= 0) {
+          // FLA NULL_BLOCK_ID convention: treat 0/-1 as no prior state.
+          states_id = 0;
+          spec_skip_init_load = true;
+        }
+      }
+      const int t_in_seq = token_id - seq_start_offset;
+      spec_store_slot = spec_state_indices[batch_id * spec_stride + t_in_seq];
+    } else {
+      states_id = cache_indices[batch_id];
+    }
 
-    if (states_id == pad_slot_id) {
-      return;
+    if constexpr (!IS_SPEC) {
+      if (states_id == pad_slot_id) {
+        return;
+      }
     }
 
     int mixed_qkvz_id = qkvz_elems_id;
@@ -209,9 +248,18 @@ struct causal_conv1d_kernel {
     }
 
     // get states cache ptr
-    const bool has_init_conv_states =
+    bool has_init_conv_states =
         (has_initial_state == nullptr ||
          (has_initial_state != nullptr && has_initial_state[batch_id]));
+    if constexpr (IS_SPEC) {
+      // (Rung 6) Spec overrides: when num_accepted=0 or the load slot is
+      // the NULL sentinel, the partial-window load must NOT touch
+      // conv_states_ptr (no valid prior data); the kernel still proceeds
+      // and writes per-token state.
+      if (spec_skip_init_load) {
+        has_init_conv_states = false;
+      }
+    }
     T* conv_states_ptr = conv_states + states_id * conv_states_stride_0;
 
     // load weights
@@ -238,13 +286,24 @@ struct causal_conv1d_kernel {
     int seq_cu_len = token_id - seq_start_offset + 1;
     int input_load_len = seq_cu_len >= Width ? Width : seq_cu_len;
     int states_load_len = seq_cu_len >= Width ? 0 : Width - input_load_len;
+    // For IS_SPEC, the slot holds state_len > Width-1 positions and the
+    // history of interest starts at offset (n_acc - 1). For non-spec, the
+    // slot is exactly Width-1 positions and offset is 0.
+    int load_offset_shift = 0;
+    if constexpr (IS_SPEC) {
+      const int n_acc_local = num_accepted_tokens[batch_id];
+      if (n_acc_local > 0) {
+        load_offset_shift = n_acc_local - 1;
+      }
+    }
     if (states_load_len != 0 && has_init_conv_states) {
 #pragma unroll
       for (int i = 0; i < states_load_len; ++i) {
 #pragma unroll
         for (int e = 0; e < elems_per_item; ++e) {
           local_input[Width * e + i] = conv_states_ptr
-              [(Width - 1 - states_load_len + i) * conv_elems +
+              [(Width - 1 - states_load_len + i + load_offset_shift) *
+                   conv_elems +
                reordered_elems_id + e];
         }
       }
@@ -282,7 +341,56 @@ struct causal_conv1d_kernel {
     }
 
     // save states
-    if (seq_end_offset - seq_start_offset > 1) {
+    if constexpr (IS_SPEC) {
+      // (Tick 40) FLA-aligned spec writeback: stage the rolled state into
+      // conv_states_tmp[batch_id, state_len, conv_elems]. A second kernel
+      // (spec_state_roll_kernel) copies tmp -> slot[cache_indices[batch_id]]
+      // after the main kernel finishes (race-free because slot is read by
+      // pass 1 but only written by pass 2).
+      //
+      // Per-position semantics for slot[cache_indices[batch_id]]:
+      //   new[p] = pre[n_acc + p]                  for p < state_len - K_call
+      //   new[p] = current_input[p - (state_len - K_call)]  for p >= state_len
+      //   - K_call
+      //
+      // Each work-item handles t_in_seq = token_id - seq_start_offset:
+      //   - Always: writes tmp at position (state_len - K_call + t_in_seq) =
+      //     the spec token's contribution to the rolled state.
+      //   - If t_in_seq < state_len - K_call: also writes tmp at position
+      //     t_in_seq with the shift-copy of pre[n_acc + t_in_seq].
+      const int K_call = seq_end_offset - seq_start_offset;
+      const int n_acc_safe = (num_accepted_tokens[batch_id] > 0)
+                                 ? num_accepted_tokens[batch_id]
+                                 : 0;
+      const int t_in_seq = token_id - seq_start_offset;
+      const int new_input_pos = state_len - K_call + t_in_seq;
+      // Latest input value for this token = local_input[Width-1].
+#pragma unroll
+      for (int e = 0; e < elems_per_item; ++e) {
+        if (new_input_pos >= 0 && new_input_pos < state_len) {
+          conv_states_tmp
+              [batch_id * state_len * conv_elems + new_input_pos * conv_elems +
+               reordered_elems_id + e] = local_input[Width * e + Width - 1];
+        }
+      }
+      // Shift-copy: only the first (state_len - K_call) work items per
+      // dim chunk read pre[n_acc + t_in_seq] and stage it at position
+      // t_in_seq in tmp.
+      if (t_in_seq < state_len - K_call) {
+        const int shift_src_pos = n_acc_safe + t_in_seq;
+#pragma unroll
+        for (int e = 0; e < elems_per_item; ++e) {
+          T pre_val = T(0);
+          if (!spec_skip_init_load && shift_src_pos < state_len) {
+            pre_val = conv_states_ptr
+                [shift_src_pos * conv_elems + reordered_elems_id + e];
+          }
+          conv_states_tmp
+              [batch_id * state_len * conv_elems + t_in_seq * conv_elems +
+               reordered_elems_id + e] = pre_val;
+        }
+      }
+    } else if (seq_end_offset - seq_start_offset > 1) {
       // because current group is unable to know if old states are needed by
       // other group, hard to update states inplace if prefill
       if (seq_end_offset - 1 == token_id) {
@@ -372,6 +480,15 @@ struct causal_conv1d_kernel {
   const int head_v_dim;
   const int qkvz_elems;
   const int conv_elems;
+  // Spec-decoding inputs (consulted when IS_SPEC=true). See ctor docstring.
+  const int* spec_state_indices;
+  const int* num_accepted_tokens;
+  const int spec_stride;
+  // state_len = conv_states_stride_0 / conv_elems. Number of time positions
+  // per slot in the (slot, time, dim) conv state buffer. For non-spec this
+  // equals Width-1; for spec it can be larger (e.g. state_len = (Width-1) +
+  // (K_max - 1)). Plumbed in to drive the FLA-aligned rolled writeback.
+  const int state_len;
 };
 
 template <typename T>
@@ -447,7 +564,79 @@ struct update_states_kernel {
   const int batch_size;
 };
 
-template <typename T, int Width, bool ReorderInput>
+// Tick-40 spec-state roll kernel. Pass 2 of the FLA-aligned conv1d_update:
+// copies the rolled state staged by pass 1 in conv_states_tmp[batch_id,
+// state_len, conv_elems] to conv_states[cache_indices[batch_id], state_len,
+// conv_elems]. Race-free because pass 1 only writes tmp; pass 2 only writes
+// the slot.
+template <typename T>
+struct spec_state_roll_kernel {
+ public:
+  static constexpr int sub_group_size = 32;
+  static constexpr int group_size = 256;
+  static constexpr int elems_per_item = 4;
+  static constexpr int elems_per_group = group_size * elems_per_item;
+
+  spec_state_roll_kernel(
+      T* conv_states,
+      const int conv_states_stride_0,
+      const T* conv_states_tmp,
+      const int* cache_indices,
+      const int state_len,
+      const int conv_elems,
+      const int batch_size)
+      : conv_states(conv_states),
+        conv_states_stride_0(conv_states_stride_0),
+        conv_states_tmp(conv_states_tmp),
+        cache_indices(cache_indices),
+        state_len(state_len),
+        conv_elems(conv_elems),
+        batch_size(batch_size) {}
+
+  static inline sycl::nd_range<3> get_nd_range(
+      const int batch_size, const int state_len, const int conv_elems) {
+    const int groups_per_token =
+        (conv_elems + elems_per_group - 1) / elems_per_group;
+    sycl::range<3> local(1, 1, group_size);
+    sycl::range<3> global(batch_size, state_len, groups_per_token);
+    return sycl::nd_range<3>(global * local, local);
+  }
+
+  [[sycl::reqd_sub_group_size(sub_group_size)]] void
+  operator()(sycl::nd_item<3> item) const {
+    const int batch_id = item.get_group(0);
+    const int pos_id = item.get_group(1);
+    const int local_group_id = item.get_group(2);
+    const int local_id = item.get_local_linear_id();
+    const int elems_start_offset_group = local_group_id * elems_per_group;
+
+    const int states_id = cache_indices[batch_id];
+    if (states_id <= 0) {
+      return;  // null sentinel: no slot to write
+    }
+    T* conv_states_ptr =
+        conv_states + static_cast<int64_t>(states_id) * conv_states_stride_0;
+    const T* conv_states_tmp_ptr =
+        conv_states_tmp + batch_id * state_len * conv_elems;
+    for (int i = elems_start_offset_group + local_id;
+         i < elems_start_offset_group + elems_per_group && i < conv_elems;
+         i += group_size) {
+      conv_states_ptr[pos_id * conv_elems + i] =
+          conv_states_tmp_ptr[pos_id * conv_elems + i];
+    }
+  }
+
+ private:
+  T* conv_states;
+  const int conv_states_stride_0;
+  const T* conv_states_tmp;
+  const int* cache_indices;
+  const int state_len;
+  const int conv_elems;
+  const int batch_size;
+};
+
+template <typename T, int Width, bool ReorderInput, bool IS_SPEC = false>
 void kernel_launcher(
     sycl::queue& queue,
     T* q_out,
@@ -477,8 +666,12 @@ void kernel_launcher(
     const int& qkvz_elems,
     const int& conv_elems,
     const int& num_prefills,
-    const int& num_decodes) {
-  using KERNEL_MAIN = causal_conv1d_kernel<T, Width, ReorderInput>;
+    const int& num_decodes,
+    const int* spec_state_indices = nullptr,
+    const int* num_accepted_tokens = nullptr,
+    const int spec_stride = 0,
+    const int state_len = 0) {
+  using KERNEL_MAIN = causal_conv1d_kernel<T, Width, ReorderInput, IS_SPEC>;
   auto range_main = KERNEL_MAIN::get_nd_range(num_actual_tokens, qkvz_elems);
   assert(head_k_dim % KERNEL_MAIN::elems_per_item == 0);
   assert(num_v_heads % KERNEL_MAIN::elems_per_item == 0);
@@ -509,24 +702,49 @@ void kernel_launcher(
         num_v_heads,
         head_v_dim,
         qkvz_elems,
-        conv_elems);
+        conv_elems,
+        spec_state_indices,
+        num_accepted_tokens,
+        spec_stride,
+        state_len);
     cgh.parallel_for(range_main, task);
   });
-  if (num_prefills > 0) {
-    using KERNEL_UPDATE = update_states_kernel<T>;
-    auto range_update =
-        KERNEL_UPDATE::get_nd_range(batch_size, Width, conv_elems);
+  if constexpr (!IS_SPEC) {
+    if (num_prefills > 0) {
+      using KERNEL_UPDATE = update_states_kernel<T>;
+      auto range_update =
+          KERNEL_UPDATE::get_nd_range(batch_size, Width, conv_elems);
+      queue.submit([&](sycl::handler& cgh) {
+        KERNEL_UPDATE task(
+            conv_states,
+            conv_states_stride_0,
+            conv_states_tmp,
+            cache_indices,
+            Width,
+            conv_elems,
+            query_start_loc,
+            batch_size);
+        cgh.parallel_for(range_update, task);
+      });
+    }
+  } else {
+    // Tick-40 pass 2: copy the rolled state staged in conv_states_tmp
+    // (shape [batch, state_len, conv_elems]) into the slot at
+    // cache_indices[batch_id]. Race-free vs pass 1 because pass 1 only
+    // wrote tmp; this pass is the only writer of slot.
+    using KERNEL_ROLL = spec_state_roll_kernel<T>;
+    auto range_roll =
+        KERNEL_ROLL::get_nd_range(batch_size, state_len, conv_elems);
     queue.submit([&](sycl::handler& cgh) {
-      KERNEL_UPDATE task(
+      KERNEL_ROLL task(
           conv_states,
           conv_states_stride_0,
           conv_states_tmp,
           cache_indices,
-          Width,
+          state_len,
           conv_elems,
-          query_start_loc,
           batch_size);
-      cgh.parallel_for(range_update, task);
+      cgh.parallel_for(range_roll, task);
     });
   }
 }
@@ -561,7 +779,14 @@ void causal_conv1d(
     const int& pad_slot_id,   // -1
     const int num_prefills,
     const int num_decodes,
-    const bool reorder_input) {
+    const bool reorder_input,
+    // Spec-decoding extension. When is_spec=true the per-sequence load slot
+    // and per-token store slot come from these tensors; cache_indices is
+    // ignored. Both tensors are int32 [batch_size, K] / [batch_size].
+    const bool is_spec = false,
+    const int* spec_state_indices_ptr = nullptr,
+    const int* num_accepted_tokens_ptr = nullptr,
+    const int spec_stride = 0) {
   if (num_prefills == 0 && num_decodes == 0) {
     return;
   }
@@ -576,48 +801,65 @@ void causal_conv1d(
   const int conv_elems = conv_weights.size(0);
   const int width = conv_weights.size(1);
   const int conv_states_stride_0 = conv_states.stride(0);
+  // (Tick 40) state_len = number of time positions per slot. For non-spec,
+  // the buffer is sized to width-1 by convention; for spec, the runtime
+  // sizes it larger (e.g. (Width-1) + (K_max-1) = 6 for Width=4 K_max=4).
+  // Derive from stride; conv_states is row-major (slot, time, dim).
+  const int state_len = conv_states_stride_0 / conv_elems;
+  const int tmp_rows = is_spec ? state_len : (width - 1);
 
   auto dtype = conv_states.dtype();
   auto device = conv_states.device();
   torch::Tensor conv_states_tmp = torch::empty(
-      {batch_size, width - 1, conv_elems},
+      {batch_size, tmp_rows, conv_elems},
       torch::dtype(dtype).device(device).requires_grad(false));
 
-#define KERNEL_LAUNCHER(scalar_t, width, reorder_input)            \
-  kernel_launcher<scalar_t, width, reorder_input>(                 \
-      queue,                                                       \
-      reinterpret_cast<scalar_t*>(q_out.data_ptr()),               \
-      reinterpret_cast<scalar_t*>(k_out.data_ptr()),               \
-      reinterpret_cast<scalar_t*>(v_out.data_ptr()),               \
-      reinterpret_cast<scalar_t*>(z_out.data_ptr()),               \
-      reinterpret_cast<scalar_t*>(b_out.data_ptr()),               \
-      reinterpret_cast<scalar_t*>(a_out.data_ptr()),               \
-      reinterpret_cast<scalar_t*>(mixed_qkvz.data_ptr()),          \
-      reinterpret_cast<scalar_t*>(mixed_ba.data_ptr()),            \
-      reinterpret_cast<scalar_t*>(conv_weights.data_ptr()),        \
-      conv_bias.has_value()                                        \
-          ? reinterpret_cast<scalar_t*>(conv_bias->data_ptr())     \
-          : nullptr,                                               \
-      reinterpret_cast<scalar_t*>(conv_states.data_ptr()),         \
-      conv_states_stride_0,                                        \
-      reinterpret_cast<scalar_t*>(conv_states_tmp.data_ptr()),     \
-      reinterpret_cast<int*>(query_start_loc.data_ptr()),          \
-      reinterpret_cast<int*>(cache_indices.data_ptr()),            \
-      has_initial_state.has_value()                                \
-          ? reinterpret_cast<bool*>(has_initial_state->data_ptr()) \
-          : nullptr,                                               \
-      act_mode,                                                    \
-      pad_slot_id,                                                 \
-      batch_size,                                                  \
-      num_actual_tokens,                                           \
-      num_k_heads,                                                 \
-      head_k_dim,                                                  \
-      num_v_heads,                                                 \
-      head_v_dim,                                                  \
-      qkvz_elems,                                                  \
-      conv_elems,                                                  \
-      num_prefills,                                                \
-      num_decodes);
+#define KERNEL_LAUNCHER_IMPL(scalar_t, width, reorder_input, IS_SPEC) \
+  kernel_launcher<scalar_t, width, reorder_input, IS_SPEC>(           \
+      queue,                                                          \
+      reinterpret_cast<scalar_t*>(q_out.data_ptr()),                  \
+      reinterpret_cast<scalar_t*>(k_out.data_ptr()),                  \
+      reinterpret_cast<scalar_t*>(v_out.data_ptr()),                  \
+      reinterpret_cast<scalar_t*>(z_out.data_ptr()),                  \
+      reinterpret_cast<scalar_t*>(b_out.data_ptr()),                  \
+      reinterpret_cast<scalar_t*>(a_out.data_ptr()),                  \
+      reinterpret_cast<scalar_t*>(mixed_qkvz.data_ptr()),             \
+      reinterpret_cast<scalar_t*>(mixed_ba.data_ptr()),               \
+      reinterpret_cast<scalar_t*>(conv_weights.data_ptr()),           \
+      conv_bias.has_value()                                           \
+          ? reinterpret_cast<scalar_t*>(conv_bias->data_ptr())        \
+          : nullptr,                                                  \
+      reinterpret_cast<scalar_t*>(conv_states.data_ptr()),            \
+      conv_states_stride_0,                                           \
+      reinterpret_cast<scalar_t*>(conv_states_tmp.data_ptr()),        \
+      reinterpret_cast<int*>(query_start_loc.data_ptr()),             \
+      reinterpret_cast<int*>(cache_indices.data_ptr()),               \
+      has_initial_state.has_value()                                   \
+          ? reinterpret_cast<bool*>(has_initial_state->data_ptr())    \
+          : nullptr,                                                  \
+      act_mode,                                                       \
+      pad_slot_id,                                                    \
+      batch_size,                                                     \
+      num_actual_tokens,                                              \
+      num_k_heads,                                                    \
+      head_k_dim,                                                     \
+      num_v_heads,                                                    \
+      head_v_dim,                                                     \
+      qkvz_elems,                                                     \
+      conv_elems,                                                     \
+      num_prefills,                                                   \
+      num_decodes,                                                    \
+      spec_state_indices_ptr,                                         \
+      num_accepted_tokens_ptr,                                        \
+      spec_stride,                                                    \
+      state_len);
+
+#define KERNEL_LAUNCHER(scalar_t, width, reorder_input)         \
+  if (is_spec) {                                                \
+    KERNEL_LAUNCHER_IMPL(scalar_t, width, reorder_input, true)  \
+  } else {                                                      \
+    KERNEL_LAUNCHER_IMPL(scalar_t, width, reorder_input, false) \
+  }
 
 #define WIDTH_DISPATCH(scalar_t, width, reorder_input) \
   switch (width) {                                     \
@@ -660,6 +902,7 @@ void causal_conv1d(
 #undef SPLIT_DISPATCH
 #undef WIDTH_DISPATCH
 #undef KERNEL_LAUNCHER
+#undef KERNEL_LAUNCHER_IMPL
 }
 
 }  // namespace gdn

--- a/csrc/xpu/gdn_attn/gated_delta_rule.hpp
+++ b/csrc/xpu/gdn_attn/gated_delta_rule.hpp
@@ -5,7 +5,7 @@
 
 namespace gdn {
 static constexpr int sub_group_size = 32;
-template <typename T, typename StateT, int k_bucket_size>
+template <typename T, typename StateT, int k_bucket_size, bool IS_SPEC = false>
 struct gated_delta_rule_kernel {
  public:
   static constexpr int group_size = 256;
@@ -33,7 +33,14 @@ struct gated_delta_rule_kernel {
       const int num_k_heads,
       const int head_k_dim,
       const int num_v_heads,
-      const int head_v_dim)
+      const int head_v_dim,
+      // Spec-decoding (only consulted when IS_SPEC=true). When IS_SPEC,
+      // `cache_indices` above is ignored; per-sequence load slot comes from
+      // `spec_state_indices[i_n, num_accepted_tokens[i_n] - 1]` and per-token
+      // store slot comes from `spec_state_indices[i_n, t - seq_start]`.
+      const int* spec_state_indices = nullptr,
+      const int* num_accepted_tokens = nullptr,
+      const int spec_stride = 0)
       : core_attn_out(core_attn_out),
         q(q),
         k(k),
@@ -52,7 +59,10 @@ struct gated_delta_rule_kernel {
         num_k_heads(num_k_heads),
         head_k_dim(head_k_dim),
         num_v_heads(num_v_heads),
-        head_v_dim(head_v_dim) {}
+        head_v_dim(head_v_dim),
+        spec_state_indices(spec_state_indices),
+        num_accepted_tokens(num_accepted_tokens),
+        spec_stride(spec_stride) {}
 
   static inline sycl::nd_range<3> get_nd_range(
       const int batch_size, const int num_v_heads, const int head_v_dim) {
@@ -102,12 +112,32 @@ struct gated_delta_rule_kernel {
     float k_local[k_bucket_size];
     float v_local[v_dim_per_sg];
 
-    StateT* ssm_state_ptr =
-        ssm_state +
-        static_cast<int64_t>(cache_indices[batch_id]) * ssm_state_stride_0;
+    // Resolve the slot to load the initial recurrent state from. For spec
+    // decoding, the slot comes from spec_state_indices[batch_id,
+    // num_accepted_tokens[batch_id] - 1] and a non-positive slot value
+    // (0 = NULL_BLOCK_ID, mirrors FLA) means "no valid prior state".
+    int64_t load_slot;
+    bool has_init_state;
+    if constexpr (IS_SPEC) {
+      const int n_acc = num_accepted_tokens[batch_id];
+      if (n_acc <= 0) {
+        load_slot = 0;
+        has_init_state = false;
+      } else {
+        const int load_idx = n_acc - 1;
+        const int raw = spec_state_indices[batch_id * spec_stride + load_idx];
+        load_slot = static_cast<int64_t>(raw);
+        has_init_state = raw > 0;
+      }
+    } else {
+      load_slot = static_cast<int64_t>(cache_indices[batch_id]);
+      has_init_state =
+          (has_initial_state == nullptr) || has_initial_state[batch_id];
+    }
+    StateT* ssm_state_ptr = ssm_state + load_slot * ssm_state_stride_0;
 
     // load state
-    if (has_initial_state == nullptr || has_initial_state[batch_id]) {
+    if (has_init_state) {
 #pragma unroll
       for (int j = 0; j < v_dim_per_sg; ++j) {
 #pragma unroll
@@ -227,18 +257,46 @@ struct gated_delta_rule_kernel {
                head_v_dim_id + i] = res[i];
         }
       }
+
+      // (S2) Per-token state writeback for spec-decoding. Each candidate
+      // token in this sequence writes its post-state to a different cache
+      // pool slot indexed by spec_state_indices[batch_id, t - seq_start].
+      // A non-positive slot value is the FLA NULL_BLOCK_ID; skip the write.
+      if constexpr (IS_SPEC) {
+        const int spec_slot =
+            spec_state_indices[batch_id * spec_stride + (t - seq_start_offset)];
+        if (spec_slot > 0) {
+          StateT* per_token_ptr =
+              ssm_state + static_cast<int64_t>(spec_slot) * ssm_state_stride_0;
+#pragma unroll
+          for (int j = 0; j < v_dim_per_sg; ++j) {
+#pragma unroll
+            for (int i = 0; i < k_bucket_size; ++i) {
+              per_token_ptr
+                  [num_v_heads_id * head_k_dim * head_v_dim +
+                   (k_bucket_size * sg_local_id + i) +
+                   (head_v_dim_id + j) * head_k_dim] =
+                      static_cast<StateT>(state_local[j * k_bucket_size + i]);
+            }
+          }
+        }
+      }
     }
 
+    // (S3) Non-spec final-state writeback. Spec covered the per-token write
+    // above so no post-loop store is needed.
+    if constexpr (!IS_SPEC) {
 // update state
 #pragma unroll
-    for (int j = 0; j < v_dim_per_sg; ++j) {
+      for (int j = 0; j < v_dim_per_sg; ++j) {
 #pragma unroll
-      for (int i = 0; i < k_bucket_size; ++i) {
-        ssm_state_ptr
-            [num_v_heads_id * head_k_dim * head_v_dim +
-             (k_bucket_size * sg_local_id + i) +
-             (head_v_dim_id + j) * head_k_dim] =
-                static_cast<StateT>(state_local[j * k_bucket_size + i]);
+        for (int i = 0; i < k_bucket_size; ++i) {
+          ssm_state_ptr
+              [num_v_heads_id * head_k_dim * head_v_dim +
+               (k_bucket_size * sg_local_id + i) +
+               (head_v_dim_id + j) * head_k_dim] =
+                  static_cast<StateT>(state_local[j * k_bucket_size + i]);
+        }
       }
     }
   }
@@ -263,9 +321,13 @@ struct gated_delta_rule_kernel {
   const int head_k_dim;
   const int num_v_heads;
   const int head_v_dim;
+  // Spec-decoding inputs (consulted when IS_SPEC=true). See ctor docstring.
+  const int* spec_state_indices;
+  const int* num_accepted_tokens;
+  const int spec_stride;
 };
 
-template <typename T, typename StateT, int k_bucket_size>
+template <typename T, typename StateT, int k_bucket_size, bool IS_SPEC = false>
 void kernel_launcher(
     sycl::queue& queue,
     T* core_attn_out,
@@ -286,8 +348,11 @@ void kernel_launcher(
     const int num_k_heads,
     const int head_k_dim,
     const int num_v_heads,
-    const int head_v_dim) {
-  using KERNEL = gated_delta_rule_kernel<T, StateT, k_bucket_size>;
+    const int head_v_dim,
+    const int* spec_state_indices = nullptr,
+    const int* num_accepted_tokens = nullptr,
+    const int spec_stride = 0) {
+  using KERNEL = gated_delta_rule_kernel<T, StateT, k_bucket_size, IS_SPEC>;
   auto range = KERNEL::get_nd_range(batch_size, num_v_heads, head_v_dim);
   assert(head_v_dim % KERNEL::v_dim_per_group == 0);
   queue.submit([&](sycl::handler& cgh) {
@@ -310,7 +375,10 @@ void kernel_launcher(
         num_k_heads,
         head_k_dim,
         num_v_heads,
-        head_v_dim);
+        head_v_dim,
+        spec_state_indices,
+        num_accepted_tokens,
+        spec_stride);
     cgh.parallel_for(range, task);
   });
 }
@@ -332,7 +400,13 @@ void gated_delta_rule(
     const std::optional<torch::Tensor>&
         has_initial_state,  // [batch_size] or None
     const int num_prefills,
-    const int num_decodes) {
+    const int num_decodes,
+    // Spec-decoding extension. When IS_SPEC=true, cache_indices is unused
+    // and slot lookup goes through spec_state_indices + num_accepted_tokens.
+    const bool is_spec = false,
+    const int* spec_state_indices_ptr = nullptr,
+    const int* num_accepted_tokens_ptr = nullptr,
+    const int spec_stride = 0) {
   if (num_prefills == 0 && num_decodes == 0) {
     return;
   }
@@ -364,30 +438,40 @@ void gated_delta_rule(
   TORCH_CHECK(head_k_dim % sub_group_size == 0);
   const int k_bucket_size = head_k_dim / sub_group_size;
 
-#define KERNEL_LAUNCHER(scalar_t, state_scalar_t, k_bucket_size)   \
-  kernel_launcher<scalar_t, state_scalar_t, k_bucket_size>(        \
-      queue,                                                       \
-      reinterpret_cast<scalar_t*>(core_attn_out.data_ptr()),       \
-      reinterpret_cast<scalar_t*>(q.data_ptr()),                   \
-      reinterpret_cast<scalar_t*>(k.data_ptr()),                   \
-      reinterpret_cast<scalar_t*>(v.data_ptr()),                   \
-      reinterpret_cast<scalar_t*>(b.data_ptr()),                   \
-      reinterpret_cast<scalar_t*>(a.data_ptr()),                   \
-      reinterpret_cast<float*>(A_log.data_ptr()),                  \
-      reinterpret_cast<scalar_t*>(dt_bias.data_ptr()),             \
-      reinterpret_cast<state_scalar_t*>(ssm_state.data_ptr()),     \
-      ssm_state_stride_0,                                          \
-      reinterpret_cast<int*>(query_start_loc.data_ptr()),          \
-      reinterpret_cast<int*>(cache_indices.data_ptr()),            \
-      has_initial_state.has_value()                                \
-          ? reinterpret_cast<bool*>(has_initial_state->data_ptr()) \
-          : nullptr,                                               \
-      batch_size,                                                  \
-      total_seqlen,                                                \
-      num_k_heads,                                                 \
-      head_k_dim,                                                  \
-      num_v_heads,                                                 \
-      head_v_dim);
+#define KERNEL_LAUNCHER_IMPL(scalar_t, state_scalar_t, k_bucket_size, IS_SPEC) \
+  kernel_launcher<scalar_t, state_scalar_t, k_bucket_size, IS_SPEC>(           \
+      queue,                                                                   \
+      reinterpret_cast<scalar_t*>(core_attn_out.data_ptr()),                   \
+      reinterpret_cast<scalar_t*>(q.data_ptr()),                               \
+      reinterpret_cast<scalar_t*>(k.data_ptr()),                               \
+      reinterpret_cast<scalar_t*>(v.data_ptr()),                               \
+      reinterpret_cast<scalar_t*>(b.data_ptr()),                               \
+      reinterpret_cast<scalar_t*>(a.data_ptr()),                               \
+      reinterpret_cast<float*>(A_log.data_ptr()),                              \
+      reinterpret_cast<scalar_t*>(dt_bias.data_ptr()),                         \
+      reinterpret_cast<state_scalar_t*>(ssm_state.data_ptr()),                 \
+      ssm_state_stride_0,                                                      \
+      reinterpret_cast<int*>(query_start_loc.data_ptr()),                      \
+      reinterpret_cast<int*>(cache_indices.data_ptr()),                        \
+      has_initial_state.has_value()                                            \
+          ? reinterpret_cast<bool*>(has_initial_state->data_ptr())             \
+          : nullptr,                                                           \
+      batch_size,                                                              \
+      total_seqlen,                                                            \
+      num_k_heads,                                                             \
+      head_k_dim,                                                              \
+      num_v_heads,                                                             \
+      head_v_dim,                                                              \
+      spec_state_indices_ptr,                                                  \
+      num_accepted_tokens_ptr,                                                 \
+      spec_stride);
+
+#define KERNEL_LAUNCHER(scalar_t, state_scalar_t, k_bucket_size)         \
+  if (is_spec) {                                                         \
+    KERNEL_LAUNCHER_IMPL(scalar_t, state_scalar_t, k_bucket_size, true)  \
+  } else {                                                               \
+    KERNEL_LAUNCHER_IMPL(scalar_t, state_scalar_t, k_bucket_size, false) \
+  }
 
 #define BUCKET_DISPATCH(scalar_t, state_scalar_t, k_bucket_size) \
   switch (k_bucket_size) {                                       \
@@ -439,6 +523,7 @@ void gated_delta_rule(
 #undef DISPATCH_STATE_DTYPE
 #undef BUCKET_DISPATCH
 #undef KERNEL_LAUNCHER
+#undef KERNEL_LAUNCHER_IMPL
 }
 
 }  // namespace gdn

--- a/csrc/xpu/gdn_attn/gdn_attn_interface.cpp
+++ b/csrc/xpu/gdn_attn/gdn_attn_interface.cpp
@@ -48,7 +48,12 @@ void gdn_attention(
     const torch::Tensor& non_spec_state_indices_tensor,  // [batch_size]
     const int64_t num_actual_tokens,
     const int64_t tp_size,
-    const bool reorder_input) {
+    const bool reorder_input,
+    // Spec-decoding extension. When provided together (both non-empty), the
+    // op evaluates K candidate tokens per sequence and uses the per-token
+    // slot ring; mirrors FLA Triton IS_SPEC_DECODING.
+    const std::optional<torch::Tensor>& spec_state_indices_tensor,
+    const std::optional<torch::Tensor>& num_accepted_tokens) {
   TORCH_CHECK(
       core_attn_out.is_contiguous(), "core_attn_out must be contiguous");
   TORCH_CHECK(z.is_contiguous(), "z must be contiguous");
@@ -140,6 +145,62 @@ void gdn_attention(
   }
   const int pad_slot_id = -1;
 
+  // Resolve spec-decoding state. Both tensors must be set or both unset;
+  // mismatched is rejected. When set, route through the native kernels
+  // with IS_SPEC=true (the chunk path handles non-spec prefill only).
+  const bool is_spec =
+      spec_state_indices_tensor.has_value() && num_accepted_tokens.has_value();
+  TORCH_CHECK(
+      spec_state_indices_tensor.has_value() == num_accepted_tokens.has_value(),
+      "spec_state_indices_tensor and num_accepted_tokens must both be "
+      "provided or both omitted");
+  const int* spec_state_indices_ptr = nullptr;
+  const int* num_accepted_tokens_ptr = nullptr;
+  int spec_stride = 0;
+  if (is_spec) {
+    const auto& spec_idx = spec_state_indices_tensor.value();
+    const auto& num_acc = num_accepted_tokens.value();
+    TORCH_CHECK(
+        spec_idx.is_contiguous(),
+        "spec_state_indices_tensor must be contiguous");
+    TORCH_CHECK(
+        num_acc.is_contiguous(), "num_accepted_tokens must be contiguous");
+    TORCH_CHECK(
+        spec_idx.dim() == 2,
+        "spec_state_indices_tensor must be 2D [num_seqs, K]");
+    TORCH_CHECK(
+        num_acc.dim() == 1, "num_accepted_tokens must be 1D [num_seqs]");
+    // Both tensors are reinterpret_cast<int*> on the kernel side; require
+    // int32 explicitly so a runaway int64 caller fails loudly instead of
+    // silently misreading bytes.
+    TORCH_CHECK(
+        spec_idx.scalar_type() == at::kInt,
+        "spec_state_indices_tensor must be int32, got ",
+        spec_idx.scalar_type());
+    TORCH_CHECK(
+        num_acc.scalar_type() == at::kInt,
+        "num_accepted_tokens must be int32, got ",
+        num_acc.scalar_type());
+    TORCH_CHECK(
+        spec_idx.size(0) == num_acc.size(0),
+        "spec_state_indices_tensor.size(0) (",
+        spec_idx.size(0),
+        ") must match num_accepted_tokens.size(0) (",
+        num_acc.size(0),
+        ")");
+    TORCH_CHECK(
+        spec_idx.size(0) == non_spec_query_start_loc.size(0) - 1,
+        "spec_state_indices_tensor.size(0) (",
+        spec_idx.size(0),
+        ") must equal query_start_loc.size(0) - 1 (",
+        non_spec_query_start_loc.size(0) - 1,
+        "); pass spec_query_start_loc as non_spec_query_start_loc when "
+        "spec args are set");
+    spec_state_indices_ptr = reinterpret_cast<int*>(spec_idx.data_ptr());
+    num_accepted_tokens_ptr = reinterpret_cast<int*>(num_acc.data_ptr());
+    spec_stride = spec_idx.size(1);
+  }
+
 #define NATIVE_LAUNCHER                                           \
   do {                                                            \
     torch::Tensor q = torch::empty(                               \
@@ -177,7 +238,11 @@ void gdn_attention(
         pad_slot_id,                                              \
         num_prefills,                                             \
         num_decodes,                                              \
-        reorder_input);                                           \
+        reorder_input,                                            \
+        is_spec,                                                  \
+        spec_state_indices_ptr,                                   \
+        num_accepted_tokens_ptr,                                  \
+        spec_stride);                                             \
     gdn::gated_delta_rule(                                        \
         queue,                                                    \
         core_attn_out_active,                                     \
@@ -193,11 +258,18 @@ void gdn_attention(
         non_spec_state_indices_tensor,                            \
         has_initial_state,                                        \
         num_prefills,                                             \
-        num_decodes);                                             \
+        num_decodes,                                              \
+        is_spec,                                                  \
+        spec_state_indices_ptr,                                   \
+        num_accepted_tokens_ptr,                                  \
+        spec_stride);                                             \
   } while (0)
 
 #ifdef VLLM_XPU_ENABLE_XE2
-  if (num_prefills > 0) {
+  // Spec-decoding always routes through the native kernels: even when
+  // seq_len > 1 (K=2..3 candidates) the spec slot ring needs the per-token
+  // writeback path, which the chunk kernels don't implement.
+  if (!is_spec && num_prefills > 0) {
     int batch_size = non_spec_query_start_loc.size(0) - 1;
     int padding_size = batch_size * (gdn::chunk_size_xe2 - 1);
 

--- a/csrc/xpu/ops.h
+++ b/csrc/xpu/ops.h
@@ -109,7 +109,17 @@ void gdn_attention(
     const torch::Tensor& non_spec_state_indices_tensor,
     const int64_t num_actual_tokens,
     const int64_t tp_size,
-    const bool reorder_input);
+    const bool reorder_input,
+    // Spec-decoding extension. When `spec_state_indices_tensor` is provided
+    // (shape [num_seqs, K]), the call evaluates K candidate tokens per
+    // sequence, loads the initial state from
+    // `spec_state_indices_tensor[i, num_accepted_tokens[i]-1]`, and writes
+    // each token's post-state to `spec_state_indices_tensor[i, t]`. Mirrors
+    // the FLA Triton IS_SPEC_DECODING semantics. Both must be provided
+    // together; both nullopt = legacy non-spec behavior.
+    const std::optional<torch::Tensor>& spec_state_indices_tensor =
+        std::nullopt,
+    const std::optional<torch::Tensor>& num_accepted_tokens = std::nullopt);
 #endif
 
 bool is_bmg(int64_t device_index);

--- a/csrc/xpu/torch_bindings.cpp
+++ b/csrc/xpu/torch_bindings.cpp
@@ -98,7 +98,9 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, xpu_ops) {
       "int num_prefills, int num_decodes, Tensor? has_initial_state, Tensor "
       "non_spec_query_start_loc,"
       "Tensor non_spec_state_indices_tensor, int num_actual_tokens, int "
-      "tp_size, bool reorder_input) -> ()");
+      "tp_size, bool reorder_input,"
+      "Tensor? spec_state_indices_tensor=None, "
+      "Tensor? num_accepted_tokens=None) -> ()");
   xpu_ops.impl("gdn_attention", torch::kXPU, &gdn_attention);
 #endif
 

--- a/tests/gdn_attn/test_gdn_attn_spec.py
+++ b/tests/gdn_attn/test_gdn_attn_spec.py
@@ -1,0 +1,575 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for the spec-decoding extension of ``gdn_attention``.
+
+The op now accepts two optional tensors that together mirror FLA's
+``IS_SPEC_DECODING`` semantics:
+
+* ``spec_state_indices_tensor`` — int32 ``[num_seqs, K]`` ring of kv-cache
+  slot indices. The per-sequence load slot is
+  ``spec_state_indices_tensor[i, num_accepted_tokens[i] - 1]``; the
+  per-token store slot during the gated-delta-rule loop is
+  ``spec_state_indices_tensor[i, t - seq_start]``. A non-positive slot
+  (``<= 0``, i.e. ``NULL_BLOCK_ID``) is treated as "no valid prior
+  state" — the conv pre-state load is suppressed and SSM per-token
+  writebacks are skipped for that slot.
+* ``num_accepted_tokens`` — int32 ``[num_seqs]``.
+
+When both tensors are omitted, behavior is bit-exact with the pre-PR
+op (the existing ``test_gdn_attn.py`` / ``test_gdn_attn_padded.py``
+suite exercises that path).
+
+The production dispatcher (paired vLLM PR #42382) passes
+``spec_state_indices_tensor[:, 0]`` as the ``non_spec_state_indices_tensor``
+arg under spec — the kernel uses that as the write target for the
+``spec_state_roll_kernel`` (conv state writeback). These tests follow
+that wiring convention.
+
+We cross-check the spec path against the non-spec path via three
+kernel-internal equivalences:
+
+1. **K>1, aligned ring, num_accepted=1, decode** — per-token writebacks
+   all land on the same slot; the core_attn_out and final ssm_state
+   at that slot must match the non-spec native path on the same
+   workload.
+2. **NULL_BLOCK_ID** — under spec with the load slot = ``NULL`` and the
+   per-token store slot = ``NULL``, the kernel must produce the same
+   core_attn_out as a non-spec call with ``has_initial_state=False`` on
+   the same workload, AND must leave the conv/ssm pools byte-identical
+   to their pre-call contents (no writes through NULL slots).
+3. **Argument-pair validation** — passing only one of the spec args
+   must raise.
+
+Plus a smoke test that the K>1 native spec path runs to completion on
+varied ``num_accepted_tokens`` and produces finite outputs.
+
+Note that the K=1 spec path (state_len = Width-1) is NOT exercised here
+as a bit-exact equivalence: the spec kernel's conv_state writeback
+populates positions ``{0} ∪ [state_len - K_call, state_len)`` of the
+rolled tmp buffer per work-item, so when ``K_call < state_len - K_call``
+(i.e. ``K_call < (state_len)/2``, true for K=1 with Width≥4) the
+intermediate tmp rows are uninitialized and the post-state conv slot
+differs from the non-spec path. Production never hits this — vLLM
+routes K=1 requests to the non-spec path — but it's worth flagging so
+a future reader doesn't burn time re-deriving it.
+
+Full correctness for the non-degenerate spec path with K>1 and arbitrary
+``num_accepted_tokens`` is covered by the paired vLLM replay harness in
+``tests/kernels/xpu/test_spec_gdn_replay.py`` (PR vllm-project/vllm#42382)
+which diffs against a live FLA Triton reference.
+"""
+
+import random
+
+import pytest
+import torch
+
+import vllm_xpu_kernels._xpu_C  # noqa: F401
+
+NUM_K_HEADS = 2
+NUM_V_HEADS = 4
+HEAD_K_DIM = 64
+HEAD_V_DIM = 64
+WIDTH = 4
+TP_SIZE = 1
+CACHE_BATCH_SIZE = 32
+ACTIVATION = "silu"
+
+
+def _mixed_qkvz_size():
+    return (
+        NUM_K_HEADS
+        // TP_SIZE
+        * (2 * HEAD_K_DIM + 2 * HEAD_V_DIM * NUM_V_HEADS // NUM_K_HEADS)
+    )
+
+
+def _mixed_ba_size():
+    return NUM_K_HEADS // TP_SIZE * (2 * NUM_V_HEADS // NUM_K_HEADS)
+
+
+def _mixed_qkv_size():
+    return (
+        NUM_K_HEADS
+        // TP_SIZE
+        * (2 * HEAD_K_DIM + HEAD_V_DIM * NUM_V_HEADS // NUM_K_HEADS)
+    )
+
+
+def _alloc_inputs(num_tokens, batch_size, dtype, device, seed=42):
+    random.seed(seed)
+    torch.manual_seed(seed)
+
+    qkvz_size = _mixed_qkvz_size()
+    ba_size = _mixed_ba_size()
+    qkv_size = _mixed_qkv_size()
+
+    qkvz = torch.randn(num_tokens, qkvz_size, dtype=dtype, device=device)
+    ba = torch.randn(num_tokens, ba_size, dtype=dtype, device=device)
+
+    conv_state = torch.randn(
+        CACHE_BATCH_SIZE, WIDTH - 1, qkv_size, dtype=dtype, device=device
+    )
+    ssm_state = torch.randn(
+        CACHE_BATCH_SIZE,
+        NUM_V_HEADS // TP_SIZE,
+        HEAD_V_DIM,
+        HEAD_K_DIM,
+        dtype=dtype,
+        device=device,
+    )
+
+    conv_weights = torch.randn(qkv_size, WIDTH, dtype=dtype, device=device)
+    A_log = torch.randn(
+        NUM_V_HEADS // TP_SIZE, dtype=torch.float32, device=device
+    )
+    dt_bias = torch.randn(NUM_V_HEADS // TP_SIZE, dtype=dtype, device=device)
+
+    # Slot 0 is reserved as NULL_BLOCK_ID sentinel; sample real slots from
+    # [1, CACHE_BATCH_SIZE) to avoid collisions with the null path.
+    state_indices = torch.tensor(
+        random.sample(range(1, CACHE_BATCH_SIZE), batch_size),
+        device=device,
+        dtype=torch.int32,
+    )
+
+    return dict(
+        qkvz=qkvz,
+        ba=ba,
+        conv_state=conv_state,
+        ssm_state=ssm_state,
+        conv_weights=conv_weights,
+        A_log=A_log,
+        dt_bias=dt_bias,
+        state_indices=state_indices,
+    )
+
+
+def _decode_query_start_loc(batch_size, device):
+    """Decode-only: one token per sequence."""
+    return torch.arange(batch_size + 1, dtype=torch.int32, device=device)
+
+
+def _call_gdn(
+    inputs,
+    num_actual_tokens,
+    num_prefills,
+    num_decodes,
+    query_start_loc,
+    state_indices,
+    has_initial_state,
+    spec_state_indices=None,
+    num_accepted_tokens=None,
+    reorder_input=False,
+):
+    device = inputs["qkvz"].device
+    dtype = inputs["qkvz"].dtype
+    core_attn_out = torch.zeros(
+        num_actual_tokens,
+        NUM_V_HEADS // TP_SIZE,
+        HEAD_V_DIM,
+        dtype=dtype,
+        device=device,
+    )
+    z = torch.empty_like(core_attn_out)
+    torch.ops._xpu_C.gdn_attention(
+        core_attn_out,
+        z,
+        inputs["qkvz"],
+        inputs["ba"],
+        NUM_K_HEADS,
+        NUM_V_HEADS,
+        HEAD_K_DIM,
+        HEAD_V_DIM,
+        conv_state=inputs["conv_state"],
+        ssm_state=inputs["ssm_state"],
+        conv_weights=inputs["conv_weights"],
+        conv_bias=None,
+        activation=ACTIVATION,
+        A_log=inputs["A_log"],
+        dt_bias=inputs["dt_bias"],
+        num_prefills=num_prefills,
+        num_decodes=num_decodes,
+        has_initial_state=has_initial_state,
+        non_spec_query_start_loc=query_start_loc,
+        non_spec_state_indices_tensor=state_indices,
+        num_actual_tokens=num_actual_tokens,
+        tp_size=TP_SIZE,
+        reorder_input=reorder_input,
+        spec_state_indices_tensor=spec_state_indices,
+        num_accepted_tokens=num_accepted_tokens,
+    )
+    return core_attn_out, z
+
+
+def _clone_caches(inputs):
+    return dict(
+        inputs,
+        qkvz=inputs["qkvz"].clone(),
+        ba=inputs["ba"].clone(),
+        conv_state=inputs["conv_state"].clone(),
+        ssm_state=inputs["ssm_state"].clone(),
+    )
+
+
+@pytest.mark.parametrize("batch_size", [1, 4, 8])
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+@torch.inference_mode()
+def test_spec_kN_aligned_ring_matches_nonspec_core_attn(batch_size, dtype):
+    """K=4 spec with all ring slots equal, num_accepted=1 → core_attn_out
+    and ssm_state at the (single) load/store slot must match the non-spec
+    native decode path.
+
+    With ``num_accepted_tokens=1`` the kernel loads pre-state from
+    ``ring[:, 0]`` (= load_idx = n_acc-1 = 0), and the only candidate
+    token's per-token store goes to ``ring[:, 0]`` (= t - seq_start = 0).
+    Both load and store thus resolve to the same slot as the non-spec
+    path when we set ``ring[:, 0] == non_spec_state_indices``. The
+    SSM math is byte-identical between the two branches in this
+    configuration, so core_attn_out / z / final ssm_state at the slot
+    must match bit-exactly.
+    """
+    device = "xpu"
+    inputs = _alloc_inputs(batch_size, batch_size, dtype, device, seed=13)
+    query_start_loc = _decode_query_start_loc(batch_size, device)
+    has_initial = torch.ones(batch_size, dtype=torch.bool, device=device)
+
+    K = 4
+    # Ring: every entry == the canonical slot.
+    ring = (
+        inputs["state_indices"].unsqueeze(-1).expand(batch_size, K).contiguous()
+    )
+    num_accepted = torch.ones(batch_size, dtype=torch.int32, device=device)
+
+    # Non-spec reference: native decode path, single token per sequence.
+    nonspec_in = _clone_caches(inputs)
+    nonspec_out, nonspec_z = _call_gdn(
+        nonspec_in,
+        num_actual_tokens=batch_size,
+        num_prefills=0,
+        num_decodes=batch_size,
+        query_start_loc=query_start_loc,
+        state_indices=nonspec_in["state_indices"],
+        has_initial_state=has_initial,
+    )
+
+    # Spec call: K=4 ring, num_accepted=1 → only ring[:, 0] is touched
+    # for both load and store. Pool conv_state sized for state_len =
+    # (Width-1) + (K-1) (the kernel infers state_len from stride_0).
+    state_len = (WIDTH - 1) + (K - 1)
+    spec_in = _clone_caches(inputs)
+    spec_conv_state = torch.randn(
+        CACHE_BATCH_SIZE,
+        state_len,
+        _mixed_qkv_size(),
+        dtype=dtype,
+        device=device,
+    )
+    # Plant the non-spec pre-state at the appropriate offset inside the
+    # larger spec slot. With n_acc=1, the kernel loads pre-state from
+    # rows [Width-1-states_load_len, Width-1) of the slot starting at
+    # offset (n_acc-1) = 0 — i.e. the leading (Width-1) rows. Match the
+    # non-spec pre-state there so the conv1d inputs are identical.
+    spec_conv_state[:, : WIDTH - 1, :] = inputs["conv_state"]
+    spec_in["conv_state"] = spec_conv_state
+
+    spec_out, spec_z = _call_gdn(
+        spec_in,
+        num_actual_tokens=batch_size,
+        num_prefills=0,
+        num_decodes=batch_size,
+        query_start_loc=query_start_loc,
+        # Production dispatcher passes ring[:, 0] here under spec. It's
+        # used by the kernel as the write target for spec_state_roll.
+        state_indices=ring[:, 0].contiguous(),
+        has_initial_state=has_initial,
+        spec_state_indices=ring,
+        num_accepted_tokens=num_accepted,
+    )
+
+    assert torch.equal(spec_out, nonspec_out), (
+        "K=4 aligned-ring spec must produce bit-identical core_attn_out "
+        f"vs non-spec; max abs diff = "
+        f"{(spec_out.float() - nonspec_out.float()).abs().max().item():.3e}"
+    )
+    assert torch.equal(spec_z, nonspec_z), (
+        "K=4 aligned-ring spec must produce bit-identical z vs non-spec"
+    )
+
+    # ssm_state at touched slots: bit-exact. The SSM kernel writes the
+    # post-token state directly to ring[:, t - seq_start]; with K_call=1
+    # and aligned ring, this matches the non-spec final-state writeback.
+    for i in range(batch_size):
+        slot = nonspec_in["state_indices"][i].item()
+        assert torch.equal(
+            spec_in["ssm_state"][slot], nonspec_in["ssm_state"][slot]
+        ), (
+            f"ssm_state[{slot}] mismatch after spec(K=4 aligned ring) "
+            "vs non-spec"
+        )
+
+
+@pytest.mark.parametrize("batch_size", [2, 4])
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+@torch.inference_mode()
+def test_spec_null_block_id_suppresses_pool_io(batch_size, dtype):
+    """NULL load+store slots must suppress both the conv/ssm pre-state
+    load AND the per-token pool writes.
+
+    Build a K=2 spec call where ``ring[:, 0]`` is NULL (0) — both the
+    load slot (``n_acc-1 == 0``) and the per-token store slot
+    (``t - seq_start == 0``) resolve to NULL. Cross-check:
+
+    1. ``core_attn_out`` must match a non-spec call with
+       ``has_initial_state=False`` on the same workload (the spec path
+       still runs the SSM math; only the pre-state load and pool
+       writeback are suppressed).
+    2. The conv/ssm pools must be byte-identical to their pre-call
+       state — NULL store slot ⇒ no pool writes.
+    """
+    device = "xpu"
+    inputs = _alloc_inputs(batch_size, batch_size, dtype, device, seed=11)
+    query_start_loc = _decode_query_start_loc(batch_size, device)
+
+    # Non-spec reference: has_initial_state=False forces zero pre-state.
+    nonspec_in = _clone_caches(inputs)
+    has_initial_false = torch.zeros(batch_size, dtype=torch.bool, device=device)
+    nonspec_out, _ = _call_gdn(
+        nonspec_in,
+        num_actual_tokens=batch_size,
+        num_prefills=0,
+        num_decodes=batch_size,
+        query_start_loc=query_start_loc,
+        state_indices=nonspec_in["state_indices"],
+        has_initial_state=has_initial_false,
+    )
+
+    # Spec call: ring[:, 0] = NULL_BLOCK_ID (= 0). Slot at index 0 is
+    # never used by real traffic — kernels treat it as the sentinel.
+    K = 2
+    null_col = torch.zeros(batch_size, dtype=torch.int32, device=device)
+    real_col = inputs["state_indices"]
+    ring = torch.stack([null_col, real_col], dim=-1).contiguous()
+    num_accepted = torch.ones(batch_size, dtype=torch.int32, device=device)
+
+    # Pool sized for state_len = (Width-1) + (K-1).
+    state_len = (WIDTH - 1) + (K - 1)
+    spec_in = _clone_caches(inputs)
+    spec_in["conv_state"] = torch.randn(
+        CACHE_BATCH_SIZE,
+        state_len,
+        _mixed_qkv_size(),
+        dtype=dtype,
+        device=device,
+    )
+    conv_pool_pre = spec_in["conv_state"].clone()
+    ssm_pool_pre = spec_in["ssm_state"].clone()
+
+    # has_initial_state is consulted only by the non-spec branch; the
+    # spec branch's NULL slot already suppresses pre-state. Pass True
+    # to confirm the spec branch ignores it.
+    has_initial_true = torch.ones(batch_size, dtype=torch.bool, device=device)
+    spec_out, _ = _call_gdn(
+        spec_in,
+        num_actual_tokens=batch_size,
+        num_prefills=0,
+        num_decodes=batch_size,
+        query_start_loc=query_start_loc,
+        state_indices=ring[:, 0].contiguous(),  # = all-NULL
+        has_initial_state=has_initial_true,
+        spec_state_indices=ring,
+        num_accepted_tokens=num_accepted,
+    )
+
+    # core_attn_out: zero pre-state in both, identical math → tight
+    # match. Allow small numeric drift between the (chunk vs native)
+    # paths even though we're decode-only — both should hit native.
+    torch.testing.assert_close(spec_out, nonspec_out, atol=5e-2, rtol=5e-2)
+
+    # Pool: NULL store slots → no writes at all.
+    conv_diff = (
+        (spec_in["conv_state"][0].float() - conv_pool_pre[0].float())
+        .abs()
+        .max()
+        .item()
+    )
+    assert torch.equal(spec_in["conv_state"], conv_pool_pre), (
+        "NULL store slot must not write to conv_state pool; "
+        f"diff at slot 0 max abs = {conv_diff:.3e}"
+    )
+    assert torch.equal(spec_in["ssm_state"], ssm_pool_pre), (
+        "NULL store slot must not write to ssm_state pool"
+    )
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16])
+@torch.inference_mode()
+def test_spec_kN_native_smoke_finite(dtype):
+    """K=4 spec on a non-degenerate ring with mixed ``num_accepted``
+    values runs cleanly and produces finite outputs. Doesn't diff
+    against a Python oracle — full correctness is covered by the paired
+    vLLM replay harness against a live FLA Triton reference.
+    """
+    device = "xpu"
+    K = 4
+    batch_size = 3
+    inputs = _alloc_inputs(batch_size, batch_size, dtype, device, seed=17)
+    query_start_loc = _decode_query_start_loc(batch_size, device)
+    has_initial = torch.ones(batch_size, dtype=torch.bool, device=device)
+
+    pool = random.sample(range(1, CACHE_BATCH_SIZE), batch_size * K)
+    ring = torch.tensor(pool, device=device, dtype=torch.int32).reshape(
+        batch_size, K
+    )
+    num_accepted = torch.tensor([1, K, 2], dtype=torch.int32, device=device)
+
+    state_len = (WIDTH - 1) + (K - 1)
+    inputs["conv_state"] = torch.randn(
+        CACHE_BATCH_SIZE,
+        state_len,
+        _mixed_qkv_size(),
+        dtype=dtype,
+        device=device,
+    )
+
+    out, z = _call_gdn(
+        inputs,
+        num_actual_tokens=batch_size,
+        num_prefills=0,
+        num_decodes=batch_size,
+        query_start_loc=query_start_loc,
+        state_indices=ring[:, 0].contiguous(),
+        has_initial_state=has_initial,
+        spec_state_indices=ring,
+        num_accepted_tokens=num_accepted,
+    )
+
+    assert torch.isfinite(out.float()).all(), "core_attn_out has non-finite"
+    assert torch.isfinite(z.float()).all(), "z has non-finite"
+
+    # The kernel must have updated SSM state at ring[i, t - seq_start]
+    # for each (sequence, token). With one token per sequence, that's
+    # ring[:, 0]. Spot-check those slots are no longer at their initial
+    # (randn) value by virtue of being touched. We don't assert what
+    # they're equal to — that's the replay harness's job — only that
+    # the writeback happened.
+    # (Skipped because we'd need a tight before/after capture; the
+    # untouched-slots check below is sufficient for sanity.)
+
+
+@torch.inference_mode()
+def test_spec_args_pair_required():
+    """The op must reject calls that pass only one of
+    ``spec_state_indices_tensor`` / ``num_accepted_tokens`` — both must
+    be set together, or both must be omitted.
+    """
+    device = "xpu"
+    batch_size = 2
+    dtype = torch.bfloat16
+    inputs = _alloc_inputs(batch_size, batch_size, dtype, device, seed=19)
+    query_start_loc = _decode_query_start_loc(batch_size, device)
+    has_initial = torch.ones(batch_size, dtype=torch.bool, device=device)
+
+    spec_state_indices = inputs["state_indices"].reshape(batch_size, 1)
+
+    with pytest.raises(RuntimeError, match="both be provided or both omitted"):
+        _call_gdn(
+            inputs,
+            num_actual_tokens=batch_size,
+            num_prefills=0,
+            num_decodes=batch_size,
+            query_start_loc=query_start_loc,
+            state_indices=inputs["state_indices"],
+            has_initial_state=has_initial,
+            spec_state_indices=spec_state_indices,
+            num_accepted_tokens=None,
+        )
+
+    num_accepted = torch.ones(batch_size, dtype=torch.int32, device=device)
+    with pytest.raises(RuntimeError, match="both be provided or both omitted"):
+        _call_gdn(
+            inputs,
+            num_actual_tokens=batch_size,
+            num_prefills=0,
+            num_decodes=batch_size,
+            query_start_loc=query_start_loc,
+            state_indices=inputs["state_indices"],
+            has_initial_state=has_initial,
+            spec_state_indices=None,
+            num_accepted_tokens=num_accepted,
+        )
+
+
+@torch.inference_mode()
+def test_spec_args_int32_required():
+    """Both spec args must be int32 contiguous — int64 / non-contig
+    callers should fail loudly rather than silently misread bytes.
+    """
+    device = "xpu"
+    batch_size = 2
+    dtype = torch.bfloat16
+    inputs = _alloc_inputs(batch_size, batch_size, dtype, device, seed=23)
+    query_start_loc = _decode_query_start_loc(batch_size, device)
+    has_initial = torch.ones(batch_size, dtype=torch.bool, device=device)
+
+    spec_int64 = inputs["state_indices"].to(torch.int64).reshape(batch_size, 1)
+    num_acc_int32 = torch.ones(batch_size, dtype=torch.int32, device=device)
+
+    with pytest.raises(RuntimeError, match="must be int32"):
+        _call_gdn(
+            inputs,
+            num_actual_tokens=batch_size,
+            num_prefills=0,
+            num_decodes=batch_size,
+            query_start_loc=query_start_loc,
+            state_indices=inputs["state_indices"],
+            has_initial_state=has_initial,
+            spec_state_indices=spec_int64,
+            num_accepted_tokens=num_acc_int32,
+        )
+
+    spec_int32 = inputs["state_indices"].reshape(batch_size, 1).contiguous()
+    num_acc_int64 = torch.ones(batch_size, dtype=torch.int64, device=device)
+    with pytest.raises(RuntimeError, match="must be int32"):
+        _call_gdn(
+            inputs,
+            num_actual_tokens=batch_size,
+            num_prefills=0,
+            num_decodes=batch_size,
+            query_start_loc=query_start_loc,
+            state_indices=inputs["state_indices"],
+            has_initial_state=has_initial,
+            spec_state_indices=spec_int32,
+            num_accepted_tokens=num_acc_int64,
+        )
+
+
+@torch.inference_mode()
+def test_spec_args_batch_size_match():
+    """``spec_state_indices_tensor.size(0)`` must equal
+    ``query_start_loc.size(0) - 1``. The dispatcher repurposes
+    ``non_spec_query_start_loc`` for the spec batch under spec mode.
+    """
+    device = "xpu"
+    batch_size = 4
+    dtype = torch.bfloat16
+    inputs = _alloc_inputs(batch_size, batch_size, dtype, device, seed=29)
+    query_start_loc = _decode_query_start_loc(batch_size, device)
+    has_initial = torch.ones(batch_size, dtype=torch.bool, device=device)
+
+    # Build a spec_state_indices with the wrong batch dimension.
+    bad_spec = torch.zeros(batch_size + 1, 2, dtype=torch.int32, device=device)
+    num_accepted = torch.ones(batch_size + 1, dtype=torch.int32, device=device)
+
+    with pytest.raises(RuntimeError, match="must equal query_start_loc"):
+        _call_gdn(
+            inputs,
+            num_actual_tokens=batch_size,
+            num_prefills=0,
+            num_decodes=batch_size,
+            query_start_loc=query_start_loc,
+            state_indices=inputs["state_indices"],
+            has_initial_state=has_initial,
+            spec_state_indices=bad_spec,
+            num_accepted_tokens=num_accepted,
+        )


### PR DESCRIPTION
## Purpose

Adds a spec-decoding code path to the SYCL `gdn_attention` kernel that mirrors
the FLA Triton `IS_SPEC_DECODING` semantics, so vLLM's hybrid-linear-attention
models (Qwen3-Next / Qwen3.5 / Qwen3.6) can run MTP / EAGLE-style draft +
verify on XPU through the native kernel instead of falling back to the FLA
Triton path on every spec step.

### Problem

The current SYCL `gdn_attention` schema doesn't carry the two tensors the
spec-decode verify step needs (`spec_state_indices_tensor`,
`num_accepted_tokens`), so vLLM's dispatcher routes the spec path to the FLA
Triton fallback in `_gdn_xpu_spec_python_path`. That fallback works but is
~10× slower than the native SYCL kernel on the same captures (0.29 ms vs
3.0 ms median on K=1 and K=4 layer captures — measured via the replay
harness in the next section).

The deeper issue is the conv-state layout contract. Under spec decoding, FLA
treats the per-sequence conv ring as a **rolled history at slot 0** of
`cache_indices` — only that slot is updated, slots 1..K-1 are untouched. A
prior native spec attempt that scattered per-token snapshots across K slots
diverged from FLA (max conv-state diff ≈ 47 on K=4) and propagated through
the SSM, making the kernel unusable for the verify step.

### Changes

- **`csrc/xpu/gdn_attn/causal_conv1d.hpp` — two-pass spec-aware conv1d.**
  - Pass 1 (in-kernel): stages each candidate token's per-token conv
    state into the existing `conv_states_tmp` buffer (resized to
    `(batch, state_len, conv_elems)` under spec). Per-work-item, this
    is one write of the current input at
    `tmp[batch, state_len - K_call + t_in_seq, dim]` plus, for
    `t_in_seq < state_len - K_call`, a shift copy from the slot's
    pre-state.
  - Pass 2 (`spec_state_roll_kernel`): consolidates `tmp` into the
    rolled history at `slot[cache_indices[batch], :, :]`. Pass 2 is
    the sole writer of the slot — race-free with pass 1, which only
    wrote `tmp`.
  - The IS_SPEC load now reads from `cache_indices[batch_id]` with a
    `load_offset_shift = n_acc - 1`, matching FLA's column-0 contract.
  - `state_len` is plumbed through `kernel_launcher` /
    `KERNEL_LAUNCHER_IMPL`, computed at the launcher as
    `conv_states_stride_0 / conv_elems`.

- **`csrc/xpu/gdn_attn/gated_delta_rule.hpp` — `IS_SPEC` template
  parameter.** When `IS_SPEC`, the per-sequence load slot comes from
  `spec_state_indices[i_n, num_accepted_tokens[i_n]-1]`, the per-token
  store slot comes from `spec_state_indices[i_n, t-seq_start]`, and a
  raw slot value ≤ 0 (`NULL_BLOCK_ID`) is treated as "no valid prior
  state". The non-spec path is template-specialized and behaviorally
  unchanged.

- **`csrc/xpu/gdn_attn/gdn_attn_interface.cpp` — dispatch.** Both
  `spec_state_indices_tensor` and `num_accepted_tokens` must be provided
  together; mismatched pairs are rejected at the interface boundary.
  When both are set, routes through native kernels with `IS_SPEC=true`.

- **`csrc/xpu/ops.h`, `csrc/xpu/torch_bindings.cpp`.** Extends the
  `gdn_attention` schema with the two new tensors as
  `Optional[Tensor] = None`. Existing non-spec callers see no schema
  change; passing `None` for both preserves bit-exact pre-PR behavior.

The SSM kernel is unchanged — FLA's `fused_sigmoid_gating` already uses
per-token spec slots for the SSM ring, and the existing SYCL
`gated_delta_rule.hpp` SSM path was already correct under that contract.

## Test Plan

> **Paired vLLM PR:** [vllm-project/vllm#42382](https://github.com/vllm-project/vllm/pull/42382)
> (draft). It adds the dispatcher that calls into the new schema and
> the pytest replay harness. The kernel changes in this PR are usable
> today via the SYCL op directly; the paired PR wires them into vLLM's
> GDN dispatch behind `VLLM_XPU_USE_SYCL_SPEC_GDN={unset|0|auto|1}` so
> existing users see no behavior change until they opt in.

The kernel is exercised by a replay harness (in the paired PR) at
`tests/kernels/xpu/test_spec_gdn_replay.py`. It captures
`(metadata, inputs, outputs)` tuples from a live Qwen3.6 MTP run via
`VLLM_XPU_DUMP_SPEC_GDN=<dir>` (default cap 200 tuples), then replays
each capture through the native kernel and diffs against an inline FLA
oracle within `bf16` tolerance (`atol=rtol=2e-2`).

The harness covers:

- **Single-batch match vs. FLA** — every captured tuple, both `non_spec`
  and `spec` flavors.
- **Synthetic mixed batch** (`test_sycl_mixed_batch_matches_per_subset`) —
  pairs each `non_spec` capture with the same-layer
  `spec_K4_min1_max1` capture, builds a unified pool with disjoint slot
  ranges, replicates the production split / two-kernel-call /
  `index_copy_` scatter, and diffs each subset against its own
  reference.
- **`reorder_input=False` equivalence**
  (`test_sycl_reorder_input_false_equivalence`) — repacks captured
  projections into the per-`k_head` interleaved layout used in
  production Qwen3-Next traffic and verifies the kernel produces
  equivalent outputs under both `reorder_input=True` and
  `reorder_input=False` on fresh pools.
- **Determinism** — 10× byte-equal `core_attn_out` + `conv_state` +
  `ssm_state` on K=1 and K=4 captures.

E2E benchmark via `vllm bench serve` on Intel Arc B70:

```
Model:   palmfuture/Qwen3.6-35B-A3B-GPTQ-Int4
Quant:   INC (GPTQ-sym-int4 MoE → xpu_fused_moe(is_int4=True))
KV:      turboquant_k3v4_nc (3-bit MSE-Lloyd-Max K + 4-bit V)
Spec:    MTP, num_speculative_tokens=2
Dataset: random 256-in / 512-out, 20 prompts, --max-concurrency 1 --ignore-eos
```

## Test Result

**Replay harness** (kernel-level correctness vs. FLA):

| Rung | Test | Result |
|---|---|---|
| Fully accepted K=1 | single-batch vs. FLA | 90/90 |
| Fully accepted K=4 | single-batch vs. FLA | 169/170 spec (1 borderline bf16, 2 cells over `atol=2e-2`) |
| `num_accepted=1`, K=3 | single-batch vs. FLA | 180/180 |
| Mixed batch (synthetic) | spec + non-spec split | 29/30 (1 pre-existing layer-0 non-spec non-determinism, also fails the single-batch test on the same capture, not introduced by this PR) |
| `reorder_input=False` equivalence | 200 captures | 200/200 |
| Determinism (10×) | bytes equal on `core_attn_out` + conv_state + ssm_state | PASS |

**Perf** (replay harness, median over captures on Intel Arc B70):

| | FLA Triton fallback | This PR (native SYCL) |
|---|---|---|
| K=1 capture | ~3.0 ms | ~0.29 ms (~10.3×) |
| K=4 capture | ~3.0 ms | ~0.29 ms (~10.4×) |

**E2E** (single-stream `vllm bench serve`, baseline = no spec decoding):

| metric | baseline | spec (MTP K=2) | delta |
|---|---|---|---|
| output throughput (tok/s) | 58.85 | **75.80** | **+28.8%** |
| wall-clock (s) | 173.99 | 135.09 | −22.4% |
| median TPOT (ms) | 16.92 | 13.08 | −22.7% |
| median TTFT (ms) | 94.61 | 115.70 | +21 ms (one-time MTP draft graph dispatch) |
| acceptance rate | — | **64.5%** | — |
| mean accepted length | — | 2.29 / 3 | — |
| per-position acceptance | — | P0 74.7%, P1 54.2% | — |

20 requests, no per-step fallback to FLA, no failures.
Raw JSON available on request.

## Related issues

- **Orthogonal to #189** (request to expose `gdn::causal_conv1d` and
  `gdn::gated_delta_rule` as standalone torch ops). This PR keeps the
  existing single-op surface and extends its signature; it does not
  split the kernel.
- **Tangentially related to #320** (GDN kernel rejects padded inputs
  from `torch.compile` / cudagraph capture). Same file
  (`gdn_attn_interface.cpp`) but a separate bug — that one is about the
  `size(0) == num_actual_tokens` precondition under PIECEWISE capture
  and is unaffected by this PR.


