### PR TITLE
[MoE] Allow reusable workspaces in XPU fused MoE

### DIFF
--- a/tests/fused_moe/test_fused_moe.py
+++ b/tests/fused_moe/test_fused_moe.py
@@ -31,6 +31,34 @@ MINI_PYTEST_PARAMS = {
         "dtype": [torch.bfloat16],
         "has_bias": [True],
     },
+    "test_fused_moe_ep": {
+        "m,n,k": [(1, 1024, 1024)],
+        "e": [16],
+        "topk": [1],
+        "ep_rank": [0],
+        "ep_size": [4],
+        "dtype": [torch.float16],
+        "w_dtype": [None],
+        "has_bias": [True],
+    },
+    "test_fused_moe_int4_ep": {
+        "m,n,k": [(1, 1024, 1024)],
+        "e": [16],
+        "topk": [1],
+        "ep_rank": [0],
+        "ep_size": [4],
+        "dtype": [torch.bfloat16],
+        "has_bias": [True],
+    },
+    "test_fused_moe_mxfp4_ep": {
+        "m,n,k": [(1, 1024, 1024)],
+        "e": [16],
+        "topk": [1],
+        "ep_rank": [0],
+        "ep_size": [4],
+        "dtype": [torch.float16],
+        "has_bias": [True],
+    },
 }
 
 
@@ -264,6 +292,70 @@ def test_fused_moe(m, n, k, e, topk, dtype, w_dtype, has_bias):
         atol = 2e-2
     torch.testing.assert_close(output, ref_out, rtol=rtol, atol=atol)
     del fused_moe_impl
+
+
+@torch.inference_mode()
+def test_fused_moe_workspace_reuse_matches_allocation_path():
+    seed_everything(11)
+
+    input_len = 4
+    hidden_size = 128
+    intermediate_size = 256
+    num_experts = 2
+    topk = 1
+    dtype = torch.bfloat16
+
+    a = torch.randn((input_len, hidden_size), device=DEVICE, dtype=dtype) / 16
+    w13 = torch.randn((num_experts, 2 * intermediate_size, hidden_size),
+                      device=DEVICE, dtype=dtype) / 16
+    w2 = torch.randn((num_experts, hidden_size, intermediate_size),
+                     device=DEVICE, dtype=dtype) / 16
+    scores = torch.randn((input_len, num_experts),
+                         device=DEVICE, dtype=torch.float32)
+    expert_scores, expert_indices = torch.topk(scores, k=topk, dim=-1,
+                                               sorted=False)
+
+    w13.data = w13.transpose(-1, -2).contiguous()
+    w2.data = w2.transpose(-1, -2).contiguous()
+    fused_moe_impl = XpuFusedMoe(
+        w13=w13,
+        w13_scales=None,
+        w13_bias=None,
+        w2=w2,
+        w2_scales=None,
+        w2_bias=None,
+        n_experts_per_token=topk,
+        activation="silu",
+        num_experts=num_experts,
+    )
+
+    allocated_output = torch.empty_like(a)
+    fused_moe_impl.apply(
+        output=allocated_output,
+        hidden_states=a,
+        topk_weights=expert_scores,
+        topk_ids=expert_indices,
+    )
+
+    num_moe_inputs = input_len * topk
+    workspace13 = torch.empty((num_moe_inputs,
+                               max(hidden_size, intermediate_size)),
+                              device=DEVICE, dtype=dtype)
+    workspace2 = torch.empty((num_moe_inputs,
+                              max(hidden_size, 2 * intermediate_size)),
+                             device=DEVICE, dtype=dtype)
+    workspace_output = torch.empty_like(a)
+    fused_moe_impl.apply(
+        output=workspace_output,
+        hidden_states=a,
+        topk_weights=expert_scores,
+        topk_ids=expert_indices,
+        workspace13=workspace13,
+        workspace2=workspace2,
+    )
+
+    torch.testing.assert_close(workspace_output, allocated_output,
+                               rtol=2e-2, atol=2e-2)
 
 
 @pytest.mark.parametrize("m,n,k", FUSED_MOE_MNK_FACTORS)

--- a/vllm_xpu_kernels/fused_moe_interface.py
+++ b/vllm_xpu_kernels/fused_moe_interface.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+import math
 import os
 
 import torch
@@ -405,7 +406,12 @@ class XpuFusedMoe:
         topk_weights,
         topk_ids,
         expert_map=None,
+        workspace13=None,
+        workspace2=None,
     ):
+        # Optional workspaces are scratch buffers sized for the largest view
+        # each buffer backs below. They are reused only after their previous
+        # contents have been consumed.
         if self._use_ref:
             self._apply_ref(output, hidden_states,
                             topk_weights, topk_ids,
@@ -413,7 +419,7 @@ class XpuFusedMoe:
         else:
             self._apply_kernel(output, hidden_states,
                                topk_weights, topk_ids,
-                               expert_map)
+                               expert_map, workspace13, workspace2)
 
     def _apply_ref(
         self,
@@ -447,17 +453,34 @@ class XpuFusedMoe:
         topk_weights,
         topk_ids,
         expert_map=None,
+        workspace13=None,
+        workspace2=None,
     ):
         num_rows, hidden_size = hidden_states.shape
         num_moe_inputs = self.n_experts_per_token * num_rows
-        
+
+        if self.num_experts <= 0:
+            raise ValueError("XpuFusedMoe requires at least one local expert")
+
         if expert_map is None and self.ep_size > 1:
             expert_map = self.expert_map
 
