### PR TITLE
[Benchmark] Adjust FA benchmark configs for B60 memory constraints

### DIFF
--- a/benchmark/src/get_model_config.py
+++ b/benchmark/src/get_model_config.py
@@ -185,12 +185,17 @@ def gen_cutlass_flash_attn_varlen_perf_configs():
                                   is_paged, kv_dtype))
 
         # Add hardcoded attention shapes (diffusion models, etc.)
+        # Use reduced params for B60 (~20G memory):
+        #   smaller seq lens and num_blocks to control memory usage.
+        b60_query_lens = ["256,512,512,2048"]
+        b60_kv_lens = ["256,256,512,2048"]
+        b60_num_blocks = [2048]
         for n_heads, n_kv_heads, h_dim in hardcoded_attn_shapes:
             configs += list(
-                itertools.product(num_seqs, query_lens, kv_lens,
+                itertools.product(num_seqs, b60_query_lens, b60_kv_lens,
                                   [(n_heads, n_kv_heads)], [h_dim],
                                   block_size, window_size, output_dtype,
-                                  soft_cap, num_blocks, fa_versions,
+                                  soft_cap, b60_num_blocks, fa_versions,
                                   q_dtype, is_sink, is_causal, is_paged,
                                   kv_dtype))
 
@@ -264,14 +269,6 @@ def gen_cutlass_flash_attn_decode_perf_configs():
     q_dtype = [None]
     is_sink = [False, True]
 
-    # Hardcoded attention shapes for models that cannot be loaded via
-    # AutoConfig (e.g. diffusion models without a standard model_type).
-    # Format: (num_attention_heads, num_key_value_heads, head_dim)
-    hardcoded_attn_shapes = [
-        # Wan-AI/Wan2.2-I2V-A14B-Diffusers (DiT video diffusion)
-        (40, 40, 128),
-    ]
-
     configs = []
     for model in model_lists:
         model_config = get_model_config(model, tp_size=1)
@@ -283,13 +280,6 @@ def gen_cutlass_flash_attn_decode_perf_configs():
             itertools.product(seq_lens, num_heads, head_size, block_size,
                               output_dtype, soft_cap, num_blocks, fa_versions,
                               q_dtype, is_sink))
-
-    # Add hardcoded attention shapes (diffusion models, etc.)
-    for n_heads, n_kv_heads, h_dim in hardcoded_attn_shapes:
-        configs += list(
-            itertools.product(seq_lens, [(n_heads, n_kv_heads)], [h_dim],
-                              block_size, output_dtype, soft_cap, num_blocks,
-                              fa_versions, q_dtype, is_sink))
 
     configs = set(configs)  # remove duplicates
 

--- a/benchmark/src/get_model_config.py
+++ b/benchmark/src/get_model_config.py
@@ -163,10 +163,21 @@ def gen_cutlass_flash_attn_varlen_perf_configs():
 
     # Hardcoded attention shapes for models that cannot be loaded via
     # AutoConfig (e.g. diffusion models without a standard model_type).
-    # Format: (num_attention_heads, num_key_value_heads, head_dim)
+    # Each entry is a dict with required keys:
+    #   "shape": (num_attention_heads, num_key_value_heads, head_dim)
+    # and optional per-entry overrides for shapes that need reduced params
+    # (e.g. to fit within a given device's memory budget):
+    #   "query_lens", "kv_lens", "num_blocks"
+    # If an override is not provided, the default values above are used.
     hardcoded_attn_shapes = [
         # Wan-AI/Wan2.2-I2V-A14B-Diffusers (DiT video diffusion)
-        (40, 40, 128),
+        # Reduced seq lens / num_blocks to fit ~20G memory (e.g. B60).
+        {
+            "shape": (40, 40, 128),
+            "query_lens": ["256,512,512,2048"],
+            "kv_lens": ["256,256,512,2048"],
+            "num_blocks": [2048],
+        },
     ]
 
     def get_configs_from_models():
@@ -185,17 +196,18 @@ def gen_cutlass_flash_attn_varlen_perf_configs():
                                   is_paged, kv_dtype))
 
         # Add hardcoded attention shapes (diffusion models, etc.)
-        # Use reduced params for B60 (~20G memory):
-        #   smaller seq lens and num_blocks to control memory usage.
-        b60_query_lens = ["256,512,512,2048"]
-        b60_kv_lens = ["256,256,512,2048"]
-        b60_num_blocks = [2048]
-        for n_heads, n_kv_heads, h_dim in hardcoded_attn_shapes:
+        # Each entry may override query_lens / kv_lens / num_blocks to
+        # control memory usage for that specific shape.
+        for entry in hardcoded_attn_shapes:
+            n_heads, n_kv_heads, h_dim = entry["shape"]
+            q_lens = entry.get("query_lens", query_lens)
+            k_lens = entry.get("kv_lens", kv_lens)
+            n_blocks = entry.get("num_blocks", num_blocks)
             configs += list(
-                itertools.product(num_seqs, b60_query_lens, b60_kv_lens,
+                itertools.product(num_seqs, q_lens, k_lens,
                                   [(n_heads, n_kv_heads)], [h_dim],
                                   block_size, window_size, output_dtype,
-                                  soft_cap, b60_num_blocks, fa_versions,
+                                  soft_cap, n_blocks, fa_versions,
                                   q_dtype, is_sink, is_causal, is_paged,
                                   kv_dtype))
 


### PR DESCRIPTION
## Summary

- **FA varlen perf**: Reduce Wan2.2 (DiT diffusion) benchmark params to fit Intel B60 (~20G memory):
  - `query_lens`: `"256,512,512,2048"` (was `"1024,2048,2048,8192"`)
  - `kv_lens`: `"256,256,512,2048"` (was `"1024,1024,2048,8192"`)
  - `num_blocks`: `2048` (was `16324`)
- **FA decode perf**: Remove Wan2.2 hardcoded attention shapes (not needed for decode benchmarks).

## Motivation

The Wan2.2 model configs with original params cause OOM on Intel B60 machines (~20G memory). This PR reduces sequence lengths and KV cache blocks for the varlen benchmark to stay within memory limits, and removes the unnecessary decode benchmark case.