### PR TITLE
[XPU][DeepSeekV4]Add Deepseek-v4  fused_indexer_q_rope_quant fp8 and mxfp4 kernel SYCL support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -615,6 +615,7 @@ if(XPU_SPECIFIC_KERNELS_ENABLED)
       "csrc/xpu/sycl/deepseek_qnorm_rope_kv_insert.cpp"
       "csrc/xpu/sycl/deepseek_inv_rope_bf16.cpp"
       "csrc/xpu/sycl/deepseek_inv_rope_fp8_quant.cpp"
+      "csrc/xpu/sycl/deepseek_fused_indexer_q_rope_fp8.cpp"
       "csrc/xpu/sycl/multimodal_rope.cpp"
       "csrc/xpu/sycl/apply_rotary_emb.cpp"
       "csrc/xpu/rand/exponential.cpp"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -616,6 +616,7 @@ if(XPU_SPECIFIC_KERNELS_ENABLED)
       "csrc/xpu/sycl/deepseek_inv_rope_bf16.cpp"
       "csrc/xpu/sycl/deepseek_inv_rope_fp8_quant.cpp"
       "csrc/xpu/sycl/deepseek_fused_indexer_q_rope_fp8.cpp"
+      "csrc/xpu/sycl/deepseek_fused_indexer_q_rope_mxfp4.cpp"
       "csrc/xpu/sycl/multimodal_rope.cpp"
       "csrc/xpu/sycl/apply_rotary_emb.cpp"
       "csrc/xpu/rand/exponential.cpp"

--- a/csrc/xpu/ops.h
+++ b/csrc/xpu/ops.h
@@ -205,3 +205,14 @@ void deepseek_fused_indexer_q_rope_fp8(
     double head_scale,
     torch::Tensor& q_fp8,
     torch::Tensor& weights_out);
+
+void deepseek_fused_indexer_q_rope_mxfp4(
+    const torch::Tensor& q,
+    const torch::Tensor& positions,
+    const torch::Tensor& cos_sin_cache,
+    const torch::Tensor& index_weights,
+    double softmax_scale,
+    double head_scale,
+    torch::Tensor& packed_out,
+    torch::Tensor& scales_out,
+    torch::Tensor& weights_out);

