### PR TITLE
[XPU][DeepSeekV4] Deepseek-v4 inv-rope sycl kernel support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -613,6 +613,7 @@ if(XPU_SPECIFIC_KERNELS_ENABLED)
       "csrc/xpu/sampler/topk_topp_sampler.cpp"
       "csrc/xpu/sycl/deepseek_scaling_rope.cpp"
       "csrc/xpu/sycl/deepseek_qnorm_rope_kv_insert.cpp"
+      "csrc/xpu/sycl/deepseek_inv_rope_bf16.cpp"
       "csrc/xpu/sycl/multimodal_rope.cpp"
       "csrc/xpu/sycl/apply_rotary_emb.cpp"
       "csrc/xpu/rand/exponential.cpp"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -614,6 +614,7 @@ if(XPU_SPECIFIC_KERNELS_ENABLED)
       "csrc/xpu/sycl/deepseek_scaling_rope.cpp"
       "csrc/xpu/sycl/deepseek_qnorm_rope_kv_insert.cpp"
       "csrc/xpu/sycl/deepseek_inv_rope_bf16.cpp"
+      "csrc/xpu/sycl/deepseek_inv_rope_fp8_quant.cpp"
       "csrc/xpu/sycl/multimodal_rope.cpp"
       "csrc/xpu/sycl/apply_rotary_emb.cpp"
       "csrc/xpu/rand/exponential.cpp"

--- a/csrc/xpu/ops.h
+++ b/csrc/xpu/ops.h
@@ -110,6 +110,15 @@ torch::Tensor deepseek_inv_rope_bf16(
     int64_t nope_dim,
     int64_t rope_dim);
 
