### PR TITLE
Align the cuda fp8 block quant API(add TMA_aligned)

### DIFF
--- a/csrc/ops.h
+++ b/csrc/ops.h
@@ -180,7 +180,9 @@ void per_token_group_quant_fp8(
     double eps,
     double fp8_min,
     double fp8_max,
-    bool scale_ue8m0);
+    bool scale_ue8m0,
+    bool dummy_is_scale_transposed = false,
+    bool dummy_is_tma_aligned = false);
 
 void per_token_group_quant_mxfp4(
     const torch::Tensor& input,

--- a/csrc/quantization/fp8/fp8_quant.cpp
+++ b/csrc/quantization/fp8/fp8_quant.cpp
@@ -608,7 +608,9 @@ void per_token_group_quant_fp8(
     double eps,
     double fp8_min,
     double fp8_max,
-    bool scale_ue8m0) {
+    bool scale_ue8m0,
+    bool dummy_is_scale_transposed,
+    bool dummy_is_tma_aligned) {
   TORCH_CHECK(input.is_contiguous());
   TORCH_CHECK(output_q.is_contiguous());
 

--- a/csrc/torch_bindings.cpp
+++ b/csrc/torch_bindings.cpp
@@ -144,7 +144,8 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
       "per_token_group_fp8_quant(Tensor input, Tensor! output_q, Tensor! "
       "output_s, "
       "int group_size, float eps, float fp8_min, float fp8_max, bool "
-      "scale_ue8m0) -> ()");
+      "scale_ue8m0, bool dummy_is_scale_transposed, bool dummy_is_tma_aligned "
+      ") -> ()");
   ops.impl(
       "per_token_group_fp8_quant", torch::kXPU, &per_token_group_quant_fp8);
 