-        remapped_hidden_states = torch.empty(
-            (num_rows * self.n_experts_per_token, hidden_size),
-            dtype=hidden_states.dtype,
-            device=hidden_states.device)
+        def _workspace_view(workspace, shape, name):
+            required = math.prod(shape)
+            if workspace.numel() < required:
+                raise ValueError(
+                    f"{name} has {workspace.numel()} elements, but {required} "
+                    f"are required for shape {shape}")
+            return workspace.view(-1)[:required].view(*shape)
+
+        if workspace13 is None:
+            remapped_hidden_states = torch.empty(
+                (num_moe_inputs, hidden_size),
+                dtype=hidden_states.dtype,
+                device=hidden_states.device)
+        else:
+            remapped_hidden_states = _workspace_view(
+                workspace13, (num_moe_inputs, hidden_size), "workspace13")
         rows_per_expert = torch.zeros((self.num_experts),
                                                 dtype=torch.int32,
                                                 device=hidden_states.device)
@@ -479,9 +502,14 @@ class XpuFusedMoe:
             local_experts_num=self.local_experts_num)
 
         ########### gemm1 ##################
-        gemm1_output = torch.empty((num_moe_inputs, 2 * self.inter_size),
-                                dtype=hidden_states.dtype,
-                                device=hidden_states.device)
+        gemm1_width = 2 * self.inter_size
+        if workspace2 is None:
+            gemm1_output = torch.empty((num_moe_inputs, gemm1_width),
+                                    dtype=hidden_states.dtype,
+                                    device=hidden_states.device)
+        else:
+            gemm1_output = _workspace_view(
+                workspace2, (num_moe_inputs, gemm1_width), "workspace2")
         torch.ops._xpu_C.cutlass_grouped_gemm_interface(
             ptr_A=remapped_hidden_states,
             ptr_B=self.w13,
@@ -496,16 +524,25 @@ class XpuFusedMoe:
             is_B_mxfp4=self.is_mxfp4)
 
         # act
-        act_output = torch.empty(
-            (num_moe_inputs, self.inter_size * self.inter_size_scale),
-            dtype=gemm1_output.dtype,
-            device=gemm1_output.device)
+        act_width = self.inter_size * self.inter_size_scale
+        if workspace13 is None:
+            act_output = torch.empty(
+                (num_moe_inputs, act_width),
+                dtype=gemm1_output.dtype,
+                device=gemm1_output.device)
+        else:
+            act_output = _workspace_view(
+                workspace13, (num_moe_inputs, act_width), "workspace13")
         self.act_func(act_output, gemm1_output)
 
         ########### gemm2 ##################
-        gemm2_output = torch.empty((num_moe_inputs, hidden_size),
-                                dtype=hidden_states.dtype,
-                                device=hidden_states.device)
+        if workspace2 is None:
+            gemm2_output = torch.empty((num_moe_inputs, hidden_size),
+                                    dtype=hidden_states.dtype,
+                                    device=hidden_states.device)
+        else:
+            gemm2_output = _workspace_view(
+                workspace2, (num_moe_inputs, hidden_size), "workspace2")
 
         torch.ops._xpu_C.cutlass_grouped_gemm_interface(
             ptr_A=act_output,


### PR DESCRIPTION
## Summary

Fixes #390.

`XpuFusedMoe.apply()` currently allocates several large scratch tensors on every kernel-path call:

- remapped hidden states
- GEMM1 output
- activation output
- GEMM2 output

In decode-heavy MoE inference this creates avoidable allocator churn, since the required workspace shapes are deterministic from `hidden_states.shape`, `n_experts_per_token`, `hidden_size`, and `inter_size`.

This PR adds optional caller-provided workspaces to the XPU fused MoE kernel path. Existing callers keep the current allocation behavior when workspaces are omitted, while optimized callers can preallocate scratch buffers and reuse them across repeated decode steps.

## Changes

- Add optional `workspace13` and `workspace2` parameters to `XpuFusedMoe.apply()` / `_apply_kernel()`.
- Use validated views into those buffers for the large scratch tensors when provided.
- Preserve the existing allocation path when no workspaces are passed.
- Add a regression test comparing reusable-workspace output against the existing allocation path.
- Expand mini fused MoE test coverage to include representative EP variants.
- Add a guard for invalid `num_experts <= 0` in the kernel path.

## Compatibility

The API change is additive. Existing callers do not need to pass any new arguments and should see the same behavior as before.

The workspace buffers are scratch only. The implementation reuses each workspace only after the previous view backed by that workspace has been consumed:

- `workspace13`: remapped hidden states, then activation output
- `workspace2`: GEMM1 output, then GEMM2 output

## Test Plan

Built this branch independently from `origin/main` in a clean worktree with:

```bash
source ~/.venv/bin/activate
PATH=/opt/intel/oneapi/compiler/2026.0/bin:$PATH \
CMPLR_ROOT=/opt/intel/oneapi/compiler/2026.0 \
VLLM_PAGED_DECODE_CONFIG=paged_decode_default.conf \
VLLM_CHUNK_PREFILL_CONFIG=chunk_prefill_default.conf \
python setup.py build_ext --inplace
```

Import smoke:

```bash
source ~/.venv/bin/activate
python - <<'PY'
import vllm_xpu_kernels._C
import vllm_xpu_kernels._xpu_C
import vllm_xpu_kernels._moe_C
print('kernel imports ok')
PY
```

Focused fused MoE tests:

```bash
source ~/.venv/bin/activate
pytest -q tests/fused_moe/test_fused_moe.py --tb=short
```

## Test Result

```text
kernel imports ok
201 passed in 52.92s
```

## Related Work

There is nearby MoE refactor work in #376. This PR is intentionally narrow: it does not refactor the MoE class hierarchy or grouped GEMM signatures; it only adds optional workspace reuse while preserving the default allocation path.
