### PR TITLE
Fix shared-local-memory write-after-read race in GDN chunk kernels (NaN at >=32K on XE2)

### DIFF
--- a/csrc/xpu/gdn_attn/xe_2/chunk_gated_delta_rule_kernels_xe2.hpp
+++ b/csrc/xpu/gdn_attn/xe_2/chunk_gated_delta_rule_kernels_xe2.hpp
@@ -199,6 +199,11 @@ CUTE_DEVICE void chunk_compute_A_kernel(
       const int chunk_start_offset = chunk_id * chunk_size;
 
       for (int v_head_id = 0; v_head_id < num_v_heads; ++v_head_id) {
+        // WAR fence: sub-groups from the previous (chunk, v_head)
+        // iteration may still be reading g_slm_ptr in the exp()
+        // epilogue; all must arrive before any sub-group refills the
+        // SLM (g_slm_ptr) for this iteration.
+        item.barrier(sycl::access::fence_space::local_space);
         CUTE_UNROLL
         for (int e = local_id; e < chunk_size; e += local_range) {
           g_slm_ptr[e] =
@@ -769,6 +774,10 @@ CUTE_DEVICE void chunk_compute_wu_kernel(
       const int chunk_start_offset = chunk_id * chunk_size;
 
       for (int v_head_id = 0; v_head_id < num_v_heads; ++v_head_id) {
+        // WAR fence: previous iteration's sub-groups may still be
+        // reading beta_slm_ptr/g_slm_ptr; all must arrive before any
+        // sub-group refills the SLM for this iteration.
+        item.barrier(sycl::access::fence_space::local_space);
         CUTE_UNROLL
         for (int e = local_id; e < chunk_size; e += local_range) {
           float beta_value =
@@ -966,6 +975,11 @@ CUTE_DEVICE void chunk_fwd_o_kernel(
           a[(chunk_offset + current_chunk_size - 1) +
             v_head_id * total_virtual_seqlen];
       float g_last_value_exp = sycl::native::exp(g_last_value);
+      // WAR fence: the previous chunk iteration's sub-groups may
+      // still be reading g_slm_ptr/g_multi_slm_ptr/g_exp_slm_ptr in
+      // their output/state GEMM epilogues; all must arrive before any
+      // sub-group refills these SLM buffers for this chunk.
+      item.barrier(sycl::access::fence_space::local_space);
       CUTE_UNROLL
       for (int e = local_id; e < current_chunk_size; e += local_range) {
         float g_cumsum_value =

--- a/tests/gdn_attn/test_gdn_attn.py
+++ b/tests/gdn_attn/test_gdn_attn.py
@@ -436,9 +436,6 @@ def test_gdn_attention(num_actual_tokens, batch_size, num_k_heads, head_k_dim,
 
     torch.testing.assert_close(z, ref_z, atol=atol, rtol=rtol)
 
-    if num_actual_tokens == 8192:
-        pytest.skip("FIXME, skip core_attn_out test because of random error")
-
     torch.testing.assert_close(core_attn_out,
                                ref_core_attn_out,
                                atol=atol,
@@ -450,14 +447,10 @@ def test_gdn_attention(num_actual_tokens, batch_size, num_k_heads, head_k_dim,
                                    ref_conv_state[state_id],
                                    atol=atol,
                                    rtol=rtol)
-        if num_actual_tokens == 8192:
-            # FIXME: remove this skip
-            # skip because of random error, will be fixed in future
-            pytest.skip("FIXME, skip ssm_state test because of random error")
-            torch.testing.assert_close(ssm_state[state_id],
-                                       ref_ssm_state[state_id],
-                                       atol=atol,
-                                       rtol=rtol)
+        torch.testing.assert_close(ssm_state[state_id],
+                                   ref_ssm_state[state_id],
+                                   atol=atol,
+                                   rtol=rtol)
 
 
 NUM_SPEC_DECODES = [1, 4]


### PR DESCRIPTION
### Environment

main (6bf5660; same race on v0.1.8/v0.1.9), torch 2.12.0+xpu, oneAPI 2025.3, IGC
2.28.4, Arc Pro B70 (BMG-G31), compute-runtime 26.05, kernel 6.17.

### Summary

I repeatedly see GDN models at >=32K on XE2 emit NaN logits ('!!!!') or
nondeterministic output at temperature 0.

`chunk_compute_A_kernel` and `chunk_compute_wu_kernel` refill `g_slm_ptr` and
`beta_slm_ptr` each (chunk, v_head) iteration with only the post-fill barrier. Nothing
orders the refill against the previous iteration's readers, so a sub-group that
finishes its GEMM early overwrites the SLM while slower sub-groups still read it in the
exp() epilogue (`sycl::exp(g_slm_ptr[m_idx] - g_slm_ptr[n_idx])`). Mismatched cumsum
pairs give wrong decay factors: a low-bit error when stale and fresh are close,
and an overflow to NaN when they're far apart. The corruption lands in one (chunk, v_head) cell and
propagates through ssm_state, matching the signature: NaN in 1 of `num_v_heads`,
mid-sequence onset.

This is the "random error" behind the `num_actual_tokens == 8192` skips in
`tests/gdn_attn/test_gdn_attn.py`, added in #261. The fix makes them pass; patch 2
removes them.

### Reproduction

I ran both reproductions on main (6bf5660), BMG-G31, stock vs fixed.

With the 8192 skips removed, the repo's own test (bf16 prefill/mix-mode):

| kernels | 16 cases x 2 reps |
|---|---|
| stock | 7/16, 8/16 FAILED |
| + fix | 16/16, 16/16 passed |

Then `repro_gdn_inverse_race.py`, which drives `torch.ops._xpu_C.gdn_attention`
directly in chains of 16 state-linked 8192-token prefills (NK=16 HK=128 NV=48 HV=128),
counting NaN/all-zero output:

| kernels | NaN out of 2000 |
|---|---|
| stock | 1/2000 |
| + fix | 0/2000 |

I used the same harness on v0.1.9 (torch 2.11): 3/2000 to 0/2000, and bitwise replay
81% to 0%. Torch 2.12 seems to introduce a separate nondeterminism: on main, replay is
95-99% on both stock and fixed, so I am reporting only NaN results there.

I also forced L1-bypass loads, which made it worse on v0.1.9 (14/2000), not better.
Slower readers widen the refill window, which rules out cache coherence and confirms
the reader-latency-scaled WAR.

### Fix

I add three `local_space` barriers, one before each SLM refill, in
`chunk_compute_A_kernel`, `chunk_compute_wu_kernel`, `chunk_fwd_o_kernel`. No new
memory, no algorithm change, and no measurable perf cost (decode 22.6 vs 22.9 tok/s,
prefill 3.40 vs 3.41 s, identical greedy output).

Separately, `chunk_fwd_o_kernel` stages tiles through global memory across sub-groups
with only `local_space` fences, which don't order global stores. On v0.1.9 I saw no
behavioral change from this (the per-Xe-core L1 seems to mask it), so the SLM fences
suffice. It's still a data race under the memory model, and #379 changed that staging,
so I can add those fences here if you want them.

### Test

Patch 2 removes the two `num_actual_tokens == 8192` FIXME skips and restores the
core_attn_out and ssm_state assertions (ssm_state was dead code after the skip). On the
repo's shapes (NV=32) the 8192 bf16 cases fail 7-8/16 on stock and pass 16/16 fixed.
