### PR TITLE
fix ep of ref moe

### DIFF
--- a/vllm_xpu_kernels/fused_moe_interface.py
+++ b/vllm_xpu_kernels/fused_moe_interface.py
@@ -221,6 +221,7 @@ def ref_fused_moe(recipe,
                                       < expert_start_id) or (expert_id
                                                              >= expert_end_id):
             continue
+        expert_id -= expert_start_id
         exp_token_idxs = token_idxs[start_idx:end_idx]
         expert_tokens = x[exp_token_idxs]
 


### PR DESCRIPTION
Fix expert index error.
Results of ep 4:
```
model=Qwen/Qwen3-30B-A3B-FP8
VLLM_XPU_FUSED_MOE_USE_REF=1 python3 examples/basic/offline_inference/generate.py --model $model  --enforce-eager --temperature 0 -tp 4 --max-model-len 1024 --enable_expert_parallel
```

<img width="805" height="218" alt="image" src="https://github.com/user-attachments/assets/f830fe0f-543e-45cf-81fd-ba2cb64d7811" />