### PR TITLE
cmake: emit -cl-intel-256-GRF-per-thread regardless of AOT

### DIFF
--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -606,6 +606,15 @@ function(add_xe2_kernel_library LIBRARY_NAME)
       XE2_GPU_LINK_FLAGS
       "-device ${XE2_AOT_DEVICES} -internal_options -cl-intel-256-GRF-per-thread"
     )
+  else()
+    # JIT path: embed the GRF hint in the SPIR-V module's compile
+    # options so IGC picks it up at first-dispatch JIT.
+    list(
+      APPEND
+      XE2_GPU_LINK_FLAGS
+      -Xsycl-target-backend=spir64
+      "-internal_options -cl-intel-256-GRF-per-thread"
+    )
   endif()
   target_link_options(${LIBRARY_NAME} PRIVATE ${XE2_GPU_LINK_FLAGS})
 endfunction()
@@ -672,6 +681,13 @@ function(add_xe_default_kernel_library LIBRARY_NAME)
     list(
       APPEND XE_DEFAULT_GPU_LINK_FLAGS
       "-device ${AOT_DEVICES} -internal_options -cl-intel-256-GRF-per-thread")
+  else()
+    # JIT path: see add_xe2_kernel_library above.
+    list(
+      APPEND
+      XE_DEFAULT_GPU_LINK_FLAGS
+      -Xsycl-target-backend=spir64
+      "-internal_options -cl-intel-256-GRF-per-thread")
   endif()
   target_link_options(${LIBRARY_NAME} PRIVATE ${XE_DEFAULT_GPU_LINK_FLAGS})
 endfunction()


### PR DESCRIPTION
The `-cl-intel-256-GRF-per-thread` IGC option is hardware tuning, not AOT tuning: Battlemage's Xe2 cores have the register file for 256 GRF per thread, the FA2 / SYCL-TLA GEMM / paged-decode kernels are tuned around that allocation, and at the default 128 GRF/thread the inner loops spill into scratch on every register-pressure-heavy access. On attention + GEMM that's a real throughput regression (~1.5–2× on head-128 BF16 chunk_prefill in our measurements), not a wash.

Upstream gates the GRF link option on `XE2_AOT_DEVICES` / `AOT_DEVICES` being non-empty, so disabling AOT to speed up the build (kernels ship as SPIR-V + JIT at first dispatch) silently drops the GRF hint and the runtime sees the slower codegen. The two concerns shouldn't be coupled — AOT picks which devices to pre-compile for, GRF mode picks how IGC allocates registers for these kernels on whatever device is present.

## Split

- AOT block keeps `-device ${...}` (only meaningful when ocloc is invoked at link time).
- `-internal_options -cl-intel-256-GRF-per-thread` moves to an `else()` branch plumbed through `-Xsycl-target-backend=spir64`, so it embeds in the SPIR-V module's compile-options metadata. IGC reads that at JIT time and applies it to whatever device the runtime is targeting.

## Backwards compatibility

The AOT path is byte-identical; only the JIT path gains the flag it was missing.

Draft — happy to iterate on the `-Xsycl-target-backend` syntax if there's a preferred upstream form.