### PR TITLE
Fix RMSNorm work-group size: round down to power of 2

### DIFF
--- a/csrc/layernorm.cpp
+++ b/csrc/layernorm.cpp
@@ -1,6 +1,7 @@
 #include <sycl/sycl.hpp>
 
 #include <algorithm>
+#include <bit>
 #include <ATen/DeviceGuard.h>
 #include "utils.h"
 #include "dispatch_utils.h"
@@ -450,8 +451,11 @@ void call_rms_norm_kernel(
       return;
     }
     sycl::range<3> grid(1, 1, num_tokens);
-    sycl::range<3> block(
-        1, 1, std::min(hidden_size / vec_size, max_block_size));
+    // Round down to nearest power of 2: sycl::reduce_over_group requires
+    // power-of-2 work-group sizes for correct results on XPU.
+    const int block_dim = std::bit_floor(
+        (unsigned)std::min(hidden_size / vec_size, max_block_size));
+    sycl::range<3> block(1, 1, block_dim);
     VLLM_DISPATCH_RANK234(num_dims, [&]() {
       queue.submit([&](sycl::handler& cgh) {
         sycl::local_accessor<float, 1> s_variance(sycl::range<1>(1), cgh);
@@ -474,7 +478,8 @@ void call_rms_norm_kernel(
     });
   } else {
     sycl::range<3> grid(1, 1, num_tokens);
-    sycl::range<3> block(1, 1, std::min(hidden_size, max_block_size));
+    sycl::range<3> block(1, 1, std::bit_floor(
+        (unsigned)std::min(hidden_size, max_block_size)));
     VLLM_DISPATCH_RANK234(num_dims, [&]() {
       queue.submit([&](sycl::handler& cgh) {
         sycl::local_accessor<float, 1> s_variance(sycl::range<1>(1), cgh);
@@ -684,8 +689,10 @@ void call_fused_add_rms_norm_kernel(
   auto& queue = vllm::xpu::vllmGetQueue();
 
   if (can_vec) {
-    sycl::range<3> block(
-        1, 1, std::min(hidden_size / vector_width, max_block_size));
+    // Round down to nearest power of 2: sycl::reduce_over_group requires
+    // power-of-2 work-group sizes for correct results on XPU.
+    sycl::range<3> block(1, 1, std::bit_floor(
+        (unsigned)std::min(hidden_size / vector_width, max_block_size)));
     queue.submit([&](sycl::handler& cgh) {
       sycl::local_accessor<float, 1> s_variance(sycl::range<1>(1), cgh);
       cgh.parallel_for(
@@ -701,7 +708,8 @@ void call_fused_add_rms_norm_kernel(
               s_variance));
     });
   } else {
-    sycl::range<3> block(1, 1, std::min(hidden_size, max_block_size));
+    sycl::range<3> block(1, 1, std::bit_floor(
+        (unsigned)std::min(hidden_size, max_block_size)));
     queue.submit([&](sycl::handler& cgh) {
       sycl::local_accessor<float, 1> s_variance(sycl::range<1>(1), cgh);
       cgh.parallel_for(

--- a/csrc/moe/moe_align_sum_kernels.cpp
+++ b/csrc/moe/moe_align_sum_kernels.cpp
@@ -764,7 +764,7 @@ class moe_lora_align_block_size_kernel {
       }
     }
 
-    item.barrier(sycl::access::fence_space::local_space);
+    item.barrier(sycl::access::fence_space::global_and_local);
 
     _moe_align_block_size(
         topk_ids,
@@ -947,7 +947,7 @@ class moe_lora_align_block_size_small_batch_expert_kernel {
       }
     }
 
-    item.barrier(sycl::access::fence_space::local_space);
+    item.barrier(sycl::access::fence_space::global_and_local);
 
     _moe_align_block_size_small_batch_expert<scalar_t, fill_threads>(
         topk_ids,


### PR DESCRIPTION
## Problem

`sycl::reduce_over_group` requires a power-of-2 work-group size for correct results on XPU. The v0.1.9.1 optimization changed the block-size formula from `min(hidden_size, 1024)` to `min(hidden_size/vec_size, max_block_size)`, which yields non-power-of-2 values for common hidden sizes (e.g. 5120/8=640, 7168/8=896).

## Fix

Wrap all four block-size expressions in `call_rms_norm_kernel` and `call_fused_add_rms_norm_kernel` with `std::bit_floor((unsigned)...)` to round down to the nearest power of 2.

## Reproducer

docker image: public.ecr.aws/q9t5s3a7/vllm-ci-test-repo:91d8220b178e3301f80fe35f4b39cbe4ef2440cf-xpu  
torch: 2.12
```
tests/kernels/ir/test_layernorm.py
```
see: https://buildkite.com/vllm/intel-ci/builds/3654#019e81c6-8b7d-4aef-89a8-1f1e1eed1edd 
