### PR TITLE
[XPU][GDN] Optimize l2_norm and chunk_fwd_o kernel for GDN attention prefill path

### DIFF
--- a/csrc/xpu/gdn_attn/gdn_attn_interface.cpp
+++ b/csrc/xpu/gdn_attn/gdn_attn_interface.cpp
@@ -436,11 +436,11 @@ void gdn_attention(
       // Tiled kernel: only valid when all Q+K features fit in a single
       // feature chunk, i.e. 2 * head_k_dim <= feats_per_wg (256).
       // Untiled kernel: always valid (entire QKV in one WG).
-      constexpr int tiled_feats_per_wg = 256;  // wg_size(64) * elems_per_item(4)
+      constexpr int tiled_feats_per_wg =
+          256;  // wg_size(64) * elems_per_item(4)
       const bool use_tiled = (non_spec_token >= gdn::conv1d_tile_size);
-      const bool fuse_l2norm = use_tiled
-          ? (2 * head_k_dim <= tiled_feats_per_wg)
-          : true;
+      const bool fuse_l2norm =
+          use_tiled ? (2 * head_k_dim <= tiled_feats_per_wg) : true;
 
       if (use_tiled) {
         gdn::chunk_causal_conv1d_tiled_xe2(

--- a/csrc/xpu/gdn_attn/gdn_attn_interface.cpp
+++ b/csrc/xpu/gdn_attn/gdn_attn_interface.cpp
@@ -9,6 +9,7 @@
 #ifdef VLLM_XPU_ENABLE_XE2
   #include "xe_2/chunk_causal_conv1d_xe2.hpp"
   #include "xe_2/chunk_causal_conv1d_tiled_xe2.hpp"
+  #include "xe_2/l2norm.hpp"
   #include "xe_2/chunk_gated_delta_rule_xe2.h"
 #endif
 
@@ -431,9 +432,17 @@ void gdn_attention(
           {num_v_heads / tp_size, non_spec_token + padding_size},
           torch::dtype(torch::kFloat32).device(device).requires_grad(false));
 
-      // Use SLM-tiled conv1d for prefill when token count is large enough
-      // to benefit from the tiling overhead (tile_size=8).
-      if (non_spec_token >= gdn::conv1d_tile_size) {
+      // Determine whether fused l2norm is valid for the chosen conv1d path.
+      // Tiled kernel: only valid when all Q+K features fit in a single
+      // feature chunk, i.e. 2 * head_k_dim <= feats_per_wg (256).
+      // Untiled kernel: always valid (entire QKV in one WG).
+      constexpr int tiled_feats_per_wg = 256;  // wg_size(64) * elems_per_item(4)
+      const bool use_tiled = (non_spec_token >= gdn::conv1d_tile_size);
+      const bool fuse_l2norm = use_tiled
+          ? (2 * head_k_dim <= tiled_feats_per_wg)
+          : true;
+
+      if (use_tiled) {
         gdn::chunk_causal_conv1d_tiled_xe2(
             queue,
             q,
@@ -456,7 +465,8 @@ void gdn_attention(
             num_decodes,
             reorder_input,
             token_indx_ptr,
-            non_spec_token);
+            non_spec_token,
+            fuse_l2norm);
       } else {
         gdn::chunk_causal_conv1d_xe2(
             queue,
@@ -480,7 +490,13 @@ void gdn_attention(
             num_decodes,
             reorder_input,
             token_indx_ptr,
-            non_spec_token);
+            non_spec_token,
+            fuse_l2norm);
+      }
+
+      // Run standalone l2norm kernel when not fused into conv1d
+      if (!fuse_l2norm) {
+        gdn::l2norm_xe2(queue, q, k);
       }
 
       chunk_gated_delta_rule_xe2(

--- a/csrc/xpu/gdn_attn/gdn_attn_interface.cpp
+++ b/csrc/xpu/gdn_attn/gdn_attn_interface.cpp
@@ -9,7 +9,7 @@
 #ifdef VLLM_XPU_ENABLE_XE2
   #include "xe_2/chunk_causal_conv1d_xe2.hpp"
   #include "xe_2/chunk_causal_conv1d_tiled_xe2.hpp"
-  #include "xe_2/l2norm.hpp"
+  #include "xe_2/l2norm.h"
   #include "xe_2/chunk_gated_delta_rule_xe2.h"
 #endif
 
@@ -496,7 +496,7 @@ void gdn_attention(
 
       // Run standalone l2norm kernel when not fused into conv1d
       if (!fuse_l2norm) {
-        gdn::l2norm_xe2(queue, q, k);
+        l2norm(queue, q, k);
       }
 
       chunk_gated_delta_rule_xe2(

--- a/csrc/xpu/gdn_attn/gdn_attn_utils.h
+++ b/csrc/xpu/gdn_attn/gdn_attn_utils.h
@@ -2,6 +2,8 @@
 
 namespace gdn {
 
+static constexpr float l2norm_eps = 0.000001f;
+
 #ifdef VLLM_XPU_ENABLE_XE2
 static constexpr int chunk_size_xe2 = 64;
 #endif

--- a/csrc/xpu/gdn_attn/xe_2/chunk_causal_conv1d_tiled_xe2.hpp
+++ b/csrc/xpu/gdn_attn/xe_2/chunk_causal_conv1d_tiled_xe2.hpp
@@ -400,7 +400,7 @@ struct chunk_causal_conv1d_tiled_kernel {
 
       // ---- Fused L2 norm for Q and K (only in feat_chunk 0) ----
       if (fuse_l2norm && feat_chunk_id == 0) {
-        constexpr float l2norm_eps = 0.000001f;
+        // l2norm_eps is defined in gdn_attn_utils.h
         float* norm_slm = reinterpret_cast<float*>(
             reinterpret_cast<char*>(slm_data) + slm_meta_bytes +
             slm_data_elems * sizeof(T));

--- a/csrc/xpu/gdn_attn/xe_2/chunk_causal_conv1d_tiled_xe2.hpp
+++ b/csrc/xpu/gdn_attn/xe_2/chunk_causal_conv1d_tiled_xe2.hpp
@@ -117,7 +117,8 @@ struct chunk_causal_conv1d_tiled_kernel {
   }
 
   static constexpr int meta_ints = 5;
-  // SLM sizes in bytes: metadata (ints) + input data (T elements) + norm (floats)
+  // SLM sizes in bytes: metadata (ints) + input data (T elements) + norm
+  // (floats)
   static constexpr int slm_meta_bytes = meta_ints * sizeof(int);
   static constexpr int feats_per_wg = wg_size * elems_per_item;
   static constexpr int slm_data_elems = (TileT + Width - 1) * feats_per_wg;
@@ -439,7 +440,7 @@ struct chunk_causal_conv1d_tiled_kernel {
           q_total += norm_slm[i * 2];
           k_total += norm_slm[i * 2 + 1];
         }
-        sycl::group_barrier(item.get_group()); // protect SLM for next token
+        sycl::group_barrier(item.get_group());  // protect SLM for next token
 
         float q_inv = sycl::rsqrt(q_total + l2norm_eps) *
                       sycl::rsqrt(static_cast<float>(q_dim));
@@ -823,7 +824,7 @@ void chunk_causal_conv1d_tiled_xe2(
       qkvz_elems,                                                  \
       conv_elems,                                                  \
       num_prefills,                                                \
-      num_decodes,                                                  \
+      num_decodes,                                                 \
       fuse_l2norm);
 
 #define TILED_WIDTH_DISPATCH(scalar_t, width, reorder_input) \

--- a/csrc/xpu/gdn_attn/xe_2/chunk_causal_conv1d_tiled_xe2.hpp
+++ b/csrc/xpu/gdn_attn/xe_2/chunk_causal_conv1d_tiled_xe2.hpp
@@ -59,7 +59,8 @@ struct chunk_causal_conv1d_tiled_kernel {
       const int& qkvz_elems,
       const int& conv_elems,
       const int& num_virtual_tokens,
-      char* slm_data)
+      char* slm_data,
+      const bool fuse_l2norm)
       : q_out(q_out),
         k_out(k_out),
         v_out(v_out),
@@ -87,7 +88,8 @@ struct chunk_causal_conv1d_tiled_kernel {
         qkvz_elems(qkvz_elems),
         conv_elems(conv_elems),
         num_virtual_tokens(num_virtual_tokens),
-        slm_data(slm_data) {}
+        slm_data(slm_data),
+        fuse_l2norm(fuse_l2norm) {}
 
   inline int lookup(int t) const { return token_indx ? token_indx[t] : t; }
 
@@ -115,13 +117,17 @@ struct chunk_causal_conv1d_tiled_kernel {
   }
 
   static constexpr int meta_ints = 5;
-  // SLM sizes in bytes: metadata (ints) + input data (T elements)
+  // SLM sizes in bytes: metadata (ints) + input data (T elements) + norm (floats)
   static constexpr int slm_meta_bytes = meta_ints * sizeof(int);
   static constexpr int feats_per_wg = wg_size * elems_per_item;
   static constexpr int slm_data_elems = (TileT + Width - 1) * feats_per_wg;
+  static constexpr int num_subgroups_per_wg = wg_size / sub_group_size;
+  // 2 floats per subgroup: one for Q partial sum, one for K partial sum
+  static constexpr int norm_slm_bytes =
+      2 * num_subgroups_per_wg * static_cast<int>(sizeof(float));
 
   static inline int get_slm_bytes() {
-    return slm_meta_bytes + slm_data_elems * sizeof(T);
+    return slm_meta_bytes + slm_data_elems * sizeof(T) + norm_slm_bytes;
   }
 
   static inline void act_swish(float& x, float beta = 1.0f) {
@@ -391,6 +397,66 @@ struct chunk_causal_conv1d_tiled_kernel {
         }
       }
 
+      // ---- Fused L2 norm for Q and K (only in feat_chunk 0) ----
+      if (fuse_l2norm && feat_chunk_id == 0) {
+        constexpr float l2norm_eps = 0.000001f;
+        float* norm_slm = reinterpret_cast<float*>(
+            reinterpret_cast<char*>(slm_data) + slm_meta_bytes +
+            slm_data_elems * sizeof(T));
+
+        float q_local_sq = 0.0f;
+        float k_local_sq = 0.0f;
+        if (is_q) {
+#pragma unroll
+          for (int e = 0; e < elems_per_item; ++e)
+            q_local_sq += res[e] * res[e];
+        }
+        if (is_k) {
+#pragma unroll
+          for (int e = 0; e < elems_per_item; ++e)
+            k_local_sq += res[e] * res[e];
+        }
+
+        // Subgroup reduce
+        auto sg = item.get_sub_group();
+        float q_sg_sum =
+            sycl::reduce_over_group(sg, q_local_sq, sycl::plus<float>());
+        float k_sg_sum =
+            sycl::reduce_over_group(sg, k_local_sq, sycl::plus<float>());
+
+        // Write subgroup partial sums to SLM
+        int sg_id = sg.get_group_linear_id();
+        if (sg.get_local_linear_id() == 0) {
+          norm_slm[sg_id * 2] = q_sg_sum;
+          norm_slm[sg_id * 2 + 1] = k_sg_sum;
+        }
+        sycl::group_barrier(item.get_group());
+
+        // Combine all subgroup partial sums
+        float q_total = 0.0f;
+        float k_total = 0.0f;
+        for (int i = 0; i < num_subgroups_per_wg; ++i) {
+          q_total += norm_slm[i * 2];
+          k_total += norm_slm[i * 2 + 1];
+        }
+        sycl::group_barrier(item.get_group()); // protect SLM for next token
+
+        float q_inv = sycl::rsqrt(q_total + l2norm_eps) *
+                      sycl::rsqrt(static_cast<float>(q_dim));
+        float k_inv = sycl::rsqrt(k_total + l2norm_eps);
+
+        if (is_q) {
+#pragma unroll
+          for (int e = 0; e < elems_per_item; ++e)
+            res[e] *= q_inv;
+        }
+        if (is_k) {
+#pragma unroll
+          for (int e = 0; e < elems_per_item; ++e)
+            res[e] *= k_inv;
+        }
+      }
+
       // Write output
       int token_in_seq = tile_start_in_seq + t;
       int out_token_id = pre_chunks * chunk_size_xe2 + token_in_seq;
@@ -553,6 +619,7 @@ struct chunk_causal_conv1d_tiled_kernel {
   const int conv_elems;
   const int num_virtual_tokens;
   char* slm_data;
+  const bool fuse_l2norm;
 };
 
 template <typename T, int Width, int TileT, bool ReorderInput>
@@ -588,7 +655,8 @@ void tiled_kernel_launcher(
     const int& qkvz_elems,
     const int& conv_elems,
     const int& num_prefills,
-    const int& num_decodes) {
+    const int& num_decodes,
+    const bool fuse_l2norm) {
   // Note: z_out, b_out, a_out, mixed_ba are passed through to the
   // ZBA reorder kernel below, not to the tiled conv1d kernel itself.
   using KERNEL_MAIN =
@@ -633,7 +701,8 @@ void tiled_kernel_launcher(
           qkvz_elems,
           conv_elems,
           num_virtual_tokens,
-          slm_ptr);
+          slm_ptr,
+          fuse_l2norm);
       task(item);
     });
   });
@@ -680,7 +749,8 @@ void chunk_causal_conv1d_tiled_xe2(
     const int num_decodes,
     const bool reorder_input,
     const int* token_indx = nullptr,
-    int num_actual_tokens_override = -1) {
+    int num_actual_tokens_override = -1,
+    const bool fuse_l2norm = false) {
   if (num_prefills == 0 && num_decodes == 0) {
     return;
   }
@@ -753,7 +823,8 @@ void chunk_causal_conv1d_tiled_xe2(
       qkvz_elems,                                                  \
       conv_elems,                                                  \
       num_prefills,                                                \
-      num_decodes);
+      num_decodes,                                                  \
+      fuse_l2norm);
 
 #define TILED_WIDTH_DISPATCH(scalar_t, width, reorder_input) \
   switch (width) {                                           \

--- a/csrc/xpu/gdn_attn/xe_2/chunk_causal_conv1d_xe2.hpp
+++ b/csrc/xpu/gdn_attn/xe_2/chunk_causal_conv1d_xe2.hpp
@@ -311,7 +311,7 @@ struct chunk_causal_conv1d_kernel {
     // ---- Fused L2 norm for Q and K ----
     // Compute per-thread partial sum of squares for Q or K
     if (fuse_l2norm) {
-      constexpr float l2norm_eps = 0.000001f;
+      // l2norm_eps is defined in gdn_attn_utils.h
       float q_local_sq = 0.0f;
       float k_local_sq = 0.0f;
       if (is_q) {

--- a/csrc/xpu/gdn_attn/xe_2/chunk_causal_conv1d_xe2.hpp
+++ b/csrc/xpu/gdn_attn/xe_2/chunk_causal_conv1d_xe2.hpp
@@ -686,48 +686,45 @@ void kernel_launcher(
   const int norm_slm_bytes = KERNEL_MAIN::get_norm_slm_bytes(
       head_k_dim, num_v_heads, num_k_heads, head_v_dim);
   queue.submit([&](sycl::handler& cgh) {
-    auto norm_slm = sycl::local_accessor<char, 1>(
-        sycl::range<1>(norm_slm_bytes), cgh);
-    cgh.parallel_for(
-        range_main,
-        [=](sycl::nd_item<2> item) {
-          char* norm_slm_ptr =
-              norm_slm
-                  .template get_multi_ptr<sycl::access::decorated::no>()
-                  .get_raw();
-          KERNEL_MAIN task(
-              q_out,
-              k_out,
-              v_out,
-              z_out,
-              b_out,
-              a_out,
-              mixed_qkvz,
-              mixed_ba,
-              conv_weights,
-              conv_bias,
-              conv_states,
-              conv_states_stride_0,
-              conv_states_tmp,
-              query_start_loc,
-              cache_indices,
-              has_initial_state,
-              token_indx,
-              act_mode,
-              pad_slot_id,
-              batch_size,
-              num_actual_tokens,
-              num_virtual_tokens,
-              num_k_heads,
-              head_k_dim,
-              num_v_heads,
-              head_v_dim,
-              qkvz_elems,
-              conv_elems,
-              norm_slm_ptr,
-              fuse_l2norm);
-          task(item);
-        });
+    auto norm_slm =
+        sycl::local_accessor<char, 1>(sycl::range<1>(norm_slm_bytes), cgh);
+    cgh.parallel_for(range_main, [=](sycl::nd_item<2> item) {
+      char* norm_slm_ptr =
+          norm_slm.template get_multi_ptr<sycl::access::decorated::no>()
+              .get_raw();
+      KERNEL_MAIN task(
+          q_out,
+          k_out,
+          v_out,
+          z_out,
+          b_out,
+          a_out,
+          mixed_qkvz,
+          mixed_ba,
+          conv_weights,
+          conv_bias,
+          conv_states,
+          conv_states_stride_0,
+          conv_states_tmp,
+          query_start_loc,
+          cache_indices,
+          has_initial_state,
+          token_indx,
+          act_mode,
+          pad_slot_id,
+          batch_size,
+          num_actual_tokens,
+          num_virtual_tokens,
+          num_k_heads,
+          head_k_dim,
+          num_v_heads,
+          head_v_dim,
+          qkvz_elems,
+          conv_elems,
+          norm_slm_ptr,
+          fuse_l2norm);
+      task(item);
+    });
   });
 
   using KERNEL_ZBA = chunk_reorder_zba_kernel<T, ReorderInput>;

--- a/csrc/xpu/gdn_attn/xe_2/chunk_causal_conv1d_xe2.hpp
+++ b/csrc/xpu/gdn_attn/xe_2/chunk_causal_conv1d_xe2.hpp
@@ -46,7 +46,9 @@ struct chunk_causal_conv1d_kernel {
       const int& num_v_heads,
       const int& head_v_dim,
       const int& qkvz_elems,
-      const int& conv_elems)
+      const int& conv_elems,
+      char* norm_slm_data,
+      const bool fuse_l2norm)
       : q_out(q_out),
         k_out(k_out),
         v_out(v_out),
@@ -74,7 +76,9 @@ struct chunk_causal_conv1d_kernel {
         num_v_heads(num_v_heads),
         head_v_dim(head_v_dim),
         qkvz_elems(qkvz_elems),
-        conv_elems(conv_elems) {}
+        conv_elems(conv_elems),
+        norm_slm_data(norm_slm_data),
+        fuse_l2norm(fuse_l2norm) {}
 
   inline int lookup(int t) const { return token_indx ? token_indx[t] : t; }
 
@@ -93,6 +97,19 @@ struct chunk_causal_conv1d_kernel {
     sycl::range<2> local(1, group_size);
     sycl::range<2> global(total_seqlen, num_k_heads);
     return sycl::nd_range<2>(global * local, local);
+  }
+
+  static inline int get_norm_slm_bytes(
+      const int head_k_dim,
+      const int num_v_heads,
+      const int num_k_heads,
+      const int head_v_dim) {
+    const int group_size =
+        (2 * head_k_dim + head_v_dim * num_v_heads / num_k_heads) /
+        elems_per_item;
+    const int num_subgroups = group_size / sub_group_size;
+    // 2 floats per subgroup: one for Q partial sum, one for K partial sum
+    return 2 * num_subgroups * static_cast<int>(sizeof(float));
   }
 
   static inline void act_swish(float& x, float beta = 1.0f) {
@@ -291,6 +308,67 @@ struct chunk_causal_conv1d_kernel {
       }
     }
 
+    // ---- Fused L2 norm for Q and K ----
+    // Compute per-thread partial sum of squares for Q or K
+    if (fuse_l2norm) {
+      constexpr float l2norm_eps = 0.000001f;
+      float q_local_sq = 0.0f;
+      float k_local_sq = 0.0f;
+      if (is_q) {
+#pragma unroll
+        for (int e = 0; e < elems_per_item; ++e)
+          q_local_sq += res[e] * res[e];
+      }
+      if (is_k) {
+#pragma unroll
+        for (int e = 0; e < elems_per_item; ++e)
+          k_local_sq += res[e] * res[e];
+      }
+
+      // Subgroup reduce
+      auto sg = item.get_sub_group();
+      float q_sg_sum =
+          sycl::reduce_over_group(sg, q_local_sq, sycl::plus<float>());
+      float k_sg_sum =
+          sycl::reduce_over_group(sg, k_local_sq, sycl::plus<float>());
+
+      // Write subgroup partial sums to SLM
+      float* norm_slm = reinterpret_cast<float*>(norm_slm_data);
+      int sg_id = sg.get_group_linear_id();
+      int sg_local_id = sg.get_local_linear_id();
+      int num_sgs = item.get_local_range().size() / sub_group_size;
+      if (sg_local_id == 0) {
+        norm_slm[sg_id * 2] = q_sg_sum;
+        norm_slm[sg_id * 2 + 1] = k_sg_sum;
+      }
+      sycl::group_barrier(item.get_group());
+
+      // Combine all subgroup partial sums
+      float q_total = 0.0f;
+      float k_total = 0.0f;
+      for (int i = 0; i < num_sgs; ++i) {
+        q_total += norm_slm[i * 2];
+        k_total += norm_slm[i * 2 + 1];
+      }
+      // No second barrier needed: SLM is read-only after this point
+      // (one token per WG, no reuse of norm_slm within this kernel)
+
+      float q_inv = sycl::rsqrt(q_total + l2norm_eps) *
+                    sycl::rsqrt(static_cast<float>(q_dim));
+      float k_inv = sycl::rsqrt(k_total + l2norm_eps);
+
+      if (is_q) {
+#pragma unroll
+        for (int e = 0; e < elems_per_item; ++e)
+          res[e] *= q_inv;
+      }
+      if (is_k) {
+#pragma unroll
+        for (int e = 0; e < elems_per_item; ++e)
+          res[e] *= k_inv;
+      }
+    }
+
     // reorder q, k, v
     if (is_q) {
 #pragma unroll
@@ -345,6 +423,8 @@ struct chunk_causal_conv1d_kernel {
   const int head_v_dim;
   const int qkvz_elems;
   const int conv_elems;
+  char* norm_slm_data;
+  const bool fuse_l2norm;
 };
 
 template <typename T, bool ReorderInput>
@@ -598,41 +678,56 @@ void kernel_launcher(
     const int& qkvz_elems,
     const int& conv_elems,
     const int& num_prefills,
-    const int& num_decodes) {
+    const int& num_decodes,
+    const bool fuse_l2norm) {
   using KERNEL_MAIN = chunk_causal_conv1d_kernel<T, Width, ReorderInput>;
   auto range_main = KERNEL_MAIN::get_nd_range(
       num_actual_tokens, num_k_heads, head_k_dim, num_v_heads, head_v_dim);
+  const int norm_slm_bytes = KERNEL_MAIN::get_norm_slm_bytes(
+      head_k_dim, num_v_heads, num_k_heads, head_v_dim);
   queue.submit([&](sycl::handler& cgh) {
-    KERNEL_MAIN task(
-        q_out,
-        k_out,
-        v_out,
-        z_out,
-        b_out,
-        a_out,
-        mixed_qkvz,
-        mixed_ba,
-        conv_weights,
-        conv_bias,
-        conv_states,
-        conv_states_stride_0,
-        conv_states_tmp,
-        query_start_loc,
-        cache_indices,
-        has_initial_state,
-        token_indx,
-        act_mode,
-        pad_slot_id,
-        batch_size,
-        num_actual_tokens,
-        num_virtual_tokens,
-        num_k_heads,
-        head_k_dim,
-        num_v_heads,
-        head_v_dim,
-        qkvz_elems,
-        conv_elems);
-    cgh.parallel_for(range_main, task);
+    auto norm_slm = sycl::local_accessor<char, 1>(
+        sycl::range<1>(norm_slm_bytes), cgh);
+    cgh.parallel_for(
+        range_main,
+        [=](sycl::nd_item<2> item) {
+          char* norm_slm_ptr =
+              norm_slm
+                  .template get_multi_ptr<sycl::access::decorated::no>()
+                  .get_raw();
+          KERNEL_MAIN task(
+              q_out,
+              k_out,
+              v_out,
+              z_out,
+              b_out,
+              a_out,
+              mixed_qkvz,
+              mixed_ba,
+              conv_weights,
+              conv_bias,
+              conv_states,
+              conv_states_stride_0,
+              conv_states_tmp,
+              query_start_loc,
+              cache_indices,
+              has_initial_state,
+              token_indx,
+              act_mode,
+              pad_slot_id,
+              batch_size,
+              num_actual_tokens,
+              num_virtual_tokens,
+              num_k_heads,
+              head_k_dim,
+              num_v_heads,
+              head_v_dim,
+              qkvz_elems,
+              conv_elems,
+              norm_slm_ptr,
+              fuse_l2norm);
+          task(item);
+        });
   });
 
   using KERNEL_ZBA = chunk_reorder_zba_kernel<T, ReorderInput>;
@@ -712,7 +807,8 @@ void chunk_causal_conv1d_xe2(
     const int num_decodes,
     const bool reorder_input,
     const int* token_indx = nullptr,
-    int num_actual_tokens_override = -1) {
+    int num_actual_tokens_override = -1,
+    const bool fuse_l2norm = false) {
   if (num_prefills == 0 && num_decodes == 0) {
     return;
   }
@@ -773,7 +869,8 @@ void chunk_causal_conv1d_xe2(
       qkvz_elems,                                                  \
       conv_elems,                                                  \
       num_prefills,                                                \
-      num_decodes);
+      num_decodes,                                                 \
+      fuse_l2norm);
 
 #define WIDTH_DISPATCH(scalar_t, width, reorder_input) \
   switch (width) {                                     \

--- a/csrc/xpu/gdn_attn/xe_2/chunk_gated_delta_rule_kernels_xe2.hpp
+++ b/csrc/xpu/gdn_attn/xe_2/chunk_gated_delta_rule_kernels_xe2.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <sycl/sycl.hpp>
 #include <torch/all.h>
 
@@ -50,23 +51,15 @@ act_softplus(float& x, float beta = 1.0f, float threshold = 20.0f) {
 
 template <typename T>
 CUTE_DEVICE void chunk_prepare_kernel(
-    const T* q,
-    const T* k,
     const float* a,
     const float* A_log,
     const T* dt_bias,
     const int* query_start_loc,
     const int total_virtual_seqlen,
     const int batch_size,
-    const int num_k_heads,
-    const int head_k_dim,
     const int num_v_heads,
     const int head_v_dim) {
   auto item = sycl::ext::oneapi::this_work_item::get_nd_item<3>();
-  int local_id = item.get_local_linear_id();
-  int local_range = item.get_local_range(2);
-
-  // l2norm for q, k
   int group_id = item.get_group(1);
   int group_range = item.get_group_range(1);
   auto sg = item.get_sub_group();
@@ -76,45 +69,6 @@ CUTE_DEVICE void chunk_prepare_kernel(
 
   int total_sg_range = group_range * sg_range;
   int total_sg_id = group_id * sg_range + sg_id;
-  float q_scale = 1.0 / sycl::sqrt(static_cast<float>(head_k_dim));
-  for (int64_t handle_idx = total_sg_id;
-       handle_idx < total_virtual_seqlen * num_k_heads;
-       handle_idx += total_sg_range) {
-    auto q_ptr = const_cast<T*>(q) + handle_idx * head_k_dim;
-    auto k_ptr = const_cast<T*>(k) + handle_idx * head_k_dim;
-    float q_sum = 0.0f;
-    float k_sum = 0.0f;
-    CUTE_UNROLL
-    for (int k_dim_idx = sg_local_id * elem_per_item; k_dim_idx < head_k_dim;
-         k_dim_idx += sub_group_size * elem_per_item) {
-      CUTE_UNROLL
-      for (int e = 0; e < elem_per_item; ++e) {
-        float q_value = q_ptr[k_dim_idx + e];
-        float k_value = k_ptr[k_dim_idx + e];
-        q_value *= q_value;
-        k_value *= k_value;
-        q_sum += q_value;
-        k_sum += k_value;
-      }
-    }
-    q_sum = sycl::reduce_over_group(sg, q_sum, sycl::plus<>());
-    k_sum = sycl::reduce_over_group(sg, k_sum, sycl::plus<>());
-    q_sum += eps;
-    k_sum += eps;
-    q_sum = sycl::sqrt(q_sum);
-    k_sum = sycl::sqrt(k_sum);
-    CUTE_UNROLL
-    for (int k_dim_idx = sg_local_id * elem_per_item; k_dim_idx < head_k_dim;
-         k_dim_idx += sub_group_size * elem_per_item) {
-      CUTE_UNROLL
-      for (int e = 0; e < elem_per_item; ++e) {
-        q_ptr[k_dim_idx + e] = static_cast<T>(
-            static_cast<float>(q_ptr[k_dim_idx + e]) / q_sum * q_scale);
-        k_ptr[k_dim_idx + e] =
-            static_cast<T>(static_cast<float>(k_ptr[k_dim_idx + e]) / k_sum);
-      }
-    }
-  }
 
   int pre_chunks = 0;
   const int chunk_range = total_sg_range / num_v_heads;
@@ -1011,14 +965,14 @@ CUTE_DEVICE void chunk_fwd_o_kernel(
       float g_last_value =
           a[(chunk_offset + current_chunk_size - 1) +
             v_head_id * total_virtual_seqlen];
-      float g_last_value_exp = sycl::exp(g_last_value);
+      float g_last_value_exp = sycl::native::exp(g_last_value);
       CUTE_UNROLL
       for (int e = local_id; e < current_chunk_size; e += local_range) {
         float g_cumsum_value =
             a[(chunk_offset + e) + v_head_id * total_virtual_seqlen];
         g_slm_ptr[e] = g_cumsum_value;
-        g_multi_slm_ptr[e] = sycl::exp(g_last_value - g_cumsum_value);
-        g_exp_slm_ptr[e] = sycl::exp(g_cumsum_value);
+        g_multi_slm_ptr[e] = sycl::native::exp(g_last_value - g_cumsum_value);
+        g_exp_slm_ptr[e] = sycl::native::exp(g_cumsum_value);
       }
 
       CUTE_UNROLL
@@ -1060,34 +1014,6 @@ CUTE_DEVICE void chunk_fwd_o_kernel(
 
       auto thr_mma = mma.get_slice(local_id);
 
-      if (has_prev_state) {
-        for (int dv = 0; dv < head_v_dim / chunk_size; ++dv) {
-          Tensor gU_C =
-              local_tile(cU, wg_tile, make_coord(0, dv, 0), Step<_1, _1, X>{});
-          auto tCrU_d = thr_copy_U_d.partition_sg_fragment_S(gU_C);
-          auto tCgU_d = thr_copy_U_d.partition_D(gU_C);
-          auto tSrU_d = thr_mma.partition_sg_fragment_C(gU_C);
-          clear(tSrU_d);
-          gemm_TTS(W_tensor, S_tensor, tSrU_d, 0, dv, mma);
-
-          auto tCrU_c_save = thr_copy_U_c.partition_sg_fragment_D(gU_C);
-          reorder(tSrU_d, tCrU_c_save);
-
-          auto tCgU_c = thr_copy_U_c.partition_S(gU_C);
-          auto tCrU_c = thr_copy_U_c.partition_sg_fragment_D(gU_C);
-          copy(copy_U_c, tCgU_c, tCrU_c);
-
-          CUTE_UNROLL
-          for (int i = 0; i < tCrU_c_save.size(); ++i) {
-            tCrU_c(i) -= tCrU_c_save(i);
-          }
-
-          reorder(tCrU_c, tCrU_d);
-          copy(copy_U_d, tCrU_d, tCgU_d);
-        }
-        item.barrier(sycl::access::fence_space::local_space);
-      }
-
       auto q_ptr =
           q + chunk_offset * num_k_heads * head_k_dim + kv_head_id * head_k_dim;
       auto Q_tensor_shape = make_shape(current_chunk_size, head_k_dim);
@@ -1122,6 +1048,7 @@ CUTE_DEVICE void chunk_fwd_o_kernel(
       auto tCgO2_c = thr_copy_O2_c.partition_D(gO2_C);
       auto tSrO2_c = thr_mma.partition_sg_fragment_C(gO2_C);
 
+      // QK MMA: compute O2 = mask(Q × K^T) first (no dependency on WS)
       clear(tSrO2_c);
       gemm_TTS(Q_tensor, K_tensor, tSrO2_c, 0, 0, mma);
 
@@ -1133,7 +1060,7 @@ CUTE_DEVICE void chunk_fwd_o_kernel(
         for (int sm = 0; sm < SG_M; ++sm) {
           int m_idx = m_tile_start + m_sg_start + sm;
           tSrO2_c(sn * SG_M + sm) *=
-              sycl::exp(g_slm_ptr[(m_idx)] - g_slm_ptr[n_idx]);
+              sycl::native::exp(g_slm_ptr[(m_idx)] - g_slm_ptr[n_idx]);
           if (m_idx < n_idx) {
             tSrO2_c(sn * SG_M + sm) = 0.0f;
           }
@@ -1162,15 +1089,44 @@ CUTE_DEVICE void chunk_fwd_o_kernel(
       auto thr_copy_O_c = copy_O_c.get_slice(local_id);
 
       if (has_prev_state) {
+        // Fused WS+QS dv loop: S[dv] is loaded once per k_tile and reused
+        // in registers for both WS (W×S) and QS (Q×S) DPAS operations.
         for (int dv = 0; dv < head_v_dim / chunk_size; ++dv) {
+          // --- Fused WS+QS MMA: share S[dv] load in registers ---
+          Tensor gU_C =
+              local_tile(cU, wg_tile, make_coord(0, dv, 0), Step<_1, _1, X>{});
+          auto tSrU_d = thr_mma.partition_sg_fragment_C(gU_C);
+          clear(tSrU_d);
+
           Tensor gO_C =
               local_tile(cO, wg_tile, make_coord(0, dv, 0), Step<_1, _1, X>{});
-          auto tCrO_c = thr_copy_O_c.partition_sg_fragment_S(gO_C);
-          auto tCgO_c = thr_copy_O_c.partition_D(gO_C);
           auto tSrO_c = thr_mma.partition_sg_fragment_C(gO_C);
-
           clear(tSrO_c);
-          gemm_TTS(Q_tensor, S_tensor, tSrO_c, 0, dv, mma);
+
+          // Fused gemm: W×S[dv] -> tSrU_d, Q×S[dv] -> tSrO_c
+          // S is loaded once and reused in registers for both
+          gemm_TTS_fused_2A(
+              W_tensor, Q_tensor, S_tensor, tSrU_d, tSrO_c, 0, 0, dv, mma);
+
+          // --- WS epilogue: U_new[dv] = U_old[dv] - W×S[dv] ---
+          auto tCrU_d = thr_copy_U_d.partition_sg_fragment_S(gU_C);
+          auto tCgU_d = thr_copy_U_d.partition_D(gU_C);
+          auto tCrU_c_save = thr_copy_U_c.partition_sg_fragment_D(gU_C);
+          reorder(tSrU_d, tCrU_c_save);
+
+          auto tCgU_c = thr_copy_U_c.partition_S(gU_C);
+          auto tCrU_c = thr_copy_U_c.partition_sg_fragment_D(gU_C);
+          copy(copy_U_c, tCgU_c, tCrU_c);
+
+          CUTE_UNROLL
+          for (int i = 0; i < tCrU_c_save.size(); ++i) {
+            tCrU_c(i) -= tCrU_c_save(i);
+          }
+
+          reorder(tCrU_c, tCrU_d);
+          copy(copy_U_d, tCrU_d, tCgU_d);
+
+          // --- QS epilogue: apply exp(g) scaling ---
           CUTE_UNROLL
           for (int sn = 0; sn < SG_N / sub_group_size; ++sn) {
             int n_idx =
@@ -1181,7 +1137,15 @@ CUTE_DEVICE void chunk_fwd_o_kernel(
               tSrO_c(sn * SG_M + sm) *= g_exp_slm_ptr[(m_idx)];
             }
           }
+
+          // Barrier: ensure U_new[dv] is visible across all subgroups
+          // before O2U reads it via U_tensor_T.
+          item.barrier(sycl::access::fence_space::local_space);
+
+          // --- O2U MMA: O[dv] += O1[dv] + O2 × U_T[dv] ---
           gemm_TTS(O2_tensor, U_tensor_T, tSrO_c, 0, dv, mma);
+          auto tCrO_c = thr_copy_O_c.partition_sg_fragment_S(gO_C);
+          auto tCgO_c = thr_copy_O_c.partition_D(gO_C);
           reorder(tSrO_c, tCrO_c);
           copy(copy_O_c, tCrO_c, tCgO_c);
         }
@@ -1318,16 +1282,12 @@ void kernel_launcher(
         kernel_props,
         [=](auto) {
           chunk_prepare_kernel<T>(
-              q,
-              k,
               a,
               A_log,
               dt_bias,
               query_start_loc,
               total_virtual_seqlen,
               batch_size,
-              num_k_heads,
-              head_k_dim,
               num_v_heads,
               head_v_dim);
         });

--- a/csrc/xpu/gdn_attn/xe_2/gemm.hpp
+++ b/csrc/xpu/gdn_attn/xe_2/gemm.hpp
@@ -378,4 +378,114 @@ CUTE_DEVICE void gemm_TTS_k_multi(
   }
 }
 
+// Fused dual-A GEMM: computes C1 += A1 * B^T and C2 += A2 * B^T
+// sharing the same B operand load. B is loaded once per k_tile and
+// reused in registers for both DPAS operations.
+template <
+    class A1Tensor,
+    class A2Tensor,
+    class BTensor,
+    class SGCTensor1,
+    class SGCTensor2,
+    class TiledMMA>
+CUTE_DEVICE void gemm_TTS_fused_2A(
+    A1Tensor const& A1,  // (M,K) first A operand
+    A2Tensor const& A2,  // (M,K) second A operand
+    BTensor const& B,    // (N,K) shared B operand
+    SGCTensor1& tCrC1,   // accumulator for A1 * B^T
+    SGCTensor2& tCrC2,   // accumulator for A2 * B^T
+    int wg_m1,           // m tile index for A1
+    int wg_m2,           // m tile index for A2
+    int wg_n,            // n tile index for B (shared)
+    TiledMMA const& mma) {
+  auto item = sycl::ext::oneapi::this_work_item::get_nd_item<3>();
+  int local_id = item.get_local_linear_id();
+
+  Tensor cA1 = make_identity_tensor(A1.shape());
+  Tensor cA2 = make_identity_tensor(A2.shape());
+  Tensor cB = make_identity_tensor(B.shape());
+
+  auto wg_tile = mma.tile_mnk();
+
+  Tensor gA1 = local_tile(cA1, select<0, 2>(wg_tile), make_coord(wg_m1, _));
+  Tensor gA2 = local_tile(cA2, select<0, 2>(wg_tile), make_coord(wg_m2, _));
+  Tensor gB = local_tile(cB, select<1, 2>(wg_tile), make_coord(wg_n, _));
+
+  auto copy_a1 = get_block_2d_copy_A<void>(mma, A1);
+  auto copy_a2 = get_block_2d_copy_A<void>(mma, A2);
+  auto copy_b = get_block_2d_copy_B<void>(mma, B);
+
+  auto thr_mma = mma.get_slice(local_id);
+  auto thr_copy_a1 = copy_a1.get_slice(local_id);
+  auto thr_copy_a2 = copy_a2.get_slice(local_id);
+  auto thr_copy_b = copy_b.get_slice(local_id);
+
+  // MMA fragments: A fragment reused for both A1 and A2, B shared
+  auto tCrA = thr_mma.partition_sg_fragment_A(gA1(_, _, 0));
+  auto tCrB = thr_mma.partition_sg_fragment_B(gB(_, _, 0));
+
+  // Copy destination registers: separate for A1 and A2
+  auto tArA1 = thr_copy_a1.partition_sg_fragment_D(gA1(_, _, 0));
+  auto tArA2 = thr_copy_a2.partition_sg_fragment_D(gA2(_, _, 0));
+  auto tBrB = thr_copy_b.partition_sg_fragment_D(gB(_, _, 0));
+
+  // Source partitions
+  Tensor tAgA1 = thr_copy_a1.partition_S(gA1);
+  Tensor tAgA2 = thr_copy_a2.partition_S(gA2);
+  Tensor tBgB = thr_copy_b.partition_S(gB);
+
+  // Prefetch setup
+  auto prefetch_a1 = make_block_2d_prefetch(copy_a1);
+  auto prefetch_a2 = make_block_2d_prefetch(copy_a2);
+  auto prefetch_b = make_block_2d_prefetch(copy_b);
+
+  auto thr_prefetch_A1 = prefetch_a1.get_slice(local_id);
+  auto thr_prefetch_A2 = prefetch_a2.get_slice(local_id);
+  auto thr_prefetch_B = prefetch_b.get_slice(local_id);
+
+  auto pAgA1 = thr_prefetch_A1.partition_S(gA1);
+  auto pAgA2 = thr_prefetch_A2.partition_S(gA2);
+  auto pBgB = thr_prefetch_B.partition_S(gB);
+
+  const int prefetch_dist = 3;
+
+  constexpr int barrier_scope = 2;
+
+  int k_tile_count = ceil_div(shape<1>(A1), get<2>(wg_tile));
+  int k_tile_prefetch = 0;
+
+  CUTE_UNROLL
+  for (; k_tile_prefetch < prefetch_dist; k_tile_prefetch++) {
+    prefetch(prefetch_a1, pAgA1(_, _, _, k_tile_prefetch));
+    prefetch(prefetch_a2, pAgA2(_, _, _, k_tile_prefetch));
+    prefetch(prefetch_b, pBgB(_, _, _, k_tile_prefetch));
+  }
+
+  for (int k_tile = 0; k_tile < k_tile_count; k_tile++, k_tile_prefetch++) {
+    barrier_arrive(barrier_scope);
+
+    // Load shared B and both A operands
+    copy(copy_b, tBgB(_, _, _, k_tile), tBrB);
+    copy(copy_a1, tAgA1(_, _, _, k_tile), tArA1);
+    copy(copy_a2, tAgA2(_, _, _, k_tile), tArA2);
+
+    if (k_tile_prefetch < k_tile_count) {
+      prefetch(prefetch_a1, pAgA1(_, _, _, k_tile_prefetch));
+      prefetch(prefetch_a2, pAgA2(_, _, _, k_tile_prefetch));
+      prefetch(prefetch_b, pBgB(_, _, _, k_tile_prefetch));
+    }
+
+    // Reorder B (shared) and A1, then first GEMM
+    reorder(tBrB, tCrB);
+    reorder(tArA1, tCrA);
+    cute::gemm(mma, tCrA, tCrB, tCrC1);
+
+    // Reorder A2 reusing MMA A fragment, B stays in register
+    reorder(tArA2, tCrA);
+    cute::gemm(mma, tCrA, tCrB, tCrC2);
+
+    barrier_wait(barrier_scope);
+  }
+}
+
 }  // namespace gdn

--- a/csrc/xpu/gdn_attn/xe_2/l2norm.cpp
+++ b/csrc/xpu/gdn_attn/xe_2/l2norm.cpp
@@ -1,0 +1,10 @@
+#include <sycl/sycl.hpp>
+#include <torch/all.h>
+
+#include "l2norm_kernel.hpp"
+#include "l2norm.h"
+
+void l2norm(
+    sycl::queue& queue, const torch::Tensor& q, const torch::Tensor& k) {
+  gdn::l2norm_impl(queue, q, k);
+}

--- a/csrc/xpu/gdn_attn/xe_2/l2norm.h
+++ b/csrc/xpu/gdn_attn/xe_2/l2norm.h
@@ -1,0 +1,3 @@
+#include <torch/all.h>
+
+void l2norm(sycl::queue& queue, const torch::Tensor& q, const torch::Tensor& k);

--- a/csrc/xpu/gdn_attn/xe_2/l2norm.hpp
+++ b/csrc/xpu/gdn_attn/xe_2/l2norm.hpp
@@ -1,0 +1,201 @@
+#pragma once
+
+#include <sycl/sycl.hpp>
+#include <torch/all.h>
+
+#include "gdn_attn_utils.h"
+#include "csrc/utils.h"
+
+namespace gdn {
+
+static constexpr int l2norm_elem_per_item = 2;
+static constexpr int l2norm_sub_group_size = 16;
+static constexpr float l2norm_eps = 0.000001f;
+static constexpr int L2NormVecSize = 8;
+
+template <typename T>
+SYCL_EXTERNAL void l2norm_kernel(
+    const T* q,
+    const T* k,
+    const int total_virtual_seqlen,
+    const int num_k_heads,
+    const int head_k_dim) {
+  auto item = sycl::ext::oneapi::this_work_item::get_nd_item<3>();
+
+  int group_id = item.get_group(1);
+  auto sg = item.get_sub_group();
+  int sg_id = sg.get_group_linear_id();
+  int sg_range = sg.get_group_linear_range();
+  int sg_local_id = sg.get_local_linear_id();
+
+  int total_sg_id = group_id * sg_range + sg_id;
+  const int total_qk_heads = total_virtual_seqlen * num_k_heads;
+  if (total_sg_id >= total_qk_heads) {
+    return;
+  }
+  float q_scale = sycl::rsqrt(static_cast<float>(head_k_dim));
+
+  auto q_ptr = const_cast<T*>(q) + total_sg_id * head_k_dim;
+  auto k_ptr = const_cast<T*>(k) + total_sg_id * head_k_dim;
+  float q_sum = 0.0f;
+  float k_sum = 0.0f;
+  for (int k_dim_idx = sg_local_id * l2norm_elem_per_item;
+       k_dim_idx < head_k_dim;
+       k_dim_idx += l2norm_sub_group_size * l2norm_elem_per_item) {
+    for (int e = 0; e < l2norm_elem_per_item; ++e) {
+      float q_value = q_ptr[k_dim_idx + e];
+      float k_value = k_ptr[k_dim_idx + e];
+      q_sum += q_value * q_value;
+      k_sum += k_value * k_value;
+    }
+  }
+  q_sum = sycl::reduce_over_group(sg, q_sum, sycl::plus<>());
+  k_sum = sycl::reduce_over_group(sg, k_sum, sycl::plus<>());
+  float q_inv = sycl::rsqrt(q_sum + l2norm_eps) * q_scale;
+  float k_inv = sycl::rsqrt(k_sum + l2norm_eps);
+  for (int k_dim_idx = sg_local_id * l2norm_elem_per_item;
+       k_dim_idx < head_k_dim;
+       k_dim_idx += l2norm_sub_group_size * l2norm_elem_per_item) {
+    for (int e = 0; e < l2norm_elem_per_item; ++e) {
+      q_ptr[k_dim_idx + e] =
+          static_cast<T>(static_cast<float>(q_ptr[k_dim_idx + e]) * q_inv);
+      k_ptr[k_dim_idx + e] =
+          static_cast<T>(static_cast<float>(k_ptr[k_dim_idx + e]) * k_inv);
+    }
+  }
+}
+
+template <typename T, int VEC_SIZE>
+SYCL_EXTERNAL void l2norm_vectorized_kernel(
+    const T* q,
+    const T* k,
+    const int total_virtual_seqlen,
+    const int num_k_heads,
+    const int head_k_dim) {
+  auto item = sycl::ext::oneapi::this_work_item::get_nd_item<3>();
+
+  using vec_t = vllm::xpu::aligned_vec<T, VEC_SIZE>;
+
+  int group_id = item.get_group(1);
+  auto sg = item.get_sub_group();
+  int sg_id = sg.get_group_linear_id();
+  int sg_range = sg.get_group_linear_range();
+  int sg_local_id = sg.get_local_linear_id();
+
+  int total_sg_id = group_id * sg_range + sg_id;
+  const int total_qk_heads = total_virtual_seqlen * num_k_heads;
+  if (total_sg_id >= total_qk_heads) {
+    return;
+  }
+
+  float q_scale = sycl::rsqrt(static_cast<float>(head_k_dim));
+  auto q_ptr = const_cast<T*>(q) + total_sg_id * head_k_dim;
+  auto k_ptr = const_cast<T*>(k) + total_sg_id * head_k_dim;
+
+  auto q_vec_ptr = reinterpret_cast<vec_t*>(q_ptr);
+  auto k_vec_ptr = reinterpret_cast<vec_t*>(k_ptr);
+  const int num_vec = head_k_dim / VEC_SIZE;
+
+  float q_sum = 0.0f;
+  float k_sum = 0.0f;
+  for (int vec_idx = sg_local_id; vec_idx < num_vec;
+       vec_idx += l2norm_sub_group_size) {
+    auto q_vec = q_vec_ptr[vec_idx];
+    auto k_vec = k_vec_ptr[vec_idx];
+    for (int e = 0; e < VEC_SIZE; ++e) {
+      float q_value = static_cast<float>(q_vec.val[e]);
+      float k_value = static_cast<float>(k_vec.val[e]);
+      q_sum += q_value * q_value;
+      k_sum += k_value * k_value;
+    }
+  }
+
+  q_sum = sycl::reduce_over_group(sg, q_sum, sycl::plus<>());
+  k_sum = sycl::reduce_over_group(sg, k_sum, sycl::plus<>());
+  float q_inv = sycl::rsqrt(q_sum + l2norm_eps) * q_scale;
+  float k_inv = sycl::rsqrt(k_sum + l2norm_eps);
+
+  for (int vec_idx = sg_local_id; vec_idx < num_vec;
+       vec_idx += l2norm_sub_group_size) {
+    auto q_vec = q_vec_ptr[vec_idx];
+    auto k_vec = k_vec_ptr[vec_idx];
+    for (int e = 0; e < VEC_SIZE; ++e) {
+      q_vec.val[e] = static_cast<T>(static_cast<float>(q_vec.val[e]) * q_inv);
+      k_vec.val[e] = static_cast<T>(static_cast<float>(k_vec.val[e]) * k_inv);
+    }
+    q_vec_ptr[vec_idx] = q_vec;
+    k_vec_ptr[vec_idx] = k_vec;
+  }
+}
+
+template <typename T>
+class L2NormKernelTag;
+
+template <typename T>
+class L2NormVecKernelTag;
+
+template <typename T>
+void l2norm_launch(
+    sycl::queue& queue,
+    const torch::Tensor& q,
+    const torch::Tensor& k,
+    const int total_virtual_seqlen,
+    const int num_k_heads,
+    const int head_k_dim) {
+  static constexpr int MaxThreadsPerSM = 512;
+  static constexpr int MaxSubgroupsPerWorkgroup =
+      MaxThreadsPerSM / l2norm_sub_group_size;
+  const int total_qk_heads = total_virtual_seqlen * num_k_heads;
+  const int wg_count =
+      (total_qk_heads + MaxSubgroupsPerWorkgroup - 1) / MaxSubgroupsPerWorkgroup;
+
+  sycl::range<3> local(1, 1, MaxThreadsPerSM);
+  sycl::range<3> global(1, wg_count, 1);
+
+  auto q_ptr = reinterpret_cast<T*>(q.data_ptr());
+  auto k_ptr = reinterpret_cast<T*>(k.data_ptr());
+
+  constexpr int l2norm_vec_width = sizeof(T) * L2NormVecSize;
+  const bool vec_enabled =
+      ((reinterpret_cast<uintptr_t>(q.data_ptr()) & (l2norm_vec_width - 1)) == 0) &&
+      ((reinterpret_cast<uintptr_t>(k.data_ptr()) & (l2norm_vec_width - 1)) == 0) &&
+      ((head_k_dim & (L2NormVecSize - 1)) == 0);
+  queue.submit([&](sycl::handler& cgh) {
+    if (vec_enabled) {
+      cgh.parallel_for<L2NormVecKernelTag<T>>(
+          sycl::nd_range<3>{global * local, local},
+          [=](auto) [[sycl::reqd_sub_group_size(l2norm_sub_group_size)]] {
+            l2norm_vectorized_kernel<T, L2NormVecSize>(
+                q_ptr, k_ptr, total_virtual_seqlen,
+                num_k_heads, head_k_dim);
+          });
+    } else {
+      cgh.parallel_for<L2NormKernelTag<T>>(
+          sycl::nd_range<3>{global * local, local},
+          [=](auto) [[sycl::reqd_sub_group_size(l2norm_sub_group_size)]] {
+            l2norm_kernel<T>(
+                q_ptr, k_ptr, total_virtual_seqlen,
+                num_k_heads, head_k_dim);
+          });
+    }
+  });
+}
+
+void l2norm_xe2(
+    sycl::queue& queue,
+    const torch::Tensor& q,
+    const torch::Tensor& k) {
+  const int total_virtual_seqlen = q.size(0);
+  const int num_k_heads = q.size(1);
+  const int head_k_dim = q.size(2);
+
+  if (q.scalar_type() == at::kBFloat16) {
+    l2norm_launch<sycl::ext::oneapi::bfloat16>(
+        queue, q, k, total_virtual_seqlen, num_k_heads, head_k_dim);
+  } else if (q.scalar_type() == at::kHalf) {
+    l2norm_launch<sycl::half>(
+        queue, q, k, total_virtual_seqlen, num_k_heads, head_k_dim);
+  }
+}
+
+}  // namespace gdn

--- a/csrc/xpu/gdn_attn/xe_2/l2norm.hpp
+++ b/csrc/xpu/gdn_attn/xe_2/l2norm.hpp
@@ -146,8 +146,8 @@ void l2norm_launch(
   static constexpr int MaxSubgroupsPerWorkgroup =
       MaxThreadsPerSM / l2norm_sub_group_size;
   const int total_qk_heads = total_virtual_seqlen * num_k_heads;
-  const int wg_count =
-      (total_qk_heads + MaxSubgroupsPerWorkgroup - 1) / MaxSubgroupsPerWorkgroup;
+  const int wg_count = (total_qk_heads + MaxSubgroupsPerWorkgroup - 1) /
+                       MaxSubgroupsPerWorkgroup;
 
   sycl::range<3> local(1, 1, MaxThreadsPerSM);
   sycl::range<3> global(1, wg_count, 1);
@@ -157,8 +157,10 @@ void l2norm_launch(
 
   constexpr int l2norm_vec_width = sizeof(T) * L2NormVecSize;
   const bool vec_enabled =
-      ((reinterpret_cast<uintptr_t>(q.data_ptr()) & (l2norm_vec_width - 1)) == 0) &&
-      ((reinterpret_cast<uintptr_t>(k.data_ptr()) & (l2norm_vec_width - 1)) == 0) &&
+      ((reinterpret_cast<uintptr_t>(q.data_ptr()) & (l2norm_vec_width - 1)) ==
+       0) &&
+      ((reinterpret_cast<uintptr_t>(k.data_ptr()) & (l2norm_vec_width - 1)) ==
+       0) &&
       ((head_k_dim & (L2NormVecSize - 1)) == 0);
   queue.submit([&](sycl::handler& cgh) {
     if (vec_enabled) {
@@ -166,25 +168,21 @@ void l2norm_launch(
           sycl::nd_range<3>{global * local, local},
           [=](auto) [[sycl::reqd_sub_group_size(l2norm_sub_group_size)]] {
             l2norm_vectorized_kernel<T, L2NormVecSize>(
-                q_ptr, k_ptr, total_virtual_seqlen,
-                num_k_heads, head_k_dim);
+                q_ptr, k_ptr, total_virtual_seqlen, num_k_heads, head_k_dim);
           });
     } else {
       cgh.parallel_for<L2NormKernelTag<T>>(
           sycl::nd_range<3>{global * local, local},
           [=](auto) [[sycl::reqd_sub_group_size(l2norm_sub_group_size)]] {
             l2norm_kernel<T>(
-                q_ptr, k_ptr, total_virtual_seqlen,
-                num_k_heads, head_k_dim);
+                q_ptr, k_ptr, total_virtual_seqlen, num_k_heads, head_k_dim);
           });
     }
   });
 }
 
 void l2norm_xe2(
-    sycl::queue& queue,
-    const torch::Tensor& q,
-    const torch::Tensor& k) {
+    sycl::queue& queue, const torch::Tensor& q, const torch::Tensor& k) {
   const int total_virtual_seqlen = q.size(0);
   const int num_k_heads = q.size(1);
   const int head_k_dim = q.size(2);

--- a/csrc/xpu/gdn_attn/xe_2/l2norm_kernel.hpp
+++ b/csrc/xpu/gdn_attn/xe_2/l2norm_kernel.hpp
@@ -10,7 +10,6 @@ namespace gdn {
 
 static constexpr int l2norm_elem_per_item = 2;
 static constexpr int l2norm_sub_group_size = 16;
-static constexpr float l2norm_eps = 0.000001f;
 static constexpr int L2NormVecSize = 8;
 
 template <typename T>
@@ -181,7 +180,7 @@ void l2norm_launch(
   });
 }
 
-void l2norm_xe2(
+void l2norm_impl(
     sycl::queue& queue, const torch::Tensor& q, const torch::Tensor& k) {
   const int total_virtual_seqlen = q.size(0);
   const int num_k_heads = q.size(1);


### PR DESCRIPTION
# Essential Elements of an Effective PR Description Checklist

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.

PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS ABOVE HAVE BEEN CONSIDERED.

## Purpose

Optimize the l2norm and chunk_fwd_o kernel performance in GDN attention prefill path
- fuse l2norm to conv1d as an epilogue, and give a optimized fallback for can't fused cases
- optimize chunk_fwd_o kernel with register data reuse

## Test Plan

 - [x] Functional correctness verified against baseline (same output from gdn_attention)
 - [x] Performance validation with benchmrk_gdn_attn.py scripts (200 iterations)

## Test Result

All tests/benchmarks run on B60

- [x] All existing unit tests passed
- [x] Performance improvement for prefill path

| shape_name | workload_name | dtype_str | latest_main_GDN(us) | this_PR_GDN(us) | speedup_ratio |
| --- | --- | --- | --- | --- | --- |
| Qwen3-Next-80B_tp1 | prefill_b1_1k | bf16 | 1143.744533 | 1046.057867 | 1.093386 |
| Qwen3-Next-80B_tp1 | prefill_b1_4k | bf16 | 2773.193867 | 2361.693867 | 1.174239 |
| Qwen3-Next-80B_tp1 | prefill_b1_8k | bf16 | 5320.065067 | 4474.919200 | 1.188863 |
| Qwen3-Next-80B_tp1 | prefill_b4_2k | bf16 | 5247.928267 | 4273.057067 | 1.228144 |
| Qwen3-Next-80B_tp1 | prefill_b8_1k | bf16 | 5300.384533 | 4370.102133 | 1.212874 |
| Qwen3-Next-80B_tp1 | prefill_b16_512 | bf16 | 4870.897600 | 4372.238133 | 1.114051 |
| Qwen3-Next-80B_tp1 | prefill_b32_256 | bf16 | 5050.569600 | 4479.063733 | 1.127595 |
| Qwen3-Next-80B_tp1 | mix_b32_1k_d050 | bf16 | 10528.408800 | 9331.206400 | 1.128301 |
| Qwen3-Next-80B_tp1 | mix_b64_512_d075 | bf16 | 6575.302933 | 5879.909333 | 1.118266 |
| Qwen3-Next-80B_tp1 | mix_b16_2k_d025 | bf16 | 14511.208800 | 13319.674667 | 1.089457 |
| Qwen3-Next-80B_tp2 | prefill_b1_1k | bf16 | 654.554933 | 589.291467 | 1.110749 |
| Qwen3-Next-80B_tp2 | prefill_b1_4k | bf16 | 1766.699733 | 1486.699733 | 1.188337 |
| Qwen3-Next-80B_tp2 | prefill_b1_8k | bf16 | 3414.631467 | 2832.301600 | 1.205603 |
| Qwen3-Next-80B_tp2 | prefill_b4_2k | bf16 | 2519.197067 | 2201.681867 | 1.144215 |
| Qwen3-Next-80B_tp2 | prefill_b8_1k | bf16 | 2528.788000 | 2207.488267 | 1.145550 |
| Qwen3-Next-80B_tp2 | prefill_b16_512 | bf16 | 2753.017333 | 2255.450667 | 1.220606 |
| Qwen3-Next-80B_tp2 | prefill_b32_256 | bf16 | 2609.502667 | 2267.249333 | 1.150955 |
| Qwen3-Next-80B_tp2 | mix_b32_1k_d050 | bf16 | 5948.448267 | 4741.911200 | 1.254441 |
| Qwen3-Next-80B_tp2 | mix_b64_512_d075 | bf16 | 3389.805600 | 2961.820533 | 1.144501 |
| Qwen3-Next-80B_tp2 | mix_b16_2k_d025 | bf16 | 8296.458400 | 6829.293600 | 1.214834 |
| Qwen3-Next-80B_tp4 | prefill_b1_1k | bf16 | 446.445867 | 394.120533 | 1.132765 |
| Qwen3-Next-80B_tp4 | prefill_b1_4k | bf16 | 1277.983200 | 1080.777333 | 1.182467 |
| Qwen3-Next-80B_tp4 | prefill_b1_8k | bf16 | 2506.859733 | 2092.247467 | 1.198166 |
| Qwen3-Next-80B_tp4 | prefill_b4_2k | bf16 | 1506.885333 | 1135.966933 | 1.326522 |
| Qwen3-Next-80B_tp4 | prefill_b8_1k | bf16 | 1259.194933 | 1092.444800 | 1.152639 |
| Qwen3-Next-80B_tp4 | prefill_b16_512 | bf16 | 1410.798133 | 1112.016267 | 1.268685 |
| Qwen3-Next-80B_tp4 | prefill_b32_256 | bf16 | 1341.820267 | 1131.927200 | 1.185430 |
| Qwen3-Next-80B_tp4 | mix_b32_1k_d050 | bf16 | 2749.144000 | 2379.498933 | 1.155346 |
| Qwen3-Next-80B_tp4 | mix_b64_512_d075 | bf16 | 1741.901600 | 1521.038933 | 1.145205 |
| Qwen3-Next-80B_tp4 | mix_b16_2k_d025 | bf16 | 4042.788000 | 3557.128533 | 1.136531 |
| Qwen3-Next-80B_tp8 | prefill_b1_1k | bf16 | 341.200800 | 307.318133 | 1.110253 |
| Qwen3-Next-80B_tp8 | prefill_b1_4k | bf16 | 1065.836800 | 891.526933 | 1.195518 |
| Qwen3-Next-80B_tp8 | prefill_b1_8k | bf16 | 2255.203467 | 1703.990400 | 1.323484 |
| Qwen3-Next-80B_tp8 | prefill_b4_2k | bf16 | 867.734400 | 726.260800 | 1.194797 |
| Qwen3-Next-80B_tp8 | prefill_b8_1k | bf16 | 688.051200 | 585.589067 | 1.174973 |
| Qwen3-Next-80B_tp8 | prefill_b16_512 | bf16 | 652.401067 | 560.246133 | 1.164490 |
| Qwen3-Next-80B_tp8 | prefill_b32_256 | bf16 | 748.766933 | 581.197867 | 1.288317 |
| Qwen3-Next-80B_tp8 | mix_b32_1k_d050 | bf16 | 1466.780000 | 1196.685867 | 1.225702 |
| Qwen3-Next-80B_tp8 | mix_b64_512_d075 | bf16 | 971.943467 | 776.396267 | 1.251865 |
| Qwen3-Next-80B_tp8 | mix_b16_2k_d025 | bf16 | 1947.354667 | 1685.047467 | 1.155668 |
| Synthetic_MHA_16x16 | prefill_b1_1k | bf16 | 746.684267 | 658.809333 | 1.133384 |
| Synthetic_MHA_16x16 | prefill_b1_4k | bf16 | 2121.663200 | 1754.300000 | 1.209407 |
| Synthetic_MHA_16x16 | prefill_b1_8k | bf16 | 4571.701067 | 3419.461867 | 1.336965 |
| Synthetic_MHA_16x16 | prefill_b4_2k | bf16 | 3456.717333 | 2821.353067 | 1.225198 |
| Synthetic_MHA_16x16 | prefill_b8_1k | bf16 | 3397.118933 | 2873.385600 | 1.182270 |
| Synthetic_MHA_16x16 | prefill_b16_512 | bf16 | 3534.667733 | 2965.956533 | 1.191746 |
| Synthetic_MHA_16x16 | prefill_b32_256 | bf16 | 3642.697333 | 3075.911467 | 1.184266 |
| Synthetic_MHA_16x16 | mix_b32_1k_d050 | bf16 | 8123.423733 | 6388.917067 | 1.271487 |
| Synthetic_MHA_16x16 | mix_b64_512_d075 | bf16 | 5013.265333 | 4022.301600 | 1.246367 |
| Synthetic_MHA_16x16 | mix_b16_2k_d025 | bf16 | 10826.216533 | 8931.961600 | 1.212076 |
| Synthetic_16x64x128 | prefill_b1_1k | bf16 | 1812.353333 | 1759.622933 | 1.029967 |
| Synthetic_16x64x128 | prefill_b1_4k | bf16 | 4117.195200 | 3921.849867 | 1.049809 |
| Synthetic_16x64x128 | prefill_b1_8k | bf16 | 7921.920000 | 7418.583467 | 1.067848 |
| Synthetic_16x64x128 | prefill_b4_2k | bf16 | 8280.700533 | 7611.912800 | 1.087861 |
| Synthetic_16x64x128 | prefill_b8_1k | bf16 | 8145.688267 | 7503.612000 | 1.085569 |
| Synthetic_16x64x128 | prefill_b16_512 | bf16 | 8136.714933 | 7529.496800 | 1.080645 |
| Synthetic_16x64x128 | prefill_b32_256 | bf16 | 8526.493067 | 7816.762400 | 1.090796 |
| Synthetic_16x64x128 | mix_b32_1k_d050 | bf16 | 17671.464533 | 16363.210133 | 1.079951 |
| Synthetic_16x64x128 | mix_b64_512_d075 | bf16 | 11728.190667 | 10261.055200 | 1.142981 |
| Synthetic_16x64x128 | mix_b16_2k_d025 | bf16 | 24979.073067 | 23789.220000 | 1.050016 |
| Synthetic_16x32x256 | prefill_b1_1k | bf16 | 2286.741600 | 1900.899200 | 1.202979 |
| Synthetic_16x32x256 | prefill_b1_4k | bf16 | 5753.151467 | 5129.606400 | 1.121558 |
| Synthetic_16x32x256 | prefill_b1_8k | bf16 | 11447.813600 | 10075.361067 | 1.136219 |
| Synthetic_16x32x256 | prefill_b4_2k | bf16 | 11618.789600 | 10360.146400 | 1.121489 |
| Synthetic_16x32x256 | prefill_b8_1k | bf16 | 12057.759467 | 11000.622933 | 1.096098 |
| Synthetic_16x32x256 | prefill_b16_512 | bf16 | 11619.528533 | 10786.278667 | 1.077251 |
| Synthetic_16x32x256 | prefill_b32_256 | bf16 | 12237.132267 | 11208.512533 | 1.091771 |
| Synthetic_16x32x256 | mix_b32_1k_d050 | bf16 | 24955.599200 | 24098.752800 | 1.035556 |
| Synthetic_16x32x256 | mix_b64_512_d075 | bf16 | 14674.086400 | 14066.762400 | 1.043174 |
| Synthetic_16x32x256 | mix_b16_2k_d025 | bf16 | 36300.517867 | 34018.544800 | 1.067080 |
| TOTAL_GEOMEAN |  |  |  |  | 1.157516 |


- [x] No performance regression for decode path

| shape_name | workload_name | dtype_str | latest_main_GDN(us) | this_PR_GDN(us) | speedup_ratio |
| --- | --- | --- | --- | --- | --- |
| Qwen3-Next-80B_tp1 | decode_b1 | bf16 | 21.069867 | 20.672800 | 1.019207 |
| Qwen3-Next-80B_tp1 | decode_b8 | bf16 | 69.492800 | 74.091733 | 0.937929 |
| Qwen3-Next-80B_tp1 | decode_b32 | bf16 | 242.132533 | 232.093867 | 1.043253 |
| Qwen3-Next-80B_tp1 | decode_b128 | bf16 | 913.827733 | 887.441867 | 1.029733 |
| Qwen3-Next-80B_tp1 | decode_b256 | bf16 | 1889.960267 | 1836.386933 | 1.029173 |
| Qwen3-Next-80B_tp1 | spec_b16_mtp1 | bf16 | 209.535733 | 209.168267 | 1.001757 |
| Qwen3-Next-80B_tp1 | spec_b32_mtp1 | bf16 | 440.944267 | 425.838400 | 1.035473 |
| Qwen3-Next-80B_tp1 | spec_b64_mtp1 | bf16 | 851.049333 | 837.103200 | 1.016660 |
| Qwen3-Next-80B_tp1 | spec_b16_mtp3 | bf16 | 448.006933 | 434.041600 | 1.032175 |
| Qwen3-Next-80B_tp2 | decode_b1 | bf16 | 20.296533 | 19.679733 | 1.031342 |
| Qwen3-Next-80B_tp2 | decode_b8 | bf16 | 27.036267 | 27.243733 | 0.992385 |
| Qwen3-Next-80B_tp2 | decode_b32 | bf16 | 102.105867 | 88.428267 | 1.154675 |
| Qwen3-Next-80B_tp2 | decode_b128 | bf16 | 505.571733 | 443.041067 | 1.141140 |
| Qwen3-Next-80B_tp2 | decode_b256 | bf16 | 1047.920000 | 920.748000 | 1.138118 |
| Qwen3-Next-80B_tp2 | spec_b16_mtp1 | bf16 | 89.329067 | 75.708800 | 1.179903 |
| Qwen3-Next-80B_tp2 | spec_b32_mtp1 | bf16 | 219.607733 | 206.295200 | 1.064531 |
| Qwen3-Next-80B_tp2 | spec_b64_mtp1 | bf16 | 439.212800 | 425.514667 | 1.032192 |
| Qwen3-Next-80B_tp2 | spec_b16_mtp3 | bf16 | 210.697067 | 210.498667 | 1.000943 |
| Qwen3-Next-80B_tp4 | decode_b1 | bf16 | 19.589333 | 20.212800 | 0.969155 |
| Qwen3-Next-80B_tp4 | decode_b8 | bf16 | 20.182133 | 20.183467 | 0.999934 |
| Qwen3-Next-80B_tp4 | decode_b32 | bf16 | 43.009600 | 43.188000 | 0.995869 |
| Qwen3-Next-80B_tp4 | decode_b128 | bf16 | 212.298400 | 212.094133 | 1.000963 |
| Qwen3-Next-80B_tp4 | decode_b256 | bf16 | 477.440267 | 462.571200 | 1.032144 |
| Qwen3-Next-80B_tp4 | spec_b16_mtp1 | bf16 | 39.272800 | 39.869333 | 0.985038 |
| Qwen3-Next-80B_tp4 | spec_b32_mtp1 | bf16 | 74.963733 | 73.480800 | 1.020181 |
| Qwen3-Next-80B_tp4 | spec_b64_mtp1 | bf16 | 221.283467 | 207.490400 | 1.066476 |
| Qwen3-Next-80B_tp4 | spec_b16_mtp3 | bf16 | 76.248000 | 75.761067 | 1.006427 |
| Qwen3-Next-80B_tp8 | decode_b1 | bf16 | 19.815467 | 19.692000 | 1.006270 |
| Qwen3-Next-80B_tp8 | decode_b8 | bf16 | 19.932800 | 18.572267 | 1.073256 |
| Qwen3-Next-80B_tp8 | decode_b32 | bf16 | 27.608533 | 27.592000 | 1.000599 |
| Qwen3-Next-80B_tp8 | decode_b128 | bf16 | 90.125867 | 89.909067 | 1.002411 |
| Qwen3-Next-80B_tp8 | decode_b256 | bf16 | 231.534933 | 231.451467 | 1.000361 |
| Qwen3-Next-80B_tp8 | spec_b16_mtp1 | bf16 | 23.254933 | 23.573600 | 0.986482 |
| Qwen3-Next-80B_tp8 | spec_b32_mtp1 | bf16 | 38.287733 | 39.227200 | 0.976051 |
| Qwen3-Next-80B_tp8 | spec_b64_mtp1 | bf16 | 74.709333 | 74.342400 | 1.004936 |
| Qwen3-Next-80B_tp8 | spec_b16_mtp3 | bf16 | 38.630400 | 38.511467 | 1.003088 |
| Synthetic_MHA_16x16 | decode_b1 | bf16 | 19.288267 | 19.437600 | 0.992317 |
| Synthetic_MHA_16x16 | decode_b8 | bf16 | 26.113333 | 25.933867 | 1.006920 |
| Synthetic_MHA_16x16 | decode_b32 | bf16 | 90.348000 | 90.282933 | 1.000721 |
| Synthetic_MHA_16x16 | decode_b128 | bf16 | 491.529067 | 465.817867 | 1.055196 |
| Synthetic_MHA_16x16 | decode_b256 | bf16 | 1103.097067 | 971.337333 | 1.135648 |
| Synthetic_MHA_16x16 | spec_b16_mtp1 | bf16 | 79.814133 | 79.400267 | 1.005212 |
| Synthetic_MHA_16x16 | spec_b32_mtp1 | bf16 | 213.691200 | 213.929067 | 0.998888 |
| Synthetic_MHA_16x16 | spec_b64_mtp1 | bf16 | 439.831733 | 439.968800 | 0.999688 |
| Synthetic_MHA_16x16 | spec_b16_mtp3 | bf16 | 218.241333 | 219.109067 | 0.996040 |
| Synthetic_16x64x128 | decode_b1 | bf16 | 21.880267 | 19.081333 | 1.146684 |
| Synthetic_16x64x128 | decode_b8 | bf16 | 83.582133 | 84.047467 | 0.994463 |
| Synthetic_16x64x128 | decode_b32 | bf16 | 422.604533 | 422.832000 | 0.999462 |
| Synthetic_16x64x128 | decode_b128 | bf16 | 1701.089067 | 1701.016533 | 1.000043 |
| Synthetic_16x64x128 | decode_b256 | bf16 | 3515.294667 | 3533.774400 | 0.994771 |
| Synthetic_16x64x128 | spec_b16_mtp1 | bf16 | 433.013867 | 419.664800 | 1.031809 |
| Synthetic_16x64x128 | spec_b32_mtp1 | bf16 | 848.614933 | 823.552267 | 1.030432 |
| Synthetic_16x64x128 | spec_b64_mtp1 | bf16 | 1670.239733 | 1631.444267 | 1.023780 |
| Synthetic_16x64x128 | spec_b16_mtp3 | bf16 | 867.122133 | 840.770400 | 1.031342 |
| Synthetic_16x32x256 | decode_b1 | bf16 | 92.632533 | 79.691200 | 1.162394 |
| Synthetic_16x32x256 | decode_b8 | bf16 | 372.423200 | 356.875200 | 1.043567 |
| Synthetic_16x32x256 | decode_b32 | bf16 | 1789.158133 | 1734.416800 | 1.031562 |
| Synthetic_16x32x256 | decode_b128 | bf16 | 7025.948000 | 6807.321600 | 1.032116 |
| Synthetic_16x32x256 | decode_b256 | bf16 | 14127.023733 | 13674.105067 | 1.033122 |
| Synthetic_16x32x256 | spec_b16_mtp1 | bf16 | 1031.384267 | 1004.659200 | 1.026601 |
| Synthetic_16x32x256 | spec_b32_mtp1 | bf16 | 2178.704533 | 1980.450400 | 1.100106 |
| Synthetic_16x32x256 | spec_b64_mtp1 | bf16 | 4495.553867 | 3936.062133 | 1.142145 |
| Synthetic_16x32x256 | spec_b16_mtp3 | bf16 | 2284.397867 | 1979.663733 | 1.153932 |
| TOTAL_GEOMEAN |  |  |  |  | 1.033246 |


## (Optional) Documentation Update

**BEFORE SUBMITTING, PLEASE READ <https://docs.vllm.ai/en/latest/contributing>** (anything written below this line will be removed by GitHub Actions)
