### PR TITLE
[XPU][GDN] Fix tiled prefill conv1d dropping z for GQA ratio 3

### DIFF
--- a/csrc/xpu/gdn_attn/xe_2/chunk_causal_conv1d_tiled_xe2.hpp
+++ b/csrc/xpu/gdn_attn/xe_2/chunk_causal_conv1d_tiled_xe2.hpp
@@ -500,10 +500,14 @@ struct chunk_causal_conv1d_tiled_kernel {
         int out_token_id = pre_chunks * chunk_size_xe2 + token_in_seq;
         int global_tok = lookup(seq_start + token_in_seq);
 
-        // z reorder: each item handles elems_per_item z features
-        // z_dim = 256 for Qwen, items 0-63 cover 64*4=256 features exactly
-        if (local_feat < z_dim) {
-          int z_dim_id = local_feat;
+        // z reorder: each item handles elems_per_item z features per pass.
+        // The 64 items cover feats_per_wg (256) features per pass, so when
+        // z_dim exceeds 256 -- e.g. GQA ratio num_v_heads/num_k_heads == 3
+        // gives z_dim = head_v_dim * 3 = 384 for Qwen3.6 -- a single pass would
+        // drop the tail z features (the 3rd v-head of each k-group). Stride by
+        // feats_per_wg so every z feature is written for any ratio.
+        for (int z_dim_id = local_feat; z_dim_id < z_dim;
+             z_dim_id += feats_per_wg) {
           int mixed_z_id;
           if constexpr (ReorderInput) {
             mixed_z_id = global_tok * num_k_heads * qkvz_dim_full +

--- a/tests/gdn_attn/test_gdn_attn.py
+++ b/tests/gdn_attn/test_gdn_attn.py
@@ -843,3 +843,102 @@ def test_gdn_attention_mtp(num_spec_decodes, num_spec_tokens, num_k_heads,
                                        ref_ssm_state[slot],
                                        atol=atol,
                                        rtol=rtol)
+
+
+# GQA ratio num_v_heads/num_k_heads == 3 regression. The SLM-tiled prefill
+# conv1d (chunk_causal_conv1d_tiled_xe2) reorders the z gate one feat_chunk at a
+# time: its 64 work-items cover feats_per_wg = wg_size * elems_per_item = 256 z
+# features in a single pass. For ratio <= 2 with head_v_dim 128 the gate width
+# z_dim = head_v_dim * num_v_heads / num_k_heads is <= 256 and fits, but ratio 3
+# gives z_dim = 384, so the tail features 256..383 -- the 3rd v-head of every
+# k-group -- were never written, corrupting z (and thus core_attn_out) for any
+# prefill of >= conv1d_tile_size (8) tokens. Reproduces with a single short
+# prefill; the existing tests only cover ratio 2 (num_v_heads = 32).
+RATIO3_DTYPES = [torch.float16, torch.bfloat16]
+RATIO3_REORDER = [True, False]
+
+
+@pytest.mark.parametrize("dtype", RATIO3_DTYPES, ids=format_tc)
+@pytest.mark.parametrize("reorder_input", RATIO3_REORDER)
+@torch.inference_mode()
+def test_gdn_attention_gqa_ratio3_prefill(dtype, reorder_input):
+    device = "xpu"
+    random.seed(0)
+    torch.manual_seed(0)
+
+    num_k_heads, head_k_dim = 2, 128
+    num_v_heads, head_v_dim = 6, 128  # ratio 3 -> z_dim = head_v_dim * 3 = 384
+    width, tp_size = 4, 1
+    activation = "silu"
+    num_actual_tokens = 16  # single prefill, >= conv1d_tile_size (8)
+    num_prefills, num_decodes = 1, 0
+    cache_batch_size = 4
+
+    mixed_qkvz_size = num_k_heads * (
+        2 * head_k_dim + 2 * head_v_dim * num_v_heads // num_k_heads)
+    mixed_ba_size = num_k_heads * (2 * num_v_heads // num_k_heads)
+    mixed_qkv_size = num_k_heads * (
+        2 * head_k_dim + head_v_dim * num_v_heads // num_k_heads)
+
+    projected_states_qkvz = torch.randn((num_actual_tokens, mixed_qkvz_size),
+                                        dtype=dtype, device=device)
+    projected_states_ba = torch.randn((num_actual_tokens, mixed_ba_size),
+                                      dtype=dtype, device=device)
+    conv_state = torch.randn((cache_batch_size, width - 1, mixed_qkv_size),
+                             dtype=dtype, device=device)
+    ref_conv_state = conv_state.clone()
+    ssm_state = torch.randn(
+        (cache_batch_size, num_v_heads, head_v_dim, head_k_dim),
+        dtype=dtype, device=device)
+    ref_ssm_state = ssm_state.clone()
+    conv_weights = torch.randn((mixed_qkv_size, width), dtype=dtype,
+                               device=device)
+    conv_bias = torch.randn((mixed_qkv_size), dtype=dtype, device=device)
+    A_log = torch.randn((num_v_heads), dtype=torch.float32, device=device)
+    dt_bias = torch.randn((num_v_heads), dtype=dtype, device=device)
+
+    non_spec_query_start_loc = torch.tensor([0, num_actual_tokens],
+                                            dtype=torch.int32, device=device)
+    has_initial_state = torch.tensor([True], dtype=torch.bool, device=device)
+    non_spec_state_indices_tensor = torch.tensor([0], dtype=torch.int32,
+                                                 device=device)
+
+    core_attn_out = torch.zeros((num_actual_tokens, num_v_heads, head_v_dim),
+                                dtype=dtype, device=device)
+    z = torch.empty_like(core_attn_out)
+
+    torch.ops._xpu_C.gdn_attention(
+        core_attn_out, z, projected_states_qkvz, projected_states_ba,
+        num_k_heads, num_v_heads, head_k_dim, head_v_dim,
+        conv_state=conv_state, ssm_state=ssm_state, conv_weights=conv_weights,
+        conv_bias=conv_bias, activation=activation, A_log=A_log,
+        dt_bias=dt_bias, num_prefills=num_prefills, num_decodes=num_decodes,
+        num_spec_decodes=0, has_initial_state=has_initial_state,
+        non_spec_query_start_loc=non_spec_query_start_loc,
+        non_spec_token_indx=None,
+        non_spec_state_indices_tensor=non_spec_state_indices_tensor,
+        spec_query_start_loc=None, spec_token_indx=None,
+        spec_state_indices_tensor=None, num_accepted_tokens=None,
+        num_actual_tokens=num_actual_tokens, tp_size=tp_size,
+        reorder_input=reorder_input)
+
+    ref_core_attn_out = torch.zeros_like(core_attn_out)
+    ref_z = torch.empty_like(core_attn_out)
+    ref_gdn_attention(
+        ref_core_attn_out, ref_z, projected_states_qkvz, projected_states_ba,
+        num_k_heads, num_v_heads, head_k_dim, head_v_dim,
+        conv_state=ref_conv_state, ssm_state=ref_ssm_state,
+        conv_weights=conv_weights, conv_bias=conv_bias, activation=activation,
+        A_log=A_log, dt_bias=dt_bias, num_prefills=num_prefills,
+        num_decodes=num_decodes, has_initial_state=has_initial_state,
+        non_spec_query_start_loc=non_spec_query_start_loc,
+        non_spec_state_indices_tensor=non_spec_state_indices_tensor,
+        num_actual_tokens=num_actual_tokens, tp_size=tp_size,
+        reorder_input=reorder_input)
+
+    atol = rtol = 5e-2
+    # z (the output gate) is reordered straight from projected_states_qkvz; with
+    # ratio 3 the tiled kernel dropped the 3rd v-head of each k-group.
+    torch.testing.assert_close(z, ref_z, atol=atol, rtol=rtol)
+    torch.testing.assert_close(core_attn_out, ref_core_attn_out, atol=atol,
+                               rtol=rtol)


### PR DESCRIPTION
## Summary

The tiled prefill conv1d kernel writes the `z` gate with a fixed pool of work items that can only cover **256 values per token in a single pass**. When a model needs more than 256 `z` values per token, everything past the first 256 is **never written** — that part of the gate is left as garbage. Qwen3.6-27B hits this, and the corrupted gate breaks the attention output so generation collapses into a repeated nonsense token.

## Root cause

`z` has `head_v_dim * num_v_heads / num_k_heads` values per token. The z-reorder step in `chunk_causal_conv1d_tiled_xe2` runs **one** pass of 64 work items × 4 values = 256, and only writes those first 256:

- Most configs keep this `<= 256` — e.g. `head_v_dim=128` with a 2:1 value/key head ratio gives exactly 256 — so the single pass covers everything and the bug is invisible.
- Qwen3.6-27B has a **3:1 ratio** (`num_v_heads=48, num_k_heads=16, head_v_dim=128`) → **384 values per token**. The work items only reach the first 256, so the last 128 (the 3rd value-head of each group) are never computed and `z` is left zero/garbage there.

That corrupt `z` flows into `core_attn_out`, so any prefill of `>= conv1d_tile_size` (8) tokens — i.e. the tiled path — produces broken output and the model degenerates into repeated tokens.

## Fix

Loop the z-reorder in steps of 256 until **all** values are written, instead of a single 256-wide pass. When there are `<= 256` values this is identical to the old code; above that it now covers the rest.

## Test

Adds a regression test with a 3:1 head ratio (384 z values per token) on a single short prefill, comparing `z` and `core_attn_out` against the reference. It fails on the current kernel (the 3rd value-head of each group is wrong) and passes with the fix. The existing tests only use the 2:1 ratio, which is why this was never caught.

## Manual Testing

Manually testing on my home server here with an Arc B70 Pro with open webui. Before I was getting !!!!!! characters, now I get full output.

Server configs: https://github.com/jasonboukheir/dotfiles/blob/4c2bb3721b38a86372b23975b649a51b64986af7/hosts/brutus/services/vllm-xpu.nix#L40

My vllm fork:
https://github.com/jasonboukheir/vllm-xpu-nix