### PR TITLE
[Benchmark] Extend kernel benchmark configs with hardcoded model shapes and new models

### DIFF
--- a/benchmark/src/flash_attn_interface_.py
+++ b/benchmark/src/flash_attn_interface_.py
@@ -54,6 +54,7 @@ def flash_attn_varlen_func_CalKernelTime(
     fa_version: int = DEFAULT_FA_VERSION,
     s_aux: Optional[torch.Tensor] = None,
     num_splits_kv: Optional[int] = None,
+    is_mix_batch: bool = True,
     start_event: Optional[torch.Event] = None,
     end_event: Optional[torch.Event] = None,
     device: str = "xpu",
@@ -158,6 +159,7 @@ def flash_attn_varlen_func_CalKernelTime(
             return_softmax_lse and dropout_p > 0,
             None,
             num_splits_kv,
+            is_mix_batch,
         )
         if end_event is not None:
             end_event.record()

--- a/benchmark/src/get_model_config.py
+++ b/benchmark/src/get_model_config.py
@@ -9,8 +9,8 @@ from tests.utils import get_model_config
 #   "deepseek-ai/DeepSeek-OCR" config failed, need to investigate
 model_lists = [
     "deepseek-ai/DeepSeek-R1-Distill-Llama-8B", "openbmb/MiniCPM-V-4",
-    "Qwen/Qwen3-30B-A3B", "Qwen/Qwen2.5-VL-32B-Instruct",
-    "deepseek-ai/DeepSeek-V2-Lite", "Qwen/Qwen3.5-35B-A3B"
+    "Qwen/Qwen3-30B-A3B-Instruct-2507", "Qwen/Qwen2.5-VL-32B-Instruct",
+    "deepseek-ai/DeepSeek-V2-Lite", "Qwen/Qwen3.5-35B-A3B", "Qwen/Qwen3-32B",
 ]
 
 
@@ -56,6 +56,53 @@ def gen_cutlass_fused_moe_perf_configs():
         configs += list(
             itertools.product(mnk, [num_experts],
                               [moe_top_k], x_dtype, w_dtype, has_bias))
+
+    # Hardcoded model shapes (n, k, num_experts, topk) for various TP sizes.
+    # Config tuple (m, n, k) produces:
+    #   GEMM1 (gate+up): [m, 2*n, k]
+    #   GEMM2 (down):    [m, k, n]
+    hardcoded_model_shapes = [
+        # Qwen/Qwen3-30B-A3B, Qwen3-30B-A3B-Instruct-2507,
+        # Qwen3-Coder-30B-A3B-Instruct, OpenGVLab/InternVL3_5-30B-A3B
+        # [128 experts, topk=8]
+        (768, 2048, 128, 8),     # tp=1: [m,1536,2048], [m,2048,768]
+        (384, 2048, 128, 8),     # tp=2: [m,768,2048],  [m,2048,384]
+        (192, 2048, 128, 8),     # tp=4: [m,384,2048],  [m,2048,192]
+        # Qwen/Qwen3-Coder-Next, Qwen3-Next-80B-A3B-Instruct,
+        # Qwen3-Next-80B-A3B-Thinking
+        # [512 experts, topk=10]
+        (512, 2048, 512, 10),    # tp=1: [m,1024,2048], [m,2048,512]
+        (256, 2048, 512, 10),    # tp=2: [m,512,2048],  [m,2048,256]
+        (128, 2048, 512, 10),    # tp=4: [m,256,2048],  [m,2048,128]
+        # deepseek-ai/DeepSeek-V2-Lite, moonshotai/Kimi-VL-A3B-Thinking
+        # [64 experts, topk=6]
+        (1408, 2048, 64, 6),     # tp=1: [m,2816,2048], [m,2048,1408]
+        (704, 2048, 64, 6),      # tp=2: [m,1408,2048], [m,2048,704]
+        (352, 2048, 64, 6),      # tp=4: [m,704,2048],  [m,2048,352]
+        # deepseek-ai/DeepSeek-OCR
+        # [64 experts, topk=6]
+        (896, 1280, 64, 6),      # tp=1: [m,1792,1280], [m,1280,896]
+        (448, 1280, 64, 6),      # tp=2: [m,896,1280],  [m,1280,448]
+        (224, 1280, 64, 6),      # tp=4: [m,448,1280],  [m,1280,224]
+        # Qwen/Qwen3.5-35B-A3B
+        # [256 experts, topk=8]
+        (512, 2048, 256, 8),     # tp=1: [m,1024,2048], [m,2048,512]
+        (256, 2048, 256, 8),     # tp=2: [m,512,2048],  [m,2048,256]
+        (128, 2048, 256, 8),     # tp=4: [m,256,2048],  [m,2048,128]
+        # mistralai/Mixtral-8x7B-Instruct-v0.1
+        # [8 experts, topk=2]
+        (14336, 4096, 8, 2),     # tp=1: [m,28672,4096],[m,4096,14336]
+        (7168, 4096, 8, 2),      # tp=2: [m,14336,4096],[m,4096,7168]
+        (3584, 4096, 8, 2),      # tp=4: [m,7168,4096], [m,4096,3584]
+    ]
+
+    for n, k, num_experts, topk in hardcoded_model_shapes:
+        mnk = list(zip(input_lens, [n] * len(input_lens),
+                       [k] * len(input_lens)))
+        configs += list(
+            itertools.product(mnk, [num_experts],
+                              [topk], x_dtype, w_dtype, has_bias))
+
     configs = set(configs)  # remove duplicates
 
     def sort_key(x):
@@ -114,6 +161,14 @@ def gen_cutlass_flash_attn_varlen_perf_configs():
     # kv_dtype = [torch.float8_e5m2, torch.float8_e4m3fn, None]     # fp8 OOM
     kv_dtype = [None]
 
+    # Hardcoded attention shapes for models that cannot be loaded via
+    # AutoConfig (e.g. diffusion models without a standard model_type).
+    # Format: (num_attention_heads, num_key_value_heads, head_dim)
+    hardcoded_attn_shapes = [
+        # Wan-AI/Wan2.2-I2V-A14B-Diffusers (DiT video diffusion)
+        (40, 40, 128),
+    ]
+
     def get_configs_from_models():
         configs = []
         for model in model_lists:
@@ -128,6 +183,17 @@ def gen_cutlass_flash_attn_varlen_perf_configs():
                                   output_dtype, soft_cap, num_blocks,
                                   fa_versions, q_dtype, is_sink, is_causal,
                                   is_paged, kv_dtype))
