### PR TITLE
Change divisible number of N to 8

### DIFF
--- a/csrc/xpu/grouped_gemm/xe_2/grouped_gemm_xe2_interface.hpp
+++ b/csrc/xpu/grouped_gemm/xe_2/grouped_gemm_xe2_interface.hpp
@@ -178,7 +178,7 @@ at::Tensor cutlass_grouped_gemm_xe2_impl(
   bool is_weight_fp8 =
       ((B_dtype == at::kFloat8_e4m3fn) || (B_dtype == at::kFloat8_e5m2));
 
-  TORCH_CHECK(N % 32 == 0, "N must be divisible by 32");
+  TORCH_CHECK(N % 8 == 0, "N must be divisible by 8");
 
   TORCH_CHECK(ptr_A.dim() == 2, "ptr_A must be 2D [Total_M, K]");
   TORCH_CHECK(ptr_B.dim() == 3, "ptr_B must be 3D [num_experts, K, N]");

--- a/tests/fused_moe/test_fused_moe.py
+++ b/tests/fused_moe/test_fused_moe.py
@@ -163,8 +163,8 @@ def test_fused_moe(m, n, k, e, topk, dtype, w_dtype, has_bias):
     seed_everything(7)
 
     input_len = m
-    hidden_size = k
-    intermediate_size = n
+    hidden_size = n
+    intermediate_size = k
     num_experts = e
 
     a = torch.randn((input_len, hidden_size), device=DEVICE, dtype=dtype) / 16
@@ -300,6 +300,10 @@ def test_fused_moe_int4(m, n, k, e, topk, dtype, has_bias):
     # scale
     group_num_13 = hidden_size // group_size
     group_num_2 = intermediate_size // group_size
+    assert hidden_size % group_size == 0, \
+        "hidden_size must be divisible by group_size"
+    assert intermediate_size % group_size == 0, \
+        "intermediate_size must be divisible by group_size"
     random_exponents = torch.randint(
         -5,
         -4, (num_experts, 2 * intermediate_size, group_num_13),
@@ -514,8 +518,8 @@ def test_fused_moe_ep(m, n, k, e, topk, ep_rank, ep_size, dtype, w_dtype,
     seed_everything(7)
 
     input_len = m
-    hidden_size = k
-    intermediate_size = n
+    hidden_size = n
+    intermediate_size = k
     num_experts = e
 
     a = torch.randn((input_len, hidden_size), device=DEVICE, dtype=dtype) / 16
@@ -664,6 +668,10 @@ def test_fused_moe_int4_ep(m, n, k, e, topk, ep_rank, ep_size, dtype,
     # scale
     group_num_13 = hidden_size // group_size
     group_num_2 = intermediate_size // group_size
+    assert hidden_size % group_size == 0, \
+        "hidden_size must be divisible by group_size"
+    assert intermediate_size % group_size == 0, \
+        "intermediate_size must be divisible by group_size"
     random_exponents = torch.randint(
         -5,
         -4, (num_experts, 2 * intermediate_size, group_num_13),
@@ -891,8 +899,8 @@ def test_fused_moe_clamp_limit(m, n, k, e, topk, dtype, gemm1_clamp_limit):
     seed_everything(7)
 
     input_len = m
-    hidden_size = k
-    intermediate_size = n
+    hidden_size = n
+    intermediate_size = k
     num_experts = e
 
     # Use /2 scaling so GEMM1 std ≈ 0.25 * sqrt(k) ≈ 8 for k=1024,


### PR DESCRIPTION
https://jira.devtools.intel.com/browse/VLLMZ-1658
Some models like nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16 have N which cannot be divisible by 32 if tp=4.
Therefore, the standard is relaxed after testing.
Change divisible number of N to 8, which is limited by sycl-tla: when N cannot be divisible by 8, output of gemm is wrong.
And fix UT params.
 
lm_eval results with limits 100:
<img width="532" height="95" alt="image" src="https://github.com/user-attachments/assets/cc5bbb14-d106-4316-b877-d47e12672a93" />