+std::tuple<torch::Tensor, torch::Tensor> deepseek_inv_rope_fp8_quant(
+    const torch::Tensor& o,
+    const torch::Tensor& positions,
+    const torch::Tensor& cos_sin_cache,
+    int64_t n_groups,
+    int64_t heads_per_group,
+    int64_t nope_dim,
+    int64_t rope_dim);
+
 #ifdef VLLM_GDN_ENABLED
 void gdn_attention(
     torch::Tensor& core_attn_out,

--- a/csrc/xpu/ops.h
+++ b/csrc/xpu/ops.h
@@ -101,6 +101,15 @@ void deepseek_qnorm_rope_kv_insert(
     int64_t block_size,
     const std::string& kv_cache_dtype);
 
+torch::Tensor deepseek_inv_rope_bf16(
+    const torch::Tensor& o,
+    const torch::Tensor& positions,
+    const torch::Tensor& cos_sin_cache,
+    int64_t n_groups,
+    int64_t heads_per_group,
+    int64_t nope_dim,
+    int64_t rope_dim);
+
 #ifdef VLLM_GDN_ENABLED
 void gdn_attention(
     torch::Tensor& core_attn_out,

--- a/csrc/xpu/ops.h
+++ b/csrc/xpu/ops.h
@@ -102,7 +102,7 @@ void deepseek_qnorm_rope_kv_insert(
     const std::string& kv_cache_dtype);
 
 torch::Tensor deepseek_inv_rope_bf16(
-    const torch::Tensor& o,
+    const torch::Tensor& attn_output,
     const torch::Tensor& positions,
     const torch::Tensor& cos_sin_cache,
     int64_t n_groups,
@@ -111,7 +111,7 @@ torch::Tensor deepseek_inv_rope_bf16(
     int64_t rope_dim);
 
 std::tuple<torch::Tensor, torch::Tensor> deepseek_inv_rope_fp8_quant(
-    const torch::Tensor& o,
+    const torch::Tensor& attn_output,
     const torch::Tensor& positions,
     const torch::Tensor& cos_sin_cache,
     int64_t n_groups,

--- a/csrc/xpu/sycl/deepseek_inv_rope_bf16.cpp
+++ b/csrc/xpu/sycl/deepseek_inv_rope_bf16.cpp
@@ -1,0 +1,223 @@
+#include <sycl/sycl.hpp>
+#include "utils.h"
+#include <cstdint>
+#include <torch/all.h>
+
+namespace vllm {
+
+using bf16_t = sycl::ext::oneapi::bfloat16;
+
+/**
+ * Fused inverse GPT-J RoPE kernel for DeepSeek-V4.
+ *
+ * Each work-item (one sub-group of SG_SIZE lanes) processes one (token, head)
+ * pair.  The kernel:
+ *   1. Copies nope_dim bf16 elements unchanged (bulk uint64 copies).
+ *   2. Applies inverse GPT-J rotation on rope_dim elements using fp32
+ *      cos/sin cache.
+ *   3. Writes output in group-major layout: [T, G, hpg*D].
+ *
+ * Input:  o             [num_tokens, num_heads, head_dim] bf16
+ *         positions     [num_tokens] int64
+ *         cos_sin_cache [max_pos, rope_dim] float32  (cos||sin concatenated)
+ * Output: out           [num_tokens, n_groups, heads_per_group * head_dim] bf16
+ */
+class deepseek_inv_rope_bf16_kernel {
+ public:
+  static constexpr int SG_SIZE = 16;
+
+  deepseek_inv_rope_bf16_kernel(
+      const bf16_t* __restrict__ o,
+      const int64_t* __restrict__ positions,
+      const float* __restrict__ cos_sin_cache,
+      bf16_t* __restrict__ out,
+      int64_t num_tokens,
+      int64_t num_heads,
+      int64_t heads_per_group,
+      int64_t head_dim,
+      int64_t nope_dim,
+      int64_t half_rope,
+      int64_t nope_iters,
+      int64_t rope_iters,
+      int64_t o_stride_token,
+      int64_t o_stride_head,
+      int64_t cache_stride_pos,
+      int64_t out_stride_token,
+      int64_t out_stride_group)
+      : o_(o),
+        positions_(positions),
+        cos_sin_cache_(cos_sin_cache),
+        out_(out),
+        num_tokens_(num_tokens),
+        num_heads_(num_heads),
+        heads_per_group_(heads_per_group),
+        head_dim_(head_dim),
+        nope_dim_(nope_dim),
+        half_rope_(half_rope),
+        nope_iters_(nope_iters),
+        rope_iters_(rope_iters),
+        o_stride_token_(o_stride_token),
+        o_stride_head_(o_stride_head),
+        cache_stride_pos_(cache_stride_pos),
+        out_stride_token_(out_stride_token),
+        out_stride_group_(out_stride_group) {}
+
+  [[sycl::reqd_sub_group_size(SG_SIZE)]]
+  void operator()(sycl::nd_item<3> item) const {
+    const int64_t token_idx = item.get_global_id(0);
+    const int64_t head_idx = item.get_global_id(1);
+    const int64_t lane = item.get_local_id(2);
+
+    if (token_idx >= num_tokens_ || head_idx >= num_heads_) return;
+
+    const int64_t group = head_idx / heads_per_group_;
+    const int64_t head_in_group = head_idx % heads_per_group_;
+
+    const bf16_t* src =
+        o_ + token_idx * o_stride_token_ + head_idx * o_stride_head_;
+    bf16_t* dst = out_ + token_idx * out_stride_token_ +
+                  group * out_stride_group_ + head_in_group * head_dim_;
+
+    // Bulk copy NoPE dimensions (uint64 = 4 bf16 elements per lane per iter)
+    {
+      const uint64_t* s8 = reinterpret_cast<const uint64_t*>(src);
+      uint64_t* d8 = reinterpret_cast<uint64_t*>(dst);
+      for (int64_t i = 0; i < nope_iters_; ++i) {
+        d8[lane + i * SG_SIZE] = s8[lane + i * SG_SIZE];
+      }
+    }
+
+    // Inverse GPT-J RoPE rotation in fp32
+    const int64_t pos = positions_[token_idx];
+    const float* cos_ptr = cos_sin_cache_ + pos * cache_stride_pos_;
+    const float* sin_ptr = cos_ptr + half_rope_;
+
+    for (int64_t pp = 0; pp < rope_iters_; ++pp) {
+      const int64_t p = lane + pp * SG_SIZE;
+      const float x_even = static_cast<float>(src[nope_dim_ + 2 * p]);
+      const float x_odd = static_cast<float>(src[nope_dim_ + 2 * p + 1]);
+      const float c = cos_ptr[p];
+      const float s = sin_ptr[p];
+      // Inverse rotation: x_new = x*cos + y*sin, y_new = y*cos - x*sin
+      dst[nope_dim_ + 2 * p] = static_cast<bf16_t>(x_even * c + x_odd * s);
+      dst[nope_dim_ + 2 * p + 1] = static_cast<bf16_t>(x_odd * c - x_even * s);
+    }
+  }
+
+ private:
+  const bf16_t* __restrict__ o_;
+  const int64_t* __restrict__ positions_;
+  const float* __restrict__ cos_sin_cache_;
+  bf16_t* __restrict__ out_;
+  int64_t num_tokens_, num_heads_;
+  int64_t heads_per_group_, head_dim_, nope_dim_, half_rope_;
+  int64_t nope_iters_, rope_iters_;
+  int64_t o_stride_token_, o_stride_head_;
+  int64_t cache_stride_pos_;
+  int64_t out_stride_token_, out_stride_group_;
+};
+
+}  // namespace vllm
+
+/**
+ * @brief Fused inverse GPT-J RoPE for DeepSeek-V4 attention output.
+ *
+ * Applies inverse RoPE rotation and regroups heads into group-major layout.
+ *
+ * @param o             Attention output [num_tokens, num_heads, head_dim] bf16
+ * @param positions     Token positions [num_tokens] int64
+ * @param cos_sin_cache Precomputed [max_pos, rope_dim] float32 (cos||sin)
+ * @param n_groups      Number of head groups
+ * @param heads_per_group Heads per group
+ * @param nope_dim      Non-RoPE dimensions per head
+ * @param rope_dim      RoPE dimensions per head
+ * @return Output tensor [num_tokens, n_groups, heads_per_group * head_dim] bf16
+ */
+torch::Tensor deepseek_inv_rope_bf16(
+    const torch::Tensor& o,
+    const torch::Tensor& positions,
+    const torch::Tensor& cos_sin_cache,
+    int64_t n_groups,
+    int64_t heads_per_group,
+    int64_t nope_dim,
+    int64_t rope_dim) {
+  using bf16_t = sycl::ext::oneapi::bfloat16;
+  constexpr int SG_SIZE = vllm::deepseek_inv_rope_bf16_kernel::SG_SIZE;
+
+  TORCH_CHECK(o.dim() == 3, "o must be 3D [num_tokens, num_heads, head_dim]");
+  TORCH_CHECK(o.scalar_type() == torch::kBFloat16, "o must be bfloat16");
+  TORCH_CHECK(
+      positions.scalar_type() == torch::kLong, "positions must be int64");
+  TORCH_CHECK(
+      cos_sin_cache.scalar_type() == torch::kFloat32,
+      "cos_sin_cache must be float32");
+
+  const int64_t num_tokens = o.size(0);
+  const int64_t num_heads = o.size(1);
+  const int64_t head_dim = o.size(2);
+
+  TORCH_CHECK(
+      num_heads == n_groups * heads_per_group,
+      "num_heads must equal n_groups * heads_per_group");
+  TORCH_CHECK(
+      head_dim == nope_dim + rope_dim,
+      "head_dim must equal nope_dim + rope_dim");
+  TORCH_CHECK(rope_dim % 2 == 0, "rope_dim must be even");
+  TORCH_CHECK(
+      cos_sin_cache.size(-1) == rope_dim,
+      "cos_sin_cache last dim must equal rope_dim");
+  TORCH_CHECK(
+      nope_dim % (4 * SG_SIZE) == 0,
+      "nope_dim must be divisible by 4*SG_SIZE (64)");
+  TORCH_CHECK(
+      (rope_dim / 2) % SG_SIZE == 0,
+      "half_rope must be divisible by SG_SIZE (16)");
+
+  const int64_t half_rope = rope_dim / 2;
+  const int64_t nope_iters = nope_dim / (4 * SG_SIZE);
+  const int64_t rope_iters = half_rope / SG_SIZE;
+
+  // Output: [num_tokens, n_groups, heads_per_group * head_dim]
+  const int64_t d = heads_per_group * head_dim;
+  auto out = torch::empty(
+      {num_tokens, n_groups, d}, o.options().dtype(torch::kBFloat16));
+
+  if (num_tokens == 0) {
+    return out;
+  }
+
+  const int64_t o_stride_token = o.stride(0);
+  const int64_t o_stride_head = o.stride(1);
+  const int64_t cache_stride_pos = cos_sin_cache.stride(0);
+  const int64_t out_stride_token = out.stride(0);
+  const int64_t out_stride_group = out.stride(1);
+
+  sycl::range<3> local(1, 1, SG_SIZE);
+  sycl::range<3> global(num_tokens, num_heads, SG_SIZE);
+
+  auto& q = vllm::xpu::vllmGetQueue();
+  q.submit([&](sycl::handler& cgh) {
+    cgh.parallel_for(
+        sycl::nd_range<3>(global, local),
+        vllm::deepseek_inv_rope_bf16_kernel(
+            reinterpret_cast<const bf16_t*>(o.data_ptr()),
+            reinterpret_cast<const int64_t*>(positions.data_ptr()),
+            reinterpret_cast<const float*>(cos_sin_cache.data_ptr()),
+            reinterpret_cast<bf16_t*>(out.data_ptr()),
+            num_tokens,
+            num_heads,
+            heads_per_group,
+            head_dim,
+            nope_dim,
+            half_rope,
+            nope_iters,
+            rope_iters,
+            o_stride_token,
+            o_stride_head,
+            cache_stride_pos,
+            out_stride_token,
+            out_stride_group));
+  });
+
+  return out;
+}

--- a/csrc/xpu/sycl/deepseek_inv_rope_bf16.cpp
+++ b/csrc/xpu/sycl/deepseek_inv_rope_bf16.cpp
@@ -147,15 +147,23 @@ torch::Tensor deepseek_inv_rope_bf16(
   const auto& o = attn_output;
   TORCH_CHECK(o.dim() == 3, "o must be 3D [num_tokens, num_heads, head_dim]");
   TORCH_CHECK(o.scalar_type() == torch::kBFloat16, "o must be bfloat16");
+  TORCH_CHECK(o.is_contiguous(), "o must be contiguous");
   TORCH_CHECK(
       positions.scalar_type() == torch::kLong, "positions must be int64");
   TORCH_CHECK(
       cos_sin_cache.scalar_type() == torch::kFloat32,
       "cos_sin_cache must be float32");
+  TORCH_CHECK(
+      cos_sin_cache.stride(-1) == 1,
+      "cos_sin_cache must have contiguous last dim");
 
   const int64_t num_tokens = o.size(0);
   const int64_t num_heads = o.size(1);
   const int64_t head_dim = o.size(2);
+
+  TORCH_CHECK(
+      positions.size(0) == num_tokens,
+      "positions length must equal num_tokens");
 
   TORCH_CHECK(
       num_heads == n_groups * heads_per_group,

--- a/csrc/xpu/sycl/deepseek_inv_rope_bf16.cpp
+++ b/csrc/xpu/sycl/deepseek_inv_rope_bf16.cpp
@@ -124,7 +124,7 @@ class deepseek_inv_rope_bf16_kernel {
  *
  * Applies inverse RoPE rotation and regroups heads into group-major layout.
  *
- * @param o             Attention output [num_tokens, num_heads, head_dim] bf16
+ * @param attn_output   Attention output [num_tokens, num_heads, head_dim] bf16
  * @param positions     Token positions [num_tokens] int64
  * @param cos_sin_cache Precomputed [max_pos, rope_dim] float32 (cos||sin)
  * @param n_groups      Number of head groups
@@ -134,7 +134,7 @@ class deepseek_inv_rope_bf16_kernel {
  * @return Output tensor [num_tokens, n_groups, heads_per_group * head_dim] bf16
  */
 torch::Tensor deepseek_inv_rope_bf16(
-    const torch::Tensor& o,
+    const torch::Tensor& attn_output,
     const torch::Tensor& positions,
     const torch::Tensor& cos_sin_cache,
     int64_t n_groups,
@@ -144,6 +144,7 @@ torch::Tensor deepseek_inv_rope_bf16(
   using bf16_t = sycl::ext::oneapi::bfloat16;
   constexpr int SG_SIZE = vllm::deepseek_inv_rope_bf16_kernel::SG_SIZE;
 
+  const auto& o = attn_output;
   TORCH_CHECK(o.dim() == 3, "o must be 3D [num_tokens, num_heads, head_dim]");
   TORCH_CHECK(o.scalar_type() == torch::kBFloat16, "o must be bfloat16");
   TORCH_CHECK(

--- a/csrc/xpu/sycl/deepseek_inv_rope_fp8_quant.cpp
+++ b/csrc/xpu/sycl/deepseek_inv_rope_fp8_quant.cpp
@@ -215,15 +215,23 @@ std::tuple<torch::Tensor, torch::Tensor> deepseek_inv_rope_fp8_quant(
   const auto& o = attn_output;
   TORCH_CHECK(o.dim() == 3, "o must be 3D [num_tokens, num_heads, head_dim]");
   TORCH_CHECK(o.scalar_type() == torch::kBFloat16, "o must be bfloat16");
+  TORCH_CHECK(o.is_contiguous(), "o must be contiguous");
   TORCH_CHECK(
       positions.scalar_type() == torch::kLong, "positions must be int64");
   TORCH_CHECK(
       cos_sin_cache.scalar_type() == torch::kFloat32,
       "cos_sin_cache must be float32");
+  TORCH_CHECK(
+      cos_sin_cache.stride(-1) == 1,
+      "cos_sin_cache must have contiguous last dim");
 
   const int64_t num_tokens = o.size(0);
   const int64_t num_heads = o.size(1);
   const int64_t head_dim = o.size(2);
+
+  TORCH_CHECK(
+      positions.size(0) == num_tokens,
+      "positions length must equal num_tokens");
 
   TORCH_CHECK(
       num_heads == n_groups * heads_per_group,

--- a/csrc/xpu/sycl/deepseek_inv_rope_fp8_quant.cpp
+++ b/csrc/xpu/sycl/deepseek_inv_rope_fp8_quant.cpp
@@ -200,7 +200,7 @@ class deepseek_inv_rope_fp8_quant_kernel {
 // PyTorch wrapper: inv RoPE + FP8 quant.
 // Returns (fp8_out [G,T,hpg*D], scale_out [G,T,hpg*chunks]) .
 std::tuple<torch::Tensor, torch::Tensor> deepseek_inv_rope_fp8_quant(
-    const torch::Tensor& o,
+    const torch::Tensor& attn_output,
     const torch::Tensor& positions,
     const torch::Tensor& cos_sin_cache,
     int64_t n_groups,
@@ -212,6 +212,7 @@ std::tuple<torch::Tensor, torch::Tensor> deepseek_inv_rope_fp8_quant(
   constexpr int SG_SIZE = vllm::deepseek_inv_rope_fp8_quant_kernel::SG_SIZE;
   constexpr int QUANT_GROUP_SIZE = vllm::QUANT_GROUP_SIZE;
 
+  const auto& o = attn_output;
   TORCH_CHECK(o.dim() == 3, "o must be 3D [num_tokens, num_heads, head_dim]");
   TORCH_CHECK(o.scalar_type() == torch::kBFloat16, "o must be bfloat16");
   TORCH_CHECK(

--- a/csrc/xpu/sycl/deepseek_inv_rope_fp8_quant.cpp
+++ b/csrc/xpu/sycl/deepseek_inv_rope_fp8_quant.cpp
@@ -1,0 +1,297 @@
+#include <sycl/sycl.hpp>
+#include "utils.h"
+#include <cstdint>
+#include <torch/all.h>
+
+namespace vllm {
+
+using bf16_t = sycl::ext::oneapi::bfloat16;
+using fp8_t = uint8_t;
+
+static constexpr int QUANT_GROUP_SIZE = 128;
+static constexpr float FP8_E4M3_MAX = 448.0f;
+
+// Ceil to power-of-2; also returns biased exponent in *out_scale_exp.
+inline float fast_ceil_pow2(float x, uint32_t& out_scale_exp) {
+  uint32_t bits;
+  __builtin_memcpy(&bits, &x, 4);
+  if (bits & 0x7FFFFF) {
+    bits = (bits + 0x800000) & 0xFF800000u;
+  }
+  out_scale_exp = bits >> 23;
+  float result;
+  __builtin_memcpy(&result, &bits, 4);
+  return result;
+}
+
+// Divide by pow2 scale + convert to fp8_e4m3 in pure integer arithmetic.
+inline uint8_t fused_scale_to_fp8(float val, uint32_t scale_exp) {
+  uint32_t bits;
+  __builtin_memcpy(&bits, &val, 4);
+  uint32_t sign = bits >> 31;
+  uint32_t v_exp = (bits >> 23) & 0xFFu;
+  uint32_t v_mant = bits & 0x7FFFFFu;
+
+  uint32_t mant3 = v_mant >> 20;
+  uint32_t remainder = v_mant & 0xFFFFFu;
+  // Round-to-nearest-even
+  if (remainder > 0x80000u || (remainder == 0x80000u && (mant3 & 1u))) {
+    mant3++;
+  }
+  uint32_t e4m3_exp = v_exp - scale_exp + 7u + (mant3 >> 3);
+  mant3 &= 7u;
+  uint32_t result = (e4m3_exp << 3) | mant3;
+  result = (v_exp + 7u >= scale_exp) ? result : 0u;
+
+  return static_cast<uint8_t>((sign << 7) | (result & 0x7Fu));
+}
+
+// Fused inv RoPE + FP8 quant kernel. One sub-group (16 lanes) per (token,
+// head). Loads all 512 elements upfront, applies inv RoPE, then per-128-block
+// quantizes.
+class deepseek_inv_rope_fp8_quant_kernel {
+ public:
+  static constexpr int SG_SIZE = 16;
+  static constexpr int CHUNKS_PER_HEAD = 4;
+  static constexpr int ELEMS_PER_LANE = QUANT_GROUP_SIZE / SG_SIZE;
+
+  deepseek_inv_rope_fp8_quant_kernel(
+      const bf16_t* __restrict__ o,
+      const int64_t* __restrict__ positions,
+      const float* __restrict__ cos_sin_cache,
+      fp8_t* __restrict__ fp8_out,
+      float* __restrict__ scale_out,
+      int64_t num_tokens,
+      int64_t num_heads,
+      int64_t heads_per_group,
+      int64_t head_dim,
+      int64_t nope_dim,
+      int64_t half_rope,
+      int64_t o_stride_token,
+      int64_t o_stride_head,
+      int64_t cache_stride_pos,
+      int64_t fp8_stride_group,
+      int64_t fp8_stride_token,
+      int64_t scale_stride_group,
+      int64_t scale_stride_token)
+      : o_(o),
+        positions_(positions),
+        cos_sin_cache_(cos_sin_cache),
+        fp8_out_(fp8_out),
+        scale_out_(scale_out),
+        num_tokens_(num_tokens),
+        num_heads_(num_heads),
+        heads_per_group_(heads_per_group),
+        head_dim_(head_dim),
+        nope_dim_(nope_dim),
+        half_rope_(half_rope),
+        o_stride_token_(o_stride_token),
+        o_stride_head_(o_stride_head),
+        cache_stride_pos_(cache_stride_pos),
+        fp8_stride_group_(fp8_stride_group),
+        fp8_stride_token_(fp8_stride_token),
+        scale_stride_group_(scale_stride_group),
+        scale_stride_token_(scale_stride_token) {}
+
+  [[sycl::reqd_sub_group_size(SG_SIZE)]]
+  void operator()(sycl::nd_item<3> item) const {
+    const int64_t token_idx = item.get_global_id(0);
+    const int64_t head_idx = item.get_global_id(1);
+    const int64_t lane = item.get_local_id(2);
+
+    if (token_idx >= num_tokens_ || head_idx >= num_heads_) return;
+
+    const int64_t group = head_idx / heads_per_group_;
+    const int64_t head_in_group = head_idx % heads_per_group_;
+
+    const bf16_t* src =
+        o_ + token_idx * o_stride_token_ + head_idx * o_stride_head_;
+
+    fp8_t* fp8_dst = fp8_out_ + group * fp8_stride_group_ +
+                     token_idx * fp8_stride_token_ + head_in_group * head_dim_;
+
+    float* scale_dst = scale_out_ + group * scale_stride_group_ +
+                       token_idx * scale_stride_token_ +
+                       head_in_group * CHUNKS_PER_HEAD;
+
+    const int lane32 = static_cast<int>(lane);
+    auto sg = item.get_sub_group();
+
+    // Load all 4 chunks into registers upfront.
+    float vals[CHUNKS_PER_HEAD][ELEMS_PER_LANE];
+
+#pragma unroll
+    for (int chunk = 0; chunk < CHUNKS_PER_HEAD; ++chunk) {
+      const uint32_t* s = reinterpret_cast<const uint32_t*>(
+          src + chunk * QUANT_GROUP_SIZE + lane32 * ELEMS_PER_LANE);
+#pragma unroll
+      for (int e = 0; e < ELEMS_PER_LANE / 2; ++e) {
+        uint32_t pair = s[e];
+        vals[chunk][e * 2] = static_cast<float>(
+            sycl::bit_cast<bf16_t>(static_cast<uint16_t>(pair)));
+        vals[chunk][e * 2 + 1] = static_cast<float>(
+            sycl::bit_cast<bf16_t>(static_cast<uint16_t>(pair >> 16)));
+      }
+    }
+
+    const int64_t pos = positions_[token_idx];
+    const float* cos_ptr = cos_sin_cache_ + pos * cache_stride_pos_;
+    const float* sin_ptr = cos_ptr + half_rope_;
+
+    // Inverse RoPE on chunk 3 (lanes 8-15 = rope region).
+    if (lane32 >= 8) {
+      const int pair_base = (lane32 - 8) * 4;
+#pragma unroll
+      for (int p = 0; p < 4; ++p) {
+        float c = cos_ptr[pair_base + p];
+        float s = sin_ptr[pair_base + p];
+        float x_even = vals[3][2 * p];
+        float x_odd = vals[3][2 * p + 1];
+        vals[3][2 * p] = x_even * c + x_odd * s;
+        vals[3][2 * p + 1] = x_odd * c - x_even * s;
+      }
+    }
+
+// Per-128-block: absmax reduce → pow2 scale → fused fp8 quantize.
+#pragma unroll
+    for (int chunk = 0; chunk < CHUNKS_PER_HEAD; ++chunk) {
+      float local_absmax = 0.0f;
+#pragma unroll
+      for (int e = 0; e < ELEMS_PER_LANE; ++e)
+        local_absmax = sycl::fmax(local_absmax, sycl::fabs(vals[chunk][e]));
+
+      float block_absmax =
+          sycl::reduce_over_group(sg, local_absmax, sycl::maximum<float>());
+      float scale_raw =
+          sycl::fmax(block_absmax, 1e-10f) * (1.0f / FP8_E4M3_MAX);
+      uint32_t scale_exp;
+      float scale = fast_ceil_pow2(scale_raw, scale_exp);
+      if (lane == 0) scale_dst[chunk] = scale;
+
+      uint64_t packed = 0;
+#pragma unroll
+      for (int e = 0; e < ELEMS_PER_LANE; ++e)
+        packed |=
+            (static_cast<uint64_t>(
+                 fused_scale_to_fp8(vals[chunk][e], scale_exp))
+             << (e * 8));
+      *reinterpret_cast<uint64_t*>(
+          fp8_dst + chunk * QUANT_GROUP_SIZE + lane32 * ELEMS_PER_LANE) =
+          packed;
+    }
+  }
+
+ private:
+  const bf16_t* __restrict__ o_;
+  const int64_t* __restrict__ positions_;
+  const float* __restrict__ cos_sin_cache_;
+  fp8_t* __restrict__ fp8_out_;
+  float* __restrict__ scale_out_;
+  int64_t num_tokens_, num_heads_;
+  int64_t heads_per_group_, head_dim_, nope_dim_, half_rope_;
+  int64_t o_stride_token_, o_stride_head_;
+  int64_t cache_stride_pos_;
+  int64_t fp8_stride_group_, fp8_stride_token_;
+  int64_t scale_stride_group_, scale_stride_token_;
+};
+
+}  // namespace vllm
+
+// PyTorch wrapper: inv RoPE + FP8 quant.
+// Returns (fp8_out [G,T,hpg*D], scale_out [G,T,hpg*chunks]) .
+std::tuple<torch::Tensor, torch::Tensor> deepseek_inv_rope_fp8_quant(
+    const torch::Tensor& o,
+    const torch::Tensor& positions,
+    const torch::Tensor& cos_sin_cache,
+    int64_t n_groups,
+    int64_t heads_per_group,
+    int64_t nope_dim,
+    int64_t rope_dim) {
+  using bf16_t = sycl::ext::oneapi::bfloat16;
+  using fp8_t = uint8_t;
+  constexpr int SG_SIZE = vllm::deepseek_inv_rope_fp8_quant_kernel::SG_SIZE;
+  constexpr int QUANT_GROUP_SIZE = vllm::QUANT_GROUP_SIZE;
+
+  TORCH_CHECK(o.dim() == 3, "o must be 3D [num_tokens, num_heads, head_dim]");
+  TORCH_CHECK(o.scalar_type() == torch::kBFloat16, "o must be bfloat16");
+  TORCH_CHECK(
+      positions.scalar_type() == torch::kLong, "positions must be int64");
+  TORCH_CHECK(
+      cos_sin_cache.scalar_type() == torch::kFloat32,
+      "cos_sin_cache must be float32");
+
+  const int64_t num_tokens = o.size(0);
+  const int64_t num_heads = o.size(1);
+  const int64_t head_dim = o.size(2);
+
+  TORCH_CHECK(
+      num_heads == n_groups * heads_per_group,
+      "num_heads must equal n_groups * heads_per_group");
+  TORCH_CHECK(
+      head_dim == nope_dim + rope_dim,
+      "head_dim must equal nope_dim + rope_dim");
+  TORCH_CHECK(rope_dim % 2 == 0, "rope_dim must be even");
+  TORCH_CHECK(
+      head_dim % QUANT_GROUP_SIZE == 0,
+      "head_dim must be divisible by QUANT_GROUP_SIZE (128)");
+  TORCH_CHECK(
+      cos_sin_cache.size(-1) == rope_dim,
+      "cos_sin_cache last dim must equal rope_dim");
+  TORCH_CHECK(
+      head_dim == 512 && nope_dim == 448 && rope_dim == 64,
+      "Currently only supports head_dim=512, nope_dim=448, rope_dim=64");
+
+  const int64_t half_rope = rope_dim / 2;
+  const int64_t d = heads_per_group * head_dim;
+  const int64_t chunks_per_head = head_dim / QUANT_GROUP_SIZE;
+  const int64_t num_scale_blocks = heads_per_group * chunks_per_head;
+
+  auto fp8_out = torch::empty(
+      {n_groups, num_tokens, d}, o.options().dtype(torch::kFloat8_e4m3fn));
+
+  auto scale_out = torch::empty(
+      {n_groups, num_tokens, num_scale_blocks},
+      o.options().dtype(torch::kFloat32));
+
+  if (num_tokens == 0) {
+    return {fp8_out, scale_out};
+  }
+
+  const int64_t o_stride_token = o.stride(0);
+  const int64_t o_stride_head = o.stride(1);
+  const int64_t cache_stride_pos = cos_sin_cache.stride(0);
+  const int64_t fp8_stride_group = fp8_out.stride(0);
+  const int64_t fp8_stride_token = fp8_out.stride(1);
+  const int64_t scale_stride_group = scale_out.stride(0);
+  const int64_t scale_stride_token = scale_out.stride(1);
+
+  sycl::range<3> local(1, 1, SG_SIZE);
+  sycl::range<3> global(num_tokens, num_heads, SG_SIZE);
+
+  auto& q = vllm::xpu::vllmGetQueue();
+  q.submit([&](sycl::handler& cgh) {
+    cgh.parallel_for(
+        sycl::nd_range<3>(global, local),
+        vllm::deepseek_inv_rope_fp8_quant_kernel(
+            reinterpret_cast<const bf16_t*>(o.data_ptr()),
+            reinterpret_cast<const int64_t*>(positions.data_ptr()),
+            reinterpret_cast<const float*>(cos_sin_cache.data_ptr()),
+            reinterpret_cast<fp8_t*>(fp8_out.data_ptr()),
+            reinterpret_cast<float*>(scale_out.data_ptr()),
+            num_tokens,
+            num_heads,
+            heads_per_group,
+            head_dim,
+            nope_dim,
+            half_rope,
+            o_stride_token,
+            o_stride_head,
+            cache_stride_pos,
+            fp8_stride_group,
+            fp8_stride_token,
+            scale_stride_group,
+            scale_stride_token));
+  });
+
+  return {fp8_out, scale_out};
+}

--- a/csrc/xpu/torch_bindings.cpp
+++ b/csrc/xpu/torch_bindings.cpp
@@ -103,6 +103,16 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, xpu_ops) {
       "                       int rope_dim) -> Tensor");
   xpu_ops.impl("deepseek_inv_rope_bf16", torch::kXPU, &deepseek_inv_rope_bf16);
 
+  // DeepSeek-V4 fused inverse RoPE + FP8 quantization: inv GPT-J rotation +
+  // per-128-block UE8M0 FP8 E4M3 quantization + group-major layout transform.
+  xpu_ops.def(
+      "deepseek_inv_rope_fp8_quant(Tensor o, Tensor positions,"
+      "                            Tensor cos_sin_cache, int n_groups,"
+      "                            int heads_per_group, int nope_dim,"
+      "                            int rope_dim) -> (Tensor, Tensor)");
+  xpu_ops.impl(
+      "deepseek_inv_rope_fp8_quant", torch::kXPU, &deepseek_inv_rope_fp8_quant);
+
   xpu_ops.def(
       "bgmv_shrink(Tensor! outputs, Tensor inputs, Tensor weights, Tensor "
       "indices, float scale) -> ()");

--- a/csrc/xpu/torch_bindings.cpp
+++ b/csrc/xpu/torch_bindings.cpp
@@ -93,6 +93,15 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, xpu_ops) {
       "deepseek_qnorm_rope_kv_insert",
       torch::kXPU,
       &deepseek_qnorm_rope_kv_insert);
+  
+// DeepSeek-V4 inverse RoPE (bf16): fused inv GPT-J rotation + group-major
+  // layout transform.
+  xpu_ops.def(
+      "deepseek_inv_rope_bf16(Tensor o, Tensor positions,"
+      "                       Tensor cos_sin_cache, int n_groups,"
+      "                       int heads_per_group, int nope_dim,"
+      "                       int rope_dim) -> Tensor");
+  xpu_ops.impl("deepseek_inv_rope_bf16", torch::kXPU, &deepseek_inv_rope_bf16);
 
   xpu_ops.def(
       "bgmv_shrink(Tensor! outputs, Tensor inputs, Tensor weights, Tensor "

--- a/csrc/xpu/torch_bindings.cpp
+++ b/csrc/xpu/torch_bindings.cpp
@@ -97,7 +97,7 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, xpu_ops) {
 // DeepSeek-V4 inverse RoPE (bf16): fused inv GPT-J rotation + group-major
   // layout transform.
   xpu_ops.def(
-      "deepseek_inv_rope_bf16(Tensor o, Tensor positions,"
+      "deepseek_inv_rope_bf16(Tensor attn_output, Tensor positions,"
       "                       Tensor cos_sin_cache, int n_groups,"
       "                       int heads_per_group, int nope_dim,"
       "                       int rope_dim) -> Tensor");
@@ -106,7 +106,7 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, xpu_ops) {
   // DeepSeek-V4 fused inverse RoPE + FP8 quantization: inv GPT-J rotation +
   // per-128-block UE8M0 FP8 E4M3 quantization + group-major layout transform.
   xpu_ops.def(
-      "deepseek_inv_rope_fp8_quant(Tensor o, Tensor positions,"
+      "deepseek_inv_rope_fp8_quant(Tensor attn_output, Tensor positions,"
       "                            Tensor cos_sin_cache, int n_groups,"
       "                            int heads_per_group, int nope_dim,"
       "                            int rope_dim) -> (Tensor, Tensor)");

--- a/csrc/xpu/torch_bindings.cpp
+++ b/csrc/xpu/torch_bindings.cpp
@@ -93,8 +93,8 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, xpu_ops) {
       "deepseek_qnorm_rope_kv_insert",
       torch::kXPU,
       &deepseek_qnorm_rope_kv_insert);
-  
-// DeepSeek-V4 inverse RoPE (bf16): fused inv GPT-J rotation + group-major
+
+  // DeepSeek-V4 inverse RoPE (bf16): fused inv GPT-J rotation + group-major
   // layout transform.
   xpu_ops.def(
       "deepseek_inv_rope_bf16(Tensor attn_output, Tensor positions,"

--- a/tests/test_deepseek_inv_rope_bf16.py
+++ b/tests/test_deepseek_inv_rope_bf16.py
@@ -136,7 +136,8 @@ def test_output_layout(num_tokens):
 
     o = torch.randn(num_tokens, num_heads, HEAD_DIM,
                     dtype=torch.bfloat16, device=DEVICE)
-    positions = torch.arange(num_tokens, dtype=torch.int64, device=DEVICE)
+    positions = torch.randint(0, max_pos, (num_tokens,),
+                              dtype=torch.int64, device=DEVICE)
     cos_sin_cache = torch.randn(max_pos, ROPE_DIM,
                                 dtype=torch.float32, device=DEVICE)
 

--- a/tests/test_deepseek_inv_rope_bf16.py
+++ b/tests/test_deepseek_inv_rope_bf16.py
@@ -1,0 +1,204 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Correctness tests for deepseek_inv_rope_bf16 SYCL kernel.
+
+Tests the fused inverse GPT-J RoPE + group-major layout transform kernel
+against a pure-PyTorch reference implementation.
+
+Run:
+    pytest tests/test_deepseek_inv_rope_bf16.py -v
+"""
+import pytest
+import torch
+
+import vllm_xpu_kernels._xpu_C  # noqa: F401
+
+DEVICE = torch.device("xpu")
+
+# DeepSeek-V4 default dimensions
+HEAD_DIM = 512
+NOPE_DIM = 448
+ROPE_DIM = 64
+HALF_ROPE = ROPE_DIM // 2
+
+
+def reference_inv_rope_bf16(
+    o: torch.Tensor,
+    positions: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    n_groups: int,
+    heads_per_group: int,
+    nope_dim: int = NOPE_DIM,
+    rope_dim: int = ROPE_DIM,
+) -> torch.Tensor:
+    """Pure PyTorch reference for inverse GPT-J RoPE.
+
+    Input:  o [T, H, D] bf16
+    Output: [T, G, hpg*D] bf16
+    """
+    T, H, D = o.shape
+    half_rope = rope_dim // 2
+    d = heads_per_group * D
+
+    # Reshape: [T, H, D] -> [T, G, hpg, D]
+    o_4d = o.view(T, n_groups, heads_per_group, D).float()
+
+    # Lookup cos/sin in fp32
+    cos_sin = cos_sin_cache[positions]  # [T, rope_dim]
+    cos = cos_sin[:, :half_rope]  # [T, half_rope]
+    sin = cos_sin[:, half_rope:]  # [T, half_rope]
+
+    # Apply inverse GPT-J RoPE on the last rope_dim elements
+    # GPT-J interleaved: pairs at (even, odd) positions
+    rope_region = o_4d[..., nope_dim:]  # [T, G, hpg, rope_dim]
+
+    x_even = rope_region[..., ::2]   # [T, G, hpg, half_rope]
+    x_odd = rope_region[..., 1::2]   # [T, G, hpg, half_rope]
+
+    # Broadcast cos/sin: [T, 1, 1, half_rope]
+    cos_b = cos[:, None, None, :]
+    sin_b = sin[:, None, None, :]
+
+    # Inverse rotation
+    new_even = x_even * cos_b + x_odd * sin_b
+    new_odd = x_odd * cos_b - x_even * sin_b
+
+    # Interleave back
+    out_rope = torch.stack([new_even, new_odd], dim=-1).flatten(-2)
+
+    # Combine NoPE + rotated RoPE
+    result = torch.cat([o_4d[..., :nope_dim], out_rope], dim=-1)
+
+    # Reshape to [T, G, hpg*D] and cast back to bf16
+    return result.reshape(T, n_groups, d).to(torch.bfloat16)
+
+
+@pytest.mark.parametrize("num_tokens", [1, 4, 8, 32, 128, 512])
+@pytest.mark.parametrize(
+    "num_heads,n_groups",
+    [(64, 8), (32, 4), (128, 8)],
+    ids=["H64_G8", "H32_G4", "H128_G8"],
+)
+@pytest.mark.parametrize("seed", [0, 42])
+def test_correctness(num_tokens, num_heads, n_groups, seed):
+    """Compare SYCL kernel output against PyTorch reference."""
+    torch.manual_seed(seed)
+    heads_per_group = num_heads // n_groups
+    max_pos = 4096
+
+    o = torch.randn(num_tokens, num_heads, HEAD_DIM,
+                    dtype=torch.bfloat16, device=DEVICE)
+    positions = torch.randint(0, max_pos, (num_tokens,),
+                              dtype=torch.int64, device=DEVICE)
+    cos_sin_cache = torch.randn(max_pos, ROPE_DIM,
+                                dtype=torch.float32, device=DEVICE)
+
+    # Reference
+    ref = reference_inv_rope_bf16(o, positions, cos_sin_cache,
+                                  n_groups, heads_per_group)
+
+    # SYCL kernel
+    out = torch.ops._xpu_C.deepseek_inv_rope_bf16(
+        o, positions, cos_sin_cache,
+        n_groups, heads_per_group, NOPE_DIM, ROPE_DIM)
+
+    # Check shapes
+    d = heads_per_group * HEAD_DIM
+    assert out.shape == (num_tokens, n_groups, d)
+    assert ref.shape == (num_tokens, n_groups, d)
+
+    # bf16 has ~0.004 relative error; kernel does fp32 rotation then casts
+    # back so max error should be within bf16 representable range
+    max_diff = (out.float() - ref.float()).abs().max().item()
+    mean_diff = (out.float() - ref.float()).abs().mean().item()
+
+    # NoPE region should be exact (just a copy)
+    nope_out = out.view(num_tokens, n_groups, heads_per_group, HEAD_DIM)
+    nope_ref = ref.view(num_tokens, n_groups, heads_per_group, HEAD_DIM)
+    nope_max_diff = (nope_out[..., :NOPE_DIM].float() -
+                     nope_ref[..., :NOPE_DIM].float()).abs().max().item()
+    assert nope_max_diff == 0.0, (
+        f"NoPE region should be exact copy, got max_diff={nope_max_diff}")
+
+    # RoPE region: allow bf16 rounding. The kernel computes x*cos + y*sin in
+    # fp32 then casts to bf16. The reference does the same but PyTorch may use
+    # FMA which causes up to 2 ULP difference at rounding boundaries.
+    # bf16 ULP at magnitude 1.0 = 2^{-7} = 0.0078125; allow up to 4 ULP.
+    assert max_diff <= 0.035, (
+        f"max_diff={max_diff:.6f}, mean_diff={mean_diff:.6f}")
+
+
+@pytest.mark.parametrize("num_tokens", [1, 4, 64, 8192])
+def test_output_layout(num_tokens):
+    """Verify output is contiguous [T, G, D] tensor."""
+    num_heads, n_groups = 64, 8
+    heads_per_group = num_heads // n_groups
+    max_pos = 4096
+
+    o = torch.randn(num_tokens, num_heads, HEAD_DIM,
+                    dtype=torch.bfloat16, device=DEVICE)
+    positions = torch.arange(num_tokens, dtype=torch.int64, device=DEVICE)
+    cos_sin_cache = torch.randn(max_pos, ROPE_DIM,
+                                dtype=torch.float32, device=DEVICE)
+
+    out = torch.ops._xpu_C.deepseek_inv_rope_bf16(
+        o, positions, cos_sin_cache,
+        n_groups, heads_per_group, NOPE_DIM, ROPE_DIM)
+
+    d = heads_per_group * HEAD_DIM
+    assert out.shape == (num_tokens, n_groups, d)
+    assert out.is_contiguous(), (
+        f"Output should be contiguous, stride={out.stride()}")
+    assert out.dtype == torch.bfloat16
+
+
+def test_zero_tokens():
+    """Edge case: zero tokens should return empty tensor."""
+    num_heads, n_groups = 64, 8
+    heads_per_group = num_heads // n_groups
+    max_pos = 4096
+
+    o = torch.empty(0, num_heads, HEAD_DIM,
+                    dtype=torch.bfloat16, device=DEVICE)
+    positions = torch.empty(0, dtype=torch.int64, device=DEVICE)
+    cos_sin_cache = torch.randn(max_pos, ROPE_DIM,
+                                dtype=torch.float32, device=DEVICE)
+
+    out = torch.ops._xpu_C.deepseek_inv_rope_bf16(
+        o, positions, cos_sin_cache,
+        n_groups, heads_per_group, NOPE_DIM, ROPE_DIM)
+
+    d = heads_per_group * HEAD_DIM
+    assert out.shape == (0, n_groups, d)
+
+
+def test_positions_independence():
+    """Different positions produce different RoPE results but same NoPE."""
+    num_tokens = 4
+    num_heads, n_groups = 64, 8
+    heads_per_group = num_heads // n_groups
+    max_pos = 4096
+
+    o = torch.randn(num_tokens, num_heads, HEAD_DIM,
+                    dtype=torch.bfloat16, device=DEVICE)
+    cos_sin_cache = torch.randn(max_pos, ROPE_DIM,
+                                dtype=torch.float32, device=DEVICE)
+
+    pos1 = torch.zeros(num_tokens, dtype=torch.int64, device=DEVICE)
+    pos2 = torch.arange(num_tokens, dtype=torch.int64, device=DEVICE) + 100
+
+    out1 = torch.ops._xpu_C.deepseek_inv_rope_bf16(
+        o, pos1, cos_sin_cache,
+        n_groups, heads_per_group, NOPE_DIM, ROPE_DIM)
+    out2 = torch.ops._xpu_C.deepseek_inv_rope_bf16(
+        o, pos2, cos_sin_cache,
+        n_groups, heads_per_group, NOPE_DIM, ROPE_DIM)
+
+    # NoPE regions should be identical (position-independent)
+    out1_4d = out1.view(num_tokens, n_groups, heads_per_group, HEAD_DIM)
+    out2_4d = out2.view(num_tokens, n_groups, heads_per_group, HEAD_DIM)
+    assert torch.equal(out1_4d[..., :NOPE_DIM], out2_4d[..., :NOPE_DIM])
+
+    # RoPE regions should differ
+    rope_diff = (out1_4d[..., NOPE_DIM:].float() -
+                 out2_4d[..., NOPE_DIM:].float()).abs().max().item()
+    assert rope_diff > 0.0, "RoPE region should differ with different positions"

--- a/tests/test_deepseek_inv_rope_fp8_quant.py
+++ b/tests/test_deepseek_inv_rope_fp8_quant.py
@@ -213,7 +213,8 @@ def test_output_layout(num_tokens):
 
     o = torch.randn(num_tokens, num_heads, HEAD_DIM,
                     dtype=torch.bfloat16, device=DEVICE)
-    positions = torch.arange(num_tokens, dtype=torch.int64, device=DEVICE)
+    positions = torch.randint(0, max_pos, (num_tokens,),
+                              dtype=torch.int64, device=DEVICE)
     cos_sin_cache = torch.randn(max_pos, ROPE_DIM,
                                 dtype=torch.float32, device=DEVICE)
 

--- a/tests/test_deepseek_inv_rope_fp8_quant.py
+++ b/tests/test_deepseek_inv_rope_fp8_quant.py
@@ -283,7 +283,7 @@ def test_scales_are_power_of_two():
 
 
 def test_fp8_values_in_range():
-    """Verify all FP8 values are within [-FP8_MAX, FP8_MAX] after dequant."""
+    """Verify all FP8 values are representable (within [-FP8_MAX, FP8_MAX])."""
     num_tokens, num_heads, n_groups = 64, 64, 8
     heads_per_group = num_heads // n_groups
     max_pos = 4096

--- a/tests/test_deepseek_inv_rope_fp8_quant.py
+++ b/tests/test_deepseek_inv_rope_fp8_quant.py
@@ -1,0 +1,305 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Correctness tests for deepseek_inv_rope_fp8_quant SYCL kernel.
+
+Tests the fused inverse GPT-J RoPE + per-128-block FP8 E4M3 quantization kernel
+against a pure-PyTorch reference implementation.
+
+Run:
+    pytest tests/test_deepseek_inv_rope_fp8_quant.py -v
+"""
+import pytest
+import torch
+
+import vllm_xpu_kernels._xpu_C  # noqa: F401
+
+DEVICE = torch.device("xpu")
+
+# DeepSeek-V4 default dimensions
+HEAD_DIM = 512
+NOPE_DIM = 448
+ROPE_DIM = 64
+HALF_ROPE = ROPE_DIM // 2
+QUANT_GROUP_SIZE = 128
+CHUNKS_PER_HEAD = HEAD_DIM // QUANT_GROUP_SIZE  # 4
+FP8_MAX = 448.0  # max value of float8_e4m3fn
+
+
+def _ref_ue8m0_quant_block(x: torch.Tensor):
+    """Per-128-block UE8M0 quantization (power-of-2 scales).
+
+    x: [T, QUANT_GROUP_SIZE] float32
+    Returns: (x_fp8 [T, QUANT_GROUP_SIZE] float8_e4m3fn, scale [T] float32)
+    """
+    absmax = x.abs().amax(dim=-1, keepdim=True).clamp(min=1e-10)
+    scale_raw = absmax / FP8_MAX
+    # ceil to power of 2
+    scale = torch.exp2(torch.ceil(torch.log2(scale_raw)))
+    x_scaled = (x / scale).clamp(-FP8_MAX, FP8_MAX)
+    x_fp8 = x_scaled.to(torch.float8_e4m3fn)
+    return x_fp8, scale.squeeze(-1)
+
+
+def reference_inv_rope_fp8_quant(
+    o: torch.Tensor,
+    positions: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    n_groups: int,
+    heads_per_group: int,
+    nope_dim: int = NOPE_DIM,
+    rope_dim: int = ROPE_DIM,
+):
+    """Full reference: inverse RoPE in fp32 + UE8M0 FP8 quant.
+
+    Returns:
+        fp8_out:   [G, T, hpg*D] float8_e4m3fn
+        scale_out: [G, T, hpg*chunks] float32
+    """
+    T, H, D = o.shape
+    half_rope = rope_dim // 2
+    d = heads_per_group * D
+    chunks_per_head = D // QUANT_GROUP_SIZE
+    S = heads_per_group * chunks_per_head
+
+    # Reshape [T, H, D] -> [T, G, hpg, D]
+    o_4d = o.view(T, n_groups, heads_per_group, D)
+
+    # Lookup cos/sin in fp32
+    cos_sin = cos_sin_cache[positions]  # [T, rope_dim] fp32
+    cos = cos_sin[:, :half_rope]  # [T, half_rope]
+    sin = cos_sin[:, half_rope:]  # [T, half_rope]
+
+    # Apply inverse RoPE in fp32
+    o_f32 = o_4d.float()
+    rope_region = o_f32[..., nope_dim:]  # [T, G, hpg, rope_dim]
+    x_even = rope_region[..., ::2]
+    x_odd = rope_region[..., 1::2]
+    cos_b = cos[:, None, None, :]
+    sin_b = sin[:, None, None, :]
+    new_even = x_even * cos_b + x_odd * sin_b
+    new_odd = x_odd * cos_b - x_even * sin_b
+    out_rope = torch.stack([new_even, new_odd], dim=-1).flatten(-2)
+    rotated = torch.cat([o_f32[..., :nope_dim], out_rope], dim=-1)
+
+    # Per-128-block FP8 quantization
+    # rotated: [T, G, hpg, D] -> quantize per chunk
+    fp8_buf = torch.empty(n_groups, T, d, dtype=torch.float8_e4m3fn,
+                          device=o.device)
+    scale_buf = torch.empty(n_groups, T, S, dtype=torch.float32,
+                            device=o.device)
+
+    for g in range(n_groups):
+        for h in range(heads_per_group):
+            for c in range(chunks_per_head):
+                offset = c * QUANT_GROUP_SIZE
+                block = rotated[:, g, h, offset:offset + QUANT_GROUP_SIZE]
+                x_fp8, scale = _ref_ue8m0_quant_block(block)
+
+                out_offset = h * D + offset
+                fp8_buf[g, :, out_offset:out_offset + QUANT_GROUP_SIZE] = x_fp8
+
+                scale_idx = h * chunks_per_head + c
+                scale_buf[g, :, scale_idx] = scale
+
+    return fp8_buf, scale_buf
+
+
+def assert_dequant_close(ref_fp8, ref_scale, fused_fp8, fused_scale,
+                         tight_atol=0.1, loose_atol=1.0,
+                         tight_pass_rate=0.98):
+    """Compare via dequantization (fp8 * scale).
+
+    FP8 quantization with power-of-2 scales has inherent boundary effects:
+    - FMA precision differences in RoPE can shift absmax by 1 bf16 ULP
+    - This can cause scale to differ by 2x at power-of-2 boundaries
+    - Result: ~0.1% of elements may have dequant diff up to 1 fp8 ULP * scale
+
+    We verify:
+    1. ALL elements within loose_atol (handles 2x scale boundary)
+    2. >tight_pass_rate elements within tight_atol (validates bulk correctness)
+    """
+    # Reshape scales for broadcasting
+    G, T, S = ref_scale.shape
+    D = ref_fp8.shape[2]
+    chunks_per_head = CHUNKS_PER_HEAD
+    heads_per_group = S // chunks_per_head
+
+    ref_deq = torch.zeros(G, T, D, dtype=torch.float32, device=ref_fp8.device)
+    fused_deq = torch.zeros(G, T, D, dtype=torch.float32, device=ref_fp8.device)
+
+    for h in range(heads_per_group):
+        for c in range(chunks_per_head):
+            offset = h * HEAD_DIM + c * QUANT_GROUP_SIZE
+            scale_idx = h * chunks_per_head + c
+            ref_s = ref_scale[:, :, scale_idx:scale_idx + 1]
+            fused_s = fused_scale[:, :, scale_idx:scale_idx + 1]
+            ref_deq[:, :, offset:offset + QUANT_GROUP_SIZE] = (
+                ref_fp8[:, :, offset:offset + QUANT_GROUP_SIZE].float() * ref_s)
+            fused_deq[:, :, offset:offset + QUANT_GROUP_SIZE] = (
+                fused_fp8[:, :, offset:offset + QUANT_GROUP_SIZE].float()
+                * fused_s)
+
+    diff = (fused_deq - ref_deq).abs()
+    max_diff = diff.max().item()
+    num_elements = diff.numel()
+    tight_pass = (diff <= tight_atol).sum().item()
+    tight_rate = tight_pass / num_elements
+
+    # Hard bound: no element should exceed loose_atol
+    assert max_diff <= loose_atol, (
+        f"Max dequant diff {max_diff:.4f} exceeds loose bound {loose_atol}. "
+        f"This indicates a real bug, not just quantization boundary effects.")
+
+    # Soft bound: vast majority should be within tight_atol
+    assert tight_rate >= tight_pass_rate, (
+        f"Only {tight_rate*100:.2f}% elements within tight_atol={tight_atol}, "
+        f"need {tight_pass_rate*100:.1f}%. "
+        f"Failing: {num_elements - tight_pass}/{num_elements}")
+
+
+@pytest.mark.parametrize("num_tokens", [1, 4, 8, 32, 128])
+@pytest.mark.parametrize(
+    "num_heads,n_groups",
+    [(64, 8), (32, 4)],
+    ids=["H64_G8", "H32_G4"],
+)
+@pytest.mark.parametrize("seed", [0, 42])
+def test_correctness(num_tokens, num_heads, n_groups, seed):
+    """Compare SYCL kernel against reference for FP8 values and scales."""
+    torch.manual_seed(seed)
+    heads_per_group = num_heads // n_groups
+    max_pos = 4096
+
+    o = torch.randn(num_tokens, num_heads, HEAD_DIM,
+                    dtype=torch.bfloat16, device=DEVICE)
+    positions = torch.randint(0, max_pos, (num_tokens,),
+                              dtype=torch.int64, device=DEVICE)
+    cos_sin_cache = torch.randn(max_pos, ROPE_DIM,
+                                dtype=torch.float32, device=DEVICE)
+
+    # Reference
+    ref_fp8, ref_scale = reference_inv_rope_fp8_quant(
+        o, positions, cos_sin_cache, n_groups, heads_per_group)
+
+    # SYCL kernel
+    fused_fp8, fused_scale = torch.ops._xpu_C.deepseek_inv_rope_fp8_quant(
+        o, positions, cos_sin_cache,
+        n_groups, heads_per_group, NOPE_DIM, ROPE_DIM)
+
+    # Check shapes
+    d = heads_per_group * HEAD_DIM
+    S = heads_per_group * CHUNKS_PER_HEAD
+    assert fused_fp8.shape == (n_groups, num_tokens, d)
+    assert fused_scale.shape == (n_groups, num_tokens, S)
+    assert ref_fp8.shape == fused_fp8.shape
+    assert ref_scale.shape == fused_scale.shape
+
+    # Scales: both use UE8M0 (power-of-2), should be very close.
+    # Allow up to factor-of-2 difference due to FMA rounding at boundaries.
+    scale_ratio = fused_scale / ref_scale.clamp(min=1e-30)
+    assert scale_ratio.max() <= 2.0 and scale_ratio.min() >= 0.5, (
+        f"Scale ratio out of [0.5, 2]: min={scale_ratio.min():.4f} "
+        f"max={scale_ratio.max():.4f}")
+
+    # Compare via dequant
+    assert_dequant_close(ref_fp8, ref_scale, fused_fp8, fused_scale)
+
+
+@pytest.mark.parametrize("num_tokens", [1, 16, 64, 8192])
+def test_output_layout(num_tokens):
+    """Verify output tensors have correct shape and dtype."""
+    num_heads, n_groups = 64, 8
+    heads_per_group = num_heads // n_groups
+    max_pos = 4096
+
+    o = torch.randn(num_tokens, num_heads, HEAD_DIM,
+                    dtype=torch.bfloat16, device=DEVICE)
+    positions = torch.arange(num_tokens, dtype=torch.int64, device=DEVICE)
+    cos_sin_cache = torch.randn(max_pos, ROPE_DIM,
+                                dtype=torch.float32, device=DEVICE)
+
+    fp8_out, scale_out = torch.ops._xpu_C.deepseek_inv_rope_fp8_quant(
+        o, positions, cos_sin_cache,
+        n_groups, heads_per_group, NOPE_DIM, ROPE_DIM)
+
+    d = heads_per_group * HEAD_DIM
+    S = heads_per_group * CHUNKS_PER_HEAD
+
+    assert fp8_out.shape == (n_groups, num_tokens, d)
+    assert fp8_out.dtype == torch.float8_e4m3fn
+    assert fp8_out.is_contiguous()
+
+    assert scale_out.shape == (n_groups, num_tokens, S)
+    assert scale_out.dtype == torch.float32
+    assert scale_out.is_contiguous()
+
+
+def test_zero_tokens():
+    """Edge case: zero tokens should return empty tensors."""
+    num_heads, n_groups = 64, 8
+    heads_per_group = num_heads // n_groups
+    max_pos = 4096
+
+    o = torch.empty(0, num_heads, HEAD_DIM,
+                    dtype=torch.bfloat16, device=DEVICE)
+    positions = torch.empty(0, dtype=torch.int64, device=DEVICE)
+    cos_sin_cache = torch.randn(max_pos, ROPE_DIM,
+                                dtype=torch.float32, device=DEVICE)
+
+    fp8_out, scale_out = torch.ops._xpu_C.deepseek_inv_rope_fp8_quant(
+        o, positions, cos_sin_cache,
+        n_groups, heads_per_group, NOPE_DIM, ROPE_DIM)
+
+    d = heads_per_group * HEAD_DIM
+    S = heads_per_group * CHUNKS_PER_HEAD
+    assert fp8_out.shape == (n_groups, 0, d)
+    assert scale_out.shape == (n_groups, 0, S)
+
+
+def test_scales_are_power_of_two():
+    """Verify all scales are exact powers of 2 (UE8M0 property)."""
+    num_tokens, num_heads, n_groups = 32, 64, 8
+    heads_per_group = num_heads // n_groups
+    max_pos = 4096
+
+    torch.manual_seed(123)
+    o = torch.randn(num_tokens, num_heads, HEAD_DIM,
+                    dtype=torch.bfloat16, device=DEVICE)
+    positions = torch.randint(0, max_pos, (num_tokens,),
+                              dtype=torch.int64, device=DEVICE)
+    cos_sin_cache = torch.randn(max_pos, ROPE_DIM,
+                                dtype=torch.float32, device=DEVICE)
+
+    _, scale_out = torch.ops._xpu_C.deepseek_inv_rope_fp8_quant(
+        o, positions, cos_sin_cache,
+        n_groups, heads_per_group, NOPE_DIM, ROPE_DIM)
+
+    # For power-of-2 floats, log2 should be exactly integer
+    log2_scales = torch.log2(scale_out)
+    is_integer = (log2_scales == log2_scales.round())
+    assert is_integer.all(), (
+        f"Not all scales are power-of-2. "
+        f"Non-pow2 count: {(~is_integer).sum().item()}")
+
+
+def test_fp8_values_in_range():
+    """Verify all FP8 values are within [-FP8_MAX, FP8_MAX] after dequant."""
+    num_tokens, num_heads, n_groups = 64, 64, 8
+    heads_per_group = num_heads // n_groups
+    max_pos = 4096
+
+    torch.manual_seed(7)
+    o = torch.randn(num_tokens, num_heads, HEAD_DIM,
+                    dtype=torch.bfloat16, device=DEVICE)
+    positions = torch.randint(0, max_pos, (num_tokens,),
+                              dtype=torch.int64, device=DEVICE)
+    cos_sin_cache = torch.randn(max_pos, ROPE_DIM,
+                                dtype=torch.float32, device=DEVICE)
+
+    fp8_out, _ = torch.ops._xpu_C.deepseek_inv_rope_fp8_quant(
+        o, positions, cos_sin_cache,
+        n_groups, heads_per_group, NOPE_DIM, ROPE_DIM)
+
+    # fp8_e4m3fn values should be in [-448, 448]
+    fp8_float = fp8_out.float()
+    assert fp8_float.abs().max() <= FP8_MAX, (
+        f"FP8 value out of range: max={fp8_float.abs().max().item()}")


### PR DESCRIPTION
# Add DeepSeek-V4 Inverse RoPE SYCL Kernels

## Purpose

Add SYCL implementations for the DeepSeek-V4 **inverse RoPE** kernels used in the O-projection stage of the MLA pipeline. This PR includes two kernels:

1. **`deepseek_inv_rope_bf16`** — Inverse RoPE with bf16 output (for downstream bf16 einsum)
2. **`deepseek_inv_rope_fp8_quant`** — Inverse RoPE fused with FP8 quantization (for downstream fp8_einsum)

Both kernels perform:
- **NoPE dimensions (448):** Coalesced block copy using vectorized loads (`uint64_t`, 4 bf16 per lane)
- **RoPE dimensions (64):** Pair-wise inverse GPT-J rotation: `new_even = even * cos + odd * sin`, `new_odd = odd * cos - even * sin`
- **Layout transform:** Reshapes from `[T, H, D]` (per-head) to `[T, G, heads_per_group * D]` (group-contiguous)

---

### Part 1: `deepseek_inv_rope_bf16`

**Commit:** `8fecdeb` — Add Deepseek-v4 inv_rope bf16 SYCL support

#### Files Changed

| File | Change |
|------|--------|
| `csrc/xpu/sycl/deepseek_inv_rope_bf16.cpp` | New SYCL kernel (203 lines) |
| `csrc/xpu/ops.h` | Function declaration |
| `csrc/xpu/torch_bindings.cpp` | Op registration (`def` + `impl`) |
| `CMakeLists.txt` | Add source to build |
| `tests/test_deepseek_inv_rope_bf16.py` | Pytest with parametrized correctness + layout + edge case tests |

#### Design

- Grid: `(num_tokens, num_heads, SG_SIZE=16)`, one subgroup per head per token
- All model parameters (`heads_per_group`, `head_dim`, `nope_dim`, `rope_dim`) are runtime arguments
- Registered as `torch.ops._xpu_C.deepseek_inv_rope_bf16`

#### Unit Test — All PASSED

```bash
pytest tests/test_deepseek_inv_rope_bf16.py -v
```

- `test_correctness`: num_tokens ∈ {1,4,8,32,128,512} × num_heads/n_groups configs × seed ∈ {0,42}
- `test_output_layout`: validates group-contiguous output shape
- `test_zero_tokens`: empty-token edge case
- `test_positions_independence`: verifies position-wise correctness

#### Kernel Benchmark: SYCL vs Triton

Platform: Intel Arc Pro B60, Warmup 50 iters, Timed 200 iters

| num_tokens | io_bytes | triton(us) | sycl(us) | triton BW(GB/s) | sycl BW(GB/s) | speedup |
|---:|---:|---:|---:|---:|---:|---:|
| 1 | 131,336 | 58.30 | 38.88 | 2.25 | 3.38 | **1.50x** |
| 2 | 262,672 | 57.44 | 38.10 | 4.57 | 6.89 | **1.51x** |
| 4 | 525,344 | 58.04 | 38.13 | 9.05 | 13.78 | **1.52x** |
| 8 | 1,050,688 | 57.02 | 38.13 | 18.43 | 27.55 | **1.50x** |
| 16 | 2,101,376 | 56.88 | 38.12 | 36.94 | 55.13 | **1.49x** |
| 32 | 4,202,752 | 57.04 | 38.14 | 73.69 | 110.18 | **1.50x** |
| 64 | 8,405,504 | 57.08 | 38.23 | 147.25 | 219.89 | **1.49x** |
| 128 | 16,811,008 | 56.75 | 38.63 | 296.22 | 435.21 | **1.47x** |
| 256 | 33,622,016 | 115.75 | 102.59 | 290.46 | 327.72 | **1.13x** |
| 512 | 67,244,032 | 215.06 | 193.04 | 312.67 | 348.34 | **1.11x** |
| 1024 | 134,488,064 | 443.57 | 361.97 | 303.20 | 371.55 | **1.23x** |
| 2048 | 268,976,128 | 885.83 | 702.28 | 303.64 | 383.00 | **1.26x** |
| 4096 | 537,952,256 | 1858.19 | 1369.68 | 289.50 | 392.76 | **1.36x** |
| 8192 | 1,075,904,512 | 4034.06 | 2740.93 | 266.70 | 392.53 | **1.47x** |
| 16384 | 2,151,809,024 | 8559.76 | 5395.05 | 251.39 | 398.85 | **1.59x** |

**SYCL achieves 1.13x–1.59x speedup.** Peak BW: 398.85 GB/s (87.5% of B60 HBM theoretical 456 GB/s).

#### Standalone SYCL Kernel (device time, event profiling)

Device: Intel Arc Pro B60 (HBM peak bandwidth: 456 GB/s)

| num_tokens | device(us) | BW(GB/s) | MBU |
|---:|---:|---:|---:|
| 1 | 1.90 | 69.06 | 15.1% |
| 2 | 1.88 | 139.73 | 30.6% |
| 4 | 1.94 | 270.49 | 59.3% |
| 8 | 2.34 | 448.41 | 98.3% |
| 16 | 2.52 | 834.59 | >100%* |
| 32 | 3.95 | 1063.59 | >100%* |
| 64 | 6.62 | 1270.29 | >100%* |
| 128 | 13.02 | 1290.88 | >100%* |
| 256 | 82.74 | 406.35 | 89.1% |
| 512 | 171.07 | 393.07 | 86.2% |
| 1024 | 340.02 | 395.53 | 86.7% |
| 2048 | 676.89 | 397.37 | 87.1% |
| 4096 | 1352.53 | 397.74 | 87.2% |
| 8192 | 2717.42 | 395.93 | 86.8% |
| 16384 | 5380.72 | 399.91 | 87.7% |

\* Small token counts show >100% MBU due to L2 cache hits (data fits in cache, not hitting HBM).

Large token regime stabilizes at **~87% MBU**, indicating near-optimal memory bandwidth utilization.

#### End-to-End Model Benchmark
**Note on E2E setup:** Due to current hardware resource constraints, we use a **10-layer trimmed checkpoint** of DeepSeek-V4-Flash-Base for E2E validation. This is sufficient to verify correct integration and no performance regression, as inv_rope executes identically in every decoder layer.

**Integration:** In `vllm/models/deepseek_v4/xpu/xpu_sparse.py` `_o_proj()`, the SYCL path calls `torch.ops._xpu_C.deepseek_inv_rope_bf16` to replace the original `rocm_inv_rope_einsum` baseline.

Model: DeepSeek-V4-Flash-Base (**10 layers**, trimmed), TP=4, input_len=2048, output_len=1024, max_concurrency=1, num_prompts=5, num_warmups=2

| Metric | baseline | SYCL | Delta |
|--------|------------------:|-----:|------:|
| Output token throughput (tok/s) | 8.11 | 8.41 | +3.7% |
| Mean TTFT (ms) | 2260.18 | 1902.40 | **-15.8%** |
| Median TTFT (ms) | 2250.30 | 1897.87 | **-15.7%** |
| P99 TTFT (ms) | 2293.55 | 1913.16 | **-16.6%** |
| Mean TPOT (ms) | 121.21 | 117.10 | **-3.4%** |
| Median TPOT (ms) | 121.42 | 116.83 | **-3.8%** |
| P99 TPOT (ms) | 121.61 | 117.74 | -3.2% |

SYCL inv_rope_bf16 shows **3.4% TPOT improvement** and **15.8% TTFT improvement** in E2E serving.

---

### Part 2: `deepseek_inv_rope_fp8_quant`

**Commit:** `52ad658` — Add Deepseek-v4 inv_rope fp8 quant SYCL support

#### Files Changed

| File | Change |
|------|--------|
| `csrc/xpu/sycl/deepseek_inv_rope_fp8_quant.cpp` | New SYCL kernel (272 lines) |
| `csrc/xpu/ops.h` | Function declaration |
| `csrc/xpu/torch_bindings.cpp` | Op registration (`def` + `impl`) |
| `CMakeLists.txt` | Add source to build |
| `tests/test_deepseek_inv_rope_fp8_quant.py` | Pytest with correctness + layout + FP8 range/scale tests |

#### Design

- Same grid/subgroup structure as bf16 variant
- Fuses inverse RoPE + per-group FP8 (E4M3) quantization in a single kernel pass
- Outputs: `fp8_tensor [T, G, heads_per_group * D]` + `scales [T, G]`
- Registered as `torch.ops._xpu_C.deepseek_inv_rope_fp8_quant`

#### Unit Test — All PASSED

```bash
pytest tests/test_deepseek_inv_rope_fp8_quant.py -v
```

- `test_correctness`: num_tokens ∈ {1,4,8,32,128} × num_heads/n_groups configs × seed ∈ {0,42}
- `test_output_layout`: validates FP8 output shape and scale shape
- `test_zero_tokens`: empty-token edge case
- `test_scales_are_power_of_two`: validates quantization scales
- `test_fp8_values_in_range`: validates FP8 output range [-448, 448]

#### Kernel Benchmark: SYCL vs Triton

Platform: Intel Arc Pro B60, Warmup 50 iters, Timed 200 iters

| num_tokens | io_bytes | triton(us) | sycl(us) | triton BW(GB/s) | sycl BW(GB/s) | speedup |
|---:|---:|---:|---:|---:|---:|---:|
| 1 | 99,592 | 95.86 | 65.42 | 1.04 | 1.52 | **1.47x** |
| 2 | 199,184 | 96.80 | 65.44 | 2.06 | 3.04 | **1.48x** |
| 4 | 398,368 | 95.66 | 65.08 | 4.16 | 6.12 | **1.47x** |
| 8 | 796,736 | 95.20 | 65.38 | 8.37 | 12.19 | **1.46x** |
| 16 | 1,593,472 | 95.49 | 65.53 | 16.69 | 24.32 | **1.46x** |
| 32 | 3,186,944 | 95.66 | 65.39 | 33.32 | 48.74 | **1.46x** |
| 64 | 6,373,888 | 95.68 | 65.61 | 66.62 | 97.15 | **1.46x** |
| 128 | 12,747,776 | 102.01 | 65.43 | 124.96 | 194.84 | **1.56x** |
| 256 | 25,495,552 | 157.76 | 89.40 | 161.61 | 285.17 | **1.76x** |
| 512 | 50,991,104 | 256.75 | 168.34 | 198.60 | 302.90 | **1.53x** |
| 1024 | 101,982,208 | 446.25 | 303.55 | 228.53 | 335.97 | **1.47x** |
| 2048 | 203,964,416 | 824.53 | 579.29 | 247.37 | 352.09 | **1.42x** |
| 4096 | 407,928,832 | 1573.43 | 1118.10 | 259.26 | 364.84 | **1.41x** |
| 8192 | 815,857,664 | 3077.91 | 2212.07 | 265.07 | 368.82 | **1.39x** |
| 16384 | 1,631,715,328 | 6257.78 | 4310.08 | 260.75 | 378.58 | **1.45x** |

**SYCL achieves 1.39x–1.76x speedup.** Peak BW: 378.58 GB/s (83.0% of B60 HBM theoretical).

#### Standalone SYCL Kernel (device time, event profiling)

Device: Intel Arc Pro B60 (HBM peak bandwidth: 456 GB/s)

| num_tokens | device(us) | BW(GB/s) | MBU |
|---:|---:|---:|---:|
| 1 | 2.31 | 43.04 | 9.4% |
| 2 | 2.37 | 83.91 | 18.4% |
| 4 | 2.48 | 160.88 | 35.3% |
| 8 | 2.75 | 289.64 | 63.5% |
| 16 | 3.94 | 404.38 | 88.7% |
| 32 | 7.06 | 451.44 | 99.0% |
| 64 | 13.31 | 478.86 | >100%* |
| 128 | 24.91 | 511.76 | >100%* |
| 256 | 59.62 | 427.66 | 93.8% |
| 512 | 138.31 | 368.67 | 80.8% |
| 1024 | 273.54 | 372.82 | 81.8% |
| 2048 | 544.04 | 374.91 | 82.2% |
| 4096 | 1077.09 | 378.73 | 83.1% |
| 8192 | 2202.25 | 370.47 | 81.2% |
| 16384 | 4276.00 | 381.60 | 83.7% |

\* Small token counts show >100% MBU due to L2 cache hits (data fits in cache, not hitting HBM).

Large token regime stabilizes at **~81–84% MBU**.


#### End-to-End Model Benchmark

> The current model pipeline uses bf16 inv_rope only. FP8 quant variant will be integrated when the fp8 path is ready.
