### PR TITLE
Fix RMSNorm work-group size: round down to power of 2

### DIFF
--- a/csrc/layernorm.cpp
+++ b/csrc/layernorm.cpp
@@ -1,6 +1,7 @@
 #include <sycl/sycl.hpp>
 
 #include <algorithm>
+#include <bit>
 #include <ATen/DeviceGuard.h>
 #include "utils.h"
 #include "dispatch_utils.h"
@@ -450,8 +451,11 @@ void call_rms_norm_kernel(
       return;
     }
     sycl::range<3> grid(1, 1, num_tokens);
-    sycl::range<3> block(
-        1, 1, std::min(hidden_size / vec_size, max_block_size));
+    // Round down to nearest power of 2: the kernel produces wrong results
+    // when the work-group size is not a power of 2 (root cause unknown).
+    const int block_dim = std::bit_floor(
+        (unsigned)std::min(hidden_size / vec_size, max_block_size));
+    sycl::range<3> block(1, 1, block_dim);
     VLLM_DISPATCH_RANK234(num_dims, [&]() {
       queue.submit([&](sycl::handler& cgh) {
         sycl::local_accessor<float, 1> s_variance(sycl::range<1>(1), cgh);
@@ -474,7 +478,8 @@ void call_rms_norm_kernel(
     });
   } else {
     sycl::range<3> grid(1, 1, num_tokens);
-    sycl::range<3> block(1, 1, std::min(hidden_size, max_block_size));
+    sycl::range<3> block(
+        1, 1, std::bit_floor((unsigned)std::min(hidden_size, max_block_size)));
     VLLM_DISPATCH_RANK234(num_dims, [&]() {
       queue.submit([&](sycl::handler& cgh) {
         sycl::local_accessor<float, 1> s_variance(sycl::range<1>(1), cgh);
@@ -684,8 +689,13 @@ void call_fused_add_rms_norm_kernel(
   auto& queue = vllm::xpu::vllmGetQueue();
 
   if (can_vec) {
+    // Round down to nearest power of 2: the kernel produces wrong results
+    // when the work-group size is not a power of 2 (root cause unknown).
     sycl::range<3> block(
-        1, 1, std::min(hidden_size / vector_width, max_block_size));
+        1,
+        1,
+        std::bit_floor(
+            (unsigned)std::min(hidden_size / vector_width, max_block_size)));
     queue.submit([&](sycl::handler& cgh) {
       sycl::local_accessor<float, 1> s_variance(sycl::range<1>(1), cgh);
       cgh.parallel_for(
@@ -701,7 +711,8 @@ void call_fused_add_rms_norm_kernel(
               s_variance));
     });
   } else {
-    sycl::range<3> block(1, 1, std::min(hidden_size, max_block_size));
+    sycl::range<3> block(
+        1, 1, std::bit_floor((unsigned)std::min(hidden_size, max_block_size)));
     queue.submit([&](sycl::handler& cgh) {
       sycl::local_accessor<float, 1> s_variance(sycl::range<1>(1), cgh);
       cgh.parallel_for(

--- a/tests/test_layernorm.py
+++ b/tests/test_layernorm.py
@@ -9,9 +9,20 @@ from tests.utils import opcheck
 
 DTYPES = [torch.half, torch.bfloat16]
 NUM_TOKENS = [1, 7, 83, 4096]  # Arbitrary values for testing
-# TODO: add back  5120, 5124, 5125, 5126, 8192, 8199 after ci env issue fixed
-HIDDEN_SIZES = [8, 768, 769, 770, 771, 5120, 5124, 5125, 5126, 8192,
-                8199]  # Arbitrary values for testing
+HIDDEN_SIZES = [
+    8,
+    768,
+    769,
+    770,
+    771,
+    5120,
+    5124,
+    5125,
+    5126,
+    7168,
+    8192,
+    8199,
+]  # Arbitrary values for testing
 HEAD_DIMS = [128, 64]
 NUM_Q_HEADS = [32, 40, 64]
 NUM_KV_HEADS = [8, 32]
@@ -76,11 +87,15 @@ def test_rms_norm(
         torch.testing.assert_close(out, ref_out, atol=1e-2, rtol=1e-2)
 
     if residual is not None:
-        opcheck(torch.ops._C.fused_add_rms_norm,
-                (x, residual, layer.weight.data, layer.variance_epsilon))
+        opcheck(
+            torch.ops._C.fused_add_rms_norm,
+            (x, residual, layer.weight.data, layer.variance_epsilon),
+        )
     else:
-        opcheck(torch.ops._C.rms_norm,
-                (out, x, layer.weight.data, layer.variance_epsilon))
+        opcheck(
+            torch.ops._C.rms_norm,
+            (out, x, layer.weight.data, layer.variance_epsilon),
+        )
 
 
 @pytest.mark.parametrize("num_tokens", NUM_TOKENS)


### PR DESCRIPTION
## Problem

The kernel produces wrong results when the work-group size is not a power of 2 (root cause unknown). The v0.1.9.1 optimization (PR #361) changed the block-size formula from `min(hidden_size, 1024)` to `min(hidden_size/vec_size, max_block_size)`, which yields non-power-of-2 values for common hidden sizes (e.g. 5120/8=640, 7168/8=896) when `num_tokens < 256`.

This was confirmed by 96 failures in the vllm CI on XPU (hidden_size=5120 and 7168, num_tokens=1,8,17,32).

## Fix

Wrap all four block-size expressions in `call_rms_norm_kernel` and `call_fused_add_rms_norm_kernel` with `std::bit_floor((unsigned)...)` to round down to the nearest power of 2.

## Reproducer

See failed vllm IR tests in https://buildkite.com/vllm/intel-ci/builds/3654#019e8147-facd-4077-bc52-3368443d23f5