### PR TITLE
Group splitkv for mixed batch decoding 

### DIFF
--- a/benchmark/benchmark_cutlass_flash_attn_decode.py
+++ b/benchmark/benchmark_cutlass_flash_attn_decode.py
@@ -336,6 +336,111 @@ def filter_configs(configs):
     return new_configs
 
 
+def _mk_cfg(seq_lens, num_heads, block_size, name, head_size=128,
+            dtype=torch.bfloat16, num_blocks=2048):
+    # 11-tuple matching make_decode_with_paged_kv_input contract.
+    return (seq_lens, num_heads, head_size, block_size, dtype, None,
+            num_blocks, 2, None, False, name)
+
+
+# Format: seq_lens="B,1+1+...,kv0+kv1+...", num_heads=(q, kv), block_size, name
+BATCH_DECODE_CONFIGS = [
+    # Uniform KV
+    _mk_cfg("32," + "+".join(["1"] * 32) + "," + "+".join(["512"] * 32),
+            (32, 2), 64, "32x512_uniform_(32,2)"),
+    _mk_cfg("32," + "+".join(["1"] * 32) + "," + "+".join(["4096"] * 32),
+            (32, 2), 64, "32x4096_uniform_(32,2)"),
+    # Mixed KV (key optimization target)
+    _mk_cfg("8,1+1+1+1+1+1+1+1,128+256+512+1024+2048+4096+8192+16384",
+            (32, 2), 64, "8xmixed_128-16384_(32,2)"),
+    _mk_cfg("8,1+1+1+1+1+1+1+1,128+256+512+1024+2048+4096+8192+16384",
+            (32, 4), 64, "8xmixed_128-16384_(32,4)"),
+    _mk_cfg("8,1+1+1+1+1+1+1+1,128+256+512+1024+2048+4096+8192+16384",
+            (32, 8), 64, "8xmixed_128-16384_(32,8)"),
+    _mk_cfg("8,1+1+1+1+1+1+1+1,128+256+512+1024+2048+4096+8192+16384",
+            (40, 8), 64, "8xmixed_128-16384_(40,8)"),
+    # Skewed (mostly short + one long)
+    _mk_cfg("8,1+1+1+1+1+1+1+1,256+256+256+256+256+256+256+16384",
+            (32, 2), 64, "8xskewed_256-16384_(32,2)"),
+    # All short
+    _mk_cfg("8,1+1+1+1+1+1+1+1,128+128+256+256+512+512+1024+1024",
+            (32, 2), 64, "8xshort_128-1024_(32,2)"),
+    # Realistic vLLM-like
+    _mk_cfg(
+        "16," + "+".join(["1"] * 16) + ","
+        + "+".join(["256", "512", "1024", "1024",
+                    "2048", "2048", "4096", "4096",
+                    "4096", "8192", "8192", "8192",
+                    "16384", "16384", "16384", "16384"]),
+        (32, 2), 64, "16xrealistic_mixed_(32,2)"),
+    # block_size=128
+    _mk_cfg("8,1+1+1+1+1+1+1+1,128+256+512+1024+2048+4096+8192+16384",
+            (32, 2), 128, "8xmixed_128-16384_bs128_(32,2)"),
+    # MHA
+    _mk_cfg("32," + "+".join(["1"] * 32) + "," + "+".join(["512"] * 32),
+            (16, 16), 64, "32x512_uniform_(16,16)_MHA"),
+    _mk_cfg("8,1+1+1+1+1+1+1+1,128+256+512+1024+2048+4096+8192+16384",
+            (16, 16), 64, "8xmixed_128-16384_(16,16)_MHA"),
+]
+
+
+def benchmark_batch_decode(config, iterations=200):
+    """Benchmark a single batch decode config with GPU-event timing."""
+    (seq_lens, num_heads, head_size, block_size, dtype, soft_cap,
+     num_blocks, fa_versions, q_dtype, is_sink, name) = config
+
+    full_config = (seq_lens, num_heads, head_size, block_size, dtype,
+                   soft_cap, num_blocks, fa_versions, q_dtype, is_sink)
+    (maybe_quantized_query, maybe_quantized_key_cache,
+     maybe_quantized_value_cache, max_query_len, cu_query_lens,
+     max_kv_len, seq_k, scale, block_tables, sink, _,
+     _, _, _, _) = make_decode_with_paged_kv_input(full_config)
+
+    num_seqs = int(seq_lens.split(",")[0])
+    max_num_blocks_per_seq = (max_kv_len + block_size - 1) // block_size
+
+    queries = [torch.rand_like(maybe_quantized_query)
+               for _ in range(iterations)]
+    bt_list = [torch.randint(0, num_blocks,
+                             (num_seqs, max_num_blocks_per_seq),
+                             dtype=torch.int32)
+               for _ in range(iterations)]
+
+    def _run(i):
+        flash_attn_varlen_func(
+            queries[i], maybe_quantized_key_cache,
+            maybe_quantized_value_cache,
+            max_query_len, cu_query_lens, max_kv_len,
+            seqused_k=seq_k, softmax_scale=scale,
+            causal=False, block_table=bt_list[i],
+            window_size=(-1, -1), s_aux=sink)
+
+    # Warmup
+    for i in range(min(10, iterations)):
+        _run(i)
+    torch.xpu.synchronize()
+
+    # Timed
+    start_event = torch.xpu.Event(enable_timing=True)
+    end_event = torch.xpu.Event(enable_timing=True)
+    measured = iterations - 10
+    start_event.record()
+    for i in range(10, iterations):
+        _run(i)
+    end_event.record()
+    torch.xpu.synchronize()
+
+    avg_us = start_event.elapsed_time(end_event) * 1000.0 / measured
+
+    # KV bandwidth (K + V, bf16 -> 2 bytes)
+    kv_lens = list(map(int, seq_lens.split(",")[2].split("+")))
+    kv_bytes = sum(kv_lens) * num_heads[1] * head_size * 2 * 2
+    bw_gbs = (kv_bytes / 1e9) / (avg_us / 1e6)
+
+    clear_xpu_cache()
+    return avg_us, bw_gbs
+
+
 if __name__ == "__main__":
 
     args = parse_args()
@@ -360,3 +465,31 @@ if __name__ == "__main__":
     save_path = ensure_save_path_exists(args.save_path)
     # Run performance benchmark
     benchmark.run(print_data=True, save_path=save_path)
+
+    # ================================================================
+    # Batch Decode Benchmark (per-seq adaptive split-K evaluation)
+    # ================================================================
+    print("\n" + "=" * 80)
+    print("Batch Decode Benchmark (per-seq adaptive split-K)")
+    print("=" * 80)
+    hdr = (f"{'config':<40} | {'batch':>5} {'kv_sum':>7} | "
+           f"{'time(us)':>9} {'BW(GB/s)':>9}")
+    print(hdr)
+    print("-" * 80)
+
+    for cfg in BATCH_DECODE_CONFIGS:
+        name = cfg[-1]
+        seq_lens = cfg[0]
+        num_seqs = int(seq_lens.split(",")[0])
+        kv_lens = list(map(int, seq_lens.split(",")[2].split("+")))
+        kv_sum = sum(kv_lens)
+        try:
+            avg_us, bw_gbs = benchmark_batch_decode(cfg, iterations=200)
+            print(f"{name:<40} | {num_seqs:>5} {kv_sum:>7} | "
+                  f"{avg_us:>9.1f} {bw_gbs:>9.1f}")
+        except Exception as e:
+            print(f"{name:<40} | {num_seqs:>5} {kv_sum:>7} | "
+                  f"{'ERROR':>9} {str(e)[:20]}")
+        clear_xpu_cache()
+
+    print("=" * 80)

--- a/benchmark/src/flash_attn_interface_.py
+++ b/benchmark/src/flash_attn_interface_.py
@@ -20,6 +20,124 @@ DEFAULT_FA_VERSION = 2
 def maybe_contiguous(x):
     return x.contiguous() if x is not None and x.stride(-1) != 1 else x
 
