### PR TITLE
[XPU][MOE] Optimize XPU MoE activation by skipping invalid rows

### DIFF
--- a/csrc/activation.cpp
+++ b/csrc/activation.cpp
@@ -92,12 +92,17 @@ class act_kernel {
   act_kernel(
       scalar_t* __restrict__ out,          // [..., d]
       const scalar_t* __restrict__ input,  // [..., d]
-      const int d)
-      : out_(out), input_(input), d_(d) {}
+      const int d,
+      const int64_t* __restrict__ valid_rows = nullptr)
+      : out_(out), input_(input), d_(d), valid_rows_(valid_rows) {}
 
   void operator() [[sycl::reqd_sub_group_size(32)]] (
       const sycl::nd_item<3>& item_ct1) const {
     const int64_t token_idx = item_ct1.get_group(2);
+    if (valid_rows_ != nullptr &&
+        token_idx >= static_cast<int64_t>(*valid_rows_)) {
+      return;
+    }
     for (int64_t idx = item_ct1.get_local_id(2); idx < d_;
          idx += item_ct1.get_local_range(2)) {
       const scalar_t x = input_[token_idx * d_ + idx];
@@ -109,6 +114,7 @@ class act_kernel {
   scalar_t* __restrict__ out_;          // [..., d]
   const scalar_t* __restrict__ input_;  // [..., d]
   const int d_;
+  const int64_t* __restrict__ valid_rows_;
 };
 
 template <
@@ -120,12 +126,17 @@ class act_and_mul_kernel {
   act_and_mul_kernel(
       scalar_t* __restrict__ out,          // [..., d]
       const scalar_t* __restrict__ input,  // [..., 2, d]
-      const int d)
-      : out_(out), input_(input), d_(d) {}
+      const int d,
+      const int64_t* __restrict__ valid_rows = nullptr)
+      : out_(out), input_(input), d_(d), valid_rows_(valid_rows) {}
 
   void operator() [[sycl::reqd_sub_group_size(32)]] (
       const sycl::nd_item<3>& item_ct1) const {
     const int64_t token_idx = item_ct1.get_group(2);
+    if (valid_rows_ != nullptr &&
+        token_idx >= static_cast<int64_t>(*valid_rows_)) {
+      return;
+    }
     for (int64_t idx = item_ct1.get_local_id(2); idx < d_;
          idx += item_ct1.get_local_range(2)) {
       const scalar_t x = input_[token_idx * 2 * d_ + idx];
@@ -138,6 +149,7 @@ class act_and_mul_kernel {
   scalar_t* __restrict__ out_;          // [..., d]
   const scalar_t* __restrict__ input_;  // [..., 2, d]
   const int d_;
+  const int64_t* __restrict__ valid_rows_;
 };
 
 // Vectorized version of act_and_mul_kernel using aligned vector loads/stores.
@@ -153,12 +165,17 @@ class act_and_mul_vec_kernel {
   act_and_mul_vec_kernel(
       scalar_t* __restrict__ out,
       const scalar_t* __restrict__ input,
-      const int d)
-      : out_(out), input_(input), d_(d) {}
+      const int d,
+      const int64_t* __restrict__ valid_rows = nullptr)
+      : out_(out), input_(input), d_(d), valid_rows_(valid_rows) {}
 
   void operator()(sycl::nd_item<1> item) const {
     using vec_t = vllm::xpu::aligned_vec<scalar_t, VEC_SIZE>;
     const int64_t token_idx = item.get_group(0);
+    if (valid_rows_ != nullptr &&
+        token_idx >= static_cast<int64_t>(*valid_rows_)) {
+      return;
+    }
     const int64_t offset = item.get_local_linear_id();
     const int64_t step = item.get_local_range(0);
     const int64_t bound = d_ / VEC_SIZE;
@@ -181,6 +198,7 @@ class act_and_mul_vec_kernel {
   scalar_t* __restrict__ out_;
   const scalar_t* __restrict__ input_;
   const int d_;
+  const int64_t* __restrict__ valid_rows_;
 };
 
 template <
@@ -321,11 +339,21 @@ class swigluoai_and_mul_kernel {
       const scalar_t* __restrict__ input,  // [..., 2, d]
       const int d,
       const float alpha,
-      const float limit)
-      : out(out), input(input), d(d), alpha(alpha), limit(limit) {}
+      const float limit,
+      const int64_t* __restrict__ valid_rows = nullptr)
+      : out(out),
+        input(input),
+        d(d),
+        alpha(alpha),
+        limit(limit),
+        valid_rows(valid_rows) {}
 
   void operator()(sycl::nd_item<1> item) const {
     const int64_t token_idx = item.get_group(0);
+    if (valid_rows != nullptr &&
+        token_idx >= static_cast<int64_t>(*valid_rows)) {
+      return;
+    }
     for (int64_t idx = item.get_local_id(0); idx < d;
          idx += item.get_local_range(0)) {
       // gate = x[..., ::2]  (even indices)
@@ -343,6 +371,7 @@ class swigluoai_and_mul_kernel {
   const int d;
   const float alpha;
   const float limit;
+  const int64_t* valid_rows;
 };
 
 template <
@@ -354,11 +383,16 @@ class swiglustep_and_mul_kernel {
       scalar_t* __restrict__ out,          // [..., d]
       const scalar_t* __restrict__ input,  // [..., 2 * d]
       const int d,
-      const float limit)
-      : out(out), input(input), d(d), limit(limit) {}
+      const float limit,
+      const int64_t* __restrict__ valid_rows = nullptr)
+      : out(out), input(input), d(d), limit(limit), valid_rows(valid_rows) {}
 
   void operator()(sycl::nd_item<1> item) const {
     const int64_t token_idx = item.get_group(0);
+    if (valid_rows != nullptr &&
+        token_idx >= static_cast<int64_t>(*valid_rows)) {
+      return;
+    }
     for (int64_t idx = item.get_local_id(0); idx < d;
          idx += item.get_local_range(0)) {
       // gate = first half, up = second half (contiguous chunks)
@@ -374,6 +408,7 @@ class swiglustep_and_mul_kernel {
   const scalar_t* input;
   const int d;
   const float limit;
+  const int64_t* valid_rows;
 };
 
 }  // namespace vllm
@@ -402,15 +437,15 @@ class swiglustep_and_mul_kernel {
   });
 
 // Vectorized launch: dispatch to vec_size=1,2,4,8,16 based on d and dtype.
-#define VEC_LAUNCH_ACT_AND_MUL(KERNEL, ACT_FIRST, N)                  \
-  case N: {                                                           \
-    queue.submit([&](sycl::handler& cgh) {                            \
-      cgh.parallel_for(                                               \
-          sycl::nd_range<1>(num_tokens * wg_size, wg_size),           \
-          vllm::act_and_mul_vec_kernel<sycl_t, KERNEL, ACT_FIRST, N>( \
-              (sycl_t*)out_ptr, (sycl_t*)input_ptr, d));              \
-    });                                                               \
-    break;                                                            \
+#define VEC_LAUNCH_ACT_AND_MUL(KERNEL, ACT_FIRST, N)                     \
+  case N: {                                                              \
+    queue.submit([&](sycl::handler& cgh) {                               \
+      cgh.parallel_for(                                                  \
+          sycl::nd_range<1>(num_tokens * wg_size, wg_size),              \
+          vllm::act_and_mul_vec_kernel<sycl_t, KERNEL, ACT_FIRST, N>(    \
+              (sycl_t*)out_ptr, (sycl_t*)input_ptr, d, valid_rows_ptr)); \
+    });                                                                  \
+    break;                                                               \
   }
 
 #define VEC_LAUNCH_ACT_AND_MUL_WITH_PARAM(KERNEL, N)                  \
@@ -424,36 +459,47 @@ class swiglustep_and_mul_kernel {
     break;                                                            \
   }
 
-#define LAUNCH_ACTIVATION_GATE_KERNEL_VEC(KERNEL, ACT_FIRST)             \
-  using sycl_t = vllm::xpu::SyclTypeTrait<scalar_t>::Type;               \
-  int d = input.size(-1) / 2;                                            \
-  int64_t num_tokens = input.numel() / input.size(-1);                   \
-  if (num_tokens == 0) {                                                 \
-    return;                                                              \
-  }                                                                      \
-  auto out_ptr = out.data_ptr<scalar_t>();                               \
-  auto input_ptr = input.data_ptr<scalar_t>();                           \
-  at::DeviceGuard device_guard(input.device());                          \
-  auto& queue = vllm::xpu::vllmGetQueue();                               \
-  int vec_size = static_cast<int>(sizeof(float) * 4 / sizeof(scalar_t)); \
-  {                                                                      \
-    int64_t tmp_wg =                                                     \
-        std::min(static_cast<int64_t>(d), static_cast<int64_t>(1024));   \
-    while (vec_size > 1 && (vec_size >> 1) * tmp_wg >= d) {              \
-      vec_size = vec_size >> 1;                                          \
-    }                                                                    \
-  }                                                                      \
-  if (d % vec_size != 0) vec_size = 1;                                   \
-  int64_t wg_size = std::min(                                            \
-      static_cast<int64_t>(d / vec_size), static_cast<int64_t>(1024));   \
-  switch (vec_size) {                                                    \
-    VEC_LAUNCH_ACT_AND_MUL(KERNEL, ACT_FIRST, 1);                        \
-    VEC_LAUNCH_ACT_AND_MUL(KERNEL, ACT_FIRST, 2);                        \
-    VEC_LAUNCH_ACT_AND_MUL(KERNEL, ACT_FIRST, 4);                        \
-    VEC_LAUNCH_ACT_AND_MUL(KERNEL, ACT_FIRST, 8);                        \
-    VEC_LAUNCH_ACT_AND_MUL(KERNEL, ACT_FIRST, 16);                       \
-    default:                                                             \
-      TORCH_CHECK(false, "Unsupported vector size: ", vec_size);         \
+#define LAUNCH_ACTIVATION_GATE_KERNEL_VEC(KERNEL, ACT_FIRST)                   \
+  using sycl_t = vllm::xpu::SyclTypeTrait<scalar_t>::Type;                     \
+  int d = input.size(-1) / 2;                                                  \
+  int64_t num_tokens = input.numel() / input.size(-1);                         \
+  if (num_tokens == 0) {                                                       \
+    return;                                                                    \
+  }                                                                            \
+  auto out_ptr = out.data_ptr<scalar_t>();                                     \
+  auto input_ptr = input.data_ptr<scalar_t>();                                 \
+  const int64_t* valid_rows_ptr = nullptr;                                     \
+  if (valid_rows.has_value()) {                                                \
+    TORCH_CHECK(                                                               \
+        valid_rows->scalar_type() == torch::kInt64,                            \
+        "valid_rows must be int64");                                           \
+    TORCH_CHECK(valid_rows->numel() == 1, "valid_rows must have one element"); \
+    TORCH_CHECK(                                                               \
+        valid_rows->device() == input.device(),                                \
+        "valid_rows must be on the same device as input");                     \
+    valid_rows_ptr = valid_rows->data_ptr<int64_t>();                          \
+  }                                                                            \
+  at::DeviceGuard device_guard(input.device());                                \
+  auto& queue = vllm::xpu::vllmGetQueue();                                     \
+  int vec_size = static_cast<int>(sizeof(float) * 4 / sizeof(scalar_t));       \
+  {                                                                            \
+    int64_t tmp_wg =                                                           \
+        std::min(static_cast<int64_t>(d), static_cast<int64_t>(1024));         \
+    while (vec_size > 1 && (vec_size >> 1) * tmp_wg >= d) {                    \
+      vec_size = vec_size >> 1;                                                \
+    }                                                                          \
+  }                                                                            \
+  if (d % vec_size != 0) vec_size = 1;                                         \
+  int64_t wg_size = std::min(                                                  \
+      static_cast<int64_t>(d / vec_size), static_cast<int64_t>(1024));         \
+  switch (vec_size) {                                                          \
+    VEC_LAUNCH_ACT_AND_MUL(KERNEL, ACT_FIRST, 1);                              \
+    VEC_LAUNCH_ACT_AND_MUL(KERNEL, ACT_FIRST, 2);                              \
+    VEC_LAUNCH_ACT_AND_MUL(KERNEL, ACT_FIRST, 4);                              \
+    VEC_LAUNCH_ACT_AND_MUL(KERNEL, ACT_FIRST, 8);                              \
+    VEC_LAUNCH_ACT_AND_MUL(KERNEL, ACT_FIRST, 16);                             \
+    default:                                                                   \
+      TORCH_CHECK(false, "Unsupported vector size: ", vec_size);               \
   }
 
 #define LAUNCH_ACTIVATION_GATE_KERNEL_WITH_PARAM_VEC(KERNEL, PARAM)      \
@@ -490,8 +536,9 @@ class swiglustep_and_mul_kernel {
   }
 
 void silu_and_mul(
-    torch::Tensor& out,    // [..., d]
-    torch::Tensor& input)  // [..., 2 * d]
+    torch::Tensor& out,                       // [..., d]
+    torch::Tensor& input,                     // [..., 2 * d]
+    std::optional<torch::Tensor> valid_rows)  // optional int64 scalar
 {
   VLLM_DISPATCH_FLOATING_TYPES(input.scalar_type(), "silu_and_mul", [&] {
     LAUNCH_ACTIVATION_GATE_KERNEL_VEC(vllm::silu_kernel, true);
@@ -569,14 +616,16 @@ void mul_and_silu(
     torch::Tensor& out,    // [..., d]
     torch::Tensor& input)  // [..., 2 * d]
 {
+  std::optional<torch::Tensor> valid_rows = std::nullopt;
   VLLM_DISPATCH_FLOATING_TYPES(input.scalar_type(), "mul_and_silu", [&] {
     LAUNCH_ACTIVATION_GATE_KERNEL_VEC(vllm::silu_kernel, false);
   });
 }
 
 void gelu_and_mul(
-    torch::Tensor& out,    // [..., d]
-    torch::Tensor& input)  // [..., 2 * d]
+    torch::Tensor& out,                       // [..., d]
+    torch::Tensor& input,                     // [..., 2 * d]
+    std::optional<torch::Tensor> valid_rows)  // optional int64 scalar
 {
   VLLM_DISPATCH_FLOATING_TYPES(input.scalar_type(), "gelu_and_mul", [&] {
     LAUNCH_ACTIVATION_GATE_KERNEL_VEC(vllm::gelu_kernel, true);
@@ -584,8 +633,9 @@ void gelu_and_mul(
 }
 
 void gelu_tanh_and_mul(
-    torch::Tensor& out,    // [..., d]
-    torch::Tensor& input)  // [..., 2 * d]
+    torch::Tensor& out,                       // [..., d]
+    torch::Tensor& input,                     // [..., 2 * d]
+    std::optional<torch::Tensor> valid_rows)  // optional int64 scalar
 {
   VLLM_DISPATCH_FLOATING_TYPES(input.scalar_type(), "gelu_tanh_and_mul", [&] {
     LAUNCH_ACTIVATION_GATE_KERNEL_VEC(vllm::gelu_tanh_kernel, true);
@@ -603,50 +653,74 @@ void fatrelu_and_mul(
 }
 
 // Launch element-wise activation kernel.
-#define LAUNCH_ACTIVATION_KERNEL(KERNEL)                   \
-  using sycl_t = vllm::xpu::SyclTypeTrait<scalar_t>::Type; \
-  int d = input.size(-1);                                  \
-  int64_t num_tokens = input.numel() / input.size(-1);     \
-  sycl::range<3> grid(1, 1, num_tokens);                   \
-  sycl::range<3> block(1, 1, std::min(d, 1024));           \
-  if (num_tokens == 0) {                                   \
-    return;                                                \
-  }                                                        \
-  auto out_ptr = out.data_ptr<scalar_t>();                 \
-  auto input_ptr = input.data_ptr<scalar_t>();             \
-  at::DeviceGuard device_guard(input.device());            \
-  auto& queue = vllm::xpu::vllmGetQueue();                 \
-  queue.submit([&](sycl::handler& cgh) {                   \
-    cgh.parallel_for(                                      \
-        sycl::nd_range<3>(grid * block, block),            \
-        vllm::act_kernel<sycl_t, KERNEL>(                  \
-            (sycl_t*)out_ptr, (sycl_t*)input_ptr, d));     \
+#define LAUNCH_ACTIVATION_KERNEL(KERNEL)                                       \
+  using sycl_t = vllm::xpu::SyclTypeTrait<scalar_t>::Type;                     \
+  int d = input.size(-1);                                                      \
+  int64_t num_tokens = input.numel() / input.size(-1);                         \
+  sycl::range<3> grid(1, 1, num_tokens);                                       \
+  sycl::range<3> block(1, 1, std::min(d, 1024));                               \
+  if (num_tokens == 0) {                                                       \
+    return;                                                                    \
+  }                                                                            \
+  auto out_ptr = out.data_ptr<scalar_t>();                                     \
+  auto input_ptr = input.data_ptr<scalar_t>();                                 \
+  const int64_t* valid_rows_ptr = nullptr;                                     \
+  if (valid_rows.has_value()) {                                                \
+    TORCH_CHECK(                                                               \
+        valid_rows->scalar_type() == torch::kInt64,                            \
+        "valid_rows must be int64");                                           \
+    TORCH_CHECK(valid_rows->numel() == 1, "valid_rows must have one element"); \
+    TORCH_CHECK(                                                               \
+        valid_rows->device() == input.device(),                                \
+        "valid_rows must be on the same device as input");                     \
+    valid_rows_ptr = valid_rows->data_ptr<int64_t>();                          \
+  }                                                                            \
+  at::DeviceGuard device_guard(input.device());                                \
+  auto& queue = vllm::xpu::vllmGetQueue();                                     \
+  queue.submit([&](sycl::handler& cgh) {                                       \
+    cgh.parallel_for(                                                          \
+        sycl::nd_range<3>(grid * block, block),                                \
+        vllm::act_kernel<sycl_t, KERNEL>(                                      \
+            (sycl_t*)out_ptr, (sycl_t*)input_ptr, d, valid_rows_ptr));         \
   });
 
-#define LAUNCH_SWIGLUOAI_AND_MUL(KERNEL, ALPHA, LIMIT)                    \
-  int d = input.size(-1) / 2;                                             \
-  int64_t num_tokens = input.numel() / input.size(-1);                    \
-  sycl::range<1> grid(num_tokens);                                        \
-  sycl::range<1> block(std::min(d, 1024));                                \
-  at::DeviceGuard device_guard(input.device());                           \
-  auto& queue = vllm::xpu::vllmGetQueue();                                \
-  VLLM_DISPATCH_FLOATING_TYPES(                                           \
-      input.scalar_type(), "clamp_swiglu_kernel_with_params", [&] {       \
-        queue.submit([&](sycl::handler& cgh) {                            \
-          cgh.parallel_for(                                               \
-              sycl::nd_range<1>(grid * block, block),                     \
-              vllm::swigluoai_and_mul_kernel<scalar_t, KERNEL<scalar_t>>( \
-                  out.data_ptr<scalar_t>(),                               \
-                  input.data_ptr<scalar_t>(),                             \
-                  d,                                                      \
-                  ALPHA,                                                  \
-                  LIMIT));                                                \
-        });                                                               \
+#define LAUNCH_SWIGLUOAI_AND_MUL(KERNEL, ALPHA, LIMIT)                         \
+  int d = input.size(-1) / 2;                                                  \
+  int64_t num_tokens = input.numel() / input.size(-1);                         \
+  sycl::range<1> grid(num_tokens);                                             \
+  sycl::range<1> block(std::min(d, 1024));                                     \
+  at::DeviceGuard device_guard(input.device());                                \
+  auto& queue = vllm::xpu::vllmGetQueue();                                     \
+  const int64_t* valid_rows_ptr = nullptr;                                     \
+  if (valid_rows.has_value()) {                                                \
+    TORCH_CHECK(                                                               \
+        valid_rows->scalar_type() == torch::kInt64,                            \
+        "valid_rows must be int64");                                           \
+    TORCH_CHECK(valid_rows->numel() == 1, "valid_rows must have one element"); \
+    TORCH_CHECK(                                                               \
+        valid_rows->device() == input.device(),                                \
+        "valid_rows must be on the same device as input");                     \
+    valid_rows_ptr = valid_rows->data_ptr<int64_t>();                          \
+  }                                                                            \
+  VLLM_DISPATCH_FLOATING_TYPES(                                                \
+      input.scalar_type(), "clamp_swiglu_kernel_with_params", [&] {            \
+        queue.submit([&](sycl::handler& cgh) {                                 \
+          cgh.parallel_for(                                                    \
+              sycl::nd_range<1>(grid * block, block),                          \
+              vllm::swigluoai_and_mul_kernel<scalar_t, KERNEL<scalar_t>>(      \
+                  out.data_ptr<scalar_t>(),                                    \
+                  input.data_ptr<scalar_t>(),                                  \
+                  d,                                                           \
+                  ALPHA,                                                       \
+                  LIMIT,                                                       \
+                  valid_rows_ptr));                                            \
+        });                                                                    \
       });
 
 void gelu_new(
-    torch::Tensor& out,    // [..., d]
-    torch::Tensor& input)  // [..., d]
+    torch::Tensor& out,                       // [..., d]
+    torch::Tensor& input,                     // [..., d]
+    std::optional<torch::Tensor> valid_rows)  // optional int64 scalar
 {
   VLLM_DISPATCH_FLOATING_TYPES(input.scalar_type(), "gelu_new", [&] {
     LAUNCH_ACTIVATION_KERNEL(vllm::gelu_new_kernel);
@@ -654,8 +728,9 @@ void gelu_new(
 }
 
 void gelu_fast(
-    torch::Tensor& out,    // [..., d]
-    torch::Tensor& input)  // [..., d]
+    torch::Tensor& out,                       // [..., d]
+    torch::Tensor& input,                     // [..., d]
+    std::optional<torch::Tensor> valid_rows)  // optional int64 scalar
 {
   VLLM_DISPATCH_FLOATING_TYPES(input.scalar_type(), "gelu_fast", [&] {
     LAUNCH_ACTIVATION_KERNEL(vllm::gelu_fast_kernel);
@@ -663,8 +738,9 @@ void gelu_fast(
 }
 
 void gelu_quick(
-    torch::Tensor& out,    // [..., d]
-    torch::Tensor& input)  // [..., d]
+    torch::Tensor& out,                       // [..., d]
+    torch::Tensor& input,                     // [..., d]
+    std::optional<torch::Tensor> valid_rows)  // optional int64 scalar
 {
   VLLM_DISPATCH_FLOATING_TYPES(input.scalar_type(), "gelu_quick", [&] {
     LAUNCH_ACTIVATION_KERNEL(vllm::gelu_quick_kernel);
@@ -672,8 +748,9 @@ void gelu_quick(
 }
 
 void relu2_no_mul(
-    torch::Tensor& out,    // [..., d]
-    torch::Tensor& input)  // [..., d]
+    torch::Tensor& out,                       // [..., d]
+    torch::Tensor& input,                     // [..., d]
+    std::optional<torch::Tensor> valid_rows)  // optional int64 scalar
 {
   VLLM_DISPATCH_FLOATING_TYPES(input.scalar_type(), "relu2_no_mul", [&] {
     LAUNCH_ACTIVATION_KERNEL(vllm::relu2_no_mul_kernel);
@@ -684,33 +761,47 @@ void swigluoai_and_mul(
     torch::Tensor& out,    // [..., d]
     torch::Tensor& input,  // [..., 2 * d]
     double alpha,
-    double limit) {
+    double limit,
+    std::optional<torch::Tensor> valid_rows) {
   LAUNCH_SWIGLUOAI_AND_MUL(vllm::swigluoai_and_mul, alpha, limit);
 }
 
-#define LAUNCH_SWIGLUSTEP_AND_MUL(KERNEL, LIMIT)                           \
-  int d = input.size(-1) / 2;                                              \
-  int64_t num_tokens = input.numel() / input.size(-1);                     \
-  sycl::range<1> grid(num_tokens);                                         \
-  sycl::range<1> block(std::min(d, 1024));                                 \
-  at::DeviceGuard device_guard(input.device());                            \
-  auto& queue = vllm::xpu::vllmGetQueue();                                 \
-  VLLM_DISPATCH_FLOATING_TYPES(                                            \
-      input.scalar_type(), "swiglustep_and_mul_kernel", [&] {              \
-        queue.submit([&](sycl::handler& cgh) {                             \
-          cgh.parallel_for(                                                \
-              sycl::nd_range<1>(grid * block, block),                      \
-              vllm::swiglustep_and_mul_kernel<scalar_t, KERNEL<scalar_t>>( \
-                  out.data_ptr<scalar_t>(),                                \
-                  input.data_ptr<scalar_t>(),                              \
-                  d,                                                       \
-                  LIMIT));                                                 \
-        });                                                                \
+#define LAUNCH_SWIGLUSTEP_AND_MUL(KERNEL, LIMIT)                               \
+  int d = input.size(-1) / 2;                                                  \
+  int64_t num_tokens = input.numel() / input.size(-1);                         \
+  sycl::range<1> grid(num_tokens);                                             \
+  sycl::range<1> block(std::min(d, 1024));                                     \
+  at::DeviceGuard device_guard(input.device());                                \
+  auto& queue = vllm::xpu::vllmGetQueue();                                     \
+  const int64_t* valid_rows_ptr = nullptr;                                     \
+  if (valid_rows.has_value()) {                                                \
+    TORCH_CHECK(                                                               \
+        valid_rows->scalar_type() == torch::kInt64,                            \
+        "valid_rows must be int64");                                           \
+    TORCH_CHECK(valid_rows->numel() == 1, "valid_rows must have one element"); \
+    TORCH_CHECK(                                                               \
+        valid_rows->device() == input.device(),                                \
+        "valid_rows must be on the same device as input");                     \
+    valid_rows_ptr = valid_rows->data_ptr<int64_t>();                          \
+  }                                                                            \
+  VLLM_DISPATCH_FLOATING_TYPES(                                                \
+      input.scalar_type(), "swiglustep_and_mul_kernel", [&] {                  \
+        queue.submit([&](sycl::handler& cgh) {                                 \
+          cgh.parallel_for(                                                    \
+              sycl::nd_range<1>(grid * block, block),                          \
+              vllm::swiglustep_and_mul_kernel<scalar_t, KERNEL<scalar_t>>(     \
+                  out.data_ptr<scalar_t>(),                                    \
+                  input.data_ptr<scalar_t>(),                                  \
+                  d,                                                           \
+                  LIMIT,                                                       \
+                  valid_rows_ptr));                                            \
+        });                                                                    \
       });
 
 void swiglustep_and_mul(
     torch::Tensor& out,    // [..., d]
     torch::Tensor& input,  // [..., 2 * d]
-    double limit) {
+    double limit,
+    std::optional<torch::Tensor> valid_rows) {
   LAUNCH_SWIGLUSTEP_AND_MUL(vllm::swiglustep_and_mul, limit);
 }

--- a/csrc/moe/moe_ops.h
+++ b/csrc/moe/moe_ops.h
@@ -109,4 +109,5 @@ void remap_hidden_states(
     torch::Tensor& unpermuted_row_to_permuted_row,
     torch::Tensor& topk_ids,
     int64_t total_experts_num,
-    int64_t local_experts_num);
+    int64_t local_experts_num,
+    const c10::optional<torch::Tensor>& valid_tokens);

--- a/csrc/moe/remap_hidden_states.cpp
+++ b/csrc/moe/remap_hidden_states.cpp
@@ -136,6 +136,7 @@ class RemapHiddenStates {
       int* expert_map,
       int* unpermuted_row_to_permuted_row,
       int* rows_per_expert,
+      int64_t* valid_tokens,
       void* topk_ids,
       bool is_topk_ids_int32,
       const int num_rows,
@@ -151,6 +152,7 @@ class RemapHiddenStates {
         expert_map(expert_map),
         unpermuted_row_to_permuted_row(unpermuted_row_to_permuted_row),
         rows_per_expert(rows_per_expert),
+        valid_tokens(valid_tokens),
         topk_ids(topk_ids),
         is_topk_ids_int32(is_topk_ids_int32),
         num_rows(num_rows),
@@ -199,6 +201,11 @@ class RemapHiddenStates {
         expert_cumsum_ptr + local_experts_num,
         expert_cumsum_ptr,
         sycl::plus<int>{});
+
+    if (valid_tokens != nullptr && group_id == 0 && local_id == 0) {
+      valid_tokens[0] = expert_cumsum_ptr[local_experts_num - 1] +
+                        rows_per_expert[local_experts_num - 1];
+    }
 
     int row = group_id;
     int global_expert_id[TopK];
@@ -335,6 +342,7 @@ class RemapHiddenStates {
   int* expert_map;
   int* unpermuted_row_to_permuted_row;
   int* rows_per_expert;
+  int64_t* valid_tokens;
   void* topk_ids;
   bool is_topk_ids_int32;
   const int num_rows;
@@ -353,6 +361,7 @@ void RemapHiddenStatesLauncher(
     int* expert_map,
     int* rows_per_expert,
     int* unpermuted_row_to_permuted_row,
+    int64_t* valid_tokens,
     void* topk_ids,
     bool is_topk_ids_int32,
     const int num_rows,
@@ -399,6 +408,7 @@ void RemapHiddenStatesLauncher(
             expert_map,
             unpermuted_row_to_permuted_row,
             rows_per_expert,
+            valid_tokens,
             topk_ids,
             is_topk_ids_int32,
             num_rows,
@@ -426,7 +436,8 @@ void remap_hidden_states(
     torch::Tensor& unpermuted_row_to_permuted_row,   // [num_rows, TopK]
     torch::Tensor& topk_ids,                         // [num_rows, TopK]
     int64_t total_experts_num,
-    int64_t local_experts_num) {
+    int64_t local_experts_num,
+    const c10::optional<torch::Tensor>& valid_tokens) {
   // dtype check
   TORCH_CHECK(
       hidden_states.scalar_type() == remapped_hidden_states.scalar_type(),
@@ -485,6 +496,14 @@ void remap_hidden_states(
   TORCH_CHECK(
       rows_per_expert.size(0) == local_experts_num,
       "rows_per_expert must be [local_experts_num]");
+  TORCH_CHECK(local_experts_num > 0, "local_experts_num must be > 0");
+  if (valid_tokens.has_value()) {
+    TORCH_CHECK(
+        valid_tokens->scalar_type() == torch::kInt64,
+        "valid_tokens must be int64");
+    TORCH_CHECK(
+        valid_tokens->numel() == 1, "valid_tokens must contain 1 element");
+  }
   TORCH_CHECK(
       topk_ids.size(0) == num_rows && topk_ids.size(1) == TopK,
       "topk_ids must be [num_rows, TopK]");
@@ -506,6 +525,9 @@ void remap_hidden_states(
                              : nullptr,                                       \
       reinterpret_cast<int*>(rows_per_expert.data_ptr()),                     \
       reinterpret_cast<int*>(unpermuted_row_to_permuted_row.data_ptr()),      \
+      (valid_tokens.has_value()                                               \
+           ? reinterpret_cast<int64_t*>(valid_tokens->data_ptr())             \
+           : nullptr),                                                        \
       reinterpret_cast<void*>(topk_ids.data_ptr()),                           \
       topk_ids.scalar_type() == torch::kInt32,                                \
       num_rows,                                                               \

--- a/csrc/moe/torch_bindings.cpp
+++ b/csrc/moe/torch_bindings.cpp
@@ -100,8 +100,8 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, m) {
       "Tensor? remapped_hidden_states_scales,"
       "Tensor? expert_map, Tensor rows_per_expert,"
       "Tensor unpermuted_row_to_permuted_row, Tensor topk_ids,"
-      "int total_experts_num, int "
-      "local_experts_num) -> "
+      "int total_experts_num, int local_experts_num, "
+      "Tensor? valid_tokens=None) -> "
       "()");
   m.impl("remap_hidden_states", torch::kXPU, &remap_hidden_states);
 }

--- a/csrc/ops.h
+++ b/csrc/ops.h
@@ -64,7 +64,10 @@ void fused_add_rms_norm_static_fp8_quant(
     torch::Tensor& scale,
     double epsilon);
 
-void silu_and_mul(torch::Tensor& out, torch::Tensor& input);
+void silu_and_mul(
+    torch::Tensor& out,
+    torch::Tensor& input,
+    std::optional<torch::Tensor> valid_rows = std::nullopt);
 
 void silu_and_mul_quant(
     torch::Tensor& out, torch::Tensor& input, torch::Tensor& scale);
@@ -87,18 +90,50 @@ void silu_and_mul_mxfp4_quant(
 
 void mul_and_silu(torch::Tensor& out, torch::Tensor& input);
 
-void gelu_and_mul(torch::Tensor& out, torch::Tensor& input);
+void gelu_and_mul(
+    torch::Tensor& out,
+    torch::Tensor& input,
+    std::optional<torch::Tensor> valid_rows = std::nullopt);
+void relu2_no_mul(
+    torch::Tensor& out,
+    torch::Tensor& input,
+    std::optional<torch::Tensor> valid_rows = std::nullopt);
 
-void gelu_tanh_and_mul(torch::Tensor& out, torch::Tensor& input);
+void swigluoai_and_mul(
+    torch::Tensor& out,
+    torch::Tensor& input,
+    double alpha = 1.702,
+    double limit = 7.0,
+    std::optional<torch::Tensor> valid_rows = std::nullopt);
+
+void swiglustep_and_mul(
+    torch::Tensor& out,
+    torch::Tensor& input,
+    double limit = 7.0,
+    std::optional<torch::Tensor> valid_rows = std::nullopt);
+
+void gelu_tanh_and_mul(
+    torch::Tensor& out,
+    torch::Tensor& input,
+    std::optional<torch::Tensor> valid_rows = std::nullopt);
 
 void fatrelu_and_mul(
     torch::Tensor& out, torch::Tensor& input, double threshold);
 
-void gelu_fast(torch::Tensor& out, torch::Tensor& input);
+void gelu_fast(
+    torch::Tensor& out,
+    torch::Tensor& input,
+    std::optional<torch::Tensor> valid_rows = std::nullopt);
 
-void gelu_new(torch::Tensor& out, torch::Tensor& input);
+void gelu_new(
+    torch::Tensor& out,
+    torch::Tensor& input,
+    std::optional<torch::Tensor> valid_rows = std::nullopt);
 
-void gelu_quick(torch::Tensor& out, torch::Tensor& input);
+void gelu_quick(
+    torch::Tensor& out,
+    torch::Tensor& input,
+    std::optional<torch::Tensor> valid_rows = std::nullopt);
 
 void rotary_embedding(
     torch::Tensor& positions,
@@ -217,17 +252,6 @@ void per_token_group_quant_mxfp4(
     torch::Tensor& output_s,
     int64_t group_size,
     double eps);
-
-void swigluoai_and_mul(
-    torch::Tensor& out,
-    torch::Tensor& input,
-    double alpha = 1.702,
-    double limit = 7.0);
-
-void relu2_no_mul(torch::Tensor& out, torch::Tensor& input);
-
-void swiglustep_and_mul(
-    torch::Tensor& out, torch::Tensor& input, double limit = 7.0);
 
 torch::Tensor get_xpu_view_from_cpu_tensor(torch::Tensor& cpu_tensor);
 

--- a/csrc/torch_bindings.cpp
+++ b/csrc/torch_bindings.cpp
@@ -77,7 +77,9 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
       &fused_add_rms_norm_static_fp8_quant);
 
   // activation ops
-  ops.def("silu_and_mul(Tensor! result, Tensor input) -> ()");
+  ops.def(
+      "silu_and_mul(Tensor! result, Tensor input, Tensor? valid_rows=None)"
+      " -> ()");
   ops.impl("silu_and_mul", torch::kXPU, &silu_and_mul);
 
   // Fused SiLU + Mul + FP8 Quantization
@@ -109,22 +111,27 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
   ops.def("mul_and_silu(Tensor! out, Tensor input) -> ()");
   ops.impl("mul_and_silu", torch::kXPU, &mul_and_silu);
 
-  ops.def("gelu_and_mul(Tensor! out, Tensor input) -> ()");
+  ops.def(
+      "gelu_and_mul(Tensor! out, Tensor input, Tensor? valid_rows=None) -> ()");
   ops.impl("gelu_and_mul", torch::kXPU, &gelu_and_mul);
 
-  ops.def("gelu_tanh_and_mul(Tensor! out, Tensor input) -> ()");
+  ops.def(
+      "gelu_tanh_and_mul(Tensor! out, Tensor input, Tensor? valid_rows=None) "
+      "-> ()");
   ops.impl("gelu_tanh_and_mul", torch::kXPU, &gelu_tanh_and_mul);
 
   ops.def("fatrelu_and_mul(Tensor! out, Tensor! input, float threshold) -> ()");
   ops.impl("fatrelu_and_mul", torch::kXPU, &fatrelu_and_mul);
 
-  ops.def("gelu_fast(Tensor! out, Tensor input) -> ()");
+  ops.def(
+      "gelu_fast(Tensor! out, Tensor input, Tensor? valid_rows=None) -> ()");
   ops.impl("gelu_fast", torch::kXPU, &gelu_fast);
 
-  ops.def("gelu_new(Tensor! out, Tensor input) -> ()");
+  ops.def("gelu_new(Tensor! out, Tensor input, Tensor? valid_rows=None) -> ()");
   ops.impl("gelu_new", torch::kXPU, &gelu_new);
 
-  ops.def("gelu_quick(Tensor! out, Tensor input) -> ()");
+  ops.def(
+      "gelu_quick(Tensor! out, Tensor input, Tensor? valid_rows=None) -> ()");
   ops.impl("gelu_quick", torch::kXPU, &gelu_quick);
 
   // pos_embedding
@@ -185,18 +192,21 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
 
   // swigluoai_and_mul
   ops.def(
-      "swigluoai_and_mul(Tensor! out, Tensor input, float alpha=1.702, float "
-      "limit=7.0) "
+      "swigluoai_and_mul(Tensor! out, Tensor input, float alpha=1.702, "
+      "float limit=7.0, Tensor? valid_rows=None) "
       "-> ()");
   ops.impl("swigluoai_and_mul", torch::kXPU, &swigluoai_and_mul);
 
   // relu2_no_mul
-  ops.def("relu2_no_mul(Tensor! out, Tensor! input) -> ()");
+  ops.def(
+      "relu2_no_mul(Tensor! out, Tensor! input, Tensor? valid_rows=None) -> "
+      "()");
   ops.impl("relu2_no_mul", torch::kXPU, &relu2_no_mul);
 
   // swiglustep_and_mul
   ops.def(
-      "swiglustep_and_mul(Tensor! out, Tensor input, float limit=7.0) "
+      "swiglustep_and_mul(Tensor! out, Tensor input, float limit=7.0, Tensor? "
+      "valid_rows=None) "
       "-> ()");
   ops.impl("swiglustep_and_mul", torch::kXPU, &swiglustep_and_mul);
 

--- a/vllm_xpu_kernels/fused_moe_interface.py
+++ b/vllm_xpu_kernels/fused_moe_interface.py
@@ -247,17 +247,23 @@ class XpuFusedMoe:
         self._use_ref = _should_use_ref_fused_moe(is_mxfp8, is_block_fp8)
         if self.activation == "silu":
             self.act_func = torch.ops._C.silu_and_mul
+            self.act_func_args = ()
         elif self.activation == "gelu":
             self.act_func = torch.ops._C.gelu_and_mul
+            self.act_func_args = ()
         elif self.activation == "gelu_tanh":
             self.act_func = torch.ops._C.gelu_tanh_and_mul
+            self.act_func_args = ()
         elif self.activation == "swigluoai" \
             or ("SWIGLUOAI" in str(self.activation)):
             self.act_func = torch.ops._C.swigluoai_and_mul
+            self.act_func_args = (1.702, 7.0)
         elif self.activation == "relu2_no_mul":
             self.act_func = torch.ops._C.relu2_no_mul
+            self.act_func_args = ()
         elif self.activation == "swiglustep":
             self.act_func = torch.ops._C.swiglustep_and_mul
+            self.act_func_args = (7.0,)
         else:
             raise ValueError(
                 f"Unsupported FusedMoe activation: {self.activation}.")
@@ -416,10 +422,8 @@ class XpuFusedMoe:
             (num_moe_inputs, self.inter_size * self.inter_size_scale),
             dtype=gemm1_output.dtype,
             device=gemm1_output.device)
-        fused_moe_activation(act_output,
-                             gemm1_output,
-                             self.activation,
-                             valid_tokens)
+        self.act_func(act_output, gemm1_output, *self.act_func_args,
+                      valid_tokens)
 
         ########### gemm2 ##################
         gemm2_output = torch.empty((num_moe_inputs, hidden_size),

--- a/vllm_xpu_kernels/fused_moe_interface.py
+++ b/vllm_xpu_kernels/fused_moe_interface.py
@@ -17,6 +17,7 @@ from .moe_utils import quant_act_xpu, ref_fused_moe
 
 REF_FUSED_MOE_ENV = "VLLM_XPU_FUSED_MOE_USE_REF"
 USE_MXFP4_FP8_ENV = "VLLM_XPU_FUSED_MOE_USE_MXFP4_FP8"
+_VALID_TOKENS_CACHE = {}
 
 def _is_env_enabled(env_name: str, default: str = "0") -> bool:
     value = os.environ.get(env_name, default).strip().upper()
@@ -27,6 +28,15 @@ def _should_use_ref_fused_moe(is_mxfp8: bool, is_block_fp8: bool) -> bool:
     if is_mxfp8 or is_block_fp8:
         return True
     return _is_env_enabled(REF_FUSED_MOE_ENV)
+
+
+def _should_use_ep_valid_tokens(total_experts_num: int,
+                                local_experts_num: int,
+                                num_rows: int) -> bool:
+    # Only enable this EP optimization for long-sequence prefill. Small-row
+    # workloads, especially decode, do not show stable benefit and should keep
+    # the existing path unchanged.
+    return total_experts_num > local_experts_num and num_rows >= 1024
 
 
 def _get_recipe(is_fp8, is_mxfp8, is_mxfp4, is_int4, is_block_fp8):
@@ -107,19 +117,24 @@ def compute_num_tokens_per_block(num_tokens, num_experts_per_node):
     return 1024
 
 
-def fused_moe_activation(act_output, gemm1_output, activation):
+def fused_moe_activation(act_output,
+                         gemm1_output,
+                         activation,
+                         valid_tokens=None):
     if activation == "silu":
-        torch.ops._C.silu_and_mul(act_output, gemm1_output)
+        torch.ops._C.silu_and_mul(act_output, gemm1_output, valid_tokens)
     elif activation == "gelu":
-        torch.ops._C.gelu_and_mul(act_output, gemm1_output)
+        torch.ops._C.gelu_and_mul(act_output, gemm1_output, valid_tokens)
     elif activation == "gelu_tanh":
-        torch.ops._C.gelu_tanh_and_mul(act_output, gemm1_output)
+        torch.ops._C.gelu_tanh_and_mul(act_output, gemm1_output, valid_tokens)
     elif activation == "swigluoai" or ("SWIGLUOAI" in str(activation)):
-        torch.ops._C.swigluoai_and_mul(act_output, gemm1_output, 1.702, 7.0)
+        torch.ops._C.swigluoai_and_mul(act_output, gemm1_output,
+                                       1.702, 7.0, valid_tokens)
     elif activation == "relu2_no_mul":
-        torch.ops._C.relu2_no_mul(act_output, gemm1_output)
+        torch.ops._C.relu2_no_mul(act_output, gemm1_output, valid_tokens)
     elif activation == "swiglustep":
-        torch.ops._C.swiglustep_and_mul(act_output, gemm1_output, 7.0)
+        torch.ops._C.swiglustep_and_mul(act_output, gemm1_output,
+                                        7.0, valid_tokens)
     else:
         raise ValueError(f"Unsupported FusedMoe activation: {activation}.")
 
@@ -263,6 +278,9 @@ class XpuFusedMoe:
         else:
             self.total_experts_num = self.num_experts * self.ep_size
         self.local_experts_num = self.num_experts
+        # Cache a 1-element int64 tensor for valid_tokens to avoid
+        # repeated device allocations per call which can increase latency.
+        self._valid_tokens = None
 
     def apply(
         self,
@@ -345,6 +363,18 @@ class XpuFusedMoe:
             dtype=torch.int32,
             device=hidden_states.device)
 
+        valid_tokens = None
+        if _should_use_ep_valid_tokens(self.total_experts_num,
+                           self.local_experts_num,
+                           num_rows):
+            # Reuse cached tensor when possible to avoid allocation overhead.
+            if (self._valid_tokens is None or
+                    self._valid_tokens.device != hidden_states.device):
+                self._valid_tokens = torch.empty((1,),
+                                                dtype=torch.int64,
+                                                device=hidden_states.device)
+            valid_tokens = self._valid_tokens
+
         torch.ops._moe_C.remap_hidden_states(
             hidden_states=hidden_states,
             hidden_states_scales=a1q_scale,
@@ -355,7 +385,8 @@ class XpuFusedMoe:
             unpermuted_row_to_permuted_row=unpermuted_row_to_permuted_row,
             topk_ids=topk_ids,
             total_experts_num=self.total_experts_num,
-            local_experts_num=self.local_experts_num)
+            local_experts_num=self.local_experts_num,
+            valid_tokens=valid_tokens)
 
         ########### gemm1 ##################
         gemm1_output = torch.empty((num_moe_inputs, 2 * self.inter_size),
@@ -380,12 +411,15 @@ class XpuFusedMoe:
             gate.clamp_(max=self.gemm1_clamp_limit)
             up.clamp_(min=-self.gemm1_clamp_limit, max=self.gemm1_clamp_limit)
 
-        # act
+        # act: pass valid_tokens to the shared kernel to skip invalid rows.
         act_output = torch.empty(
             (num_moe_inputs, self.inter_size * self.inter_size_scale),
             dtype=gemm1_output.dtype,
             device=gemm1_output.device)
-        self.act_func(act_output, gemm1_output)
+        fused_moe_activation(act_output,
+                             gemm1_output,
+                             self.activation,
+                             valid_tokens)
 
         ########### gemm2 ##################
         gemm2_output = torch.empty((num_moe_inputs, hidden_size),
@@ -543,6 +577,26 @@ def xpu_fused_moe(hidden_states,
         dtype=torch.int32,
         device=hidden_states.device)
 
+    valid_tokens = None
+    if _should_use_ep_valid_tokens(total_experts_num,
+                                   local_experts_num,
+                                   num_rows):
+        # Reuse a module-level cache for functional API to avoid
+        # allocating a new tensor on every call.
+        dev_key = str(hidden_states.device)
+        cached_tokens = _VALID_TOKENS_CACHE.get(dev_key)
+        if (
+            cached_tokens is None
+            or cached_tokens.device != hidden_states.device
+        ):
+            cached_tokens = torch.empty(
+                (1,),
+                dtype=torch.int64,
+                device=hidden_states.device,
+            )
+            _VALID_TOKENS_CACHE[dev_key] = cached_tokens
+        valid_tokens = cached_tokens
+
     torch.ops._moe_C.remap_hidden_states(
         hidden_states=hidden_states,
         hidden_states_scales=None,
@@ -553,7 +607,8 @@ def xpu_fused_moe(hidden_states,
         unpermuted_row_to_permuted_row=unpermuted_row_to_permuted_row,
         topk_ids=topk_ids,
         total_experts_num=total_experts_num,
-        local_experts_num=local_experts_num)
+        local_experts_num=local_experts_num,
+        valid_tokens=valid_tokens)
 
     ########### gemm1 ##################
     input_B = w13
@@ -579,12 +634,12 @@ def xpu_fused_moe(hidden_states,
         gate.clamp_(max=gemm1_clamp_limit)
         up.clamp_(min=-gemm1_clamp_limit, max=gemm1_clamp_limit)
 
-    # act
     inter_size_scale = 2 if activation == "relu2_no_mul" else 1
+    # act: pass valid_tokens to the shared kernel to skip invalid rows.
     act_output = torch.empty((num_moe_inputs, inter_size * inter_size_scale),
                              dtype=gemm1_output.dtype,
                              device=gemm1_output.device)
-    fused_moe_activation(act_output, gemm1_output, activation)
+    fused_moe_activation(act_output, gemm1_output, activation, valid_tokens)
 
     ########### gemm2 ##################
     input_A = act_output.contiguous()


### PR DESCRIPTION
Summary
This PR optimizes the XPU fused MoE activation path for EP prefill by passing the valid routed row count into fusion and skipping invalid trailing rows on device.

In EP, the real routed rows can be smaller than num_rows * topk. Without this information, activation still runs on the full upper-bound shape even though grouped GEMM already uses the real routed rows. Carrying the valid row count into fusion avoids redundant activation work without introducing Python-side host synchronization.

This path is only enabled for EP prefill. Decode keeps the existing behavior, and TP is unaffected because it does not use this EP-specific valid-row path

In https://github.com/Tencent/hpc-ops, they also use valid_row_range_ptr to skip unused rows