+
+        # Add hardcoded attention shapes (diffusion models, etc.)
+        for n_heads, n_kv_heads, h_dim in hardcoded_attn_shapes:
+            configs += list(
+                itertools.product(num_seqs, query_lens, kv_lens,
+                                  [(n_heads, n_kv_heads)], [h_dim],
+                                  block_size, window_size, output_dtype,
+                                  soft_cap, num_blocks, fa_versions,
+                                  q_dtype, is_sink, is_causal, is_paged,
+                                  kv_dtype))
+
         configs = set(configs)  # remove duplicates
 
         def sort_key(x):
@@ -198,6 +264,14 @@ def gen_cutlass_flash_attn_decode_perf_configs():
     q_dtype = [None]
     is_sink = [False, True]
 
+    # Hardcoded attention shapes for models that cannot be loaded via
+    # AutoConfig (e.g. diffusion models without a standard model_type).
+    # Format: (num_attention_heads, num_key_value_heads, head_dim)
+    hardcoded_attn_shapes = [
+        # Wan-AI/Wan2.2-I2V-A14B-Diffusers (DiT video diffusion)
+        (40, 40, 128),
+    ]
+
     configs = []
     for model in model_lists:
         model_config = get_model_config(model, tp_size=1)
@@ -209,6 +283,14 @@ def gen_cutlass_flash_attn_decode_perf_configs():
             itertools.product(seq_lens, num_heads, head_size, block_size,
                               output_dtype, soft_cap, num_blocks, fa_versions,
                               q_dtype, is_sink))
+
+    # Add hardcoded attention shapes (diffusion models, etc.)
+    for n_heads, n_kv_heads, h_dim in hardcoded_attn_shapes:
+        configs += list(
+            itertools.product(seq_lens, [(n_heads, n_kv_heads)], [h_dim],
+                              block_size, output_dtype, soft_cap, num_blocks,
+                              fa_versions, q_dtype, is_sink))
+
     configs = set(configs)  # remove duplicates
 
     def sort_key(x):


### PR DESCRIPTION
## Summary

Update `benchmark/src/get_model_config.py` to extend the kernel benchmark coverage with hardcoded model shapes and additional models.

### Changes

#### 1. Model list updates
- Replaced `Qwen/Qwen3-30B-A3B` with `Qwen/Qwen3-30B-A3B-Instruct-2507` (updated model variant).
- Added `Qwen/Qwen3-32B` to the benchmark model list.

#### 2. Hardcoded MoE (Fused MoE) benchmark shapes
Added hardcoded `(n, k, num_experts, topk)` configurations for models whose configs are already known, covering **TP=1/2/4** splits:

| Model | Experts | TopK |
|-------|---------|------|
| Qwen3-30B-A3B / Qwen3-Coder-30B-A3B / InternVL3_5-30B-A3B | 128 | 8 |
| Qwen3-Coder-Next / Qwen3-Next-80B-A3B | 512 | 10 |
| DeepSeek-V2-Lite / Kimi-VL-A3B-Thinking | 64 | 6 |
| DeepSeek-OCR | 64 | 6 |
| Qwen3.5-35B-A3B | 256 | 8 |
| Mixtral-8x7B-Instruct-v0.1 | 8 | 2 |

#### 3. Hardcoded Flash Attention shapes (varlen + decode)
Added hardcoded attention shapes `(num_attention_heads, num_key_value_heads, head_dim)` for models that cannot be loaded via `AutoConfig` (e.g., diffusion models):

- **Wan-AI/Wan2.2-I2V-A14B-Diffusers** (DiT video diffusion): `(40, 40, 128)`

These shapes are injected into both `gen_cutlass_flash_attn_varlen_perf_configs()` and `gen_cutlass_flash_attn_decode_perf_configs()`.

