### PR TITLE
cmake: expose kernel-build memory knobs via cache vars

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -207,11 +207,14 @@ if(VLLM_GPU_LANG STREQUAL "SYCL")
   set(VLLM_GPU_COMPILE_FLAGS ${SYCL_COMPILE_FLAGS})
 
   # ============= LINK OPTIONS ==================
+  set(VLLM_XPU_SYCL_LINK_PARALLELISM "16" CACHE STRING
+      "Inner parallelism for SYCL device link (-fsycl-max-parallel-link-jobs). Lower values reduce peak link-time memory.")
   set(SYCL_LINK_FLAGS "")
   list(APPEND SYCL_LINK_FLAGS "-fsycl")
   set(SYCL_DEVICE_LINK_FLAGS ${SYCL_LINK_FLAGS})
   set(SYCL_DEVICE_LINK_FLAGS
-      ${SYCL_DEVICE_LINK_FLAGS} -fsycl-max-parallel-link-jobs=16
+      ${SYCL_DEVICE_LINK_FLAGS}
+      -fsycl-max-parallel-link-jobs=${VLLM_XPU_SYCL_LINK_PARALLELISM}
       -flink-huge-device-code)
   set(SYCL_DEVICE_LINK_FLAGS
       ${SYCL_DEVICE_LINK_FLAGS}
@@ -314,7 +317,9 @@ if(VLLM_GPU_LANG STREQUAL "SYCL")
   list(APPEND VLLM_CUTLASS_FLAGS "-DCUTLASS_ENABLE_SYCL")
   list(APPEND VLLM_CUTLASS_FLAGS "-DSYCL_INTEL_TARGET")
   list(APPEND VLLM_CUTLASS_FLAGS "-DCUTLASS_VERSIONS_GENERATED")
-  list(APPEND VLLM_CUTLASS_FLAGS "-ftemplate-backtrace-limit=0")
+  set(VLLM_XPU_CUTLASS_TEMPLATE_BACKTRACE_LIMIT "0" CACHE STRING
+      "Template instantiation backtrace depth for CUTLASS-SYCL TUs. Lower values reduce frontend memory retention; 0 = unlimited.")
+  list(APPEND VLLM_CUTLASS_FLAGS "-ftemplate-backtrace-limit=${VLLM_XPU_CUTLASS_TEMPLATE_BACKTRACE_LIMIT}")
   list(APPEND VLLM_CUTLASS_FLAGS "-fdiagnostics-color=always")
 endif()
 


### PR DESCRIPTION
Exposes the two flags that dominate peak compile-/link-time RAM of the SYCL kernel libraries (`attn_kernels_xe_2` and friends) as CMake cache vars, so memory-constrained builders can dial them down without patching upstream. **Defaults match the previous hardcoded behaviour — no change for existing builds.**

## Changes

- `VLLM_XPU_SYCL_LINK_PARALLELISM` (default `16`) replaces the hardcoded `-fsycl-max-parallel-link-jobs=16`. Device link is the memory peak: every inner job holds the full fat-module bitcode plus its own LLVM context plus the AOT backend, and up to four kernel libraries link concurrently — 16 inner jobs is far more aggressive than typical hardware can absorb. Downstream builders running on 24-core / 96-GB boxes drop to `4` to stay out of swap.

- `VLLM_XPU_CUTLASS_TEMPLATE_BACKTRACE_LIMIT` (default `0` = unlimited) replaces the hardcoded `-ftemplate-backtrace-limit=0` on the CUTLASS-SYCL TUs. The unlimited backtrace makes the frontend retain the entire template instantiation chain for diagnostics that almost never fire; CUTLASS-SYCL is template-pathological and pays this cost across ~200 TUs. Downstream builders cap at `10` to recover the frontend RSS without breaking error reporting.

`-flink-huge-device-code` is intentionally left in place — at this kernel scale the device linker truncates relocations without it.

## Backwards compatibility

Pure additive — both cache vars default to the value that was hardcoded before this PR. Existing builds get byte-equivalent flags. Builders that need lower memory pass `-DVLLM_XPU_SYCL_LINK_PARALLELISM=4 -DVLLM_XPU_CUTLASS_TEMPLATE_BACKTRACE_LIMIT=10` (or whatever fits their box) at configure time.

Draft — happy to bikeshed the cache-var names if there's a preferred prefix style.