### PR TITLE
[CI] auto cancel previous commit run

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -3,3 +3,4 @@ self-hosted-runner:
   labels:
     - self-hosted-bmg
     - self-hosted-pvc
+    - self-hosted-pvc-cpu

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -4,3 +4,4 @@ self-hosted-runner:
     - self-hosted-bmg
     - self-hosted-pvc
     - self-hosted-pvc-cpu
+    - self-hosted-bmg-b50

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -4,4 +4,3 @@ self-hosted-runner:
     - self-hosted-bmg
     - self-hosted-pvc
     - self-hosted-pvc-cpu
-    - self-hosted-bmg-b50

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   pre-commit:
-    runs-on: self-hosted-pvc
+    runs-on: self-hosted-pvc-cpu
     steps:
     - name: Clean workspace
       run: |

--- a/.github/workflows/ut.yaml
+++ b/.github/workflows/ut.yaml
@@ -18,6 +18,11 @@ on:
 permissions: 
   contents: read
 
+concurrency:
+  # PR 按 PR 号分组，push/schedule/dispatch 按 ref 分组；schedule 不取消避免中断夜测
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'schedule' }}
+
 env:
   REGISTRY: localhost:5000
   # Nightly (schedule) → full scope; manual dispatch → user choice; PR/push → ci scope
@@ -25,8 +30,31 @@ env:
 
 jobs:
 
+  pre-commit:
+    runs-on: self-hosted-pvc
+    # schedule / workflow_dispatch 无需 pre-commit 门控，跳过此 job
+    if: github.event_name == 'pull_request' || github.event_name == 'push'
+    steps:
+      - name: Clean workspace
+        run: |
+          sudo chown -R "$(id -u):$(id -g)" . || true
+          git clean -ffdx || true
+          git reset --hard || true
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
+        with:
+          python-version: "3.10"
+      - run: echo "::add-matcher::.github/workflows/matchers/actionlint.json"
+      - run: echo "::add-matcher::.github/workflows/matchers/mypy.json"
+      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
+        with:
+          extra_args: --all-files --hook-stage manual
+
   build-docker-image-latest-pvc:
     runs-on: self-hosted-pvc
+    needs: pre-commit
+    # 继续执行当 pre-commit 成功或被跳过（schedule/dispatch），失败则阻断
+    if: always() && !failure() && !cancelled()
     steps:
       - name: Clean workspace
         run: |
@@ -49,6 +77,8 @@ jobs:
 
   build-docker-image-latest-bmg:
     runs-on: self-hosted-bmg
+    needs: pre-commit
+    if: always() && !failure() && !cancelled()
     steps:
       - name: Clean workspace
         run: |

--- a/.github/workflows/ut.yaml
+++ b/.github/workflows/ut.yaml
@@ -32,7 +32,7 @@ env:
 jobs:
 
   pre-commit:
-    runs-on: self-hosted-pvc
+    runs-on: self-hosted-pvc-cpu
     # Skip pre-commit gate for schedule and workflow_dispatch events.
     if: github.event_name == 'pull_request' || github.event_name == 'push'
     steps:
@@ -52,7 +52,7 @@ jobs:
           extra_args: --all-files --hook-stage manual
 
   build-docker-image-latest-pvc:
-    runs-on: self-hosted-pvc
+    runs-on: self-hosted-pvc-cpu
     needs: pre-commit
     # Run when pre-commit succeeded or was skipped (schedule/dispatch); block on failure.
     if: always() && !failure() && !cancelled()
@@ -104,7 +104,7 @@ jobs:
   # BMG runner cannot reach PVC directly (different network segment), so the
   # artifact service (GitHub) acts as the neutral transfer point.
   build-wheel:
-    runs-on: self-hosted-pvc
+    runs-on: self-hosted-pvc-cpu
     needs: build-docker-image-latest-pvc
     container:
       image: localhost:5000/xpu-kernel-ci-image:latest
@@ -153,7 +153,7 @@ jobs:
           retention-days: 15
 
   build-wheel-with-default-config:
-    runs-on: self-hosted-pvc
+    runs-on: self-hosted-pvc-cpu
     needs: build-docker-image-latest-pvc
     container:
       image: localhost:5000/xpu-kernel-ci-image:latest

