### PR TITLE
[Ref] fix ref block fp8

### DIFF
--- a/vllm_xpu_kernels/_mx_utils.py
+++ b/vllm_xpu_kernels/_mx_utils.py
@@ -489,7 +489,7 @@ def hp_from_128x128(x_lp, x_scale):
     orig_shape = x_lp.shape
     M, K = orig_shape
     x_lp = x_lp.view(M // 128, 128, K // 128, 128)
-    x_scale = x_scale.unsqueeze(1).unsqueeze(-1)
+    x_scale = x_scale.view(M // 128, K // 128).unsqueeze(1).unsqueeze(-1)
     x_hp = x_lp.to(torch.float32)
     x_hp = x_hp * x_scale
     return x_hp.reshape(orig_shape).to(torch.float32)
@@ -497,9 +497,13 @@ def hp_from_128x128(x_lp, x_scale):
 
 def hp_from_1x128(x_lp, x_scale):
     orig_shape = x_lp.shape
-    x_lp = x_lp.reshape(x_lp.shape[0], x_lp.shape[-1] // 128, 128)
-    x_hp = x_lp.to(torch.float32)
-    x_hp = x_hp * x_scale.unsqueeze(-1)
+    x_lp_flat = x_lp.reshape(-1, orig_shape[-1])
+    M = x_lp_flat.shape[0]
+    K_groups = x_lp_flat.shape[-1] // 128
+    x_lp_3d = x_lp_flat.reshape(M, K_groups, 128)
+    x_scale = x_scale.reshape(M, K_groups, 1)
+    x_hp = x_lp_3d.to(torch.float32)
+    x_hp = x_hp * x_scale
     return x_hp.reshape(orig_shape).to(torch.float32)
 
 

--- a/vllm_xpu_kernels/fused_moe_interface.py
+++ b/vllm_xpu_kernels/fused_moe_interface.py
@@ -261,7 +261,7 @@ def ref_fused_moe(recipe,
                                         w2_scales[expert_id, :, :])
             gemm2_input_f = gemm2_input.to(torch.float32)
             _q, _scale = quant_fp8_act(gemm2_input_f)
-            gemm2_input = hp_from_1x128(_q, _scale)
+            gemm2_input = hp_from_1x128(_q, _scale).to(activation_dtype)
         elif recipe == "mxfp8":
             _q, _scale = quant_mxfp_act(gemm2_input, "mxfp8")
             gemm2_input = (
@@ -276,7 +276,7 @@ def ref_fused_moe(recipe,
                                               (_q.shape[-1] * 2, ))
         ###
 
-        expert_out = ((gemm2_input.to(activation_dtype)) @ expert_w2.T.to(activation_dtype))
+        expert_out = (gemm2_input) @ expert_w2.T.to(activation_dtype)
 
         if w2_bias is not None:
             expert_out += w2_bias[expert_id, :].to(activation_dtype)

--- a/vllm_xpu_kernels/fused_moe_interface.py
+++ b/vllm_xpu_kernels/fused_moe_interface.py
@@ -186,8 +186,11 @@ def ref_fused_moe(recipe,
     token_idxs = idxs // num_per_tok
 
     if recipe == "fp8block":
-        _q, _scale = quant_fp8_act(x)
+        x_f = x.to(torch.float32)
+        _q, _scale = quant_fp8_act(x_f)
         x = hp_from_1x128(_q, _scale)
+        w13 = w13.transpose(1, 2).contiguous()
+        w2 = w2.transpose(1, 2).contiguous()
     elif recipe == "mxfp8":
         w13 = w13.transpose(1, 2).contiguous()
         w2 = w2.transpose(1, 2).contiguous()
@@ -256,7 +259,8 @@ def ref_fused_moe(recipe,
         if recipe == "fp8block":
             expert_w2 = hp_from_128x128(w2[expert_id, :, :],
                                         w2_scales[expert_id, :, :])
-            _q, _scale = quant_fp8_act(gemm2_input)
+            gemm2_input_f = gemm2_input.to(torch.float32)
+            _q, _scale = quant_fp8_act(gemm2_input_f)
             gemm2_input = hp_from_1x128(_q, _scale)
         elif recipe == "mxfp8":
             _q, _scale = quant_mxfp_act(gemm2_input, "mxfp8")
@@ -272,7 +276,7 @@ def ref_fused_moe(recipe,
                                               (_q.shape[-1] * 2, ))
         ###
 
-        expert_out = ((gemm2_input) @ expert_w2.T.to(activation_dtype))
+        expert_out = ((gemm2_input.to(activation_dtype)) @ expert_w2.T.to(activation_dtype))
 
         if w2_bias is not None:
             expert_out += w2_bias[expert_id, :].to(activation_dtype)


### PR DESCRIPTION
This pull request improves the handling of FP8 quantization and dequantization in the Mixture-of-Experts (MoE) kernel utilities, with a focus on ensuring correct tensor shapes and data types during quantization, dequantization, and matrix operations. The changes enhance numerical stability and compatibility with various activation and weight formats.

**Improvements to quantization and dequantization:**

* Updated `hp_from_128x128` and `hp_from_1x128` functions in `vllm_xpu_kernels/_mx_utils.py` to ensure that scaling tensors are reshaped appropriately for broadcasting and that dequantization operates on correctly-shaped tensors.
* Modified quantization calls in `ref_fused_moe` to explicitly cast inputs to `float32` before quantization, reducing the risk of unintended type issues. [[1]](diffhunk://#diff-8babe9a369c9c80ba2d4dba806a1600eff00a85c0d2e2d6ee02570e5ae21058cL189-R193) [[2]](diffhunk://#diff-8babe9a369c9c80ba2d4dba806a1600eff00a85c0d2e2d6ee02570e5ae21058cL259-R263)

**Matrix operation improvements:**

* Ensured that matrix multiplications in `ref_fused_moe` explicitly cast both operands to the correct activation data type, improving numerical accuracy.

**Activation function handling:**

* Removed support for the `"gelu_tanh"` activation function from the MoE interface initialization, likely due to deprecation or lack of backend support.

**Weight handling consistency:**

* Added explicit transposition and contiguous memory layout for weight tensors (`w13` and `w2`) in the `"fp8block"` recipe to match the handling in the `"mxfp8"` recipe, ensuring consistent behavior across quantization schemes.