### PR TITLE
[Attn]enhance sliding_attn boundary check

### DIFF
--- a/csrc/xpu/attn/xe_2/collective/chunk_prefill_mainloop.hpp
+++ b/csrc/xpu/attn/xe_2/collective/chunk_prefill_mainloop.hpp
@@ -269,7 +269,9 @@ struct FMHAFwdMainloop<
       int blk_k1_causal,
       int thr_id,
       int seq_len,
-      int full_tile_offset) {
+      int full_tile_offset,
+      int blk_local_l_safe,
+      int blk_local_r_safe) {
     using namespace sycl::ext::oneapi::this_work_item;
 
     // Short dimension names:
@@ -465,18 +467,22 @@ struct FMHAFwdMainloop<
       }
       /* Local masking */
       if constexpr (LocalMask) {
-        Tensor cPgP = make_identity_tensor(make_shape(seq_len, seq_len));
-        Tensor gP = local_tile(
-            cPgP, take<0, 2>(TileShapeQK{}), make_coord(get<0>(blk_qv), K));
-        auto cS_thread = thr_mma_qk.partition_C(gP);
-        CUTLASS_PRAGMA_UNROLL
-        for (int i = 0; i < tSrS.size(); ++i) {
-          int row_idx = get<0>(cS_thread(i));
-          int col_idx = get<1>(cS_thread(i)) - full_tile_offset;
-          bool left_mask = col_idx < row_idx - params.local_left;
-          bool right_mask = col_idx > row_idx + params.local_right;
-          if (left_mask || right_mask) {
-            tSrS(i) = ElementS(-INFINITY);
+        const bool need_left = (K < blk_local_l_safe);
+        const bool need_right = (K > blk_local_r_safe);
+        if (need_left || need_right) {
+          Tensor cPgP = make_identity_tensor(make_shape(seq_len, seq_len));
+          Tensor gP = local_tile(
+              cPgP, take<0, 2>(TileShapeQK{}), make_coord(get<0>(blk_qv), K));
+          auto cS_thread = thr_mma_qk.partition_C(gP);
+          CUTLASS_PRAGMA_UNROLL
+          for (int i = 0; i < tSrS.size(); ++i) {
+            int row_idx = get<0>(cS_thread(i));
+            int col_idx = get<1>(cS_thread(i)) - full_tile_offset;
+            bool left_mask = col_idx < row_idx - params.local_left;
+            bool right_mask = col_idx > row_idx + params.local_right;
+            if (left_mask || right_mask) {
+              tSrS(i) = ElementS(-INFINITY);
+            }
           }
         }
       }

--- a/csrc/xpu/attn/xe_2/kernel/chunk_prefill_kernel.hpp
+++ b/csrc/xpu/attn/xe_2/kernel/chunk_prefill_kernel.hpp
@@ -272,16 +272,16 @@ class XeFMHAFwdKernel {
           cute::min(seq_len_qo, (blk_q * get<0>(TileShapeQK{}) + q_offset_sg));
 
       // calc sg level seq_len_kv
-      const int seq_len =
-          CausalMask
-              ? LocalMask
+      const int sg_seq_len =
+          LocalMask
+              ? cute::min(
+                    seq_len_kv,
+                    full_tile_offset + seq_coord + q_sg_tile +
+                        params.mainloop.local_right)
+              : CausalMask
                     ? cute::min(
-                          seq_len_kv,
-                          full_tile_offset + seq_coord + q_sg_tile +
-                              params.mainloop.local_right)
-                    : cute::min(
                           seq_len_kv, full_tile_offset + seq_coord + q_sg_tile)
-              : seq_len_kv;
+                    : seq_len_kv;
       const int sg_k_block0 =
           LocalMask
               ? cute::max(
@@ -289,18 +289,40 @@ class XeFMHAFwdKernel {
                     0) /
                     get<1>(TileShapeQK{})
               : 0;
-      const int sg_k_blocks = cute::ceil_div(seq_len, get<1>(TileShapeQK{}));
+      const int sg_k_blocks =
+          cute::ceil_div(sg_seq_len, get<1>(TileShapeQK{}));
       const int sg_k_blocks_causal =
           CausalMask ? (seq_coord + full_tile_offset) / get<1>(TileShapeQK{})
                      : 0;
+      const int sg_k_block_local_l_safe =
+          LocalMask
+              ? cute::ceil_div(
+                    cute::max(
+                        seq_coord + q_sg_tile - 1 + full_tile_offset -
+                            params.mainloop.local_left,
+                        0),
+                    get<1>(TileShapeQK{}))
+              : 0;
+      const int sg_k_block_local_r_safe =
+          LocalMask
+              ? (seq_coord + full_tile_offset +
+                 params.mainloop.local_right + 1) /
+                        get<1>(TileShapeQK{}) -
+                    1
+              : 0;
 
       // The mainloop wraps each K iteration in a workgroup-scoped barrier
       // pair, so every subgroup in the workgroup must execute the same
       // K-loop trip count. Reduce the per-SG bounds across the WG:
       //   k_block0        = min across WG (start no later than any SG)
       //   k_blocks        = max across WG (end no earlier than any SG)
+      //   seq_len         = max across WG (common LocalMask upper bound)
       //   k_blocks_causal = min across WG (turn on causal masking no later
       //                                    than any SG needs it)
+      //   k_block_local_l_safe = max across WG (left mask off no earlier
+      //                                         than any SG needs it on)
+      //   k_block_local_r_safe = min across WG (right mask on no earlier
+      //                                         than any SG needs it on)
       // Per-element causal / local / remainder masking inside the mainloop
       // handles the widened range safely for SGs that didn't need it.
       auto wg = sycl::ext::oneapi::this_work_item::get_work_group<3>();
@@ -312,10 +334,24 @@ class XeFMHAFwdKernel {
           (CausalMask || LocalMask)
               ? sycl::reduce_over_group(wg, sg_k_blocks, sycl::maximum<int>{})
               : sg_k_blocks;
+      const int seq_len =
+          LocalMask ? sycl::reduce_over_group(
+                          wg, sg_seq_len, sycl::maximum<int>{})
+                    : sg_seq_len;
       const int k_blocks_causal =
           CausalMask ? sycl::reduce_over_group(
                            wg, sg_k_blocks_causal, sycl::minimum<int>{})
                      : 0;
+      const int k_block_local_l_safe =
+          LocalMask
+              ? sycl::reduce_over_group(
+                    wg, sg_k_block_local_l_safe, sycl::maximum<int>{})
+              : 0;
+      const int k_block_local_r_safe =
+          LocalMask
+              ? sycl::reduce_over_group(
+                    wg, sg_k_block_local_r_safe, sycl::minimum<int>{})
+              : 0;
 
       int offset_q = 0, offset_k = 0, offset_v = 0, offset_o = 0;
       if constexpr (is_var_len) {
@@ -378,7 +414,9 @@ class XeFMHAFwdKernel {
           k_blocks_causal,
           thr_id,
           seq_len,
-          full_tile_offset);
+          full_tile_offset,
+          k_block_local_l_safe,
+          k_block_local_r_safe);
 
       // return softmax_lse
       if constexpr (SoftmaxLSE) {

--- a/csrc/xpu/attn/xe_2/kernel/chunk_prefill_kernel.hpp
+++ b/csrc/xpu/attn/xe_2/kernel/chunk_prefill_kernel.hpp
@@ -273,15 +273,13 @@ class XeFMHAFwdKernel {
 
       // calc sg level seq_len_kv
       const int sg_seq_len =
-          LocalMask
-              ? cute::min(
-                    seq_len_kv,
-                    full_tile_offset + seq_coord + q_sg_tile +
-                        params.mainloop.local_right)
-              : CausalMask
-                    ? cute::min(
-                          seq_len_kv, full_tile_offset + seq_coord + q_sg_tile)
-                    : seq_len_kv;
+          LocalMask ? cute::min(
+                          seq_len_kv,
+                          full_tile_offset + seq_coord + q_sg_tile +
+                              params.mainloop.local_right)
+          : CausalMask
+              ? cute::min(seq_len_kv, full_tile_offset + seq_coord + q_sg_tile)
+              : seq_len_kv;
       const int sg_k_block0 =
           LocalMask
               ? cute::max(
@@ -289,25 +287,22 @@ class XeFMHAFwdKernel {
                     0) /
                     get<1>(TileShapeQK{})
               : 0;
-      const int sg_k_blocks =
-          cute::ceil_div(sg_seq_len, get<1>(TileShapeQK{}));
+      const int sg_k_blocks = cute::ceil_div(sg_seq_len, get<1>(TileShapeQK{}));
       const int sg_k_blocks_causal =
           CausalMask ? (seq_coord + full_tile_offset) / get<1>(TileShapeQK{})
                      : 0;
       const int sg_k_block_local_l_safe =
-          LocalMask
-              ? cute::ceil_div(
-                    cute::max(
-                        seq_coord + q_sg_tile - 1 + full_tile_offset -
-                            params.mainloop.local_left,
-                        0),
-                    get<1>(TileShapeQK{}))
-              : 0;
+          LocalMask ? cute::ceil_div(
+                          cute::max(
+                              seq_coord + q_sg_tile - 1 + full_tile_offset -
+                                  params.mainloop.local_left,
+                              0),
+                          get<1>(TileShapeQK{}))
+                    : 0;
       const int sg_k_block_local_r_safe =
           LocalMask
-              ? (seq_coord + full_tile_offset +
-                 params.mainloop.local_right + 1) /
-                        get<1>(TileShapeQK{}) -
+              ? (seq_coord + full_tile_offset + params.mainloop.local_right +
+                 1) / get<1>(TileShapeQK{}) -
                     1
               : 0;
 
@@ -334,24 +329,21 @@ class XeFMHAFwdKernel {
           (CausalMask || LocalMask)
               ? sycl::reduce_over_group(wg, sg_k_blocks, sycl::maximum<int>{})
               : sg_k_blocks;
-      const int seq_len =
-          LocalMask ? sycl::reduce_over_group(
-                          wg, sg_seq_len, sycl::maximum<int>{})
-                    : sg_seq_len;
+      const int seq_len = LocalMask ? sycl::reduce_over_group(
+                                          wg, sg_seq_len, sycl::maximum<int>{})
+                                    : sg_seq_len;
       const int k_blocks_causal =
           CausalMask ? sycl::reduce_over_group(
                            wg, sg_k_blocks_causal, sycl::minimum<int>{})
                      : 0;
       const int k_block_local_l_safe =
-          LocalMask
-              ? sycl::reduce_over_group(
-                    wg, sg_k_block_local_l_safe, sycl::maximum<int>{})
-              : 0;
+          LocalMask ? sycl::reduce_over_group(
+                          wg, sg_k_block_local_l_safe, sycl::maximum<int>{})
+                    : 0;
       const int k_block_local_r_safe =
-          LocalMask
-              ? sycl::reduce_over_group(
-                    wg, sg_k_block_local_r_safe, sycl::minimum<int>{})
-              : 0;
+          LocalMask ? sycl::reduce_over_group(
+                          wg, sg_k_block_local_r_safe, sycl::minimum<int>{})
+                    : 0;
 
       int offset_q = 0, offset_k = 0, offset_v = 0, offset_o = 0;
       if constexpr (is_var_len) {


### PR DESCRIPTION
This PR tightens and optimizes sliding-window attention (`LocalMask`) in the XPU `xe_2` chunk-prefill attention kernel (`csrc/xpu/attn/xe_2/`).
In chunk prefill, the query tile is right-aligned against the full KV sequence. The kernel receives:

- `seq_len_qo`: the current query/chunk length
- `seq_len_kv`: the total KV length, including previous cached tokens
- `full_tile_offset = seq_len_kv - seq_len_qo`

The pre-existing implementation had 3 related shortcomings:
1.**Missing right-edge clipping for (CausalMask=false, LocalMask=true).** The outer seq_len (and therefore the K-block count) fell back to the full seq_len_kv instead of being clipped by local_right. Correctness was preserved because the element-wise local mask still zeroed out invalid positions, but the kernel issued unnecessary K/V loads and ran extra QK/PV work.
2. **SG-local bounds used without work-group reconciliation**. The K-loop boundary values (k_block0, k_blocks, the LocalMask seq_len, and k_blocks_causal) are naturally computed per SG, but were not consistently reduced to a single WG-wide range before being used as loop bounds under the WG barrier.
3. **No interior-block fast path for LocalMask.** The causal path already skips mask evaluation for blocks below its causal boundary, but the local-mask path evaluated left_mask || right_mask element-wise for every K block — including blocks that lie fully inside the window for all SGs and can never trigger a mask.

This PR makes the sliding-window boundary handling explicit and conservative at the work-group level.
- Work-group-level K-loop bounds cover the union of all subgroup requirements, so no subgroup misses K blocks it may need.
- Any extra K blocks introduced by work-group reduction are still protected by the existing element-wise local/causal/remainder masks.
- The new local-mask skip path is only taken when the K block is fully inside the local window for all subgroups in the work-group.
- When LocalMask=false, the new local-safe-bound logic is compiled out or reduced to neutral values, so non-sliding-window paths are not affected.
- If no K block is right-safe for a work-group, the right-safe boundary can conservatively make need_right true for all K blocks, which falls back to the previous element-wise local-mask behavior.


## Impact
We have verified benefits (i.e. reduction in TTFT) on sliding-attention models (eg. Gemma4 & Ministral) without afftecting other decode-related metrics such as TPOT and generation rate. We have also verified that non-sliding-attention models (eg. Qwen3) is not influenced. 

| Model |  Device & Config | TTFT mean <br> Before fix (ms) | TTFT mean <br> After fix (ms) |  Relative Ratio | 
| --- | --- | ---: | ---: | ---: |
| Gemma-4-26B-it | B70, isl/osl=4k/1k <br> tp=4, concurrency=32 |**4130.28** |**3726.19**| **-9.79%** |
| Gemma-4-26B-it | B60, isl/osl=4k/1k <br> tp=4, concurrency=16 |**3417.15** |**3358.03**| **-1.73%** |
| Gemma-4-12B-it | B60, isl/osl=4k/1k <br> tp=4, concurrency=16 |**4842.34** |**4661.33**| **-3.74%** |
| Ministral-8B-Instruct-2410 | B60, isl/osl=32k/1k <br> tp=4, concurrency=8 |**34648.85** |**27808.37**| **-19.74%** |

The expected improvement depends on:
-  the ratio between local-window size and total KV length
-  how much of the attention time is spent in mask-related work versus QK/PV GEMM
-  how much the work-group reduction widens the conservative boundary region.





## Co-authors

- Yongqi Wang (@yongqiw-i)