+def _as_int32_device_tensor(x, device: torch.device) -> torch.Tensor:
+    if isinstance(x, torch.Tensor):
+        return x.to(device=device, dtype=torch.int32)
+    return torch.tensor(x, device=device, dtype=torch.int32)
+
+
+def _kv_tile_from_block_size(block_size: int) -> int:
+    # Mirror of flash_api.cpp get_num_splits() / TileShapeQK<1>.
+    if block_size == 16:
+        return 16
+    if block_size == 32:
+        return 32
+    return 64
+
+
+def _min_blocks_for_split(kv_tile: int) -> int:
+    # Mirror of XeFMHAFwdSplitKVKernel::kMinBlocksForSplit /
+    # ReduceSplitK::kMinBlocksForSplit. Below this threshold a sequence is
+    # processed as a single split for numerical stability.
+    return 32 if kv_tile <= 64 else 128
+
+
+def _infer_num_xe_cores(device: torch.device) -> int:
+    # Prefer runtime query; fall back to 20 (Xe2/BMG default).
+    try:
+        props = torch.xpu.get_device_properties(device)
+    except Exception:
+        return 20
+    slices = (getattr(props, "gpu_slices", None)
+              or getattr(props, "num_slices", None)
+              or getattr(props, "slices", None))
+    subslices = (getattr(props, "gpu_subslices_per_slice", None)
+                 or getattr(props, "num_subslices_per_slice", None)
+                 or getattr(props, "subslices_per_slice", None))
+    if slices is not None and subslices is not None:
+        return max(1, int(slices) * int(subslices))
+    return 20
+
+
+def build_decode_split_plan(
+    kv_lens,
+    kv_tile: int,
+    num_kv_splits: int,
+    num_xe_cores: int,
+    num_heads_kv: int,
+):
+    """Produce (splits_per_seq, work_list) for the compact-grid decode kernel.
+
+    Inputs
+    ------
+    kv_lens         : per-seq KV length in tokens (list/tensor, on host).
+    kv_tile         : KV tile width in tokens (must equal the kernel's
+                      get<1>(TileShapeQK{})).
+    num_kv_splits   : global cap on per-seq split count (buffer dim).
+    num_xe_cores    : Xe-core count used for the target-WG heuristic.
+    num_heads_kv    : KV heads (workload is sliced across heads_kv heads).
+
+    Returns
+    -------
+    splits_per_seq  : int32 cpu tensor [batch], splits[i] >= 1.
+    work_list       : int32 cpu tensor [total_wgs, 4] of
+                      (seq_idx, kv_tile_start, kv_tile_count, split_idx).
+
+    Guarantees
+    ----------
+    - sum(splits_per_seq) == work_list.size(0) == total_wgs
+    - For every emitted work item, kv_tile_count >= 1
+    - For each seq, the work items partition [0, kv_tiles) exactly once
+    - splits_per_seq[i] <= num_kv_splits (so Oaccum/exp_sums/max_logits
+      buffer indexing is safe)
+    - splits_per_seq[i] folds in {single-split heuristic, balanced
+      assignment, hard cap}; the kernel never needs to second-guess it.
+    """
+    if isinstance(kv_lens, torch.Tensor):
+        kv_lens_list = kv_lens.to(dtype=torch.int32, device="cpu").tolist()
+    else:
+        kv_lens_list = [int(v) for v in kv_lens]
+
+    tiles_per_seq = [max(1, (kv + kv_tile - 1) // kv_tile)
+                     for kv in kv_lens_list]
+    total_tiles = sum(tiles_per_seq)
+
+    # Target: ~2x oversubscription of Xe cores per kv head, minimum 4 tiles
+    # per WG so split-K overhead stays amortized.
+    min_wgs = max(1, num_xe_cores * 2 // max(1, num_heads_kv))
+    target_tiles_per_wg = max(4, total_tiles // min_wgs)
+
+    # Mirror of the kernel's is_single_split heuristic: avoid split-reduce
+    # for short sequences (numerical stability + overhead).
+    min_blocks_for_split = _min_blocks_for_split(kv_tile)
+
+    splits_per_seq = []
+    work_items = []
+    for i, n_tiles in enumerate(tiles_per_seq):
+        if (n_tiles <= target_tiles_per_wg
+                or n_tiles < min_blocks_for_split
+                or num_kv_splits <= 1):
+            n_splits = 1
+        else:
+            n_splits = ((n_tiles + target_tiles_per_wg - 1)
+                        // target_tiles_per_wg)
+            # Cap to the static buffer dim AND to n_tiles, so every emitted
+            # work item has kv_tile_count >= 1.
+            n_splits = min(n_splits, num_kv_splits, n_tiles)
+        splits_per_seq.append(n_splits)
+
+        # Even partitioning: first `rem` splits get base+1 tiles, the rest
+        # get base. Guarantees count >= 1 since n_splits <= n_tiles.
+        base, rem = divmod(n_tiles, n_splits)
+        start = 0
+        for s in range(n_splits):
+            count = base + (1 if s < rem else 0)
+            work_items.append([i, start, count, s])
+            start += count
+
+    splits_t = torch.tensor(splits_per_seq, dtype=torch.int32)
+    work_t = torch.tensor(work_items, dtype=torch.int32)
+    return splits_t, work_t
 
 # vllm_xpu_kernel,main,
 #   https://github.com/vllm-project/vllm-xpu-kernels/tree/3cf991b
@@ -58,6 +176,7 @@ def flash_attn_varlen_func_CalKernelTime(
     start_event: Optional[torch.Event] = None,
     end_event: Optional[torch.Event] = None,
     device: str = "xpu",
+    host_kv_lens: Optional[torch.Tensor] = None,
 ):
     """
     FlashAttention interface for variable-length sequences, with optional
@@ -129,6 +248,31 @@ def flash_attn_varlen_func_CalKernelTime(
             raise NotImplementedError(
                 "FA2 only supports both KV cache descaled")
 
+                # Compute per-seq splits and work_list on host, upload to device.
+        # Only enable for decode (max_seqlen_q == 1) with paged KV cache,
+        # multi-seq batches, and global num_splits_kv > 1.
+        splits_per_seq_dev = None
+        work_list_dev = None
+        if (block_table is not None and host_kv_lens is not None
+                and num_splits_kv is not None and num_splits_kv > 1
+                and max_seqlen_q == 1):
+            block_size = k.size(1)
+            kv_tile = _kv_tile_from_block_size(block_size)
+            num_xe_cores = _infer_num_xe_cores(q.device)
+            num_heads_kv = k.size(2)
+            splits_cpu, work_list_cpu = build_decode_split_plan(
+                host_kv_lens,
+                kv_tile=kv_tile,
+                num_kv_splits=num_splits_kv,
+                num_xe_cores=num_xe_cores,
+                num_heads_kv=num_heads_kv,
+            )
+            if work_list_cpu.numel() > 0:
+                splits_per_seq_dev = splits_cpu.to(
+                    device=q.device, non_blocking=True)
+                work_list_dev = work_list_cpu.to(
+                    device=q.device, non_blocking=True)
+
         if start_event is not None:
             start_event.record()
         out, softmax_lse = torch.ops._vllm_fa2_C.varlen_fwd(
@@ -160,6 +304,8 @@ def flash_attn_varlen_func_CalKernelTime(
             None,
             num_splits_kv,
             is_mix_batch,
+            splits_per_seq_dev,
+            work_list_dev,
         )
         if end_event is not None:
             end_event.record()

--- a/benchmark/src/flash_attn_interface_.py
+++ b/benchmark/src/flash_attn_interface_.py
@@ -248,7 +248,7 @@ def flash_attn_varlen_func_CalKernelTime(
             raise NotImplementedError(
                 "FA2 only supports both KV cache descaled")
 
-                # Compute per-seq splits and work_list on host, upload to device.
+        # Compute per-seq splits and work_list on host, upload to device.
         # Only enable for decode (max_seqlen_q == 1) with paged KV cache,
         # multi-seq batches, and global num_splits_kv > 1.
         splits_per_seq_dev = None

--- a/csrc/flash_attn/flash_api.cpp
+++ b/csrc/flash_attn/flash_api.cpp
@@ -447,7 +447,8 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
       "float softmax_scale, Tensor? softmax_sink, bool zero_tensors, "
       "bool is_causal, int window_size_left, int window_size_right, float "
       "softcap, bool return_softmax, "
-      "Generator? gen, int? num_splits, bool mix_batch, Tensor? splits_per_seq, Tensor? work_list) -> Tensor[]");
+      "Generator? gen, int? num_splits, bool mix_batch, Tensor? "
+      "splits_per_seq, Tensor? work_list) -> Tensor[]");
   ops.impl(
       "varlen_fwd",
       torch::kXPU,

--- a/csrc/flash_attn/flash_api.cpp
+++ b/csrc/flash_attn/flash_api.cpp
@@ -119,7 +119,9 @@ std::vector<at::Tensor> mha_varlen_fwd(
     const bool return_softmax,
     std::optional<at::Generator> gen_,
     std::optional<int> num_splits,
-    bool mix_batch) {
+    bool mix_batch,
+    std::optional<at::Tensor>& splits_per_seq,
+    std::optional<at::Tensor>& work_list) {
   auto q_type = q.scalar_type();
   auto k_type = k.scalar_type();
   TORCH_CHECK(
@@ -315,7 +317,9 @@ std::vector<at::Tensor> mha_varlen_fwd(
         is_local,
         is_sink,
         num_kv_splits,
-        is_prefill_opt);
+        is_prefill_opt,
+        splits_per_seq,
+        work_list);
   } else {
     // Normalize -1 (unbounded) to max_seqlen_k for kernel masking logic
     // In decode phase the window_size_right doesn't have effect
@@ -416,7 +420,9 @@ std::vector<at::Tensor> mha_varlen_fwd(
         is_local,
         is_sink,
         num_kv_splits,
-        no_mask);
+        no_mask,
+        splits_per_seq,
+        work_list);
   }
 
   if (return_softmax) {
@@ -441,7 +447,7 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
       "float softmax_scale, Tensor? softmax_sink, bool zero_tensors, "
       "bool is_causal, int window_size_left, int window_size_right, float "
       "softcap, bool return_softmax, "
-      "Generator? gen, int? num_splits, bool mix_batch) -> Tensor[]");
+      "Generator? gen, int? num_splits, bool mix_batch, Tensor? splits_per_seq, Tensor? work_list) -> Tensor[]");
   ops.impl(
       "varlen_fwd",
       torch::kXPU,

--- a/csrc/xpu/attn/attn_interface.cpp
+++ b/csrc/xpu/attn/attn_interface.cpp
@@ -92,7 +92,9 @@ void cutlass_paged_decode_interface(
     bool is_local,
     bool is_sink,
     int num_kv_splits,
-    std::optional<const at::Tensor>& is_prefill) {
+    std::optional<const at::Tensor>& is_prefill,
+    std::optional<at::Tensor>& splits_per_seq,
+    std::optional<at::Tensor>& work_list) {
   if (vllm::xpu::is_xe2_arch() || vllm::xpu::is_xe3_arch()) {
 #ifdef VLLM_XPU_ENABLE_XE2
     // Use XE2 cutlass kernel (also used as WA for XE3/XE3P)
@@ -122,7 +124,9 @@ void cutlass_paged_decode_interface(
         is_local,
         is_sink,
         num_kv_splits,
-        is_prefill);
+        is_prefill,
+        splits_per_seq,
+        work_list);
 #else
     TORCH_CHECK(false, "XE2 cutlass kernel is not enabled in this build.");
 #endif

--- a/csrc/xpu/attn/attn_interface.h
+++ b/csrc/xpu/attn/attn_interface.h
@@ -51,4 +51,6 @@ void cutlass_paged_decode_interface(
     bool is_local,
     bool is_sink,
     int num_kv_splits,
-    std::optional<const at::Tensor>& is_prefill);
+    std::optional<const at::Tensor>& is_prefill,
+    std::optional<at::Tensor>& splits_per_seq,
+    std::optional<at::Tensor>& work_list);

--- a/csrc/xpu/attn/xe_2/collective/chunk_prefill_mainloop.hpp
+++ b/csrc/xpu/attn/xe_2/collective/chunk_prefill_mainloop.hpp
@@ -904,7 +904,7 @@ struct DecodeFwdMainloop<
 
         reorder(tQrQ, tSrQ);
         // reorder() performs the (vectorized) fp8 -> ElementQ cast; the
-        // per-tensor scale_k has been folded into params.scale above.
+        // per-tensor scale_k has been folded into effective_scale above.
         reorder(tKrK, tSrK);
 
         cute::gemm(mma_qk, tSrQ, tSrK, tSrS);

--- a/csrc/xpu/attn/xe_2/collective/chunk_prefill_scheduler.hpp
+++ b/csrc/xpu/attn/xe_2/collective/chunk_prefill_scheduler.hpp
@@ -91,10 +91,10 @@ struct XeFHMAIndividualTileScheduler {
 
 // Work item for compact grid dispatch: each WG reads one entry
 struct DecodeWorkItem {
-  int seq_idx;       // which sequence (batch index)
-  int kv_tile_start; // starting KV tile index (absolute, not per-split)
-  int kv_tile_count; // number of KV tiles this WG processes
-  int split_idx;     // which split within this seq (for Oaccum indexing)
+  int seq_idx;        // which sequence (batch index)
+  int kv_tile_start;  // starting KV tile index (absolute, not per-split)
+  int kv_tile_count;  // number of KV tiles this WG processes
+  int split_idx;      // which split within this seq (for Oaccum indexing)
 };
 
 struct DecodeTileScheduler {
@@ -140,8 +140,13 @@ struct DecodeTileScheduler {
         grid.z *= num_kv_splits;
       }
     }
-    return Params{grid, {num_head}, {shape.batch * num_head}, num_kv_splits,
-                  work_list, total_wgs};
+    return Params{
+        grid,
+        {num_head},
+        {shape.batch * num_head},
+        num_kv_splits,
+        work_list,
+        total_wgs};
   }
 
   template <int Num_SGs>
@@ -168,22 +173,34 @@ struct DecodeTileScheduler {
       DecodeWorkItem wi = params.work_list[work_idx];
       idx_b = wi.seq_idx;
       idx_kv_split = wi.split_idx;
-      return make_coord(BlockIdxY(), BlockIdxX(), head, idx_b, idx_kv_split,
-                        wi.kv_tile_start, wi.kv_tile_count);
+      return make_coord(
+          BlockIdxY(),
+          BlockIdxX(),
+          head,
+          idx_b,
+          idx_kv_split,
+          wi.kv_tile_start,
+          wi.kv_tile_count);
     }
 
     if (params.num_kv_splits_ >= 1) {
       idx_kv_split = flat_idx;
       params.divmod_batch(idx_kv_split, idx_b, idx_kv_split);
       params.divmod_num_heads(idx_b, head, idx_b);
-      return make_coord(BlockIdxY(), BlockIdxX(), head, idx_b, idx_kv_split,
-                        (int)-1, (int)-1);
+      return make_coord(
+          BlockIdxY(),
+          BlockIdxX(),
+          head,
+          idx_b,
+          idx_kv_split,
+          (int)-1,
+          (int)-1);
     }
 
     idx_b = flat_idx;
     params.divmod_num_heads(idx_b, head, idx_b);
-    return make_coord(BlockIdxY(), BlockIdxX(), head, idx_b, (int)-1,
-                      (int)-1, (int)-1);
+    return make_coord(
+        BlockIdxY(), BlockIdxX(), head, idx_b, (int)-1, (int)-1, (int)-1);
   }
 
   CUTLASS_DEVICE

--- a/csrc/xpu/attn/xe_2/collective/chunk_prefill_scheduler.hpp
+++ b/csrc/xpu/attn/xe_2/collective/chunk_prefill_scheduler.hpp
@@ -89,12 +89,23 @@ struct XeFHMAIndividualTileScheduler {
   }
 };
 
+// Work item for compact grid dispatch: each WG reads one entry
+struct DecodeWorkItem {
+  int seq_idx;       // which sequence (batch index)
+  int kv_tile_start; // starting KV tile index (absolute, not per-split)
+  int kv_tile_count; // number of KV tiles this WG processes
+  int split_idx;     // which split within this seq (for Oaccum indexing)
+};
+
 struct DecodeTileScheduler {
   struct Params {
     dim3 grid;
     FastDivmod divmod_num_heads;
     FastDivmod divmod_batch;
     int num_kv_splits_ = -1;
+    // Compact grid mode: work_list[total_wgs] lookup table
+    const DecodeWorkItem* work_list = nullptr;
+    int total_wgs = 0;  // = sum(splits_per_seq) per head
   };
 
   bool valid_ = true;
@@ -108,7 +119,9 @@ struct DecodeTileScheduler {
       ProblemShape const& shape,
       KernelHardwareInfo hw_info,
       TileShape const& tile_shape,
-      const int& num_kv_splits = -1) {
+      const int& num_kv_splits = -1,
+      const DecodeWorkItem* work_list = nullptr,
+      int total_wgs = 0) {
     using namespace cute;
 
     dim3 grid(
@@ -117,12 +130,18 @@ struct DecodeTileScheduler {
         size(shape.batch * shape.num_heads_q));  // (h,b) -- split later
     int num_head = shape.num_heads_q;
     if (num_kv_splits >= 1) {
-      // for splitKV, each wg handles group query heads
-      grid.z = size(shape.batch * shape.num_heads_kv);
-      grid.z *= num_kv_splits;
       num_head = shape.num_heads_kv;
+      if (work_list != nullptr && total_wgs > 0) {
+        // Compact grid: exactly total_wgs × num_heads_kv WGs
+        grid.z = total_wgs * shape.num_heads_kv;
+      } else {
+        // Original: batch × heads_kv × num_kv_splits
+        grid.z = size(shape.batch * shape.num_heads_kv);
+        grid.z *= num_kv_splits;
+      }
     }
-    return Params{grid, {num_head}, {shape.batch * num_head}, num_kv_splits};
+    return Params{grid, {num_head}, {shape.batch * num_head}, num_kv_splits,
+                  work_list, total_wgs};
   }
 
   template <int Num_SGs>
@@ -136,18 +155,35 @@ struct DecodeTileScheduler {
   CUTLASS_DEVICE
   auto get_block_coord() {
     using namespace cute;
-    int idx_kv_split = BlockIdxZ();
+    int flat_idx = BlockIdxZ();
     int head, idx_b;
+    int idx_kv_split;
 
-    if (params.num_kv_splits_ >= 1) {
-      params.divmod_batch(idx_kv_split, idx_b, idx_kv_split);
-      params.divmod_num_heads(idx_b, head, idx_b);
-      return make_coord(BlockIdxY(), BlockIdxX(), head, idx_b, idx_kv_split);
+    if (params.work_list != nullptr && params.total_wgs > 0) {
+      // Compact grid: direct lookup, O(1)
+      // flat_idx = head_kv * total_wgs + work_idx
+      int work_idx = flat_idx % params.total_wgs;
+      head = flat_idx / params.total_wgs;
+      // Read pre-computed work assignment — O(1) direct lookup
+      DecodeWorkItem wi = params.work_list[work_idx];
+      idx_b = wi.seq_idx;
+      idx_kv_split = wi.split_idx;
+      return make_coord(BlockIdxY(), BlockIdxX(), head, idx_b, idx_kv_split,
+                        wi.kv_tile_start, wi.kv_tile_count);
     }
 
-    idx_b = idx_kv_split;
+    if (params.num_kv_splits_ >= 1) {
+      idx_kv_split = flat_idx;
+      params.divmod_batch(idx_kv_split, idx_b, idx_kv_split);
+      params.divmod_num_heads(idx_b, head, idx_b);
+      return make_coord(BlockIdxY(), BlockIdxX(), head, idx_b, idx_kv_split,
+                        (int)-1, (int)-1);
+    }
+
+    idx_b = flat_idx;
     params.divmod_num_heads(idx_b, head, idx_b);
-    return make_coord(BlockIdxY(), BlockIdxX(), head, idx_b, (int)-1);
+    return make_coord(BlockIdxY(), BlockIdxX(), head, idx_b, (int)-1,
+                      (int)-1, (int)-1);
   }
 
   CUTLASS_DEVICE

--- a/csrc/xpu/attn/xe_2/kernel/paged_decode_kernel.hpp
+++ b/csrc/xpu/attn/xe_2/kernel/paged_decode_kernel.hpp
@@ -146,6 +146,7 @@ class XeFMHAFwdSplitKVKernel {
 
     // per-batch mask: true = prefill, false = decode; nullptr = process all
     const bool* is_prefill;
+    const int* splits_per_seq = nullptr;  // per-seq split counts; null => use global num_kv_splits
   };
   using KernelParams = KernelArguments;
 
@@ -251,8 +252,9 @@ class XeFMHAFwdSplitKVKernel {
 
     CUTLASS_PRAGMA_NO_UNROLL
     for (; tile_scheduler.is_valid(); ++tile_scheduler) {
-      auto [blk_q, blk_v, head, idx_b, idx_kv_split] =
-          tile_scheduler.get_block_coord();  // (Q,V,h,b,id_split)
+      auto [blk_q, blk_v, head, idx_b, idx_kv_split,
+           wl_tile_start, wl_tile_count] =
+          tile_scheduler.get_block_coord();  // (Q,V,h,b,split,tile_start,tile_count)
 
       // Skip prefill batches when is_prefill mask is provided
       if (p.is_prefill != nullptr && p.is_prefill[idx_b]) continue;
@@ -328,37 +330,53 @@ class XeFMHAFwdSplitKVKernel {
           make_shape(head_group_q, num_kv_splits, s.num_heads_kv, batch_dim);
       auto shape_sink = make_shape(s.num_heads_kv, head_group_q);
 
-      int num_blocks_per_split =
-          cute::ceil_div(windowed_k_blocks, num_kv_splits);
-
-      // Per-sequence split decision: short sequences are treated as
-      // single-split even when num_kv_splits > 1, avoiding precision
-      // loss from the split-reduce roundtrip.
-      // Scale threshold with tile width: smaller tiles (p64) have fewer
-      // SGs per WG, so splitting becomes beneficial at fewer blocks.
-      constexpr int tile_n = get<1>(TileShapeQK{});
-      constexpr int kMinBlocksForSplit = (tile_n <= 64) ? 32 : 128;
-      bool is_single_split =
-          (num_kv_splits > 1) && (windowed_k_blocks < kMinBlocksForSplit);
-
       int kv_split_offset;
       int num_effective_kv_blocks;
-      if (is_single_split) {
-        // Split 0 processes all blocks; splits 1+ skip entirely.
-        if (idx_kv_split > 0) {
+      int seq_num_kv_splits;
+      bool is_single_split;
+
+      if (wl_tile_start >= 0) {
+        // Compact grid: use pre-computed tile range from work_list.
+        // Python (build_decode_split_plan) has already folded the
+        // single-split heuristic and balanced assignment into the plan.
+        kv_split_offset = k_block0 + wl_tile_start;
+        num_effective_kv_blocks = wl_tile_count;
+        seq_num_kv_splits = (p.splits_per_seq != nullptr)
+            ? p.splits_per_seq[idx_b] : num_kv_splits;
+        is_single_split = (seq_num_kv_splits <= 1);
+      } else {
+        // Legacy path: compute split range on the fly
+        seq_num_kv_splits = (p.splits_per_seq != nullptr)
+            ? p.splits_per_seq[idx_b]
+            : num_kv_splits;
+
+        if (idx_kv_split >= seq_num_kv_splits) {
           continue;
         }
-        kv_split_offset = k_block0;
-        num_effective_kv_blocks = windowed_k_blocks;
-      } else {
-        kv_split_offset = k_block0 + idx_kv_split * num_blocks_per_split;
-        num_effective_kv_blocks = cute::min(
-            windowed_k_blocks - idx_kv_split * num_blocks_per_split,
-            num_blocks_per_split);
+
+        int num_blocks_per_split =
+            cute::ceil_div(windowed_k_blocks, seq_num_kv_splits);
+
+        constexpr int tile_n = get<1>(TileShapeQK{});
+        constexpr int kMinBlocksForSplit = (tile_n <= 64) ? 32 : 128;
+        is_single_split =
+            (seq_num_kv_splits > 1) && (windowed_k_blocks < kMinBlocksForSplit);
+
+        if (is_single_split) {
+          if (idx_kv_split > 0) {
+            continue;
+          }
+          kv_split_offset = k_block0;
+          num_effective_kv_blocks = windowed_k_blocks;
+        } else {
+          kv_split_offset = k_block0 + idx_kv_split * num_blocks_per_split;
+          num_effective_kv_blocks = cute::min(
+              windowed_k_blocks - idx_kv_split * num_blocks_per_split,
+              num_blocks_per_split);
+        }
       }
 
       if (num_effective_kv_blocks <= 0) {
-        // no need computation
         continue;
       }
 
@@ -527,6 +545,7 @@ class ReduceSplitK {
 
     // per-batch mask: true = prefill, false = decode; nullptr = process all
     const bool* is_prefill;
+    const int* splits_per_seq = nullptr;  // per-seq split counts
   };
   using KernelParams = KernelArguments;
 
@@ -648,16 +667,28 @@ class ReduceSplitK {
                           get<1>(TileShapeQK{})
                     : 0;
       const int windowed_k_blocks = k_blocks - k_block0;
-      int num_blocks_per_split =
-          cute::ceil_div(windowed_k_blocks, num_kv_splits);
+      // Per-sequence adaptive split count
+      int seq_num_kv_splits = (p.splits_per_seq != nullptr)
+          ? p.splits_per_seq[idx_b]
+          : num_kv_splits;
 
-      // Mirror the FMHA kernel's is_single_split decision so we only
-      // read split slots that were actually written.
-      constexpr int tile_n = get<1>(typename FMHAKernel_::TileShapeQK{});
-      constexpr int kMinBlocksForSplit = (tile_n <= 64) ? 32 : 128;
-      bool is_single_split =
-          (num_kv_splits > 1) && (windowed_k_blocks < kMinBlocksForSplit);
-      int effective_splits = is_single_split ? 1 : num_kv_splits;
+      int num_blocks_per_split =
+          cute::ceil_div(windowed_k_blocks, seq_num_kv_splits);
+
+      // is_single_split is a heuristic owned by the FMHA kernel; when the
+      // host provides splits_per_seq, the host has already applied the same
+      // policy (see build_decode_split_plan in flash_attn_interface.py), so
+      // trust it directly. Otherwise (legacy path), mirror the FMHA kernel.
+      int effective_splits;
+      if (p.splits_per_seq != nullptr) {
+        effective_splits = seq_num_kv_splits;
+      } else {
+        constexpr int tile_n = get<1>(typename FMHAKernel_::TileShapeQK{});
+        constexpr int kMinBlocksForSplit = (tile_n <= 64) ? 32 : 128;
+        bool is_single_split = (seq_num_kv_splits > 1) &&
+            (windowed_k_blocks < kMinBlocksForSplit);
+        effective_splits = is_single_split ? 1 : seq_num_kv_splits;
+      }
 
       int offset_o = 0, offset_o_accum = 0;
       int offset_exp_sums = 0, offset_max_logits = 0;

--- a/csrc/xpu/attn/xe_2/kernel/paged_decode_kernel.hpp
+++ b/csrc/xpu/attn/xe_2/kernel/paged_decode_kernel.hpp
@@ -146,7 +146,8 @@ class XeFMHAFwdSplitKVKernel {
 
     // per-batch mask: true = prefill, false = decode; nullptr = process all
     const bool* is_prefill;
-    const int* splits_per_seq = nullptr;  // per-seq split counts; null => use global num_kv_splits
+    const int* splits_per_seq =
+        nullptr;  // per-seq split counts; null => use global num_kv_splits
   };
   using KernelParams = KernelArguments;
 
@@ -252,9 +253,16 @@ class XeFMHAFwdSplitKVKernel {
 
     CUTLASS_PRAGMA_NO_UNROLL
     for (; tile_scheduler.is_valid(); ++tile_scheduler) {
-      auto [blk_q, blk_v, head, idx_b, idx_kv_split,
-           wl_tile_start, wl_tile_count] =
-          tile_scheduler.get_block_coord();  // (Q,V,h,b,split,tile_start,tile_count)
+      auto
+          [blk_q,
+           blk_v,
+           head,
+           idx_b,
+           idx_kv_split,
+           wl_tile_start,
+           wl_tile_count] =
+              tile_scheduler
+                  .get_block_coord();  // (Q,V,h,b,split,tile_start,tile_count)
 
       // Skip prefill batches when is_prefill mask is provided
       if (p.is_prefill != nullptr && p.is_prefill[idx_b]) continue;
@@ -342,13 +350,14 @@ class XeFMHAFwdSplitKVKernel {
         kv_split_offset = k_block0 + wl_tile_start;
         num_effective_kv_blocks = wl_tile_count;
         seq_num_kv_splits = (p.splits_per_seq != nullptr)
-            ? p.splits_per_seq[idx_b] : num_kv_splits;
+                                ? p.splits_per_seq[idx_b]
+                                : num_kv_splits;
         is_single_split = (seq_num_kv_splits <= 1);
       } else {
         // Legacy path: compute split range on the fly
         seq_num_kv_splits = (p.splits_per_seq != nullptr)
-            ? p.splits_per_seq[idx_b]
-            : num_kv_splits;
+                                ? p.splits_per_seq[idx_b]
+                                : num_kv_splits;
 
         if (idx_kv_split >= seq_num_kv_splits) {
           continue;
@@ -669,8 +678,8 @@ class ReduceSplitK {
       const int windowed_k_blocks = k_blocks - k_block0;
       // Per-sequence adaptive split count
       int seq_num_kv_splits = (p.splits_per_seq != nullptr)
-          ? p.splits_per_seq[idx_b]
-          : num_kv_splits;
+                                  ? p.splits_per_seq[idx_b]
+                                  : num_kv_splits;
 
       int num_blocks_per_split =
           cute::ceil_div(windowed_k_blocks, seq_num_kv_splits);
@@ -685,8 +694,8 @@ class ReduceSplitK {
       } else {
         constexpr int tile_n = get<1>(typename FMHAKernel_::TileShapeQK{});
         constexpr int kMinBlocksForSplit = (tile_n <= 64) ? 32 : 128;
-        bool is_single_split = (seq_num_kv_splits > 1) &&
-            (windowed_k_blocks < kMinBlocksForSplit);
+        bool is_single_split =
+            (seq_num_kv_splits > 1) && (windowed_k_blocks < kMinBlocksForSplit);
         effective_splits = is_single_split ? 1 : seq_num_kv_splits;
       }
 

--- a/csrc/xpu/attn/xe_2/paged_decode.hpp
+++ b/csrc/xpu/attn/xe_2/paged_decode.hpp
@@ -117,9 +117,11 @@ struct paged_decode_args_t {
   bool is_local = false;
   bool is_sink = false;
   int num_kv_splits = 1;
-  const int* splits_per_seq = nullptr;  // per-seq split counts; null => use global num_kv_splits
-  const void* work_list = nullptr;      // DecodeWorkItem[total_wgs]; null => old grid
-  int total_wgs = 0;                    // sum(splits_per_seq); 0 => old grid
+  const int* splits_per_seq =
+      nullptr;  // per-seq split counts; null => use global num_kv_splits
+  const void* work_list =
+      nullptr;        // DecodeWorkItem[total_wgs]; null => old grid
+  int total_wgs = 0;  // sum(splits_per_seq); 0 => old grid
   // KV cache strides [num_blocks, block_size, num_heads_kv, head_size]
   int64_t k_stride_page = 0;
   int64_t k_stride_seq = 0;
@@ -381,7 +383,8 @@ struct DecodeKernelLauncher {
     // Compact grid: patch scheduler params with work_list if available
     if (args.work_list != nullptr && args.total_wgs > 0) {
       params.scheduler.work_list =
-          reinterpret_cast<const cutlass::fmha::kernel::DecodeWorkItem*>(args.work_list);
+          reinterpret_cast<const cutlass::fmha::kernel::DecodeWorkItem*>(
+              args.work_list);
       params.scheduler.total_wgs = args.total_wgs;
       // Override grid.z to compact size
       params.scheduler.grid.z = args.total_wgs * args.num_heads_k;

--- a/csrc/xpu/attn/xe_2/paged_decode.hpp
+++ b/csrc/xpu/attn/xe_2/paged_decode.hpp
@@ -117,6 +117,9 @@ struct paged_decode_args_t {
   bool is_local = false;
   bool is_sink = false;
   int num_kv_splits = 1;
+  const int* splits_per_seq = nullptr;  // per-seq split counts; null => use global num_kv_splits
+  const void* work_list = nullptr;      // DecodeWorkItem[total_wgs]; null => old grid
+  int total_wgs = 0;                    // sum(splits_per_seq); 0 => old grid
   // KV cache strides [num_blocks, block_size, num_heads_kv, head_size]
   int64_t k_stride_page = 0;
   int64_t k_stride_seq = 0;
@@ -316,6 +319,7 @@ struct DecodeKernelLauncher {
             stride_max_logits,
             reinterpret_cast<ElementQ*>(args.sm_sink),
             static_cast<const bool*>(args.is_prefill),
+            args.splits_per_seq,
         },
         {args.sm_scale,
          args.k_scale,
@@ -344,7 +348,8 @@ struct DecodeKernelLauncher {
          reinterpret_cast<ElementLSE*>(args.max_logits),
          stride_max_logits,
          args.window_size_left,
-         static_cast<const bool*>(args.is_prefill)},
+         static_cast<const bool*>(args.is_prefill),
+         args.splits_per_seq},
         hw_info,
         args.num_kv_splits};
 
@@ -372,6 +377,15 @@ struct DecodeKernelLauncher {
         FMHAKernel::to_underlying_arguments(arguments, workspace.get());
     auto reduce_params = ReductionSplitKernel::to_underlying_arguments(
         reduce_arg, workspace.get() + workspace_size);
+
+    // Compact grid: patch scheduler params with work_list if available
+    if (args.work_list != nullptr && args.total_wgs > 0) {
+      params.scheduler.work_list =
+          reinterpret_cast<const cutlass::fmha::kernel::DecodeWorkItem*>(args.work_list);
+      params.scheduler.total_wgs = args.total_wgs;
+      // Override grid.z to compact size
+      params.scheduler.grid.z = args.total_wgs * args.num_heads_k;
+    }
 
     ReductionSplitKernel::initialize_workspace(
         reduce_arg, workspace.get() + workspace_size);

--- a/csrc/xpu/attn/xe_2/paged_decode_utils.hpp
+++ b/csrc/xpu/attn/xe_2/paged_decode_utils.hpp
@@ -139,4 +139,6 @@ void cutlass_paged_decode_impl(
     bool is_local,
     bool is_sink,
     int num_kv_splits,
-    std::optional<const at::Tensor>& is_prefill);
+    std::optional<const at::Tensor>& is_prefill,
+    std::optional<at::Tensor>& splits_per_seq,
+    std::optional<at::Tensor>& work_list);

--- a/csrc/xpu/attn/xe_2/paged_decode_xe2.cpp
+++ b/csrc/xpu/attn/xe_2/paged_decode_xe2.cpp
@@ -31,7 +31,9 @@ void cutlass_paged_decode_xe2(
     bool is_local,
     bool is_sink,
     int num_kv_splits,
-    std::optional<const at::Tensor>& is_prefill) {
+    std::optional<const at::Tensor>& is_prefill,
+    std::optional<at::Tensor>& splits_per_seq,
+    std::optional<at::Tensor>& work_list) {
   cutlass_paged_decode_impl(
       queue,
       query,
@@ -58,7 +60,9 @@ void cutlass_paged_decode_xe2(
       is_local,
       is_sink,
       num_kv_splits,
-      is_prefill);
+      is_prefill,
+      splits_per_seq,
+      work_list);
 }
 
 inline bool is_single_value_broadcast_tensor(const at::Tensor& t) {
@@ -100,7 +104,9 @@ void cutlass_paged_decode_impl(
     bool is_local,
     bool is_sink,
     int num_kv_splits,
-    std::optional<const at::Tensor>& is_prefill) {
+    std::optional<const at::Tensor>& is_prefill,
+    std::optional<at::Tensor>& splits_per_seq,
+    std::optional<at::Tensor>& work_list) {
   bool is_fp8_kv = key_cache.scalar_type() == at::ScalarType::Float8_e5m2 ||
                    key_cache.scalar_type() == at::ScalarType::Float8_e4m3fn;
   if (is_fp8_kv) {
@@ -199,6 +205,9 @@ void cutlass_paged_decode_impl(
       is_local,
       is_sink,
       num_kv_splits,
+      nullptr,  // splits_per_seq, filled in below if applicable
+      nullptr,  // work_list, filled in below if applicable
+      0,        // total_wgs, filled in below if applicable
       key_cache.stride(0),
       key_cache.stride(1),
       key_cache.stride(2),
@@ -223,6 +232,18 @@ void cutlass_paged_decode_impl(
     if (effective_total > args.total_seqlen_k) {
       args.total_seqlen_k = static_cast<int>(effective_total);
     }
+  }
+
+  // Per-sequence adaptive split-K: use pre-computed splits_per_seq from Python
+  // if available. This avoids GPU→CPU sync and extra computation here.
+  if (splits_per_seq.has_value() && splits_per_seq->numel() > 0) {
+    args.splits_per_seq = splits_per_seq->data_ptr<int>();
+  }
+
+  // Per-sequence work_list for compact grid scheduling
+  if (work_list.has_value() && work_list->numel() > 0) {
+    args.work_list = work_list->data_ptr<int>();
+    args.total_wgs = work_list->size(0);  // [total_wgs, 4]
   }
 
   TORCH_CHECK(

--- a/csrc/xpu/attn/xe_2/paged_decode_xe2.h
+++ b/csrc/xpu/attn/xe_2/paged_decode_xe2.h
@@ -27,4 +27,6 @@ void cutlass_paged_decode_xe2(
     bool is_local,
     bool is_sink,
     int num_kv_splits,
-    std::optional<const at::Tensor>& is_prefill);
+    std::optional<const at::Tensor>& is_prefill,
+    std::optional<at::Tensor>& splits_per_seq,
+    std::optional<at::Tensor>& work_list);

--- a/docs/group_split_kv_design.md
+++ b/docs/group_split_kv_design.md
@@ -1,0 +1,216 @@
+# Group Split-K for Mixed-Length Batch Decoding (Xe2)
+
+## 1. Problem statement
+
+The existing `paged_decode_xe2` kernel uses a static `(batch × heads_kv × num_kv_splits)`
+work-group (WG) grid. For mixed-length decode batches this has two failure modes:
+
+1. **Idle WGs.** A short sequence gets the same `num_kv_splits` slots as a long
+   one. Splits whose tile range is empty exit immediately but still occupy a WG
+   slot, so the launched grid is much larger than the work it carries.
+2. **Unfair partition.** `num_blocks_per_split = ceil_div(blocks, splits)`
+   concentrates work on the first `floor(blocks / blocks_per_split)` splits;
+   the trailing split can be tiny or empty.
+3. **Hidden GPU→CPU sync.** Any C++-side decision that wants to look at per-seq
+   KV lengths must either pay for a `.item()` round-trip or duplicate the
+   logic the scheduler already needs in Python.
+
+The vLLM scheduler already knows `kv_lens` on the host. The PR pushes the
+split planning to Python and makes the GPU read a precomputed `work_list`.
+
+## 2. Architecture overview
+
+```
+                  vLLM scheduler                  (host)
+                         │   kv_lens, num_splits_kv,
+                         │   num_xe_cores, num_heads_kv
+                         ▼
+       flash_attn_interface.build_decode_split_plan      (host, Python)
+                         │   splits_per_seq[B]    int32
+                         │   work_list[total_wgs, 4]   int32
+                         ▼  (.to(device, non_blocking=True))
+              flash_attn_varlen_func → varlen_fwd        (PyTorch op)
+                         │
+                         ▼
+              cutlass_paged_decode_impl                  (C++)
+                         │  fills args.splits_per_seq,
+                         │  args.work_list, args.total_wgs
+                         ▼
+            DecodeKernelLauncher::run                    (host launch)
+                         │  patches scheduler.work_list,
+                         │  scheduler.total_wgs,
+                         │  scheduler.grid.z = total_wgs × heads_kv
+                         ▼
+                ┌────────┴────────┐
+                ▼                 ▼
+      XeFMHAFwdSplitKVKernel    ReduceSplitK
+      (compact-grid branch)    (uses splits_per_seq
+       reads work_list[wi]      directly, no heuristic
+       → seq_idx, tile_start,    reapplied)
+         tile_count, split_idx
+```
+
+Two execution modes live side-by-side in the kernels:
+
+- **Legacy mode** (`work_list == nullptr`): identical to pre-PR behavior. The
+  scheduler builds a `(B × H_kv × num_kv_splits)` grid and each kernel
+  invocation reapplies the `is_single_split` heuristic on its own.
+- **Compact mode** (`work_list != nullptr && total_wgs > 0`): grid is exactly
+  `total_wgs × heads_kv`. Each WG reads one `DecodeWorkItem` from `work_list`
+  and processes exactly its tile range. The kernel does no per-seq split math.
+
+## 3. Algorithm — `build_decode_split_plan`
+
+Inputs: `kv_lens[B]`, `kv_tile`, `num_kv_splits`, `num_xe_cores`, `num_heads_kv`.
+
+```
+tiles_per_seq[i]      = max(1, ceil_div(kv_lens[i], kv_tile))
+total_tiles           = Σ tiles_per_seq
+
+min_wgs               = max(1, num_xe_cores * 2 / num_heads_kv)
+target_tiles_per_wg   = max(4, total_tiles / min_wgs)
+min_blocks_for_split  = 32 if kv_tile ≤ 64 else 128
+
+for each seq i:
+    if tiles ≤ target_tiles_per_wg  or  tiles < min_blocks_for_split  or  num_kv_splits ≤ 1:
+        n_splits = 1                              # single-split path
+    else:
+        n_splits = ceil_div(tiles, target_tiles_per_wg)
+        n_splits = min(n_splits, num_kv_splits, tiles)   # cap
+
+    base, rem = divmod(tiles, n_splits)
+    for s in 0..n_splits-1:
+        count = base + (1 if s < rem else 0)
+        emit work_item(seq_idx = i,
+                        kv_tile_start = running_offset,
+                        kv_tile_count = count,
+                        split_idx     = s)
+        running_offset += count
+```
+
+### Correctness contract
+
+The function returns `(splits_per_seq, work_list)` with these guarantees:
+
+1. `Σ splits_per_seq == work_list.shape[0]`.
+2. Every emitted `kv_tile_count ≥ 1`. (Cap `n_splits ≤ tiles` makes
+   `base ≥ 1` regardless of `rem`.)
+3. Per seq, the work items partition `[0, tiles)` exactly once
+   (`Σ counts == tiles`, half-open, contiguous).
+4. `splits_per_seq[i] ≤ num_kv_splits` so the static reduction buffer
+   `[Oaccum, exp_sums, max_logits]` indexing on the GPU is in-bounds.
+
+Properties 1 and 4 are exactly what `ReduceSplitK` needs to read only the
+slots that were written. Properties 2 and 3 prevent the "phantom split"
+problem that motivated the patch.
+
+### Heuristics chosen
+
+- `target_tiles_per_wg = max(4, total_tiles / min_wgs)` keeps the split-K
+  overhead amortized (≥ 4 tiles per launched WG) while still oversubscribing
+  the Xe-core count 2× when work is plentiful.
+- `min_blocks_for_split` mirrors the GPU-side single-split threshold so
+  short sequences keep the cheap path.
+- Single-split is treated as `is_single_split == true` in the reducer, so
+  the output goes directly to slot 0 with no cross-split reduction.
+
+## 4. C++ plumbing
+
+| File | Change |
+|---|---|
+| `flash_api.cpp` | Schema gains `Tensor? splits_per_seq, Tensor? work_list`. Forwarded to both prefill-opt and decode paths of `cutlass_paged_decode_interface`. |
+| `attn_interface.{h,cpp}` | Adds the two optional tensors and forwards them to `cutlass_paged_decode_xe2`. |
+| `paged_decode_xe2.{h,cpp}` | Wires the tensors into `paged_decode_args_t`: `args.splits_per_seq`, `args.work_list`, `args.total_wgs`. Both default to null/0 (legacy behavior). |
+| `paged_decode.hpp` | `paged_decode_args_t` gains `splits_per_seq`, `work_list`, `total_wgs`. `DecodeKernelLauncher::run` patches the scheduler params *after* `to_underlying_arguments` so the compact-grid path is opt-in per launch. |
+| `chunk_prefill_scheduler.hpp` | Adds `DecodeWorkItem` POD struct. `DecodeTileScheduler::Params` gains `work_list`, `total_wgs`. `to_underlying_arguments` shrinks `grid.z` to `total_wgs × heads_kv` when work-list is present. `get_block_coord()` returns a 7-tuple `(blk_q, blk_v, head, idx_b, idx_kv_split, wl_tile_start, wl_tile_count)`; the last two fields are `-1` in legacy mode so the FMHA kernel can branch. |
+| `paged_decode_kernel.hpp` | `XeFMHAFwdSplitKVKernel` reads the 7-tuple, branches on `wl_tile_start >= 0`. Compact branch uses the precomputed range. Legacy branch keeps the original heuristic. `ReduceSplitK` reads `splits_per_seq[idx_b]` when provided and trusts it; otherwise mirrors the legacy heuristic. |
+
+The legacy branch is intentionally preserved so:
+- existing callers that do not provide `host_kv_lens` keep working,
+- prefill (where `max_seqlen_q > 1`) never hits the new path.
+
+## 5. Python interface
+
+`flash_attn_varlen_func` accepts a new optional `host_kv_lens` tensor (or
+list). When supplied, it is converted once to an `int32` device tensor and
+used as `seqused_k`. The decode gate is:
+
+```python
+block_table is not None
+and host_kv_lens is not None
+and num_splits_kv is not None and num_splits_kv > 1
+and max_seqlen_q == 1
+```
+
+Only inside this gate do we build the plan, and we only upload when
+`work_list_cpu.numel() > 0`. Everywhere else the schema-default `None`
+tensors are forwarded and the kernel takes the legacy branch.
+
+## 6. Backward compatibility
+
+- `varlen_fwd` schema gained two trailing `Tensor?` arguments; both default
+  to `None`. Callers built against the old signature must be re-bound (this
+  is a kernel package; pinning is expected).
+- `paged_decode_args_t` defaults `splits_per_seq=nullptr`, `work_list=nullptr`,
+  `total_wgs=0`. Any C++ caller that does not opt in gets the original grid.
+- The FMHA kernel and the reducer both keep their original code paths under
+  `wl_tile_start < 0` / `splits_per_seq == nullptr`.
+- `compute_splits_per_seq` (legacy entry point) is kept as a thin shim over
+  `build_decode_split_plan`.
+
+## 7. Code review summary
+
+### Correctness
+
+- **Reducer / FMHA consistency.** Previously the reducer reapplied the
+  `is_single_split` heuristic, which could diverge from the kernel when the
+  host had already decided to split. Fix: when `splits_per_seq != nullptr`,
+  the reducer trusts it; otherwise it preserves the legacy mirror logic.
+- **Even partition guarantees `count ≥ 1`.** The cap `n_splits = min(n_splits,
+  num_kv_splits, n_tiles)` plus `base, rem = divmod(n_tiles, n_splits)`
+  ensures no empty work item is emitted. Pre-cap code could emit a trailing
+  zero-count slot.
+- **`is_single_split` scope fix.** In the FMHA kernel, the variable used to
+  be declared inside the legacy `else` block but referenced by the epilogue
+  call after the block. The work-list path would have left it undeclared.
+  Now it is declared once at outer scope and set in both branches.
+- **`cutlass_paged_decode_xe2` forwards `work_list`.** Previously the wrapper
+  swallowed `work_list`, so the compact-grid path was effectively dead code.
+  Now both `splits_per_seq` and `work_list` are forwarded.
+
+### Robustness
+
+- `_infer_num_xe_cores` quotes all `getattr` keys (`"gpu_slices"`,
+  `"num_slices"`, `"slices"`, `"gpu_subslices_per_slice"`,
+  `"num_subslices_per_slice"`, `"subslices_per_slice"`) and wraps the
+  device-property query in `try/except` with a fallback to 20.
+- The Python builder accepts a `list`, `tuple` or `torch.Tensor` for
+  `kv_lens`, and converts internally without forcing device sync (it pulls
+  the tensor to CPU only).
+
+### Style / lint
+
+- The Python file is `pycodestyle`-clean.
+- `benchmark_cutlass_flash_attn_decode.py` was reformatted to respect
+  line-length limits; configs are built with a single `_mk_cfg` helper to
+  cut duplication. One pre-existing 84-char line remains and is not in
+  scope of this PR.
+
+### Things deliberately left out
+
+- No GPU-side fallback computation: if Python decides splits, the kernel
+  trusts them. The legacy branch is preserved verbatim for callers that do
+  not opt in.
+- The compact grid patches `scheduler.grid.z` after
+  `to_underlying_arguments`; a cleaner solution would be to thread
+  `work_list` through `to_underlying_arguments`, but that would require
+  touching the upstream CUTLASS-SYCL adapter. The post-patch is local and
+  reversible.
+
+## 8. Performance
+
+See `benchmark/benchmark_cutlass_flash_attn_decode.py` and the CSVs in
+`benchmark/` for end-to-end and kernel-level numbers on mixed-length
+batches. The wins concentrate on configs where a single long sequence
+shared a batch with short sequences (`8xskewed`, `8xmixed`,
+`16xrealistic_mixed`).

--- a/vllm_xpu_kernels/flash_attn_interface.py
+++ b/vllm_xpu_kernels/flash_attn_interface.py
@@ -21,6 +21,139 @@ def maybe_contiguous(x):
     return x.contiguous() if x is not None and x.stride(-1) != 1 else x
 
 
+def _as_int32_device_tensor(x, device: torch.device) -> torch.Tensor:
+    if isinstance(x, torch.Tensor):
+        return x.to(device=device, dtype=torch.int32)
+    return torch.tensor(x, device=device, dtype=torch.int32)
+
+
+def _kv_tile_from_block_size(block_size: int) -> int:
+    # Mirror of flash_api.cpp get_num_splits() / TileShapeQK<1>.
+    if block_size == 16:
+        return 16
+    if block_size == 32:
+        return 32
+    return 64
+
+
+def _min_blocks_for_split(kv_tile: int) -> int:
+    # Mirror of XeFMHAFwdSplitKVKernel::kMinBlocksForSplit /
+    # ReduceSplitK::kMinBlocksForSplit. Below this threshold a sequence is
+    # processed as a single split for numerical stability.
+    return 32 if kv_tile <= 64 else 128
+
+
+def _infer_num_xe_cores(device: torch.device) -> int:
+    # Prefer runtime query; fall back to 20 (Xe2/BMG default).
+    try:
+        props = torch.xpu.get_device_properties(device)
+    except Exception:
+        return 20
+    slices = (getattr(props, "gpu_slices", None)
+              or getattr(props, "num_slices", None)
+              or getattr(props, "slices", None))
+    subslices = (getattr(props, "gpu_subslices_per_slice", None)
+                 or getattr(props, "num_subslices_per_slice", None)
+                 or getattr(props, "subslices_per_slice", None))
+    if slices is not None and subslices is not None:
+        return max(1, int(slices) * int(subslices))
+    return 20
+
+
+def build_decode_split_plan(
+    kv_lens,
+    kv_tile: int,
+    num_kv_splits: int,
+    num_xe_cores: int,
+    num_heads_kv: int,
+):
+    """Produce (splits_per_seq, work_list) for the compact-grid decode kernel.
+
+    Inputs
+    ------
+    kv_lens         : per-seq KV length in tokens (list/tensor, on host).
+    kv_tile         : KV tile width in tokens (must equal the kernel's
+                      get<1>(TileShapeQK{})).
+    num_kv_splits   : global cap on per-seq split count (buffer dim).
+    num_xe_cores    : Xe-core count used for the target-WG heuristic.
+    num_heads_kv    : KV heads (workload is sliced across heads_kv heads).
+
+    Returns
+    -------
+    splits_per_seq  : int32 cpu tensor [batch], splits[i] >= 1.
+    work_list       : int32 cpu tensor [total_wgs, 4] of
+                      (seq_idx, kv_tile_start, kv_tile_count, split_idx).
+
+    Guarantees
+    ----------
+    - sum(splits_per_seq) == work_list.size(0) == total_wgs
+    - For every emitted work item, kv_tile_count >= 1
+    - For each seq, the work items partition [0, kv_tiles) exactly once
+    - splits_per_seq[i] <= num_kv_splits (so Oaccum/exp_sums/max_logits
+      buffer indexing is safe)
+    - splits_per_seq[i] folds in {single-split heuristic, balanced
+      assignment, hard cap}; the kernel never needs to second-guess it.
+    """
+    if isinstance(kv_lens, torch.Tensor):
+        kv_lens_list = kv_lens.to(dtype=torch.int32, device="cpu").tolist()
+    else:
+        kv_lens_list = [int(v) for v in kv_lens]
+
+    tiles_per_seq = [max(1, (kv + kv_tile - 1) // kv_tile)
+                     for kv in kv_lens_list]
+    total_tiles = sum(tiles_per_seq)
+
+    # Target: ~2x oversubscription of Xe cores per kv head, minimum 4 tiles
+    # per WG so split-K overhead stays amortized.
+    min_wgs = max(1, num_xe_cores * 2 // max(1, num_heads_kv))
+    target_tiles_per_wg = max(4, total_tiles // min_wgs)
+
+    # Mirror of the kernel's is_single_split heuristic: avoid split-reduce
+    # for short sequences (numerical stability + overhead).
+    min_blocks_for_split = _min_blocks_for_split(kv_tile)
+
+    splits_per_seq = []
+    work_items = []
+    for i, n_tiles in enumerate(tiles_per_seq):
+        if (n_tiles <= target_tiles_per_wg
+                or n_tiles < min_blocks_for_split
+                or num_kv_splits <= 1):
+            n_splits = 1
+        else:
+            n_splits = ((n_tiles + target_tiles_per_wg - 1)
+                        // target_tiles_per_wg)
+            # Cap to the static buffer dim AND to n_tiles, so every emitted
+            # work item has kv_tile_count >= 1.
+            n_splits = min(n_splits, num_kv_splits, n_tiles)
+        splits_per_seq.append(n_splits)
+
+        # Even partitioning: first `rem` splits get base+1 tiles, the rest
+        # get base. Guarantees count >= 1 since n_splits <= n_tiles.
+        base, rem = divmod(n_tiles, n_splits)
+        start = 0
+        for s in range(n_splits):
+            count = base + (1 if s < rem else 0)
+            work_items.append([i, start, count, s])
+            start += count
+
+    splits_t = torch.tensor(splits_per_seq, dtype=torch.int32)
+    work_t = torch.tensor(work_items, dtype=torch.int32)
+    return splits_t, work_t
+
+
+# Backward-compat shim: previously this returned only splits_per_seq.
+def compute_splits_per_seq(
+    kv_lens,
+    kv_tile: int,
+    num_kv_splits: int = 32,
+    num_xe_cores: int = 20,
+    num_heads_kv: int = 2,
+) -> torch.Tensor:
+    splits, _ = build_decode_split_plan(
+        kv_lens, kv_tile, num_kv_splits, num_xe_cores, num_heads_kv)
+    return splits
+
+
 def flash_attn_varlen_func(
     q,
     k,
@@ -53,6 +186,7 @@ def flash_attn_varlen_func(
     s_aux: Optional[torch.Tensor] = None,
     num_splits_kv: Optional[int] = None,
     is_mix_batch: bool = True,
+    host_kv_lens: Optional[torch.Tensor] = None,
 ):
     """
     FlashAttention interface for variable-length sequences, with optional
@@ -66,6 +200,9 @@ def flash_attn_varlen_func(
         cu_seqlens_k: Cumulative sequence lengths for keys/values when not
             using paged KV cache.
         seqused_k: Number of tokens used per sequence when using paged KV.
+        host_kv_lens: Optional host-side per-seq KV lengths. If provided,
+            this function converts them to an int32 device tensor and uses
+            it as seqused_k.
         block_table: Optional block table for paged KV cache.
         num_splits: Backend-specific split parameter (non-KV specific),
             typically used to control work partitioning in some FA versions.
@@ -75,8 +212,14 @@ def flash_attn_varlen_func(
             unit is KV blocks, not individual tokens or pages.
         fa_version: FlashAttention backend version selector.
     """
+    if host_kv_lens is not None:
+        if seqused_k is not None:
+            raise ValueError("Provide only one of host_kv_lens and seqused_k")
+        seqused_k = _as_int32_device_tensor(host_kv_lens, q.device)
+
     assert cu_seqlens_k is not None or seqused_k is not None, \
         "cu_seqlens_k or seqused_k must be provided"
+
     assert cu_seqlens_k is None or seqused_k is None, \
         "cu_seqlens_k and seqused_k cannot be provided at the same time"
     assert block_table is None or seqused_k is not None, \
@@ -123,6 +266,31 @@ def flash_attn_varlen_func(
                                            and v_descale is not None):
             raise NotImplementedError(
                 "FA2 only supports both KV cache descaled")
+        # Compute per-seq splits and work_list on host, upload to device.
+        # Only enable for decode (max_seqlen_q == 1) with paged KV cache,
+        # multi-seq batches, and global num_splits_kv > 1.
+        splits_per_seq_dev = None
+        work_list_dev = None
+        if (block_table is not None and host_kv_lens is not None
+                and num_splits_kv is not None and num_splits_kv > 1
+                and max_seqlen_q == 1):
+            block_size = k.size(1)
+            kv_tile = _kv_tile_from_block_size(block_size)
+            num_xe_cores = _infer_num_xe_cores(q.device)
+            num_heads_kv = k.size(2)
+            splits_cpu, work_list_cpu = build_decode_split_plan(
+                host_kv_lens,
+                kv_tile=kv_tile,
+                num_kv_splits=num_splits_kv,
+                num_xe_cores=num_xe_cores,
+                num_heads_kv=num_heads_kv,
+            )
+            if work_list_cpu.numel() > 0:
+                splits_per_seq_dev = splits_cpu.to(
+                    device=q.device, non_blocking=True)
+                work_list_dev = work_list_cpu.to(
+                    device=q.device, non_blocking=True)
+
         out, softmax_lse = torch.ops._vllm_fa2_C.varlen_fwd(
             q,
             k,
@@ -151,7 +319,9 @@ def flash_attn_varlen_func(
             return_softmax_lse,
             None,
             num_splits_kv,
-            is_mix_batch
+            is_mix_batch,
+            splits_per_seq_dev,
+            work_list_dev,
         )
     else:
         raise NotImplementedError("not support yet")


### PR DESCRIPTION
# Group Split-K for Mixed-Length Batch Decoding (Xe2)

## 1. Problem statement

The existing `paged_decode_xe2` kernel uses a static `(batch × heads_kv × num_kv_splits)` work-group (WG) grid. For mixed-length decode batches this has two failure modes:

1. **Idle WGs.** A short sequence gets the same `num_kv_splits` slots as a long one. Splits whose tile range is empty exit immediately but still occupy a WG slot, so the launched grid is much larger than the work it carries.
2. **Unfair partition.** `num_blocks_per_split = ceil_div(blocks, splits)` concentrates work on the first `floor(blocks / blocks_per_split)` splits; the trailing split can be tiny or empty.
3. **Hidden GPU→CPU sync.** Any C++-side decision that wants to look at per-seq KV lengths must either pay for a `.item()` round-trip or duplicate the logic the scheduler already needs in Python.

The vLLM scheduler already knows `kv_lens` on the host. This PR pushes the split planning to Python and makes the GPU read a precomputed `work_list`.

## 2. Architecture overview

```
                  vLLM scheduler                  (host)
                         │   kv_lens, num_splits_kv,
                         │   num_xe_cores, num_heads_kv
                         ▼
       flash_attn_interface.build_decode_split_plan      (host, Python)
                         │   splits_per_seq[B]         int32
                         │   work_list[total_wgs, 4]   int32
                         ▼  (.to(device, non_blocking=True))
              flash_attn_varlen_func → varlen_fwd        (PyTorch op)
                         │
                         ▼
              cutlass_paged_decode_impl                  (C++)
                         │  fills args.splits_per_seq,
                         │  args.work_list, args.total_wgs
                         ▼
            DecodeKernelLauncher::run                    (host launch)
                         │  patches scheduler.work_list,
                         │  scheduler.total_wgs,
                         │  scheduler.grid.z = total_wgs × heads_kv
                         ▼
                ┌────────┴────────┐
                ▼                 ▼
      XeFMHAFwdSplitKVKernel    ReduceSplitK
      (compact-grid branch)    (uses splits_per_seq
       reads work_list[wi]      directly, no heuristic
       → seq_idx, tile_start,    reapplied)
         tile_count, split_idx
```

Two execution modes live side-by-side in the kernels:

- **Legacy mode** (`work_list == nullptr`): identical to pre-PR behavior. The scheduler builds a `(B × H_kv × num_kv_splits)` grid and each kernel invocation reapplies the `is_single_split` heuristic on its own.
- **Compact mode** (`work_list != nullptr && total_wgs > 0`): grid is exactly `total_wgs × heads_kv`. Each WG reads one `DecodeWorkItem` from `work_list` and processes exactly its tile range. The kernel does no per-seq split math.

## 3. Algorithm — `build_decode_split_plan`

Inputs: `kv_lens[B]`, `kv_tile`, `num_kv_splits`, `num_xe_cores`, `num_heads_kv`.

```
tiles_per_seq[i]      = max(1, ceil_div(kv_lens[i], kv_tile))
total_tiles           = Σ tiles_per_seq

min_wgs               = max(1, num_xe_cores * 2 / num_heads_kv)
target_tiles_per_wg   = max(4, total_tiles / min_wgs)
min_blocks_for_split  = 32 if kv_tile ≤ 64 else 128

for each seq i:
    if tiles ≤ target_tiles_per_wg  or  tiles < min_blocks_for_split  or  num_kv_splits ≤ 1:
        n_splits = 1                                     # single-split path
    else:
        n_splits = ceil_div(tiles, target_tiles_per_wg)
        n_splits = min(n_splits, num_kv_splits, tiles)   # cap

    base, rem = divmod(tiles, n_splits)
    for s in 0..n_splits-1:
        count = base + (1 if s < rem else 0)
        emit work_item(seq_idx       = i,
                       kv_tile_start = running_offset,
                       kv_tile_count = count,
                       split_idx     = s)
        running_offset += count
```

### Correctness contract

The function returns `(splits_per_seq, work_list)` with these guarantees:

1. `Σ splits_per_seq == work_list.shape[0]`.
2. Every emitted `kv_tile_count ≥ 1`. (Cap `n_splits ≤ tiles` makes `base ≥ 1` regardless of `rem`.)
3. Per seq, the work items partition `[0, tiles)` exactly once (`Σ counts == tiles`, half-open, contiguous).
4. `splits_per_seq[i] ≤ num_kv_splits` so the static reduction buffer `[Oaccum, exp_sums, max_logits]` indexing on the GPU is in-bounds.

Properties 1 and 4 are exactly what `ReduceSplitK` needs to read only the slots that were written. Properties 2 and 3 prevent the "phantom split" problem that motivated the patch.

### Heuristics chosen

- `target_tiles_per_wg = max(4, total_tiles / min_wgs)` keeps the split-K overhead amortized (≥ 4 tiles per launched WG) while still oversubscribing the Xe-core count 2× when work is plentiful.
- `min_blocks_for_split` mirrors the GPU-side single-split threshold so short sequences keep the cheap path.
- Single-split is treated as `is_single_split == true` in the reducer, so the output goes directly to slot 0 with no cross-split reduction.

## 4. C++ plumbing

| File | Change |
| --- | --- |
| `flash_api.cpp` | Schema gains `Tensor? splits_per_seq`, `Tensor? work_list`. Forwarded to both prefill-opt and decode paths of `cutlass_paged_decode_interface`. |
| `attn_interface.{h,cpp}` | Adds the two optional tensors and forwards them to `cutlass_paged_decode_xe2`. |
| `paged_decode_xe2.{h,cpp}` | Wires the tensors into `paged_decode_args_t`: `args.splits_per_seq`, `args.work_list`, `args.total_wgs`. Both default to null/0 (legacy behavior). |
| `paged_decode.hpp` | `paged_decode_args_t` gains `splits_per_seq`, `work_list`, `total_wgs`. `DecodeKernelLauncher::run` patches the scheduler params after `to_underlying_arguments` so the compact-grid path is opt-in per launch. |
| `chunk_prefill_scheduler.hpp` | Adds `DecodeWorkItem` POD struct. `DecodeTileScheduler::Params` gains `work_list`, `total_wgs`. `to_underlying_arguments` shrinks `grid.z` to `total_wgs × heads_kv` when work-list is present. `get_block_coord()` returns a 7-tuple `(blk_q, blk_v, head, idx_b, idx_kv_split, wl_tile_start, wl_tile_count)`; the last two fields are `-1` in legacy mode so the FMHA kernel can branch. |
| `paged_decode_kernel.hpp` | `XeFMHAFwdSplitKVKernel` reads the 7-tuple, branches on `wl_tile_start >= 0`. Compact branch uses the precomputed range. Legacy branch keeps the original heuristic. `ReduceSplitK` reads `splits_per_seq[idx_b]` when provided and trusts it; otherwise mirrors the legacy heuristic. |

The legacy branch is intentionally preserved so:

- existing callers that do not provide `host_kv_lens` keep working,
- prefill (where `max_seqlen_q > 1`) never hits the new path.

## 5. Python interface

`flash_attn_varlen_func` accepts a new optional `host_kv_lens` tensor (or list). When supplied, it is converted once to an `int32` device tensor and used as `seqused_k`. The decode gate is:

```python
block_table is not None
and host_kv_lens is not None
and num_splits_kv is not None and num_splits_kv > 1
and max_seqlen_q == 1
```

Only inside this gate do we build the plan, and we only upload when `work_list_cpu.numel() > 0`. Everywhere else the schema-default `None` tensors are forwarded and the kernel takes the legacy branch.

## 6. Backward compatibility

- `varlen_fwd` schema gained two trailing `Tensor?` arguments; both default to `None`. Callers built against the old signature must be re-bound (this is a kernel package; pinning is expected).
- `paged_decode_args_t` defaults `splits_per_seq=nullptr`, `work_list=nullptr`, `total_wgs=0`. Any C++ caller that does not opt in gets the original grid.
- The FMHA kernel and the reducer both keep their original code paths under `wl_tile_start < 0` / `splits_per_seq == nullptr`.
- `compute_splits_per_seq` (legacy entry point) is kept as a thin shim over `build_decode_split_plan`.

## 7. Performance

Thanks @wuxun-zhang for helping to test.

| row | case               | reference (us) | optimized (us) | delta (us) | perf change | speedup |
| --: | ------------------ | -------------: | -------------: | ---------: | ----------: | ------: |
|  0  | 1,1,4096, (32,2)   |        130.340 |         30.292 |   -100.048 |     +76.76% |  4.303x |
|  1  | 1,1,4096, (32,4)   |        126.117 |         45.559 |    -80.558 |     +63.87% |  2.768x |
|  2  | 1,1,4096, (40,40)  |        217.249 |        222.678 |     +5.429 |      -2.50% |  0.976x |
|  3  | 1,1,4096, (64,8)   |        136.982 |         66.636 |    -70.346 |     +51.35% |  2.056x |
|  4  | 32 x 512, (32,2)   |         71.708 |         69.534 |     -2.174 |      +3.03% |  1.031x |
|  5  | 32 x 512, (32,4)   |        103.518 |         90.393 |    -13.125 |     +12.68% |  1.145x |
|  6  | 32 x 512, (40,40)  |        787.231 |        781.414 |     -5.817 |      +0.74% |  1.007x |
|  7  | 32 x 512, (64,8)   |        166.400 |        163.457 |     -2.943 |      +1.77% |  1.018x |
|  8  | mixed len, (32,2)  |        288.066 |        103.636 |   -184.430 |     +64.02% |  2.780x |
|  9  | mixed len, (32,4)  |        611.125 |        189.415 |   -421.710 |     +69.00% |  3.226x |
| 10  | mixed len, (40,40) |       1649.260 |       1584.079 |    -65.180 |      +3.95% |  1.041x |
| 11  | mixed len, (64,8)  |        385.712 |        349.079 |    -36.632 |      +9.50% |  1.105x |