--- a/tests/ops/fp8_quant_op.py
+++ b/tests/ops/fp8_quant_op.py
@@ -184,6 +184,15 @@ def scaled_fp8_quant(
     return output, scale
 
 
+def _ceil_div(x: int, y: int) -> int:
+    return (x + y - 1) // y
+
+
+def get_tma_aligned_size(x: int, element_size: int) -> int:
+    alignment = 16 // element_size
+    return _ceil_div(x, alignment) * alignment
+
+
 def per_token_group_quant_fp8(
     x: torch.Tensor,
     group_size: int,
@@ -191,6 +200,7 @@ def per_token_group_quant_fp8(
     dtype: torch.dtype = torch.float8_e4m3fn,
     out_q: torch.Tensor | None = None,
     column_major_scales: bool = False,
+    tma_aligned_scales: bool = False,
     use_ue8m0: bool | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Function to perform per-token-group quantization on an input tensor `x`.
@@ -204,6 +214,7 @@ def per_token_group_quant_fp8(
         is supported for now.
         out_q: Optional output tensor. If not provided, function will create.
         column_major_scales: Outputs scales in column major.
+        tma_aligned_scales: Outputs scales in TMA-aligned layout.
     Returns:
         tuple[torch.Tensor, torch.Tensor]: The quantized tensor and the
         scaling factor.
@@ -224,16 +235,30 @@ def per_token_group_quant_fp8(
         x_q = torch.empty_like(x, device=x.device, dtype=dtype)
 
     if column_major_scales:
-        shape = (x.shape[-1] // group_size, ) + x.shape[:-1]
-        x_s = torch.empty(shape, device=x.device,
-                          dtype=torch.float32).permute(-1, -2)
+        if tma_aligned_scales:
+            m = x.shape[-2]
+            sf_k = x.shape[-1] // group_size
+            tma_aligned_m = get_tma_aligned_size(m, 4)
+            shape = x.shape[:-2] + (m, sf_k)
+            stride = ((1, tma_aligned_m) if x.dim() == 2 else
+                      (tma_aligned_m * sf_k, 1, tma_aligned_m))
+            x_s = torch.empty_strided(shape,
+                                      stride,
+                                      device=x.device,
+                                      dtype=torch.float32)
+        else:
+            shape = x.shape[:-2] + (x.shape[-1] // group_size, x.shape[-2])
+            x_s = torch.empty(shape, device=x.device,
+                              dtype=torch.float32).permute(-1, -2)
     else:
         shape = x.shape[:-1] + (x.shape[-1] // group_size, )
         x_s = torch.empty(shape, device=x.device, dtype=torch.float32)
 
     # TODO(bnell): this causes some fp8 moe test to fail.
     torch.ops._C.per_token_group_fp8_quant(x, x_q, x_s, group_size, eps,
-                                           fp8_min, fp8_max, use_ue8m0)
+                                           fp8_min, fp8_max, use_ue8m0,
+                                           column_major_scales,
+                                           tma_aligned_scales)
 
     if use_ue8m0:
         x_s = x_s.to(torch.float8_e8m0fnu)

--- a/tests/test_fp8_quant.py
+++ b/tests/test_fp8_quant.py
@@ -8,7 +8,8 @@ import numpy as np
 import pytest
 import torch
 
-from tests.ops.fp8_quant_op import (per_token_group_quant_fp8,
+from tests.ops.fp8_quant_op import (get_tma_aligned_size,
+                                    per_token_group_quant_fp8,
                                     scaled_fp8_quant, scaled_quantize)
 from tests.ops.mx_utils import to_mxfp
 
@@ -200,10 +201,11 @@ FP8_DTYPES = [torch.float8_e5m2, torch.float8_e4m3fn]
 
 # block quant parameters
 MXFP8_HP_DTYPES = [torch.float, torch.bfloat16]
-NUM_TOKENS_BLOCK_QUANT = [1, 2, 4, 8]
+NUM_TOKENS_BLOCK_QUANT = [1, 2, 3, 4, 8, 31]
 HIDDEN_SIZES_BLOCK_QUANT = [256]
 GROUP_SIZE = [32, 64, 128]
 COLUMN_MAJOR_SCALE = [True, False]
+TMA_ALIGNED_SCALE = [True, False]
 
 # Test static FP8 quantization with 2D group scales
 GROUP_SHAPES_2D = [
@@ -308,6 +310,7 @@ def test_dynamic_per_token_fp8_quant(
 @pytest.mark.parametrize("group_size", GROUP_SIZE)
 @pytest.mark.parametrize("seed", SEEDS)
 @pytest.mark.parametrize("column_major_scale", COLUMN_MAJOR_SCALE)
+@pytest.mark.parametrize("tma_aligned_scale", TMA_ALIGNED_SCALE)
 @torch.inference_mode()
 def test_per_block_fp8_quant(
     num_tokens_block_quant: int,
@@ -316,6 +319,7 @@ def test_per_block_fp8_quant(
     group_size: int,
     seed: int,
     column_major_scale: bool,
+    tma_aligned_scale: bool,
 ) -> None:
     seed_everything(seed)
 
@@ -331,7 +335,8 @@ def test_per_block_fp8_quant(
         group_size=group_size,
         dtype=torch.float8_e4m3fn,
         use_ue8m0=False,
-        column_major_scales=column_major_scale)
+        column_major_scales=column_major_scale,
+        tma_aligned_scales=tma_aligned_scale)
 
     assert torch.allclose(ref_out.float(),
                           ops_out.float(),
@@ -342,12 +347,19 @@ def test_per_block_fp8_quant(
                           atol=0.01,
                           rtol=0.01)
 
+    if column_major_scale:
+        assert ops_scales.stride()[-2] == 1
+        if tma_aligned_scale:
+            assert ops_scales.stride()[-1] == get_tma_aligned_size(
+                num_tokens_block_quant, 4)
+
 
 @pytest.mark.parametrize("num_tokens_block_quant", NUM_TOKENS_BLOCK_QUANT)
 @pytest.mark.parametrize("hidden_size_block_quant", HIDDEN_SIZES_BLOCK_QUANT)
 @pytest.mark.parametrize("mxfp8_hp_dtypes", MXFP8_HP_DTYPES)
 @pytest.mark.parametrize("seed", SEEDS)
 @pytest.mark.parametrize("column_major_scale", COLUMN_MAJOR_SCALE)
+@pytest.mark.parametrize("tma_aligned_scale", TMA_ALIGNED_SCALE)
 @torch.inference_mode()
 def test_per_block_mxfp8_quant(
     num_tokens_block_quant: int,
@@ -355,6 +367,7 @@ def test_per_block_mxfp8_quant(
     mxfp8_hp_dtypes: torch.dtype,
     seed: int,
     column_major_scale: bool,
+    tma_aligned_scale: bool,
 ) -> None:
     seed_everything(seed)
 
@@ -370,7 +383,8 @@ def test_per_block_mxfp8_quant(
         group_size=32,
         dtype=torch.float8_e4m3fn,
         use_ue8m0=True,
-        column_major_scales=column_major_scale)
+        column_major_scales=column_major_scale,
+        tma_aligned_scales=tma_aligned_scale)
 
     assert torch.allclose(ref_out.float(),
                           ops_out.float(),


### PR DESCRIPTION
Follow upstream PR [#32619](https://github.com/vllm-project/vllm/pull/32619) to add TMA_algined API.
Performance improvements are expected on the GPU platform that includes the TMA feature.