--- a/.github/workflows/ut.yaml
+++ b/.github/workflows/ut.yaml
@@ -61,7 +61,7 @@ jobs:
           docker push "${{ env.REGISTRY }}/xpu-kernel-ci-image:${IMAGE_TAG}"
 
   build-docker-image-latest-bmg:
-    runs-on: self-hosted-bmg-b50
+    runs-on: self-hosted-bmg
     outputs:
       image_tag: ${{ steps.set-tag.outputs.image_tag }}
     steps:
@@ -237,7 +237,7 @@ jobs:
           git reset --hard || true
 
   run-unit-tests-bmg:
-    runs-on: self-hosted-bmg-b50
+    runs-on: self-hosted-bmg
     needs: [build-docker-image-latest-bmg, build-wheel]
     timeout-minutes: 50
     container: 
@@ -272,7 +272,7 @@ jobs:
           VLLM_XPU_FORCE_XE_DEFAULT_KERNEL=1 XPU_KERNEL_TEST_SCOPE=${{ env.XPU_KERNEL_TEST_SCOPE }} ZE_AFFINITY_MASK=0,1 pytest -v -s tests/fused_moe/test_grouped_gemm.py::test_grouped_gemm
 
   clean-repo-bmg:
-    runs-on: self-hosted-bmg-b50
+    runs-on: self-hosted-bmg
     needs: run-unit-tests-bmg
     steps:
       - name: Clean workspace

--- a/.github/workflows/ut.yaml
+++ b/.github/workflows/ut.yaml
@@ -33,6 +33,8 @@ jobs:
 
   build-docker-image-latest-pvc:
     runs-on: self-hosted-pvc-cpu
+    outputs:
+      image_tag: ${{ steps.set-tag.outputs.image_tag }}
     steps:
       - name: Clean workspace
         run: |
@@ -46,15 +48,22 @@ jobs:
           set-safe-directory: true
           clean: true
 
+      - name: Set image tag
+        id: set-tag
+        run: echo "image_tag=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+
       - name: build docker image & push to local
         id: build-image
         run: |
-          docker build -t xpu-kernel-ci-image:latest -f Dockerfile.xpu .
-          docker tag xpu-kernel-ci-image:latest ${{ env.REGISTRY }}/xpu-kernel-ci-image:latest
-          docker push ${{ env.REGISTRY }}/xpu-kernel-ci-image:latest
+          IMAGE_TAG=${GITHUB_SHA::7}
+          docker build -t "xpu-kernel-ci-image:${IMAGE_TAG}" -f Dockerfile.xpu .
+          docker tag "xpu-kernel-ci-image:${IMAGE_TAG}" "${{ env.REGISTRY }}/xpu-kernel-ci-image:${IMAGE_TAG}"
+          docker push "${{ env.REGISTRY }}/xpu-kernel-ci-image:${IMAGE_TAG}"
 
   build-docker-image-latest-bmg:
     runs-on: self-hosted-bmg
+    outputs:
+      image_tag: ${{ steps.set-tag.outputs.image_tag }}
     steps:
       - name: Clean workspace
         run: |
@@ -68,12 +77,17 @@ jobs:
           set-safe-directory: true
           clean: true
 
+      - name: Set image tag
+        id: set-tag
+        run: echo "image_tag=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+
       - name: build docker image & push to local
         id: build-image
         run: |
-          docker build -t xpu-kernel-ci-image:latest -f Dockerfile.xpu .
-          docker tag xpu-kernel-ci-image:latest ${{ env.REGISTRY }}/xpu-kernel-ci-image:latest
-          docker push ${{ env.REGISTRY }}/xpu-kernel-ci-image:latest
+          IMAGE_TAG=${GITHUB_SHA::7}
+          docker build -t "xpu-kernel-ci-image:${IMAGE_TAG}" -f Dockerfile.xpu .
+          docker tag "xpu-kernel-ci-image:${IMAGE_TAG}" "${{ env.REGISTRY }}/xpu-kernel-ci-image:${IMAGE_TAG}"
+          docker push "${{ env.REGISTRY }}/xpu-kernel-ci-image:${IMAGE_TAG}"
 
   # Build wheel only once on PVC, then share via GitHub Actions artifact.
   # BMG runner cannot reach PVC directly (different network segment), so the
