### PR TITLE
[Attn] Fix k/v cache scale issue

### DIFF
--- a/vllm_xpu_kernels/flash_attn_interface.py
+++ b/vllm_xpu_kernels/flash_attn_interface.py
@@ -337,12 +337,10 @@ def flash_attn_varlen_func(
     if softmax_scale is None:
         softmax_scale = q.shape[-1]**(-0.5)
     if k_descale is not None:
-        assert sum(k_descale.stride()) == 0 and \
-            k_descale.dtype == torch.float32, \
+        assert k_descale.untyped_storage().nbytes() == 4, \
             "k_descale must be view of single float32 scalar tensor"
     if v_descale is not None:
-        assert sum(v_descale.stride()) == 0 and \
-            v_descale.dtype == torch.float32, \
+        assert v_descale.untyped_storage().nbytes() == 4, \
             "v_descale must be view of single float32 scalar tensor"
     # custom op does not support non-tuple input
     real_window_size: tuple[int, int]

--- a/vllm_xpu_kernels/flash_attn_interface.py
+++ b/vllm_xpu_kernels/flash_attn_interface.py
@@ -337,10 +337,12 @@ def flash_attn_varlen_func(
     if softmax_scale is None:
         softmax_scale = q.shape[-1]**(-0.5)
     if k_descale is not None:
-        assert k_descale.untyped_storage().nbytes() == 4, \
+        assert k_descale.untyped_storage().nbytes() == 4 and \
+            k_descale.dtype == torch.float32, \
             "k_descale must be view of single float32 scalar tensor"
     if v_descale is not None:
-        assert v_descale.untyped_storage().nbytes() == 4, \
+        assert v_descale.untyped_storage().nbytes() == 4 and \
+            v_descale.dtype == torch.float32, \
             "v_descale must be view of single float32 scalar tensor"
     # custom op does not support non-tuple input
     real_window_size: tuple[int, int]


### PR DESCRIPTION
# Essential Elements of an Effective PR Description Checklist

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.

PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS ABOVE HAVE BEEN CONSIDERED.

## Purpose
we always assert `sum(k_descale.stride()) == 0` for k/v cache scale. 
while there are some corner case in vllm that we will call like: 

```
_k_scale = torch.ones(1)
descale_shape = (num_tokens, num_kv_heads)
k_scale = _k_scale.expand(descale_shape)
```
if num_kv_heads == 1, expand().stride() result will not be zero, assert here will fail.

this PR try to use  `untyped_storage().nbytes()` to avoid such case.

## Test Plan

python3 examples/basic/offline_inference/generate.py --model RedHatAI/Qwen3-Next-80B-A3B-Instruct-quantized.w4a16 -tp 2 --max-model-len 4096 --enforce-eager

## Test Result

## (Optional) Documentation Update

**BEFORE SUBMITTING, PLEASE READ <https://docs.vllm.ai/en/latest/contributing>** (anything written below this line will be removed by GitHub Actions)
