### PR TITLE
cmake: include project root for quoted csrc/* includes

### DIFF
--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -517,7 +517,7 @@ function(define_gpu_extension_target GPU_MOD_NAME)
                              PRIVATE "-DTORCH_EXTENSION_NAME=${GPU_MOD_NAME}")
 
   message(STATUS "GPU_MOD_NAME: ${GPU_MOD_NAME}")
-  target_include_directories(${GPU_MOD_NAME} PRIVATE csrc
+  target_include_directories(${GPU_MOD_NAME} PRIVATE ${CMAKE_SOURCE_DIR} csrc
                                                      ${GPU_INCLUDE_DIRECTORIES})
 
   target_link_libraries(${GPU_MOD_NAME} PRIVATE torch ${GPU_LIBRARIES})


### PR DESCRIPTION
`csrc/xpu/attn/attn_interface.cpp` and other files use quoted includes of the form `#include "csrc/utils.h"`, which require the project root to be in the header search path. The existing `define_gpu_extension_target` adds `csrc` (i.e. `<project>/csrc`), so `csrc/utils.h` resolves to `<project>/csrc/csrc/utils.h` — which doesn't exist.

Upstream's CI happens to work because of a build-environment quirk (likely `-I.` injected somewhere in the manylinux toolchain). In a clean sandbox build it fails reproducibly. Adding `${CMAKE_SOURCE_DIR}` to the PRIVATE include path of every `define_gpu_extension_target` invocation fixes the build without changing semantics on upstream CI.

Draft — single-line cmake change, but I'd appreciate confirmation that upstream's CI does NOT rely on the `csrc/csrc/...` path resolution before merging.