### PR TITLE
cmake: add VLLM_XPU_LIBS_ONLY + prebuilt-kernel-lib hooks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -323,6 +323,9 @@ set(GROUPED_GEMM_LIB_NAME "")
 set(GDN_ATTN_LIB_NAME "")
 set(MQA_LOGITS_LIB_NAME "")
 
+option(VLLM_XPU_LIBS_ONLY
+       "Build only kernel SHARED libs, skip extension modules" OFF)
+
 if(BUILD_SYCL_TLA_KERNELS)
 
   set(SYCL_TLA_INCLUDE_DIRS
@@ -338,32 +341,80 @@ if(BUILD_SYCL_TLA_KERNELS)
   set(SYCL_TLA_COMPILE_OPTIONS "")
   if(VLLM_XPU_ENABLE_XE_DEFAULT)
     if(MOE_KERNELS_ENABLED)
-      add_subdirectory(csrc/xpu/grouped_gemm/xe_default)
+      if(VLLM_XPU_PREBUILT_GROUPED_GEMM_XE_DEFAULT_LIB)
+        add_library(grouped_gemm_xe_default SHARED IMPORTED GLOBAL)
+        set_target_properties(grouped_gemm_xe_default PROPERTIES
+          IMPORTED_LOCATION
+            "${VLLM_XPU_PREBUILT_GROUPED_GEMM_XE_DEFAULT_LIB}"
+          INTERFACE_INCLUDE_DIRECTORIES
+            "${CMAKE_SOURCE_DIR}/csrc/xpu/grouped_gemm/xe_default;${CMAKE_SOURCE_DIR}/csrc/xpu/grouped_gemm")
+      else()
+        add_subdirectory(csrc/xpu/grouped_gemm/xe_default)
+      endif()
       list(APPEND GROUPED_GEMM_LIB_NAME "grouped_gemm_xe_default")
     endif()
     list(APPEND SYCL_TLA_COMPILE_OPTIONS -DVLLM_XPU_ENABLE_XE_DEFAULT)
   endif()
   if(VLLM_XPU_ENABLE_XE2)
     if(MOE_KERNELS_ENABLED)
-      add_subdirectory(csrc/xpu/grouped_gemm/xe_2)
+      if(VLLM_XPU_PREBUILT_GROUPED_GEMM_XE_2_LIB)
+        add_library(grouped_gemm_xe_2 SHARED IMPORTED GLOBAL)
+        set_target_properties(grouped_gemm_xe_2 PROPERTIES
+          IMPORTED_LOCATION "${VLLM_XPU_PREBUILT_GROUPED_GEMM_XE_2_LIB}"
+          INTERFACE_INCLUDE_DIRECTORIES
+            "${CMAKE_SOURCE_DIR}/csrc/xpu/grouped_gemm/xe_2;${CMAKE_SOURCE_DIR}/csrc/xpu/grouped_gemm")
+      else()
+        add_subdirectory(csrc/xpu/grouped_gemm/xe_2)
+      endif()
       list(APPEND GROUPED_GEMM_LIB_NAME "grouped_gemm_xe_2")
     endif()
     if(FA2_KERNELS_ENABLED)
-      add_subdirectory(csrc/xpu/attn/xe_2)
+      if(VLLM_XPU_PREBUILT_ATTN_KERNELS_XE_2_LIB)
+        add_library(attn_kernels_xe_2 SHARED IMPORTED GLOBAL)
+        set_target_properties(attn_kernels_xe_2 PROPERTIES
+          IMPORTED_LOCATION "${VLLM_XPU_PREBUILT_ATTN_KERNELS_XE_2_LIB}"
+          INTERFACE_INCLUDE_DIRECTORIES
+            "${CMAKE_SOURCE_DIR}/csrc/xpu/attn/xe_2;${CMAKE_SOURCE_DIR}/csrc/xpu/attn")
+      else()
+        add_subdirectory(csrc/xpu/attn/xe_2)
+      endif()
       list(APPEND ATTN_KERNEL_LIB_NAME "attn_kernels_xe_2")
     endif()
     if(GDN_KERNELS_ENABLED)
-      add_subdirectory(csrc/xpu/gdn_attn/xe_2)
+      if(VLLM_XPU_PREBUILT_GDN_ATTN_KERNELS_XE_2_LIB)
+        add_library(gdn_attn_kernels_xe_2 SHARED IMPORTED GLOBAL)
+        set_target_properties(gdn_attn_kernels_xe_2 PROPERTIES
+          IMPORTED_LOCATION
+            "${VLLM_XPU_PREBUILT_GDN_ATTN_KERNELS_XE_2_LIB}"
+          INTERFACE_INCLUDE_DIRECTORIES
+            "${CMAKE_SOURCE_DIR}/csrc/xpu/gdn_attn/xe_2;${CMAKE_SOURCE_DIR}/csrc/xpu/gdn_attn")
+      else()
+        add_subdirectory(csrc/xpu/gdn_attn/xe_2)
+      endif()
       list(APPEND GDN_ATTN_LIB_NAME "gdn_attn_kernels_xe_2")
     endif()
     if(MQA_LOGITS_KERNELS_ENABLED)
-      add_subdirectory(csrc/xpu/mqa_logits/xe_2)
+      if(VLLM_XPU_PREBUILT_MQA_LOGITS_KERNELS_XE_2_LIB)
+        add_library(mqa_logits_kernels_xe_2 SHARED IMPORTED GLOBAL)
+        set_target_properties(mqa_logits_kernels_xe_2 PROPERTIES
+          IMPORTED_LOCATION
+            "${VLLM_XPU_PREBUILT_MQA_LOGITS_KERNELS_XE_2_LIB}"
+          INTERFACE_INCLUDE_DIRECTORIES
+            "${CMAKE_SOURCE_DIR}/csrc/xpu/mqa_logits/xe_2;${CMAKE_SOURCE_DIR}/csrc/xpu/mqa_logits")
+      else()
+        add_subdirectory(csrc/xpu/mqa_logits/xe_2)
+      endif()
       list(APPEND MQA_LOGITS_LIB_NAME "mqa_logits_kernels_xe_2")
     endif()
     list(APPEND SYCL_TLA_COMPILE_OPTIONS -DVLLM_XPU_ENABLE_XE2)
   endif()
   list(APPEND VLLM_GPU_COMPILE_FLAGS ${SYCL_TLA_COMPILE_OPTIONS})
 
+endif()
+
+if(VLLM_XPU_LIBS_ONLY)
+  message(STATUS "VLLM_XPU_LIBS_ONLY is ON, skipping extension modules.")
+  return()
 endif()
 
 # Feature compile defines — these guard op registrations and interface code so

--- a/setup.py
+++ b/setup.py
@@ -317,6 +317,12 @@ class cmake_build_ext(build_ext):
             prefix = outdir.parent if '.' in first_ext.name else outdir
 
             for lib_name, file_path in additional_libraries.items():
+                # Libs supplied via VLLM_XPU_PREBUILT_<NAME>_LIB are wired in
+                # as SHARED IMPORTED targets in CMakeLists; the corresponding
+                # csrc/.../{lib} subdir is never add_subdirectory()'d, so its
+                # build/temp dir does not exist for `cmake --install` to chdir to.
+                if "VLLM_XPU_PREBUILT_{}_LIB".format(lib_name.upper()) in os.environ:
+                    continue
                 install_args = [
                     "cmake",
                     "--install",

--- a/setup.py
+++ b/setup.py
@@ -200,6 +200,19 @@ class cmake_build_ext(build_ext):
             cmake_args.append('-D{}={}'.format(
                 opt, "ON" if _is_enabled(opt) else "OFF"))
 
+        # Forward prebuilt-library overrides so packagers can supply
+        # pre-built kernel SHARED libs and skip recompilation.
+        _prebuilt_lib_options = [
+            "VLLM_XPU_PREBUILT_ATTN_KERNELS_XE_2_LIB",
+            "VLLM_XPU_PREBUILT_GDN_ATTN_KERNELS_XE_2_LIB",
+            "VLLM_XPU_PREBUILT_MQA_LOGITS_KERNELS_XE_2_LIB",
+            "VLLM_XPU_PREBUILT_GROUPED_GEMM_XE_2_LIB",
+            "VLLM_XPU_PREBUILT_GROUPED_GEMM_XE_DEFAULT_LIB",
+        ]
+        for opt in _prebuilt_lib_options:
+            if opt in os.environ:
+                cmake_args.append('-D{}={}'.format(opt, os.environ[opt]))
+
         # Override the base directory for FetchContent downloads to $ROOT/.deps
         # This allows sharing dependencies between profiles,
         # and plays more nicely with sccache.


### PR DESCRIPTION
Adds two CMake-level affordances for build systems that produce the per-target kernel `.so` files outside the upstream cmake build (distributed CI, sccache shards, Bazel, Buck2, Nix per-derivation builds).

## Changes

**Commit 1 — `cmake: add VLLM_XPU_LIBS_ONLY + prebuilt-kernel-lib hooks`**

- `VLLM_XPU_LIBS_ONLY` (OFF by default): when ON, the build configures and emits the kernel-library targets (`attn_kernels_xe_2`, ...) but skips the host-side Python extension modules. Use case: build just the `.so` artifacts for caching / sharing between consumers.
- `VLLM_XPU_PREBUILT_<NAME>_LIB`: a per-library override that wires an existing `.so` in as a `SHARED IMPORTED` target instead of building it from source. The downstream extension module then links against the imported target by name. Use case: assemble the final wheel from a mix of cached / locally-rebuilt kernel libs.
- `setup.py` forwards `VLLM_XPU_PREBUILT_*_LIB` env vars through to cmake-configure so the same overrides work via `pip install`.

**Commit 2 — `setup.py: skip cmake-install for libs supplied via VLLM_XPU_PREBUILT_*_LIB`**

Libs supplied via the prebuilt-lib hook are wired in as `SHARED IMPORTED` targets and the corresponding `csrc/.../{lib}` subdir is intentionally never `add_subdirectory()`'d, so its build/temp dir doesn't exist for `cmake --install` to chdir into. Skip the install step in that case — the `.so` is already in its final location.

## Backwards compatibility

All defaults are no-ops on existing upstream builds: when no option is set and no `_LIB` env var is exported, the build is byte-equivalent to the unpatched tree.

## Motivation

This is the minimum surface needed for a Nix per-derivation build that compiles each kernel library independently and assembles them into the final wheel. The same mechanism is useful for any consumer that wants to cache kernel-lib `.so` artifacts across builds.

Draft — happy to iterate on naming / option style.