--- a/csrc/xpu/ops.h
+++ b/csrc/xpu/ops.h
@@ -195,3 +195,13 @@ torch::Tensor fp8_paged_mqa_logits(
 #endif
 
 std::string get_onednn_version();
+
+void deepseek_fused_indexer_q_rope_fp8(
+    const torch::Tensor& q,
+    const torch::Tensor& positions,
+    const torch::Tensor& cos_sin_cache,
+    const torch::Tensor& index_weights,
+    double softmax_scale,
+    double head_scale,
+    torch::Tensor& q_fp8,
+    torch::Tensor& weights_out);

--- a/csrc/xpu/sycl/deepseek_fused_indexer_q_rope_fp8.cpp
+++ b/csrc/xpu/sycl/deepseek_fused_indexer_q_rope_fp8.cpp
@@ -57,8 +57,9 @@ class deepseek_fused_indexer_q_rope_fp8_kernel {
   static constexpr int HALF_ROPE = ROPE_DIM / 2;
   static constexpr int HALF_BLOCK = SG_SIZE;
   static constexpr int HEADS_COARSEN = HEADS_COARSEN_;
-  static_assert(ROPE_DIM % 2 == 0 && HALF_ROPE >= SG_SIZE,
-                "ROPE_DIM/2 must be >= SG_SIZE");
+  static_assert(
+      ROPE_DIM % 2 == 0 && HALF_ROPE >= SG_SIZE,
+      "ROPE_DIM/2 must be >= SG_SIZE");
   static_assert(NOPE_DIM > 0, "HEAD_DIM must be > ROPE_DIM");
 
   deepseek_fused_indexer_q_rope_fp8_kernel(
@@ -217,9 +218,7 @@ void deepseek_fused_indexer_q_rope_fp8(
       rope_dim,
       ". Supported: head_dim=128, rope_dim=64");
 
-  TORCH_CHECK(
-      num_heads % 2 == 0,
-      "num_heads must be divisible by 2");
+  TORCH_CHECK(num_heads % 2 == 0, "num_heads must be divisible by 2");
 
   const int64_t nhg = num_heads / 2;
 

--- a/csrc/xpu/sycl/deepseek_fused_indexer_q_rope_fp8.cpp
+++ b/csrc/xpu/sycl/deepseek_fused_indexer_q_rope_fp8.cpp
@@ -12,12 +12,6 @@ namespace vllm {
 
 using bf16_t = sycl::ext::oneapi::bfloat16;
 
-static constexpr int HEAD_DIM = 128;
-static constexpr int NOPE_DIM = 64;
-static constexpr int ROPE_DIM = 64;
-static constexpr int HALF_ROPE = 32;
-static constexpr int HALF_BLOCK = 16;
-static constexpr int HEADS_COARSEN = 2;
 static constexpr int SG_SIZE = 16;
 static constexpr float INV_FP8_MAX = 1.0f / 448.0f;
 
@@ -54,8 +48,19 @@ inline uint8_t fp8_cvt(float x) {
   return (uint8_t)(sign | res);
 }
 
+template <int HEAD_DIM_, int ROPE_DIM_, int HEADS_COARSEN_ = 2>
 class deepseek_fused_indexer_q_rope_fp8_kernel {
  public:
+  static constexpr int HEAD_DIM = HEAD_DIM_;
+  static constexpr int ROPE_DIM = ROPE_DIM_;
+  static constexpr int NOPE_DIM = HEAD_DIM - ROPE_DIM;
+  static constexpr int HALF_ROPE = ROPE_DIM / 2;
+  static constexpr int HALF_BLOCK = SG_SIZE;
+  static constexpr int HEADS_COARSEN = HEADS_COARSEN_;
+  static_assert(ROPE_DIM % 2 == 0 && HALF_ROPE >= SG_SIZE,
+                "ROPE_DIM/2 must be >= SG_SIZE");
+  static_assert(NOPE_DIM > 0, "HEAD_DIM must be > ROPE_DIM");
+
   deepseek_fused_indexer_q_rope_fp8_kernel(
       const bf16_t* __restrict__ q,
       const int64_t* __restrict__ positions,
@@ -194,26 +199,29 @@ void deepseek_fused_indexer_q_rope_fp8(
     torch::Tensor& q_fp8,
     torch::Tensor& weights_out) {
   TORCH_CHECK(q.dim() == 3, "q must be [T, H, HEAD_DIM]");
-  TORCH_CHECK(
-      q.size(2) == vllm::HEAD_DIM,
-      "q HEAD_DIM must be ",
-      vllm::HEAD_DIM,
-      ", got ",
-      q.size(2));
 
   const int64_t num_tokens = q.size(0);
   const int64_t num_heads = q.size(1);
+  const int64_t head_dim = q.size(2);
+  const int64_t rope_dim = cos_sin_cache.size(1);
   const int64_t cos_sin_stride = cos_sin_cache.stride(0);
   const float weight_combined =
       static_cast<float>(softmax_scale) * static_cast<float>(head_scale);
 
+  // Dispatch based on (head_dim, rope_dim). Add new cases for future models.
   TORCH_CHECK(
-      num_heads % vllm::HEADS_COARSEN == 0,
-      "num_heads must be divisible by ",
-      vllm::HEADS_COARSEN);
+      head_dim == 128 && rope_dim == 64,
+      "deepseek_fused_indexer_q_rope_fp8: unsupported head_dim=",
+      head_dim,
+      " rope_dim=",
+      rope_dim,
+      ". Supported: head_dim=128, rope_dim=64");
 
-  const int64_t nhg =
-      (num_heads + vllm::HEADS_COARSEN - 1) / vllm::HEADS_COARSEN;
+  TORCH_CHECK(
+      num_heads % 2 == 0,
+      "num_heads must be divisible by 2");
+
+  const int64_t nhg = num_heads / 2;
 
   auto& queue = vllm::xpu::vllmGetQueue();
   queue.submit([&](sycl::handler& cgh) {
@@ -228,7 +236,7 @@ void deepseek_fused_indexer_q_rope_fp8(
         sycl::nd_range<2>(
             {(size_t)num_tokens, (size_t)(nhg * vllm::SG_SIZE)},
             {1, (size_t)vllm::SG_SIZE}),
-        vllm::deepseek_fused_indexer_q_rope_fp8_kernel(
+        vllm::deepseek_fused_indexer_q_rope_fp8_kernel<128, 64, 2>(
             q_ptr,
             pos_ptr,
             cs_ptr,

--- a/csrc/xpu/sycl/deepseek_fused_indexer_q_rope_fp8.cpp
+++ b/csrc/xpu/sycl/deepseek_fused_indexer_q_rope_fp8.cpp
@@ -1,0 +1,218 @@
+// SPDX-License-Identifier: Apache-2.0
+// Fused DeepSeek-V4 indexer Q: GPT-J RoPE + per-head FP8 quantize + weight fold.
+// One sub-group (16 lanes) handles 2 heads (COARSEN=2) per token.
+// Matches the Triton _fused_indexer_q_rope_quant_kernel semantics.
+
+#include <sycl/sycl.hpp>
+#include "utils.h"
+#include <cstdint>
+#include <torch/all.h>
+
+namespace vllm {
+
+using bf16_t = sycl::ext::oneapi::bfloat16;
+
+static constexpr int HEAD_DIM      = 128;
+static constexpr int NOPE_DIM      = 64;
+static constexpr int ROPE_DIM      = 64;
+static constexpr int HALF_ROPE     = 32;
+static constexpr int HALF_BLOCK    = 16;
+static constexpr int HEADS_COARSEN = 2;
+static constexpr int SG_SIZE       = 16;
+static constexpr float INV_FP8_MAX = 1.0f / 448.0f;
+
+// Division-free power-of-2 scale + inv_scale computation.
+inline void fp8_scale_pair(float amax, float& scale, float& inv_scale) {
+  float ratio = sycl::fmax(amax, 1e-4f) * INV_FP8_MAX;
+  uint32_t bits;
+  __builtin_memcpy(&bits, &ratio, 4);
+  if (bits & 0x7FFFFFu) bits = (bits + 0x800000u) & 0xFF800000u;
+  if ((bits & 0x7F800000u) == 0) bits = 0x00800000u;
+  __builtin_memcpy(&scale, &bits, 4);
+  uint32_t inv_bits = (254u - ((bits >> 23) & 0xFFu)) << 23;
+  __builtin_memcpy(&inv_scale, &inv_bits, 4);
+}
+
+// Branchless FP8 E4M3FN conversion.
+inline uint8_t fp8_cvt(float x) {
+  uint32_t b;
+  __builtin_memcpy(&b, &x, 4);
+  uint32_t sign = (b >> 24) & 0x80u;
+  b &= 0x7FFFFFFFu;
+  uint32_t rd = b + (1u << 19);
+  rd = (rd < 0x43E00000u) ? rd : 0x43E00000u;
+  uint32_t e32 = (rd >> 23) & 0xFFu, m3 = (rd >> 20) & 0x7u;
+  int32_t e8 = (int32_t)e32 - 120;
+  int32_t sh = 1 - e8;
+  sh = (sh > 7) ? 7 : sh;
+  uint32_t sub = ((8u + m3) >> sh) & 0x7u;
+  uint32_t nor = ((uint32_t)e8 << 3) | m3;
+  uint32_t mk = (uint32_t)-(e8 > 0);
+  uint32_t res = (nor & mk) | (sub & ~mk);
+  uint32_t nan_m = (uint32_t)-(res == 0x7Fu);
+  res = (res & ~nan_m) | (0x7Eu & nan_m);
+  return (uint8_t)(sign | res);
+}
+
+class deepseek_fused_indexer_q_rope_fp8_kernel {
+ public:
+  deepseek_fused_indexer_q_rope_fp8_kernel(
+      const bf16_t* __restrict__ q,
+      const int64_t* __restrict__ positions,
+      const float* __restrict__ cos_sin_cache,
+      const bf16_t* __restrict__ weights,
+      uint8_t* __restrict__ q_fp8,
+      float* __restrict__ weights_out,
+      float weight_combined,
+      int64_t num_tokens,
+      int64_t num_heads,
+      int64_t cos_sin_stride)
+      : q_(q), positions_(positions), cos_sin_cache_(cos_sin_cache),
+        weights_(weights), q_fp8_(q_fp8), weights_out_(weights_out),
+        weight_combined_(weight_combined), num_tokens_(num_tokens),
+        num_heads_(num_heads), cos_sin_stride_(cos_sin_stride) {}
+
+  [[sycl::reqd_sub_group_size(SG_SIZE)]]
+  void operator()(sycl::nd_item<2> item) const {
+    const int64_t tok = item.get_global_id(0);
+    const int64_t hg = item.get_global_id(1) / SG_SIZE;
+    const int lane = item.get_local_id(1) % SG_SIZE;
+    const int64_t bh = hg * HEADS_COARSEN;
+    if (tok >= num_tokens_ || bh >= num_heads_) return;
+    auto sg = item.get_sub_group();
+
+    // Load cos/sin for this token's position.
+    const float* csr = cos_sin_cache_ + positions_[tok] * cos_sin_stride_;
+    const float c0 = csr[lane], s0 = csr[HALF_ROPE + lane];
+    const float c1 = csr[HALF_BLOCK + lane], s1 = csr[HALF_ROPE + HALF_BLOCK + lane];
+    const int64_t q_token_stride = num_heads_ * HEAD_DIM;
+
+    // Prefetch 2 heads of Q data as packed uint32 (2×bf16 per lane).
+    uint32_t dd[HEADS_COARSEN][4];
+    #pragma unroll
+    for (int i = 0; i < HEADS_COARSEN; ++i) {
+      const uint32_t* q32 = reinterpret_cast<const uint32_t*>(
+          q_ + tok * q_token_stride + (bh + i) * HEAD_DIM);
+      dd[i][0] = q32[lane];
+      dd[i][1] = q32[HALF_BLOCK + lane];
+      dd[i][2] = q32[NOPE_DIM / 2 + lane];
+      dd[i][3] = q32[NOPE_DIM / 2 + HALF_BLOCK + lane];
+    }
+
+    #pragma unroll
+    for (int hc = 0; hc < HEADS_COARSEN; ++hc) {
+      const int64_t h = bh + hc;
+
+      // Decode bf16 pairs from packed uint32.
+      float n0l = (float)sycl::bit_cast<bf16_t>((uint16_t)dd[hc][0]);
+      float n0h = (float)sycl::bit_cast<bf16_t>((uint16_t)(dd[hc][0] >> 16));
+      float n1l = (float)sycl::bit_cast<bf16_t>((uint16_t)dd[hc][1]);
+      float n1h = (float)sycl::bit_cast<bf16_t>((uint16_t)(dd[hc][1] >> 16));
+      float xe0 = (float)sycl::bit_cast<bf16_t>((uint16_t)dd[hc][2]);
+      float xo0 = (float)sycl::bit_cast<bf16_t>((uint16_t)(dd[hc][2] >> 16));
+      float xe1 = (float)sycl::bit_cast<bf16_t>((uint16_t)dd[hc][3]);
+      float xo1 = (float)sycl::bit_cast<bf16_t>((uint16_t)(dd[hc][3] >> 16));
+
+      // GPT-J RoPE + bf16 roundtrip (matches Triton reference numerics).
+      float re0 = xe0 * c0 - xo0 * s0, ro0 = xo0 * c0 + xe0 * s0;
+      re0 = (float)(bf16_t)re0; ro0 = (float)(bf16_t)ro0;
+      float re1 = xe1 * c1 - xo1 * s1, ro1 = xo1 * c1 + xe1 * s1;
+      re1 = (float)(bf16_t)re1; ro1 = (float)(bf16_t)ro1;
+
+      // Per-head absmax reduction.
+      float lm = sycl::fmax(sycl::fmax(sycl::fabs(n0l), sycl::fabs(n0h)),
+                            sycl::fmax(sycl::fabs(n1l), sycl::fabs(n1h)));
+      lm = sycl::fmax(lm, sycl::fmax(
+          sycl::fmax(sycl::fabs(re0), sycl::fabs(ro0)),
+          sycl::fmax(sycl::fabs(re1), sycl::fabs(ro1))));
+      float amax = sycl::reduce_over_group(sg, lm, sycl::maximum<float>());
+
+      // Scale (division-free power-of-2).
+      float scale, inv_s;
+      fp8_scale_pair(amax, scale, inv_s);
+
+      // Quantize to FP8 E4M3FN.
+      uint8_t f0 = fp8_cvt(n0l * inv_s), f1 = fp8_cvt(n0h * inv_s);
+      uint8_t f2 = fp8_cvt(n1l * inv_s), f3 = fp8_cvt(n1h * inv_s);
+      uint8_t f4 = fp8_cvt(re0 * inv_s), f5 = fp8_cvt(ro0 * inv_s);
+      uint8_t f6 = fp8_cvt(re1 * inv_s), f7 = fp8_cvt(ro1 * inv_s);
+
+      // Store FP8 as uint16 pairs (coalesced).
+      uint8_t* out = q_fp8_ + (tok * num_heads_ + h) * HEAD_DIM;
+      reinterpret_cast<uint16_t*>(out)[lane] =
+          (uint16_t)f0 | ((uint16_t)f1 << 8);
+      reinterpret_cast<uint16_t*>(out + 32)[lane] =
+          (uint16_t)f2 | ((uint16_t)f3 << 8);
+      reinterpret_cast<uint16_t*>(out + NOPE_DIM)[lane] =
+          (uint16_t)f4 | ((uint16_t)f5 << 8);
+      reinterpret_cast<uint16_t*>(out + NOPE_DIM + 32)[lane] =
+          (uint16_t)f6 | ((uint16_t)f7 << 8);
+
+      // Weight fold: weights_out = weights * scale * softmax_scale * head_scale
+      if (lane == 0) {
+        weights_out_[tok * num_heads_ + h] =
+            (float)weights_[tok * num_heads_ + h] * scale * weight_combined_;
+      }
+    }
+  }
+
+ private:
+  const bf16_t* __restrict__ q_;
+  const int64_t* __restrict__ positions_;
+  const float* __restrict__ cos_sin_cache_;
+  const bf16_t* __restrict__ weights_;
+  uint8_t* __restrict__ q_fp8_;
+  float* __restrict__ weights_out_;
+  float weight_combined_;
+  int64_t num_tokens_, num_heads_;
+  int64_t cos_sin_stride_;
+};
+
+}  // namespace vllm
+
+using vllm::bf16_t;
+
+void deepseek_fused_indexer_q_rope_fp8(
+    const torch::Tensor& q,
+    const torch::Tensor& positions,
+    const torch::Tensor& cos_sin_cache,
+    const torch::Tensor& index_weights,
+    double softmax_scale,
+    double head_scale,
+    torch::Tensor& q_fp8,
+    torch::Tensor& weights_out) {
+
+  TORCH_CHECK(q.dim() == 3, "q must be [T, H, HEAD_DIM]");
+  TORCH_CHECK(q.size(2) == vllm::HEAD_DIM,
+      "q HEAD_DIM must be ", vllm::HEAD_DIM, ", got ", q.size(2));
+
+  const int64_t num_tokens = q.size(0);
+  const int64_t num_heads = q.size(1);
+  const int64_t cos_sin_stride = cos_sin_cache.stride(0);
+  const float weight_combined =
+      static_cast<float>(softmax_scale) * static_cast<float>(head_scale);
+
+  TORCH_CHECK(num_heads % vllm::HEADS_COARSEN == 0,
+      "num_heads must be divisible by ", vllm::HEADS_COARSEN);
+
+  const int64_t nhg =
+      (num_heads + vllm::HEADS_COARSEN - 1) / vllm::HEADS_COARSEN;
+
+  auto& queue = vllm::xpu::vllmGetQueue();
+  queue.submit([&](sycl::handler& cgh) {
+    auto* q_ptr = reinterpret_cast<const bf16_t*>(q.data_ptr());
+    auto* pos_ptr = positions.data_ptr<int64_t>();
+    auto* cs_ptr = cos_sin_cache.data_ptr<float>();
+    auto* w_ptr = reinterpret_cast<const bf16_t*>(index_weights.data_ptr());
+    auto* fp8_ptr = reinterpret_cast<uint8_t*>(q_fp8.data_ptr());
+    auto* wo_ptr = weights_out.data_ptr<float>();
+
+    cgh.parallel_for(
+        sycl::nd_range<2>(
+            {(size_t)num_tokens, (size_t)(nhg * vllm::SG_SIZE)},
+            {1, (size_t)vllm::SG_SIZE}),
+        vllm::deepseek_fused_indexer_q_rope_fp8_kernel(
+            q_ptr, pos_ptr, cs_ptr, w_ptr, fp8_ptr, wo_ptr,
+            weight_combined, num_tokens, num_heads, cos_sin_stride));
+  });
+}

--- a/csrc/xpu/sycl/deepseek_fused_indexer_q_rope_fp8.cpp
+++ b/csrc/xpu/sycl/deepseek_fused_indexer_q_rope_fp8.cpp
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
-// Fused DeepSeek-V4 indexer Q: GPT-J RoPE + per-head FP8 quantize + weight fold.
-// One sub-group (16 lanes) handles 2 heads (COARSEN=2) per token.
-// Matches the Triton _fused_indexer_q_rope_quant_kernel semantics.
+// Fused DeepSeek-V4 indexer Q: GPT-J RoPE + per-head FP8 quantize + weight
+// fold. One sub-group (16 lanes) handles 2 heads (COARSEN=2) per token. Matches
+// the Triton _fused_indexer_q_rope_quant_kernel semantics.
 
 #include <sycl/sycl.hpp>
 #include "utils.h"
@@ -12,13 +12,13 @@ namespace vllm {
 
 using bf16_t = sycl::ext::oneapi::bfloat16;
 
-static constexpr int HEAD_DIM      = 128;
-static constexpr int NOPE_DIM      = 64;
-static constexpr int ROPE_DIM      = 64;
-static constexpr int HALF_ROPE     = 32;
-static constexpr int HALF_BLOCK    = 16;
+static constexpr int HEAD_DIM = 128;
+static constexpr int NOPE_DIM = 64;
+static constexpr int ROPE_DIM = 64;
+static constexpr int HALF_ROPE = 32;
+static constexpr int HALF_BLOCK = 16;
 static constexpr int HEADS_COARSEN = 2;
-static constexpr int SG_SIZE       = 16;
+static constexpr int SG_SIZE = 16;
 static constexpr float INV_FP8_MAX = 1.0f / 448.0f;
 
 // Division-free power-of-2 scale + inv_scale computation.
@@ -67,10 +67,16 @@ class deepseek_fused_indexer_q_rope_fp8_kernel {
       int64_t num_tokens,
       int64_t num_heads,
       int64_t cos_sin_stride)
-      : q_(q), positions_(positions), cos_sin_cache_(cos_sin_cache),
-        weights_(weights), q_fp8_(q_fp8), weights_out_(weights_out),
-        weight_combined_(weight_combined), num_tokens_(num_tokens),
-        num_heads_(num_heads), cos_sin_stride_(cos_sin_stride) {}
+      : q_(q),
+        positions_(positions),
+        cos_sin_cache_(cos_sin_cache),
+        weights_(weights),
+        q_fp8_(q_fp8),
+        weights_out_(weights_out),
+        weight_combined_(weight_combined),
+        num_tokens_(num_tokens),
+        num_heads_(num_heads),
+        cos_sin_stride_(cos_sin_stride) {}
 
   [[sycl::reqd_sub_group_size(SG_SIZE)]]
   void operator()(sycl::nd_item<2> item) const {
@@ -84,12 +90,13 @@ class deepseek_fused_indexer_q_rope_fp8_kernel {
     // Load cos/sin for this token's position.
     const float* csr = cos_sin_cache_ + positions_[tok] * cos_sin_stride_;
     const float c0 = csr[lane], s0 = csr[HALF_ROPE + lane];
-    const float c1 = csr[HALF_BLOCK + lane], s1 = csr[HALF_ROPE + HALF_BLOCK + lane];
+    const float c1 = csr[HALF_BLOCK + lane],
+                s1 = csr[HALF_ROPE + HALF_BLOCK + lane];
     const int64_t q_token_stride = num_heads_ * HEAD_DIM;
 
     // Prefetch 2 heads of Q data as packed uint32 (2×bf16 per lane).
     uint32_t dd[HEADS_COARSEN][4];
-    #pragma unroll
+#pragma unroll
     for (int i = 0; i < HEADS_COARSEN; ++i) {
       const uint32_t* q32 = reinterpret_cast<const uint32_t*>(
           q_ + tok * q_token_stride + (bh + i) * HEAD_DIM);
@@ -99,7 +106,7 @@ class deepseek_fused_indexer_q_rope_fp8_kernel {
       dd[i][3] = q32[NOPE_DIM / 2 + HALF_BLOCK + lane];
     }
 
-    #pragma unroll
+#pragma unroll
     for (int hc = 0; hc < HEADS_COARSEN; ++hc) {
       const int64_t h = bh + hc;
 
@@ -115,16 +122,21 @@ class deepseek_fused_indexer_q_rope_fp8_kernel {
 
       // GPT-J RoPE + bf16 roundtrip (matches Triton reference numerics).
       float re0 = xe0 * c0 - xo0 * s0, ro0 = xo0 * c0 + xe0 * s0;
-      re0 = (float)(bf16_t)re0; ro0 = (float)(bf16_t)ro0;
+      re0 = (float)(bf16_t)re0;
+      ro0 = (float)(bf16_t)ro0;
       float re1 = xe1 * c1 - xo1 * s1, ro1 = xo1 * c1 + xe1 * s1;
-      re1 = (float)(bf16_t)re1; ro1 = (float)(bf16_t)ro1;
+      re1 = (float)(bf16_t)re1;
+      ro1 = (float)(bf16_t)ro1;
 
       // Per-head absmax reduction.
-      float lm = sycl::fmax(sycl::fmax(sycl::fabs(n0l), sycl::fabs(n0h)),
-                            sycl::fmax(sycl::fabs(n1l), sycl::fabs(n1h)));
-      lm = sycl::fmax(lm, sycl::fmax(
-          sycl::fmax(sycl::fabs(re0), sycl::fabs(ro0)),
-          sycl::fmax(sycl::fabs(re1), sycl::fabs(ro1))));
+      float lm = sycl::fmax(
+          sycl::fmax(sycl::fabs(n0l), sycl::fabs(n0h)),
+          sycl::fmax(sycl::fabs(n1l), sycl::fabs(n1h)));
+      lm = sycl::fmax(
+          lm,
+          sycl::fmax(
+              sycl::fmax(sycl::fabs(re0), sycl::fabs(ro0)),
+              sycl::fmax(sycl::fabs(re1), sycl::fabs(ro1))));
       float amax = sycl::reduce_over_group(sg, lm, sycl::maximum<float>());
 
       // Scale (division-free power-of-2).
@@ -181,10 +193,13 @@ void deepseek_fused_indexer_q_rope_fp8(
     double head_scale,
     torch::Tensor& q_fp8,
     torch::Tensor& weights_out) {
-
   TORCH_CHECK(q.dim() == 3, "q must be [T, H, HEAD_DIM]");
-  TORCH_CHECK(q.size(2) == vllm::HEAD_DIM,
-      "q HEAD_DIM must be ", vllm::HEAD_DIM, ", got ", q.size(2));
+  TORCH_CHECK(
+      q.size(2) == vllm::HEAD_DIM,
+      "q HEAD_DIM must be ",
+      vllm::HEAD_DIM,
+      ", got ",
+      q.size(2));
 
   const int64_t num_tokens = q.size(0);
   const int64_t num_heads = q.size(1);
@@ -192,8 +207,10 @@ void deepseek_fused_indexer_q_rope_fp8(
   const float weight_combined =
       static_cast<float>(softmax_scale) * static_cast<float>(head_scale);
 
-  TORCH_CHECK(num_heads % vllm::HEADS_COARSEN == 0,
-      "num_heads must be divisible by ", vllm::HEADS_COARSEN);
+  TORCH_CHECK(
+      num_heads % vllm::HEADS_COARSEN == 0,
+      "num_heads must be divisible by ",
+      vllm::HEADS_COARSEN);
 
   const int64_t nhg =
       (num_heads + vllm::HEADS_COARSEN - 1) / vllm::HEADS_COARSEN;
@@ -212,7 +229,15 @@ void deepseek_fused_indexer_q_rope_fp8(
             {(size_t)num_tokens, (size_t)(nhg * vllm::SG_SIZE)},
             {1, (size_t)vllm::SG_SIZE}),
         vllm::deepseek_fused_indexer_q_rope_fp8_kernel(
-            q_ptr, pos_ptr, cs_ptr, w_ptr, fp8_ptr, wo_ptr,
-            weight_combined, num_tokens, num_heads, cos_sin_stride));
+            q_ptr,
+            pos_ptr,
+            cs_ptr,
+            w_ptr,
+            fp8_ptr,
+            wo_ptr,
+            weight_combined,
+            num_tokens,
+            num_heads,
+            cos_sin_stride));
   });
 }

--- a/csrc/xpu/sycl/deepseek_fused_indexer_q_rope_mxfp4.cpp
+++ b/csrc/xpu/sycl/deepseek_fused_indexer_q_rope_mxfp4.cpp
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
-// Fused DeepSeek-V4 indexer Q: GPT-J RoPE + per-block MXFP4 quantize + weight fold.
-// One sub-group (16 lanes) handles 4 heads (COARSEN=4) per token.
-// Each head has 4 x 32-element blocks quantized to MXFP4 with ue8m0 scales.
+// Fused DeepSeek-V4 indexer Q: GPT-J RoPE + per-block MXFP4 quantize + weight
+// fold. One sub-group (16 lanes) handles 4 heads (COARSEN=4) per token. Each
+// head has 4 x 32-element blocks quantized to MXFP4 with ue8m0 scales.
 
 #include <sycl/sycl.hpp>
 #include "utils.h"
@@ -12,16 +12,16 @@ namespace vllm {
 
 using bf16_t = sycl::ext::oneapi::bfloat16;
 
-static constexpr int HEAD_DIM        = 128;
-static constexpr int NOPE_DIM        = 64;
-static constexpr int ROPE_DIM        = 64;
-static constexpr int HALF_ROPE       = 32;
-static constexpr int HALF_BLOCK      = 16;
-static constexpr int NUM_BLOCKS      = 4;  // HEAD_DIM / MXFP4_BLOCK_SIZE
-static constexpr int HEADS_COARSEN   = 4;
-static constexpr int SG_SIZE         = 16;
-static constexpr float FP4_MAX       = 6.0f;
-static constexpr float INV_FP4_MAX   = 1.0f / 6.0f;
+static constexpr int HEAD_DIM = 128;
+static constexpr int NOPE_DIM = 64;
+static constexpr int ROPE_DIM = 64;
+static constexpr int HALF_ROPE = 32;
+static constexpr int HALF_BLOCK = 16;
+static constexpr int NUM_BLOCKS = 4;  // HEAD_DIM / MXFP4_BLOCK_SIZE
+static constexpr int HEADS_COARSEN = 4;
+static constexpr int SG_SIZE = 16;
+static constexpr float FP4_MAX = 6.0f;
+static constexpr float INV_FP4_MAX = 1.0f / 6.0f;
 
 // Staircase FP4 E2M1 encoder: maps float -> 4-bit code (sign|mantissa).
 inline uint8_t encode_fp4(float x) {
@@ -101,7 +101,7 @@ class deepseek_fused_indexer_q_rope_mxfp4_kernel {
 
     // Batch-load all 4 heads upfront (16 uint32 loads)
     uint32_t data[HEADS_COARSEN][4];
-    #pragma unroll
+#pragma unroll
     for (int hc = 0; hc < HEADS_COARSEN; ++hc) {
       const uint32_t* q32 = reinterpret_cast<const uint32_t*>(
           q_ + tok * qs0 + (bh + hc) * HEAD_DIM);
@@ -111,7 +111,7 @@ class deepseek_fused_indexer_q_rope_mxfp4_kernel {
       data[hc][3] = q32[NOPE_DIM / 2 + HALF_BLOCK + lane];
     }
 
-    #pragma unroll
+#pragma unroll
     for (int hc = 0; hc < HEADS_COARSEN; ++hc) {
       const int h = bh + hc;
       uint8_t* pd = packed_ + ((int64_t)tok * H_ + h) * (HEAD_DIM / 2);
@@ -221,7 +221,8 @@ void deepseek_fused_indexer_q_rope_mxfp4(
   const bf16_t* q_ptr = reinterpret_cast<const bf16_t*>(q.data_ptr());
   const int64_t* pos_ptr = positions.data_ptr<int64_t>();
   const float* cs_ptr = cos_sin_cache.data_ptr<float>();
-  const bf16_t* w_ptr = reinterpret_cast<const bf16_t*>(index_weights.data_ptr());
+  const bf16_t* w_ptr =
+      reinterpret_cast<const bf16_t*>(index_weights.data_ptr());
   uint8_t* packed_ptr = packed_out.data_ptr<uint8_t>();
   uint8_t* scales_ptr = scales_out.data_ptr<uint8_t>();
   float* wo_ptr = weights_out.data_ptr<float>();
@@ -236,7 +237,15 @@ void deepseek_fused_indexer_q_rope_mxfp4(
              static_cast<size_t>(nhg * SG_SIZE)},
             {1, static_cast<size_t>(SG_SIZE)}),
         deepseek_fused_indexer_q_rope_mxfp4_kernel(
-            q_ptr, pos_ptr, cs_ptr, w_ptr, packed_ptr, scales_ptr, wo_ptr,
-            num_tokens, num_heads, combined_scale));
+            q_ptr,
+            pos_ptr,
+            cs_ptr,
+            w_ptr,
+            packed_ptr,
+            scales_ptr,
+            wo_ptr,
+            num_tokens,
+            num_heads,
+            combined_scale));
   });
 }

--- a/csrc/xpu/sycl/deepseek_fused_indexer_q_rope_mxfp4.cpp
+++ b/csrc/xpu/sycl/deepseek_fused_indexer_q_rope_mxfp4.cpp
@@ -1,0 +1,242 @@
+// SPDX-License-Identifier: Apache-2.0
+// Fused DeepSeek-V4 indexer Q: GPT-J RoPE + per-block MXFP4 quantize + weight fold.
+// One sub-group (16 lanes) handles 4 heads (COARSEN=4) per token.
+// Each head has 4 x 32-element blocks quantized to MXFP4 with ue8m0 scales.
+
+#include <sycl/sycl.hpp>
+#include "utils.h"
+#include <cstdint>
+#include <torch/all.h>
+
+namespace vllm {
+
+using bf16_t = sycl::ext::oneapi::bfloat16;
+
+static constexpr int HEAD_DIM        = 128;
+static constexpr int NOPE_DIM        = 64;
+static constexpr int ROPE_DIM        = 64;
+static constexpr int HALF_ROPE       = 32;
+static constexpr int HALF_BLOCK      = 16;
+static constexpr int NUM_BLOCKS      = 4;  // HEAD_DIM / MXFP4_BLOCK_SIZE
+static constexpr int HEADS_COARSEN   = 4;
+static constexpr int SG_SIZE         = 16;
+static constexpr float FP4_MAX       = 6.0f;
+static constexpr float INV_FP4_MAX   = 1.0f / 6.0f;
+
+// Staircase FP4 E2M1 encoder: maps float -> 4-bit code (sign|mantissa).
+inline uint8_t encode_fp4(float x) {
+  uint8_t sign = (x < 0.0f) ? 0x8u : 0x0u;
+  float a = sycl::fabs(x);
+  uint8_t code = (a > 0.25f) + (a > 0.75f) + (a > 1.25f) + (a > 1.75f) +
+                 (a > 2.5f) + (a > 3.5f) + (a > 5.0f);
+  return code | sign;
+}
+
+// Compute 1/scale and ue8m0 scale byte directly from amax.
+// scale = 2^ceil(log2(amax/FP4_MAX)), always power-of-2.
+// inv = 2^(127-k), computed via bit manipulation (no division).
+inline float fast_inv_scale(float amax, uint8_t& ue8m0) {
+  float ratio = amax * INV_FP4_MAX;
+  uint32_t bits;
+  __builtin_memcpy(&bits, &ratio, 4);
+  if ((bits & 0x7F800000u) == 0) bits = 0x00800000u;
+  if (bits & 0x7FFFFFu) bits = (bits + 0x800000u) & 0xFF800000u;
+  ue8m0 = static_cast<uint8_t>((bits >> 23) & 0xFFu);
+  const uint32_t inv_bits = 0x7F000000u - bits;
+  float inv;
+  __builtin_memcpy(&inv, &inv_bits, 4);
+  return inv;
+}
+
+// Quantize a pair of floats to packed MXFP4 byte (lo=bits[3:0], hi=bits[7:4]).
+inline uint8_t quant_pair(float x0, float x1, float inv_s) {
+  float q0 = sycl::fmax(-FP4_MAX, sycl::fmin(x0 * inv_s, FP4_MAX));
+  float q1 = sycl::fmax(-FP4_MAX, sycl::fmin(x1 * inv_s, FP4_MAX));
+  return ((encode_fp4(q1) & 0xFu) << 4) | (encode_fp4(q0) & 0xFu);
+}
+
+class deepseek_fused_indexer_q_rope_mxfp4_kernel {
+ public:
+  deepseek_fused_indexer_q_rope_mxfp4_kernel(
+      const bf16_t* __restrict__ q,
+      const int64_t* __restrict__ pos,
+      const float* __restrict__ cs,
+      const bf16_t* __restrict__ w,
+      uint8_t* __restrict__ packed,
+      uint8_t* __restrict__ scales,
+      float* __restrict__ wo,
+      int64_t num_tokens,
+      int64_t num_heads,
+      float combined_scale)
+      : q_(q),
+        pos_(pos),
+        cs_(cs),
+        w_(w),
+        packed_(packed),
+        scales_(scales),
+        wo_(wo),
+        T_(num_tokens),
+        H_(num_heads),
+        combined_scale_(combined_scale) {}
+
+  [[sycl::reqd_sub_group_size(SG_SIZE)]]
+  void operator()(sycl::nd_item<2> item) const {
+    const int tok = item.get_global_id(0);
+    const int hg = item.get_global_id(1) / SG_SIZE;
+    const int lane = item.get_local_id(1) % SG_SIZE;
+    const int bh = hg * HEADS_COARSEN;
+
+    if (tok >= T_ || bh >= H_) return;
+
+    auto sg = item.get_sub_group();
+
+    // Load cos/sin for this token's position
+    const float* csr = cs_ + pos_[tok] * ROPE_DIM;
+    const float c0 = csr[lane];
+    const float s0 = csr[HALF_ROPE + lane];
+    const float c1 = csr[HALF_BLOCK + lane];
+    const float s1 = csr[HALF_ROPE + HALF_BLOCK + lane];
+
+    const int64_t qs0 = (int64_t)H_ * HEAD_DIM;
+
+    // Batch-load all 4 heads upfront (16 uint32 loads)
+    uint32_t data[HEADS_COARSEN][4];
+    #pragma unroll
+    for (int hc = 0; hc < HEADS_COARSEN; ++hc) {
+      const uint32_t* q32 = reinterpret_cast<const uint32_t*>(
+          q_ + tok * qs0 + (bh + hc) * HEAD_DIM);
+      data[hc][0] = q32[lane];
+      data[hc][1] = q32[HALF_BLOCK + lane];
+      data[hc][2] = q32[NOPE_DIM / 2 + lane];
+      data[hc][3] = q32[NOPE_DIM / 2 + HALF_BLOCK + lane];
+    }
+
+    #pragma unroll
+    for (int hc = 0; hc < HEADS_COARSEN; ++hc) {
+      const int h = bh + hc;
+      uint8_t* pd = packed_ + ((int64_t)tok * H_ + h) * (HEAD_DIM / 2);
+      uint8_t* sd = scales_ + ((int64_t)tok * H_ + h) * NUM_BLOCKS;
+
+      // NoPE block 0 & 1
+      float n0_lo = static_cast<float>(
+          sycl::bit_cast<bf16_t>(static_cast<uint16_t>(data[hc][0])));
+      float n0_hi = static_cast<float>(
+          sycl::bit_cast<bf16_t>(static_cast<uint16_t>(data[hc][0] >> 16)));
+      float n1_lo = static_cast<float>(
+          sycl::bit_cast<bf16_t>(static_cast<uint16_t>(data[hc][1])));
+      float n1_hi = static_cast<float>(
+          sycl::bit_cast<bf16_t>(static_cast<uint16_t>(data[hc][1] >> 16)));
+
+      // RoPE block 0: GPT-J style
+      float r0_e = static_cast<float>(
+          sycl::bit_cast<bf16_t>(static_cast<uint16_t>(data[hc][2])));
+      float r0_o = static_cast<float>(
+          sycl::bit_cast<bf16_t>(static_cast<uint16_t>(data[hc][2] >> 16)));
+      float r0_er = r0_e * c0 - r0_o * s0;
+      float r0_or = r0_o * c0 + r0_e * s0;
+      r0_er = static_cast<float>(static_cast<bf16_t>(r0_er));
+      r0_or = static_cast<float>(static_cast<bf16_t>(r0_or));
+
+      // RoPE block 1: GPT-J style
+      float r1_e = static_cast<float>(
+          sycl::bit_cast<bf16_t>(static_cast<uint16_t>(data[hc][3])));
+      float r1_o = static_cast<float>(
+          sycl::bit_cast<bf16_t>(static_cast<uint16_t>(data[hc][3] >> 16)));
+      float r1_er = r1_e * c1 - r1_o * s1;
+      float r1_or = r1_o * c1 + r1_e * s1;
+      r1_er = static_cast<float>(static_cast<bf16_t>(r1_er));
+      r1_or = static_cast<float>(static_cast<bf16_t>(r1_or));
+
+      // Per-block absmax reduction
+      float am0 = sycl::fmax(sycl::fabs(n0_lo), sycl::fabs(n0_hi));
+      float am1 = sycl::fmax(sycl::fabs(n1_lo), sycl::fabs(n1_hi));
+      float am2 = sycl::fmax(sycl::fabs(r0_er), sycl::fabs(r0_or));
+      float am3 = sycl::fmax(sycl::fabs(r1_er), sycl::fabs(r1_or));
+
+      am0 = sycl::reduce_over_group(sg, am0, sycl::maximum<float>());
+      am1 = sycl::reduce_over_group(sg, am1, sycl::maximum<float>());
+      am2 = sycl::reduce_over_group(sg, am2, sycl::maximum<float>());
+      am3 = sycl::reduce_over_group(sg, am3, sycl::maximum<float>());
+
+      // Scale + quantize all 4 blocks
+      uint8_t ue0, ue1, ue2, ue3;
+      float inv0 = fast_inv_scale(am0, ue0);
+      float inv1 = fast_inv_scale(am1, ue1);
+      float inv2 = fast_inv_scale(am2, ue2);
+      float inv3 = fast_inv_scale(am3, ue3);
+
+      uint8_t p0 = quant_pair(n0_lo, n0_hi, inv0);
+      uint8_t p1 = quant_pair(n1_lo, n1_hi, inv1);
+      uint8_t p2 = quant_pair(r0_er, r0_or, inv2);
+      uint8_t p3 = quant_pair(r1_er, r1_or, inv3);
+
+      // Batched writes
+      pd[lane] = p0;
+      pd[HALF_BLOCK + lane] = p1;
+      pd[NOPE_DIM / 2 + lane] = p2;
+      pd[NOPE_DIM / 2 + HALF_BLOCK + lane] = p3;
+
+      if (lane == 0) {
+        uint32_t sp = (uint32_t)ue0 | ((uint32_t)ue1 << 8) |
+                      ((uint32_t)ue2 << 16) | ((uint32_t)ue3 << 24);
+        *reinterpret_cast<uint32_t*>(sd) = sp;
+        wo_[tok * H_ + h] =
+            static_cast<float>(w_[tok * H_ + h]) * combined_scale_;
+      }
+    }
+  }
+
+ private:
+  const bf16_t* __restrict__ q_;
+  const int64_t* __restrict__ pos_;
+  const float* __restrict__ cs_;
+  const bf16_t* __restrict__ w_;
+  uint8_t* __restrict__ packed_;
+  uint8_t* __restrict__ scales_;
+  float* __restrict__ wo_;
+  int64_t T_;
+  int64_t H_;
+  float combined_scale_;
+};
+
+}  // namespace vllm
+
+void deepseek_fused_indexer_q_rope_mxfp4(
+    const at::Tensor& q,
+    const at::Tensor& positions,
+    const at::Tensor& cos_sin_cache,
+    const at::Tensor& index_weights,
+    double softmax_scale,
+    double head_scale,
+    at::Tensor& packed_out,
+    at::Tensor& scales_out,
+    at::Tensor& weights_out) {
+  using namespace vllm;
+
+  const int64_t num_tokens = q.size(0);
+  const int64_t num_heads = q.size(1);
+  const float combined_scale =
+      static_cast<float>(softmax_scale) * static_cast<float>(head_scale);
+
+  const bf16_t* q_ptr = reinterpret_cast<const bf16_t*>(q.data_ptr());
+  const int64_t* pos_ptr = positions.data_ptr<int64_t>();
+  const float* cs_ptr = cos_sin_cache.data_ptr<float>();
+  const bf16_t* w_ptr = reinterpret_cast<const bf16_t*>(index_weights.data_ptr());
+  uint8_t* packed_ptr = packed_out.data_ptr<uint8_t>();
+  uint8_t* scales_ptr = scales_out.data_ptr<uint8_t>();
+  float* wo_ptr = weights_out.data_ptr<float>();
+
+  const int nhg = (num_heads + HEADS_COARSEN - 1) / HEADS_COARSEN;
+  auto& queue = xpu::vllmGetQueue();
+
+  queue.submit([&](sycl::handler& cgh) {
+    cgh.parallel_for(
+        sycl::nd_range<2>(
+            {static_cast<size_t>(num_tokens),
+             static_cast<size_t>(nhg * SG_SIZE)},
+            {1, static_cast<size_t>(SG_SIZE)}),
+        deepseek_fused_indexer_q_rope_mxfp4_kernel(
+            q_ptr, pos_ptr, cs_ptr, w_ptr, packed_ptr, scales_ptr, wo_ptr,
+            num_tokens, num_heads, combined_scale));
+  });
+}

--- a/csrc/xpu/sycl/deepseek_fused_indexer_q_rope_mxfp4.cpp
+++ b/csrc/xpu/sycl/deepseek_fused_indexer_q_rope_mxfp4.cpp
@@ -59,8 +59,9 @@ class deepseek_fused_indexer_q_rope_mxfp4_kernel {
   static constexpr int HEADS_COARSEN = HEADS_COARSEN_;
   static constexpr int MXFP4_BLOCK_SIZE = 32;
   static constexpr int NUM_BLOCKS = HEAD_DIM / MXFP4_BLOCK_SIZE;
-  static_assert(ROPE_DIM % 2 == 0 && HALF_ROPE >= SG_SIZE,
-                "ROPE_DIM/2 must be >= SG_SIZE");
+  static_assert(
+      ROPE_DIM % 2 == 0 && HALF_ROPE >= SG_SIZE,
+      "ROPE_DIM/2 must be >= SG_SIZE");
   static_assert(NOPE_DIM > 0, "HEAD_DIM must be > ROPE_DIM");
 
   deepseek_fused_indexer_q_rope_mxfp4_kernel(
@@ -237,9 +238,7 @@ void deepseek_fused_indexer_q_rope_mxfp4(
       rope_dim,
       ". Supported: head_dim=128, rope_dim=64");
 
-  TORCH_CHECK(
-      num_heads % 4 == 0,
-      "num_heads must be divisible by 4");
+  TORCH_CHECK(num_heads % 4 == 0, "num_heads must be divisible by 4");
 
   const int nhg = num_heads / 4;
 

--- a/csrc/xpu/sycl/deepseek_fused_indexer_q_rope_mxfp4.cpp
+++ b/csrc/xpu/sycl/deepseek_fused_indexer_q_rope_mxfp4.cpp
@@ -12,13 +12,6 @@ namespace vllm {
 
 using bf16_t = sycl::ext::oneapi::bfloat16;
 
-static constexpr int HEAD_DIM = 128;
-static constexpr int NOPE_DIM = 64;
-static constexpr int ROPE_DIM = 64;
-static constexpr int HALF_ROPE = 32;
-static constexpr int HALF_BLOCK = 16;
-static constexpr int NUM_BLOCKS = 4;  // HEAD_DIM / MXFP4_BLOCK_SIZE
-static constexpr int HEADS_COARSEN = 4;
 static constexpr int SG_SIZE = 16;
 static constexpr float FP4_MAX = 6.0f;
 static constexpr float INV_FP4_MAX = 1.0f / 6.0f;
@@ -55,8 +48,21 @@ inline uint8_t quant_pair(float x0, float x1, float inv_s) {
   return ((encode_fp4(q1) & 0xFu) << 4) | (encode_fp4(q0) & 0xFu);
 }
 
+template <int HEAD_DIM_, int ROPE_DIM_, int HEADS_COARSEN_ = 4>
 class deepseek_fused_indexer_q_rope_mxfp4_kernel {
  public:
+  static constexpr int HEAD_DIM = HEAD_DIM_;
+  static constexpr int ROPE_DIM = ROPE_DIM_;
+  static constexpr int NOPE_DIM = HEAD_DIM - ROPE_DIM;
+  static constexpr int HALF_ROPE = ROPE_DIM / 2;
+  static constexpr int HALF_BLOCK = SG_SIZE;
+  static constexpr int HEADS_COARSEN = HEADS_COARSEN_;
+  static constexpr int MXFP4_BLOCK_SIZE = 32;
+  static constexpr int NUM_BLOCKS = HEAD_DIM / MXFP4_BLOCK_SIZE;
+  static_assert(ROPE_DIM % 2 == 0 && HALF_ROPE >= SG_SIZE,
+                "ROPE_DIM/2 must be >= SG_SIZE");
+  static_assert(NOPE_DIM > 0, "HEAD_DIM must be > ROPE_DIM");
+
   deepseek_fused_indexer_q_rope_mxfp4_kernel(
       const bf16_t* __restrict__ q,
       const int64_t* __restrict__ pos,
@@ -201,6 +207,8 @@ class deepseek_fused_indexer_q_rope_mxfp4_kernel {
 
 }  // namespace vllm
 
+using vllm::bf16_t;
+
 void deepseek_fused_indexer_q_rope_mxfp4(
     const at::Tensor& q,
     const at::Tensor& positions,
@@ -215,8 +223,25 @@ void deepseek_fused_indexer_q_rope_mxfp4(
 
   const int64_t num_tokens = q.size(0);
   const int64_t num_heads = q.size(1);
+  const int64_t head_dim = q.size(2);
+  const int64_t rope_dim = cos_sin_cache.size(1);
   const float combined_scale =
       static_cast<float>(softmax_scale) * static_cast<float>(head_scale);
+
+  // Dispatch based on (head_dim, rope_dim). Add new cases for future models.
+  TORCH_CHECK(
+      head_dim == 128 && rope_dim == 64,
+      "deepseek_fused_indexer_q_rope_mxfp4: unsupported head_dim=",
+      head_dim,
+      " rope_dim=",
+      rope_dim,
+      ". Supported: head_dim=128, rope_dim=64");
+
+  TORCH_CHECK(
+      num_heads % 4 == 0,
+      "num_heads must be divisible by 4");
+
+  const int nhg = num_heads / 4;
 
   const bf16_t* q_ptr = reinterpret_cast<const bf16_t*>(q.data_ptr());
   const int64_t* pos_ptr = positions.data_ptr<int64_t>();
@@ -227,7 +252,6 @@ void deepseek_fused_indexer_q_rope_mxfp4(
   uint8_t* scales_ptr = scales_out.data_ptr<uint8_t>();
   float* wo_ptr = weights_out.data_ptr<float>();
 
-  const int nhg = (num_heads + HEADS_COARSEN - 1) / HEADS_COARSEN;
   auto& queue = xpu::vllmGetQueue();
 
   queue.submit([&](sycl::handler& cgh) {
@@ -236,7 +260,7 @@ void deepseek_fused_indexer_q_rope_mxfp4(
             {static_cast<size_t>(num_tokens),
              static_cast<size_t>(nhg * SG_SIZE)},
             {1, static_cast<size_t>(SG_SIZE)}),
-        deepseek_fused_indexer_q_rope_mxfp4_kernel(
+        deepseek_fused_indexer_q_rope_mxfp4_kernel<128, 64, 4>(
             q_ptr,
             pos_ptr,
             cs_ptr,

--- a/csrc/xpu/torch_bindings.cpp
+++ b/csrc/xpu/torch_bindings.cpp
@@ -190,16 +190,20 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, xpu_ops) {
       "deepseek_fused_indexer_q_rope_fp8(Tensor q, Tensor positions, "
       "Tensor cos_sin_cache, Tensor index_weights, float softmax_scale, "
       "float head_scale, Tensor! q_fp8, Tensor! weights_out) -> ()");
-  xpu_ops.impl("deepseek_fused_indexer_q_rope_fp8", torch::kXPU,
-               &deepseek_fused_indexer_q_rope_fp8);
+  xpu_ops.impl(
+      "deepseek_fused_indexer_q_rope_fp8",
+      torch::kXPU,
+      &deepseek_fused_indexer_q_rope_fp8);
 
   xpu_ops.def(
       "deepseek_fused_indexer_q_rope_mxfp4(Tensor q, Tensor positions, "
       "Tensor cos_sin_cache, Tensor index_weights, float softmax_scale, "
       "float head_scale, Tensor! packed_out, Tensor! scales_out, "
       "Tensor! weights_out) -> ()");
-  xpu_ops.impl("deepseek_fused_indexer_q_rope_mxfp4", torch::kXPU,
-               &deepseek_fused_indexer_q_rope_mxfp4);
+  xpu_ops.impl(
+      "deepseek_fused_indexer_q_rope_mxfp4",
+      torch::kXPU,
+      &deepseek_fused_indexer_q_rope_mxfp4);
 }
 
 REGISTER_EXTENSION(TORCH_EXTENSION_NAME)

--- a/csrc/xpu/torch_bindings.cpp
+++ b/csrc/xpu/torch_bindings.cpp
@@ -185,6 +185,13 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, xpu_ops) {
 
   xpu_ops.def("get_onednn_version() -> str");
   xpu_ops.impl("get_onednn_version", &get_onednn_version);
+  
+  xpu_ops.def(
+      "deepseek_fused_indexer_q_rope_fp8(Tensor q, Tensor positions, "
+      "Tensor cos_sin_cache, Tensor index_weights, float softmax_scale, "
+      "float head_scale, Tensor! q_fp8, Tensor! weights_out) -> ()");
+  xpu_ops.impl("deepseek_fused_indexer_q_rope_fp8", torch::kXPU,
+               &deepseek_fused_indexer_q_rope_fp8);
 }
 
 REGISTER_EXTENSION(TORCH_EXTENSION_NAME)

--- a/csrc/xpu/torch_bindings.cpp
+++ b/csrc/xpu/torch_bindings.cpp
@@ -192,6 +192,14 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, xpu_ops) {
       "float head_scale, Tensor! q_fp8, Tensor! weights_out) -> ()");
   xpu_ops.impl("deepseek_fused_indexer_q_rope_fp8", torch::kXPU,
                &deepseek_fused_indexer_q_rope_fp8);
+
+  xpu_ops.def(
+      "deepseek_fused_indexer_q_rope_mxfp4(Tensor q, Tensor positions, "
+      "Tensor cos_sin_cache, Tensor index_weights, float softmax_scale, "
+      "float head_scale, Tensor! packed_out, Tensor! scales_out, "
+      "Tensor! weights_out) -> ()");
+  xpu_ops.impl("deepseek_fused_indexer_q_rope_mxfp4", torch::kXPU,
+               &deepseek_fused_indexer_q_rope_mxfp4);
 }
 
 REGISTER_EXTENSION(TORCH_EXTENSION_NAME)

--- a/csrc/xpu/torch_bindings.cpp
+++ b/csrc/xpu/torch_bindings.cpp
@@ -185,7 +185,7 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, xpu_ops) {
 
   xpu_ops.def("get_onednn_version() -> str");
   xpu_ops.impl("get_onednn_version", &get_onednn_version);
-  
+
   xpu_ops.def(
       "deepseek_fused_indexer_q_rope_fp8(Tensor q, Tensor positions, "
       "Tensor cos_sin_cache, Tensor index_weights, float softmax_scale, "

--- a/tests/test_deepseek_fused_indexer_q_rope_fp8.py
+++ b/tests/test_deepseek_fused_indexer_q_rope_fp8.py
@@ -1,0 +1,162 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Correctness tests for deepseek_fused_indexer_q_rope_fp8 SYCL kernel.
+
+Tests the fused GPT-J RoPE + per-head FP8 quantize + weight-fold kernel
+against a pure-PyTorch reference matching the Triton implementation.
+
+Run:
+    pytest tests/test_deepseek_fused_indexer_q_rope_fp8.py -v
+"""
+import math
+
+import pytest
+import torch
+
+import vllm_xpu_kernels._xpu_C  # noqa: F401
+
+DEVICE = torch.device("xpu")
+
+# DeepSeek-V4 indexer Q constants
+NUM_HEADS = 64
+HEAD_DIM = 128
+NOPE_DIM = 64
+ROPE_DIM = 64
+HALF_ROPE = 32
+
+
+def reference_fused_indexer_q_rope_fp8(
+    q, positions, cos_sin_cache, index_weights, softmax_scale, head_scale
+):
+    """Pure PyTorch reference matching Triton _fused_indexer_q_rope_quant_kernel."""
+    num_tokens = q.shape[0]
+    num_heads = q.shape[1]
+
+    q_fp8 = torch.zeros(num_tokens, num_heads, HEAD_DIM,
+                        dtype=torch.uint8, device=q.device)
+    weights_out = torch.zeros(num_tokens, num_heads,
+                              dtype=torch.float32, device=q.device)
+
+    for t in range(num_tokens):
+        pos = positions[t].item()
+        cos = cos_sin_cache[pos, :HALF_ROPE].float()
+        sin = cos_sin_cache[pos, HALF_ROPE:].float()
+
+        for h in range(num_heads):
+            q_f = q[t, h].float()
+            nope = q_f[:NOPE_DIM]
+            rope = q_f[NOPE_DIM:]
+
+            # GPT-J RoPE
+            x_even = rope[0::2]
+            x_odd = rope[1::2]
+            r_even = x_even * cos - x_odd * sin
+            r_odd = x_odd * cos + x_even * sin
+
+            # bf16 roundtrip (matches Triton/SYCL numerics)
+            r_even = r_even.to(torch.bfloat16).float()
+            r_odd = r_odd.to(torch.bfloat16).float()
+
+            # Reconstruct full head
+            rope_out = torch.stack([r_even, r_odd], dim=-1).flatten()
+            vals = torch.cat([nope, rope_out])
+
+            # Per-head scale: 2^ceil(log2(max(amax, 1e-4) / 448))
+            amax = vals.abs().max().clamp(min=1e-4).item()
+            scale = 2.0 ** math.ceil(math.log2(amax / 448.0))
+            inv_scale = 1.0 / scale
+
+            # Quantize to fp8_e4m3fn via torch
+            scaled = (vals * inv_scale).clamp(-448.0, 448.0)
+            fp8_vals = scaled.to(torch.float8_e4m3fn)
+            q_fp8[t, h] = fp8_vals.view(torch.uint8)
+
+            # Weight fold
+            w = index_weights[t, h].float().item()
+            weights_out[t, h] = w * scale * softmax_scale * head_scale
+
+    return q_fp8, weights_out
+
+
+@pytest.mark.parametrize("num_tokens", [1, 64, 128])
+@pytest.mark.parametrize("seed", [0, 42])
+def test_correctness(num_tokens, seed):
+    """Test FP8 quantized Q and folded weights against reference."""
+    torch.manual_seed(seed)
+    max_pos = 4096
+    softmax_scale = 0.08838834764831845
+    head_scale = 0.125
+
+    q = torch.randn(num_tokens, NUM_HEADS, HEAD_DIM,
+                    dtype=torch.bfloat16, device=DEVICE)
+    positions = torch.randint(0, max_pos, (num_tokens,),
+                              dtype=torch.int64, device=DEVICE)
+    cos_sin_cache = torch.randn(max_pos, ROPE_DIM,
+                                dtype=torch.float32, device=DEVICE) * 0.5
+    index_weights = torch.rand(num_tokens, NUM_HEADS,
+                               dtype=torch.bfloat16, device=DEVICE)
+
+    # Reference
+    q_ref, w_ref = reference_fused_indexer_q_rope_fp8(
+        q, positions, cos_sin_cache, index_weights, softmax_scale, head_scale)
+
+    # SYCL kernel
+    q_fp8 = torch.empty(num_tokens, NUM_HEADS, HEAD_DIM,
+                        dtype=torch.uint8, device=DEVICE)
+    weights_out = torch.empty(num_tokens, NUM_HEADS,
+                              dtype=torch.float32, device=DEVICE)
+    torch.ops._xpu_C.deepseek_fused_indexer_q_rope_fp8(
+        q, positions, cos_sin_cache, index_weights,
+        softmax_scale, head_scale, q_fp8, weights_out)
+
+    # Check FP8 bytes: allow ±1 (rounding mode difference)
+    q_dev = q_fp8.to(torch.int16)
+    q_r = q_ref.to(torch.int16)
+    byte_diff = (q_dev - q_r).abs()
+    assert byte_diff.max().item() <= 1, (
+        f"FP8 byte diff > 1: max={byte_diff.max().item()}")
+
+    # Check weights: should match within float precision
+    w_diff = (weights_out - w_ref).abs()
+    w_rel = w_diff / (w_ref.abs() + 1e-8)
+    assert w_rel.max().item() < 1e-3, (
+        f"Weight rel diff: max={w_rel.max().item():.6f}")
+
+
+def test_weight_fold_semantics():
+    """Verify weight_out = weight * scale * softmax_scale * head_scale."""
+    torch.manual_seed(123)
+    num_tokens = 8
+    max_pos = 4096
+    softmax_scale = 0.1
+    head_scale = 0.2
+
+    # Use small Q so scale is predictable
+    q = torch.ones(num_tokens, NUM_HEADS, HEAD_DIM,
+                   dtype=torch.bfloat16, device=DEVICE) * 0.5
+    positions = torch.zeros(num_tokens, dtype=torch.int64, device=DEVICE)
+    cos_sin_cache = torch.zeros(max_pos, ROPE_DIM,
+                                dtype=torch.float32, device=DEVICE)
+    cos_sin_cache[:, :HALF_ROPE] = 1.0  # cos=1, sin=0 → identity RoPE
+    index_weights = torch.ones(num_tokens, NUM_HEADS,
+                               dtype=torch.bfloat16, device=DEVICE)
+
+    q_fp8 = torch.empty(num_tokens, NUM_HEADS, HEAD_DIM,
+                        dtype=torch.uint8, device=DEVICE)
+    weights_out = torch.empty(num_tokens, NUM_HEADS,
+                              dtype=torch.float32, device=DEVICE)
+    torch.ops._xpu_C.deepseek_fused_indexer_q_rope_fp8(
+        q, positions, cos_sin_cache, index_weights,
+        softmax_scale, head_scale, q_fp8, weights_out)
+
+    # All values are 0.5, so amax=0.5, scale=2^ceil(log2(0.5/448))=2^(-10)=1/1024? 
+    # Actually: log2(0.5/448) = log2(0.001116) ≈ -9.807, ceil=-9, scale=2^-9=1/512
+    # No wait: max(0.5, 1e-4)=0.5, 0.5/448≈0.001116, log2≈-9.807, ceil=-9
+    # scale = 2^(-9) = 1/512
+    expected_scale = 2.0 ** math.ceil(math.log2(0.5 / 448.0))
+    expected_w = 1.0 * expected_scale * softmax_scale * head_scale
+
+    # All weights should be the same
+    assert torch.allclose(weights_out,
+                          torch.full_like(weights_out, expected_w),
+                          rtol=1e-3, atol=1e-6), (
+        f"Expected {expected_w}, got {weights_out[0, 0].item()}")

--- a/tests/test_deepseek_fused_indexer_q_rope_fp8.py
+++ b/tests/test_deepseek_fused_indexer_q_rope_fp8.py
@@ -27,7 +27,10 @@ HALF_ROPE = 32
 def reference_fused_indexer_q_rope_fp8(
     q, positions, cos_sin_cache, index_weights, softmax_scale, head_scale
 ):
-    """Pure PyTorch reference matching Triton _fused_indexer_q_rope_quant_kernel."""
+    """Pure PyTorch reference matching Triton.
+
+    Matches `_fused_indexer_q_rope_quant_kernel` semantics.
+    """
     num_tokens = q.shape[0]
     num_heads = q.shape[1]
 
@@ -148,9 +151,8 @@ def test_weight_fold_semantics():
         q, positions, cos_sin_cache, index_weights,
         softmax_scale, head_scale, q_fp8, weights_out)
 
-    # All values are 0.5, so amax=0.5, scale=2^ceil(log2(0.5/448))=2^(-10)=1/1024? 
-    # Actually: log2(0.5/448) = log2(0.001116) ≈ -9.807, ceil=-9, scale=2^-9=1/512
-    # No wait: max(0.5, 1e-4)=0.5, 0.5/448≈0.001116, log2≈-9.807, ceil=-9
+    # All values are 0.5, so amax=0.5.
+    # log2(0.5 / 448) ~= -9.807, ceil = -9, so scale = 2^-9 = 1/512.
     # scale = 2^(-9) = 1/512
     expected_scale = 2.0 ** math.ceil(math.log2(0.5 / 448.0))
     expected_w = 1.0 * expected_scale * softmax_scale * head_scale

--- a/tests/test_deepseek_fused_indexer_q_rope_mxfp4.py
+++ b/tests/test_deepseek_fused_indexer_q_rope_mxfp4.py
@@ -75,13 +75,16 @@ def reference_fused_indexer_q_rope_mxfp4(
                 base = b * MXFP4_BLOCK_SIZE
                 block = fp[base:base + MXFP4_BLOCK_SIZE]
 
-                # amax with minimum floor (matches fast_inv_scale subnormal guard)
+                # amax with minimum floor.
+                # Matches fast_inv_scale subnormal guard.
                 amax = block.abs().max().item()
                 if amax == 0:
                     amax = FP4_MAX * (2.0 ** -126)
 
                 # ue8m0: biased exponent of scale = 2^ceil(log2(amax/6))
-                lr = math.ceil(math.log2(max(amax / FP4_MAX, 2.0**-126)))
+                lr = math.ceil(
+                    math.log2(max(amax / FP4_MAX, 2.0**-126))
+                )
                 lr = min(max(lr, -127), 127)
                 ue8m0 = int(lr + 127)
                 scales_out[t, h, b] = ue8m0
@@ -90,8 +93,10 @@ def reference_fused_indexer_q_rope_mxfp4(
                 for p in range(16):
                     vl = max(-FP4_MAX, min(fp[base + p * 2].item() * inv_scale,
                                            FP4_MAX))
-                    vh = max(-FP4_MAX, min(fp[base + p * 2 + 1].item() * inv_scale,
-                                           FP4_MAX))
+                    vh = max(
+                        -FP4_MAX,
+                        min(fp[base + p * 2 + 1].item() * inv_scale, FP4_MAX),
+                    )
                     packed_out[t, h, base // 2 + p] = (
                         ((encode_fp4(vh) & 0xF) << 4) | (encode_fp4(vl) & 0xF))
 

--- a/tests/test_deepseek_fused_indexer_q_rope_mxfp4.py
+++ b/tests/test_deepseek_fused_indexer_q_rope_mxfp4.py
@@ -1,0 +1,208 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Correctness tests for deepseek_fused_indexer_q_rope_mxfp4 SYCL kernel.
+
+Tests the fused GPT-J RoPE + per-block MXFP4 quantize + weight-fold kernel
+against a pure-PyTorch reference matching the standalone benchmark's ref_kernel.
+
+Run:
+    pytest tests/test_deepseek_fused_indexer_q_rope_mxfp4.py -v
+"""
+import math
+
+import pytest
+import torch
+
+import vllm_xpu_kernels._xpu_C  # noqa: F401
+
+DEVICE = torch.device("xpu")
+
+# DeepSeek-V4 indexer Q constants
+NUM_HEADS = 64
+HEAD_DIM = 128
+NOPE_DIM = 64
+ROPE_DIM = 64
+HALF_ROPE = 32
+MXFP4_BLOCK_SIZE = 32
+NUM_BLOCKS = 4
+FP4_MAX = 6.0
+
+
+def encode_fp4(x: float) -> int:
+    """Staircase FP4 E2M1 encoder."""
+    sign = 0x8 if x < 0 else 0x0
+    a = abs(x)
+    code = (int(a > 0.25) + int(a > 0.75) + int(a > 1.25) +
+            int(a > 1.75) + int(a > 2.5) + int(a > 3.5) + int(a > 5.0))
+    return code | sign
+
+
+def reference_fused_indexer_q_rope_mxfp4(
+    q, positions, cos_sin_cache, index_weights, softmax_scale, head_scale
+):
+    """Pure PyTorch reference matching standalone ref_kernel semantics."""
+    num_tokens = q.shape[0]
+    num_heads = q.shape[1]
+    combined_scale = softmax_scale * head_scale
+
+    packed_out = torch.zeros(num_tokens, num_heads, HEAD_DIM // 2,
+                             dtype=torch.uint8, device=q.device)
+    scales_out = torch.zeros(num_tokens, num_heads, NUM_BLOCKS,
+                             dtype=torch.uint8, device=q.device)
+    weights_out = torch.zeros(num_tokens, num_heads,
+                              dtype=torch.float32, device=q.device)
+
+    for t in range(num_tokens):
+        pos = positions[t].item()
+        cos = cos_sin_cache[pos, :HALF_ROPE].float()
+        sin = cos_sin_cache[pos, HALF_ROPE:].float()
+
+        for h in range(num_heads):
+            q_f = q[t, h].float()
+
+            # NoPE passthrough + GPT-J RoPE with bf16 roundtrip
+            fp = torch.zeros(HEAD_DIM, dtype=torch.float32)
+            fp[:NOPE_DIM] = q_f[:NOPE_DIM]
+            for p in range(HALF_ROPE):
+                xe = q_f[NOPE_DIM + 2 * p]
+                xo = q_f[NOPE_DIM + 2 * p + 1]
+                fp[NOPE_DIM + 2 * p] = (xe * cos[p] - xo * sin[p]).to(
+                    torch.bfloat16).float()
+                fp[NOPE_DIM + 2 * p + 1] = (xo * cos[p] + xe * sin[p]).to(
+                    torch.bfloat16).float()
+
+            # Per-block MXFP4 quantization
+            for b in range(NUM_BLOCKS):
+                base = b * MXFP4_BLOCK_SIZE
+                block = fp[base:base + MXFP4_BLOCK_SIZE]
+
+                # amax with minimum floor (matches fast_inv_scale subnormal guard)
+                amax = block.abs().max().item()
+                if amax == 0:
+                    amax = FP4_MAX * (2.0 ** -126)
+
+                # ue8m0: biased exponent of scale = 2^ceil(log2(amax/6))
+                lr = math.ceil(math.log2(max(amax / FP4_MAX, 2.0**-126)))
+                lr = min(max(lr, -127), 127)
+                ue8m0 = int(lr + 127)
+                scales_out[t, h, b] = ue8m0
+
+                inv_scale = 1.0 / (2.0 ** lr)
+                for p in range(16):
+                    vl = max(-FP4_MAX, min(fp[base + p * 2].item() * inv_scale,
+                                           FP4_MAX))
+                    vh = max(-FP4_MAX, min(fp[base + p * 2 + 1].item() * inv_scale,
+                                           FP4_MAX))
+                    packed_out[t, h, base // 2 + p] = (
+                        ((encode_fp4(vh) & 0xF) << 4) | (encode_fp4(vl) & 0xF))
+
+            # Weight fold
+            w = index_weights[t, h].float().item()
+            weights_out[t, h] = w * combined_scale
+
+    return packed_out, scales_out, weights_out
+
+
+@pytest.mark.parametrize("num_tokens", [1, 4, 16])
+@pytest.mark.parametrize("seed", [42])
+def test_correctness(num_tokens, seed):
+    """Test packed FP4, scales, and folded weights against reference."""
+    torch.manual_seed(seed)
+    max_pos = 4096
+    softmax_scale = 0.08838834764831845
+    head_scale = 0.125
+
+    q = torch.randn(num_tokens, NUM_HEADS, HEAD_DIM,
+                    dtype=torch.bfloat16, device=DEVICE)
+    positions = torch.randint(0, max_pos, (num_tokens,),
+                              dtype=torch.int64, device=DEVICE)
+    cos_sin_cache = torch.randn(max_pos, ROPE_DIM,
+                                dtype=torch.float32, device=DEVICE) * 0.5
+    index_weights = torch.rand(num_tokens, NUM_HEADS,
+                               dtype=torch.bfloat16, device=DEVICE)
+
+    # Reference
+    pk_ref, sc_ref, w_ref = reference_fused_indexer_q_rope_mxfp4(
+        q, positions, cos_sin_cache, index_weights, softmax_scale, head_scale)
+
+    # SYCL kernel
+    packed_out = torch.empty(num_tokens, NUM_HEADS, HEAD_DIM // 2,
+                             dtype=torch.uint8, device=DEVICE)
+    scales_out = torch.empty(num_tokens, NUM_HEADS, NUM_BLOCKS,
+                             dtype=torch.uint8, device=DEVICE)
+    weights_out = torch.empty(num_tokens, NUM_HEADS,
+                              dtype=torch.float32, device=DEVICE)
+    torch.ops._xpu_C.deepseek_fused_indexer_q_rope_mxfp4(
+        q, positions, cos_sin_cache, index_weights,
+        softmax_scale, head_scale, packed_out, scales_out, weights_out)
+
+    # Check scales: must match exactly
+    sc_diff = (scales_out.int() - sc_ref.int()).abs()
+    assert sc_diff.max().item() == 0, (
+        f"Scale mismatch: {sc_diff.sum().item()} bytes differ")
+
+    # Check packed FP4: must match exactly
+    pk_diff = (packed_out.int() - pk_ref.int()).abs()
+    assert pk_diff.max().item() == 0, (
+        f"Packed FP4 mismatch: {pk_diff.sum().item()} bytes differ")
+
+    # Check weights: should match within float precision
+    w_diff = (weights_out - w_ref).abs()
+    assert w_diff.max().item() < 1e-5, (
+        f"Weight diff: max={w_diff.max().item():.8f}")
+
+
+@pytest.mark.parametrize("dist", ["uniform_50", "tiny", "zeros", "mixed"])
+def test_edge_cases(dist):
+    """Test with extreme input distributions."""
+    torch.manual_seed(7)
+    num_tokens = 4
+    max_pos = 4096
+    softmax_scale = 0.08838834764831845
+    head_scale = 0.125
+
+    if dist == "uniform_50":
+        q = (torch.rand(num_tokens, NUM_HEADS, HEAD_DIM, device=DEVICE) * 100
+             - 50).to(torch.bfloat16)
+    elif dist == "tiny":
+        q = (torch.randn(num_tokens, NUM_HEADS, HEAD_DIM, device=DEVICE)
+             * 1e-30).to(torch.bfloat16)
+    elif dist == "zeros":
+        q = torch.zeros(num_tokens, NUM_HEADS, HEAD_DIM,
+                        dtype=torch.bfloat16, device=DEVICE)
+    elif dist == "mixed":
+        # Different magnitudes per block within each head
+        q = torch.zeros(num_tokens, NUM_HEADS, HEAD_DIM,
+                        dtype=torch.bfloat16, device=DEVICE)
+        mags = [0.01, 1.0, 30.0, 200.0]
+        for b in range(4):
+            base = b * MXFP4_BLOCK_SIZE
+            q[:, :, base:base + MXFP4_BLOCK_SIZE] = (
+                torch.randn(num_tokens, NUM_HEADS, MXFP4_BLOCK_SIZE,
+                            device=DEVICE) * mags[b]).to(torch.bfloat16)
+
+    positions = torch.randint(0, max_pos, (num_tokens,),
+                              dtype=torch.int64, device=DEVICE)
+    cos_sin_cache = torch.randn(max_pos, ROPE_DIM,
+                                dtype=torch.float32, device=DEVICE) * 0.5
+    index_weights = torch.rand(num_tokens, NUM_HEADS,
+                               dtype=torch.bfloat16, device=DEVICE)
+
+    pk_ref, sc_ref, w_ref = reference_fused_indexer_q_rope_mxfp4(
+        q, positions, cos_sin_cache, index_weights, softmax_scale, head_scale)
+
+    packed_out = torch.empty(num_tokens, NUM_HEADS, HEAD_DIM // 2,
+                             dtype=torch.uint8, device=DEVICE)
+    scales_out = torch.empty(num_tokens, NUM_HEADS, NUM_BLOCKS,
+                             dtype=torch.uint8, device=DEVICE)
+    weights_out = torch.empty(num_tokens, NUM_HEADS,
+                              dtype=torch.float32, device=DEVICE)
+    torch.ops._xpu_C.deepseek_fused_indexer_q_rope_mxfp4(
+        q, positions, cos_sin_cache, index_weights,
+        softmax_scale, head_scale, packed_out, scales_out, weights_out)
+
+    sc_diff = (scales_out.int() - sc_ref.int()).abs()
+    pk_diff = (packed_out.int() - pk_ref.int()).abs()
+    w_diff = (weights_out - w_ref).abs()
+    assert sc_diff.max().item() == 0, f"[{dist}] Scale mismatch"
+    assert pk_diff.max().item() == 0, f"[{dist}] Packed FP4 mismatch"
+    assert w_diff.max().item() < 1e-5, f"[{dist}] Weight diff too large"


### PR DESCRIPTION
# Add DeepSeek-V4 Fused Indexer Q + RoPE SYCL Kernels

## Purpose

Add SYCL implementations for the DeepSeek-V4 **fused indexer Q + RoPE** kernels used in the Q-projection stage of the MLA sparse attention pipeline. This PR includes two kernels:

1. **`deepseek_fused_indexer_q_rope_fp8`** — Fused indexer Q + RoPE + FP8 E4M3 quantization
2. **`deepseek_fused_indexer_q_rope_mxfp4`** — Fused indexer Q + RoPE + MXFP4 quantization

Both kernels fuse the following operations into a single pass:
- **Index select:** Extract the sparse Q heads from the full Q projection
- **RoPE rotation:** GPT-J style RoPE on the rope dimensions (dim 64–127)
- **Quantization:** Per-head FP8 or per-block MXFP4 quantization with power-of-2 scales
- **Output layout:** NoPE dimensions straight-quantized, RoPE dimensions interleaved `[re, ro]` pairs

---

### Part 1: `deepseek_fused_indexer_q_rope_fp8`

**Commit:** `b3446a4` — Add Deepseek-v4 fused_indexer_q_rope_fp8 sycl kernel

#### Files Changed

| File | Change |
|------|--------|
| `csrc/xpu/sycl/deepseek_fused_indexer_q_rope_fp8.cpp` | New SYCL kernel (218 lines) |
| `csrc/xpu/ops.h` | Function declaration |
| `csrc/xpu/torch_bindings.cpp` | Op registration (`def` + `impl`) |
| `CMakeLists.txt` | Add source to build |
| `tests/test_deepseek_fused_indexer_q_rope_fp8.py` | Pytest with parametrized correctness + semantic tests |

#### Design

- Grid: one subgroup (SG_SIZE=16) per `(token, head_group)`, HEADS_COARSEN=2
- Per-head: load 128 bf16 → apply RoPE on dim[64:127] → absmax reduce → pow2 scale → FP8 E4M3 quantize
- Branchless FP8 conversion (bitmask select, no divergent branches)
- Registered as `torch.ops._xpu_C.deepseek_fused_indexer_q_rope_fp8`

#### Unit Test — All PASSED

```bash
pytest tests/test_deepseek_fused_indexer_q_rope_fp8.py -v
```

- `test_correctness`: num_tokens ∈ {1, 64, 128} × seed ∈ {0, 42}
- `test_weight_fold_semantics`: validates indexer weight folding correctness

#### Kernel Benchmark: SYCL vs Triton

Platform: Intel Arc Pro B60 (HBM peak bandwidth: 456 GB/s), Warmup 50 iters, Timed 200 iters

| num_tokens | triton(us) | sycl(us) | triton BW(GB/s) | sycl BW(GB/s) | MBU | speedup |
|---:|---:|---:|---:|---:|---:|---:|
| 1 | 53.20 | 41.86 | 0.47 | 0.60 | 0.1% | **1.27x** |
| 4 | 52.96 | 40.93 | 1.90 | 2.47 | 0.5% | **1.29x** |
| 16 | 52.68 | 40.72 | 7.66 | 9.91 | 2.2% | **1.29x** |
| 64 | 53.27 | 40.77 | 30.30 | 39.59 | 8.7% | **1.31x** |
| 128 | 52.80 | 40.87 | 61.12 | 78.99 | 17.3% | **1.29x** |
| 256 | 54.67 | 40.88 | 118.11 | 157.96 | 34.6% | **1.34x** |
| 512 | 75.72 | 52.09 | 170.52 | 247.89 | 54.4% | **1.45x** |
| 1024 | 123.10 | 85.69 | 209.78 | 301.37 | 66.1% | **1.44x** |
| 2048 | 218.33 | 165.11 | 236.61 | 312.87 | 68.6% | **1.32x** |
| 4096 | 434.03 | 309.31 | 238.07 | 333.97 | 73.2% | **1.40x** |
| 8192 | 839.01 | 589.06 | 246.28 | 350.79 | 76.9% | **1.42x** |
| 16384 | 3138.89 | 1146.54 | 131.66 | 360.45 | 79.0% | **2.74x** |

**SYCL achieves 1.27x–2.74x speedup** over Triton. Large token regime: ~73–79% MBU.

#### Standalone SYCL Kernel (device time, event profiling)

Device: Intel Arc Pro B60 (HBM peak bandwidth: 456 GB/s)

| num_tokens | device(us) | BW(GB/s) | MBU |
|---:|---:|---:|---:|
| 1 | 1.77 | 14.27 | 3.1% |
| 4 | 2.29 | 44.10 | 9.7% |
| 16 | 2.29 | 176.39 | 38.7% |
| 64 | 4.47 | 360.99 | 79.2% |
| 128 | 8.22 | 392.97 | 86.2% |
| 256 | 14.87 | 434.19 | 95.2% |
| 512 | 29.64 | 435.72 | 95.6% |
| 1024 | 65.21 | 396.11 | 86.9% |
| 2048 | 145.39 | 355.31 | 77.9% |
| 4096 | 284.65 | 362.97 | 79.6% |
| 8192 | 568.46 | 363.50 | 79.7% |
| 16384 | 1130.17 | 365.67 | 80.2% |

Peak device MBU: **95.6%** at 512 tokens. Large token regime stabilizes at ~80% MBU.

#### End-to-End Model Benchmark (FP8 path)

**Note on E2E setup:** Due to current hardware resource constraints, we use a **10-layer trimmed checkpoint** of DeepSeek-V4-Flash-Base for E2E validation. This is sufficient to verify correct integration and no performance regression, as the kernel executes identically in every decoder layer.

**Integration:** In `vllm/models/deepseek_v4/common/ops/fused_indexer_q.py`, the SYCL path calls `torch.ops._xpu_C.deepseek_fused_indexer_q_rope_fp8` to replace the original Triton `fused_indexer_q_rope_quant` implementation.

Model: DeepSeek-V4-Flash-Base (**10 layers**, trimmed), TP=4, input_len=2048, output_len=1024, max_concurrency=1, num_prompts=5, num_warmups=2

| Metric | Triton (baseline) | SYCL | Delta |
|--------|---:|---:|---:|
| Output token throughput (tok/s) | 8.44 | 8.46 | +0.2% |
| Total token throughput (tok/s) | 25.32 | 25.39 | +0.3% |
| Mean TTFT (ms) | 2241.94 | 2244.87 | +0.1% |
| Median TTFT (ms) | 2244.76 | 2244.29 | 0.0% |
| P99 TTFT (ms) | 2250.69 | 2254.80 | +0.2% |
| Mean TPOT (ms) | 116.42 | 116.08 | **-0.3%** |
| Median TPOT (ms) | 116.46 | 115.98 | **-0.4%** |
| P99 TPOT (ms) | 116.69 | 116.86 | +0.1% |

E2E results confirm **no performance regression**. The fused_indexer_q kernel is a lightweight op in the overall decode pipeline (device time ~2us at decode batch size), so its E2E impact is negligible. TPOT and TTFT are within noise range, indicating correct integration with no overhead.

---

### Part 2: `deepseek_fused_indexer_q_rope_mxfp4`

**Commit:** `4da7c4a` — Add Deepseek-v4 fused_indexer_q_rope_mxfp4 sycl kernel

#### Files Changed

| File | Change |
|------|--------|
| `csrc/xpu/sycl/deepseek_fused_indexer_q_rope_mxfp4.cpp` | New SYCL kernel (242 lines) |
| `csrc/xpu/ops.h` | Function declaration |
| `csrc/xpu/torch_bindings.cpp` | Op registration (`def` + `impl`) |
| `CMakeLists.txt` | Add source to build |
| `tests/test_deepseek_fused_indexer_q_rope_mxfp4.py` | Pytest with correctness + edge case tests |

#### Design

- Grid: one subgroup (SG_SIZE=16) per `(token, head_group)`, HEADS_COARSEN=4
- Per-head: 128 bf16 split into 4 MXFP4 blocks (32 elements each)
- Each block: absmax reduce → pow2 scale → nibble-pack to 4-bit output
- Uses `sycl::reduce_over_group` for efficient sub-group reduction
- Registered as `torch.ops._xpu_C.deepseek_fused_indexer_q_rope_mxfp4`

#### Unit Test — All PASSED

```bash
pytest tests/test_deepseek_fused_indexer_q_rope_mxfp4.py -v
```

- `test_correctness`: num_tokens ∈ {1, 4, 16} × seed ∈ {42}
- `test_edge_cases`: distribution ∈ {uniform_50, tiny, zeros, mixed}

#### Kernel Benchmark: SYCL vs Triton

Platform: Intel Arc Pro B60 (HBM peak bandwidth: 456 GB/s), Warmup 50 iters, Timed 200 iters

> Note: Triton MXFP4 implementation relies on CUDA PTX inline asm; comparison here uses Triton's XPU fallback path.

| num_tokens | triton(us) | sycl(us) | triton BW(GB/s) | sycl BW(GB/s) | MBU | speedup |
|---:|---:|---:|---:|---:|---:|---:|
| 1 | 83.70 | 69.85 | 0.26 | 0.31 | 0.1% | **1.20x** |
| 4 | 83.80 | 68.81 | 1.02 | 1.24 | 0.3% | **1.22x** |
| 16 | 83.33 | 68.38 | 4.10 | 5.00 | 1.1% | **1.22x** |
| 64 | 83.75 | 68.62 | 16.34 | 19.95 | 4.4% | **1.22x** |
| 128 | 83.62 | 68.53 | 32.73 | 39.94 | 8.8% | **1.22x** |
| 256 | 83.54 | 68.64 | 65.50 | 79.75 | 17.5% | **1.22x** |
| 512 | 119.77 | 68.89 | 91.37 | 158.92 | 34.9% | **1.74x** |
| 1024 | 193.80 | 91.21 | 112.95 | 240.07 | 52.6% | **2.12x** |
| 2048 | 345.51 | 161.35 | 126.73 | 271.43 | 59.5% | **2.14x** |
| 4096 | 644.72 | 287.89 | 135.82 | 304.25 | 66.7% | **2.24x** |
| 8192 | 1251.79 | 531.45 | 139.90 | 329.62 | 72.3% | **2.35x** |
| 16384 | 2773.88 | 1027.27 | 126.28 | 341.05 | 74.8% | **2.70x** |

**SYCL achieves 1.20x–2.70x speedup** over Triton. Large token regime: ~67–75% MBU.

#### Standalone SYCL Kernel (device time, event profiling)

Device: Intel Arc Pro B60 (HBM peak bandwidth: 456 GB/s)

| num_tokens | device(us) | BW(GB/s) | MBU |
|---:|---:|---:|---:|
| 1 | 3.00 | 7.1 | 1.6% |
| 4 | 3.09 | 27.6 | 6.1% |
| 16 | 3.22 | 106.4 | 23.3% |
| 64 | 4.72 | 289.8 | 63.6% |
| 128 | 8.78 | 311.8 | 68.4% |
| 256 | 16.23 | 337.2 | 73.9% |
| 512 | 29.36 | 372.9 | 81.8% |
| 1024 | 58.17 | 376.5 | 82.6% |
| 2048 | 130.19 | 336.4 | 73.8% |
| 4096 | 250.78 | 349.3 | 76.6% |
| 8192 | 495.22 | 353.7 | 77.6% |
| 16384 | 986.69 | 355.1 | 77.9% |

Peak device MBU: **82.6%** at 1024 tokens. Large token regime stabilizes at ~77–78% MBU.

#### End-to-End Model Benchmark

> The current model pipeline uses FP8 fused_indexer_q only. MXFP4 path is not ready yet so there is no E2E model benchmark results.