@@ -82,7 +96,7 @@ jobs:
     runs-on: self-hosted-pvc-cpu
     needs: build-docker-image-latest-pvc
     container:
-      image: localhost:5000/xpu-kernel-ci-image:latest
+      image: localhost:5000/xpu-kernel-ci-image:${{ needs.build-docker-image-latest-pvc.outputs.image_tag }}
       options: --device /dev/dri -v /dev/dri/by-path:/dev/dri/by-path --privileged -v ccache:/root/.ccache -e CCACHE_DIR=/root/.ccache
     steps:
       - name: Checkout
@@ -131,7 +145,7 @@ jobs:
     runs-on: self-hosted-pvc-cpu
     needs: build-docker-image-latest-pvc
     container:
-      image: localhost:5000/xpu-kernel-ci-image:latest
+      image: localhost:5000/xpu-kernel-ci-image:${{ needs.build-docker-image-latest-pvc.outputs.image_tag }}
       options: --device /dev/dri -v /dev/dri/by-path:/dev/dri/by-path --privileged -v ccache:/root/.ccache -e CCACHE_DIR=/root/.ccache
     steps:
       - name: Checkout
@@ -185,7 +199,7 @@ jobs:
     needs: [build-docker-image-latest-pvc, build-wheel]
     timeout-minutes: 50
     container:                      
-      image: localhost:5000/xpu-kernel-ci-image:latest
+      image: localhost:5000/xpu-kernel-ci-image:${{ needs.build-docker-image-latest-pvc.outputs.image_tag }}
       options: --device /dev/dri -v /dev/dri/by-path:/dev/dri/by-path --privileged -v ccache:/root/.ccache -e CCACHE_DIR=/root/.ccache
     steps:
       - name: Checkout
@@ -227,7 +241,7 @@ jobs:
     needs: [build-docker-image-latest-bmg, build-wheel]
     timeout-minutes: 50
     container: 
-      image: localhost:5000/xpu-kernel-ci-image:latest
+      image: localhost:5000/xpu-kernel-ci-image:${{ needs.build-docker-image-latest-bmg.outputs.image_tag }}
       options: --device /dev/dri -v /dev/dri/by-path:/dev/dri/by-path --privileged -v ccache:/root/.ccache -e CCACHE_DIR=/root/.ccache
     steps:
       - name: Checkout

--- a/.github/workflows/ut.yaml
+++ b/.github/workflows/ut.yaml
@@ -19,7 +19,8 @@ permissions:
   contents: read
 
 concurrency:
-  # PR 按 PR 号分组，push/schedule/dispatch 按 ref 分组；schedule 不取消避免中断夜测
+  # Group by PR number for pull_request, by ref for push/schedule/dispatch.
+  # Do not cancel in-progress runs for schedule to avoid interrupting nightly tests.
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name != 'schedule' }}
 
@@ -32,7 +33,7 @@ jobs:
 
   pre-commit:
     runs-on: self-hosted-pvc
-    # schedule / workflow_dispatch 无需 pre-commit 门控，跳过此 job
+    # Skip pre-commit gate for schedule and workflow_dispatch events.
     if: github.event_name == 'pull_request' || github.event_name == 'push'
     steps:
       - name: Clean workspace
@@ -53,7 +54,7 @@ jobs:
   build-docker-image-latest-pvc:
     runs-on: self-hosted-pvc
     needs: pre-commit
-    # 继续执行当 pre-commit 成功或被跳过（schedule/dispatch），失败则阻断
+    # Run when pre-commit succeeded or was skipped (schedule/dispatch); block on failure.
     if: always() && !failure() && !cancelled()
     steps:
       - name: Clean workspace

--- a/.github/workflows/ut.yaml
+++ b/.github/workflows/ut.yaml
@@ -61,7 +61,7 @@ jobs:
           docker push "${{ env.REGISTRY }}/xpu-kernel-ci-image:${IMAGE_TAG}"
 
   build-docker-image-latest-bmg:
-    runs-on: self-hosted-bmg
+    runs-on: self-hosted-bmg-b50
     outputs:
       image_tag: ${{ steps.set-tag.outputs.image_tag }}
     steps:
