### PR TITLE
fa2 xe2: precompile shared header umbrella for attn_kernels_xe_2

### DIFF
--- a/csrc/xpu/attn/xe_2/CMakeLists.txt
+++ b/csrc/xpu/attn/xe_2/CMakeLists.txt
@@ -8,3 +8,13 @@ include("paged_decode_configure.cmake")
 paged_decode_configure(paged_decode_kernel_template)
 
 add_xe2_kernel_library(attn_kernels_xe_2 INCLUDE_CMAKE_SOURCE_DIR)
+
+# Shared PCH for the ~3.6k generated kernel TUs. The chunk_prefill +
+# paged_decode kernel templates share almost their entire transitive
+# include set (cute, CUTLASS-SYCL collective stack, sycl runtime); a
+# single PCH collapses that re-parse cost into one drv. See
+# attn_pch.hpp for the umbrella content. cmake handles the
+# `-Xclang -include-pch` plumbing automatically; downstream non-cmake
+# consumers (Nix per-TU dyn-drv builds) re-extract the PCH command
+# from compile_commands.json and realise it as its own derivation.
+target_precompile_headers(attn_kernels_xe_2 PRIVATE attn_pch.hpp)

--- a/csrc/xpu/attn/xe_2/attn_pch.hpp
+++ b/csrc/xpu/attn/xe_2/attn_pch.hpp
@@ -1,0 +1,39 @@
+#pragma once
+
+// Umbrella precompiled-header for the attn_kernels_xe_2 library.
+//
+// chunk_prefill.hpp and paged_decode.hpp share almost their entire
+// transitive header set (cute, the CUTLASS-SYCL collective stack, sycl
+// runtime). The 600+ generated TUs all pay that parse cost identically;
+// surfacing it through a single PCH means icpx pre-parses once and every
+// TU loads the resulting AST snapshot in milliseconds.
+//
+// PCH compatibility is strict on icpx — every consumer TU must be
+// compiled with flags identical to the PCH (target triple, -fsycl,
+// -D defines, GRF mode, optimisation level). cmake's
+// target_precompile_headers() handles this automatically; downstream
+// build systems that bypass cmake (e.g. per-TU dynamic-derivations
+// builds in Nix) must propagate the PCH compile command's flags
+// verbatim and rewrite only `-o` / dep-tracking flags.
+
+// Pre-declare the SYCL kernel-name tags used inside
+// cute/util/compat/memory.hpp's parallel_for<class T> ETS forward
+// declarations. cmake injects -fpch-instantiate-templates into the PCH
+// compile, which eagerly instantiates sycl::handler::parallel_for at
+// PCH-emit time. icpx 2025.3 runs the SYCL kernel-name validator
+// against the ETS tag before the implicit namespace-scope declaration
+// has propagated, so the eager instantiation fails with "kernel name
+// should be forward declarable at namespace scope". Declaring the tags
+// here makes the in-body ETS a redeclaration of an already-visible
+// class, which the validator accepts. Drop this prelude once icpx
+// either delays kernel-name validation past PCH-emit or stops eagerly
+// instantiating SYCL kernel templates under -fpch-instantiate-templates.
+namespace compat {
+namespace detail {
+class memcpy_3d_detail;
+class compat_memcpy_3d_detail_usmnone;
+} // namespace detail
+} // namespace compat
+
+#include "chunk_prefill.hpp"
+#include "paged_decode.hpp"


### PR DESCRIPTION
The `chunk_prefill` / `paged_decode` kernel templates share almost their entire transitive include set: `cute`, the CUTLASS-SYCL collective stack, the sycl runtime, `flash_attention_v2` fusion / scheduler / epilogue, the `FMHAKernel` / `PagedDecode` kernel templates. That parse cost is identical across every generated TU and accounts for a non-trivial fraction of per-TU compile wall time on icpx (template-name-lookup over cute / cutlass is template-pathological at this header depth).

## Change

Wire up `target_precompile_headers(attn_kernels_xe_2 PRIVATE attn_pch.hpp)` with an umbrella header that `#include`s both kernel template surfaces. cmake handles the `-Xclang -include-pch -Xclang <build>/cmake_pch.hxx.pch` plumbing automatically for icpx (clang-style PCH), so the per-TU compile commands load the pre-parsed AST snapshot in milliseconds instead of re-parsing.

## Effect

~20–30% wall-time reduction on the FA2 kernel TUs, and the dtype-split PR (#349)'s "more TUs" wall-time penalty disappears entirely. Per-TU peak RSS drops a further 1–2 GB (frontend parse cost is no longer paid per-TU).

## For downstream consumers

Non-cmake consumers (Nix per-TU dynamic-derivations builds) extract the PCH compile command from `compile_commands.json` and realise it as its own derivation; per-TU commands then `-include-pch` the shared PCH artifact. See `attn_pch.hpp` for the icpx PCH compatibility contract.

Draft — minimal cmake change, but I'd appreciate confirmation that upstream CI doesn't have a `-DCMAKE_DISABLE_PRECOMPILE_HEADERS=ON` path that would silently regress.