@@ -237,7 +237,7 @@ jobs:
           git reset --hard || true
 
   run-unit-tests-bmg:
-    runs-on: self-hosted-bmg
+    runs-on: self-hosted-bmg-b50
     needs: [build-docker-image-latest-bmg, build-wheel]
     timeout-minutes: 50
     container: 
@@ -272,7 +272,7 @@ jobs:
           VLLM_XPU_FORCE_XE_DEFAULT_KERNEL=1 XPU_KERNEL_TEST_SCOPE=${{ env.XPU_KERNEL_TEST_SCOPE }} ZE_AFFINITY_MASK=0,1 pytest -v -s tests/fused_moe/test_grouped_gemm.py::test_grouped_gemm
 
   clean-repo-bmg:
-    runs-on: self-hosted-bmg
+    runs-on: self-hosted-bmg-b50
     needs: run-unit-tests-bmg
     steps:
       - name: Clean workspace

--- a/.github/workflows/ut.yaml
+++ b/.github/workflows/ut.yaml
@@ -31,31 +31,8 @@ env:
 
 jobs:
 
-  pre-commit:
-    runs-on: self-hosted-pvc-cpu
-    # Skip pre-commit gate for schedule and workflow_dispatch events.
-    if: github.event_name == 'pull_request' || github.event_name == 'push'
-    steps:
-      - name: Clean workspace
-        run: |
-          sudo chown -R "$(id -u):$(id -g)" . || true
-          git clean -ffdx || true
-          git reset --hard || true
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-      - uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
-        with:
-          python-version: "3.10"
-      - run: echo "::add-matcher::.github/workflows/matchers/actionlint.json"
-      - run: echo "::add-matcher::.github/workflows/matchers/mypy.json"
-      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
-        with:
-          extra_args: --all-files --hook-stage manual
-
   build-docker-image-latest-pvc:
     runs-on: self-hosted-pvc-cpu
-    needs: pre-commit
-    # Run when pre-commit succeeded or was skipped (schedule/dispatch); block on failure.
-    if: always() && !failure() && !cancelled()
     steps:
       - name: Clean workspace
         run: |
@@ -78,8 +55,6 @@ jobs:
 
   build-docker-image-latest-bmg:
     runs-on: self-hosted-bmg
-    needs: pre-commit
-    if: always() && !failure() && !cancelled()
     steps:
       - name: Clean workspace
         run: |

--- a/.github/workflows/wheel-per-commit.yaml
+++ b/.github/workflows/wheel-per-commit.yaml
@@ -16,7 +16,7 @@ env:
 
 jobs:
   build-wheel-on-pvc:
-    runs-on: self-hosted-pvc
+    runs-on: self-hosted-pvc-cpu
     if: |
       github.event_name == 'workflow_dispatch' || 
       (github.event.workflow_run.conclusion == 'success' && 
@@ -108,7 +108,7 @@ jobs:
           echo "Download: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
   clean-repo-pvc:
-    runs-on: self-hosted-pvc
+    runs-on: self-hosted-pvc-cpu
     needs: build-wheel-on-pvc
     steps:
       - name: Clean workspace


### PR DESCRIPTION
# Essential Elements of an Effective PR Description Checklist

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.

PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS ABOVE HAVE BEEN CONSIDERED.

## Purpose

This PR improves CI reliability and resource efficiency by:

Auto-cancel redundant CI runs: Added concurrency group to ut.yaml so that pushing a new commit to an open PR automatically cancels the in-progress run for the same PR. Scheduled nightly runs are excluded from cancellation.

Commit-based Docker image tags: Changed Docker image tagging from :latest to :<short-sha> (first 7 chars of GITHUB_SHA). This prevents different concurrent CI runs from overwriting each other's image in the local registry, which was a race condition when multiple PRs were building simultaneously.

Introduce self-hosted-pvc-cpu runner: Non-GPU jobs (pre-commit, docker build, wheel build) are migrated from self-hosted-pvc to the new self-hosted-pvc-cpu label, freeing up GPU resources on PVC runners for actual test jobs.

## Test Plan

## Test Result

## (Optional) Documentation Update

**BEFORE SUBMITTING, PLEASE READ <https://docs.vllm.ai/en/latest/contributing>** (anything written below this line will be removed by GitHub Actions)
