### PR TITLE
[MiniMax-M3] add the fused_minimax_m3_qknorm_rope_kv_insert kernel and optimized for BMG

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -515,6 +515,7 @@ if(BASIC_KERNELS_ENABLED)
       "csrc/activation.cpp"
       "csrc/pos_encoding_kernels.cpp"
       "csrc/fused_qknorm_rope.cpp"
+      "csrc/fused_minimax_m3_qknorm_rope_kv_insert.cpp"
       "csrc/torch_bindings.cpp"
       "csrc/quantization/fp8/fp8_quant.cpp"
       "csrc/quantization/fp4/mxfp4_quant.cpp"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -535,6 +535,7 @@ if(BASIC_KERNELS_ENABLED)
       "csrc/activation.cpp"
       "csrc/pos_encoding_kernels.cpp"
       "csrc/fused_qknorm_rope.cpp"
+      "csrc/fused_minimax_m3_qknorm_rope_kv_insert.cpp"
       "csrc/torch_bindings.cpp"
       "csrc/quantization/fp8/fp8_quant.cpp"
       "csrc/quantization/fp4/mxfp4_quant.cpp"

--- a/csrc/fused_minimax_m3_qknorm_rope_kv_insert.cpp
+++ b/csrc/fused_minimax_m3_qknorm_rope_kv_insert.cpp
@@ -13,13 +13,15 @@
 //
 // All branches share head_dim=128 and the same partial-NeoX RoPE table
 // (``rotary_dim`` leading dims rotated, the trailing dims pass through). The
-// four norms are Gemma-style RMSNorm: ``x * rsqrt(mean(x^2)+eps) * (1+weight)``.
+// four norms are Gemma-style RMSNorm: ``x * rsqrt(mean(x^2)+eps) *
+// (1+weight)``.
 //
 // The fused ``qkv`` packs, per token: [ q | k | v | index_q | index_k ] in the
 // sparse layer, or just [ q | k | v ] in the dense layer (no index, no insert).
 //
 //   - q       : Gemma-norm + rope -> q_out (sparse) or in place in qkv (dense)
-//   - k       : Gemma-norm + rope -> in place in qkv, scatter into kv_cache[:,0]
+//   - k       : Gemma-norm + rope -> in place in qkv, scatter into
+//   kv_cache[:,0]
 //   - v       : untouched,                          scatter into kv_cache[:,1]
 //   - index_q : Gemma-norm + rope -> index_q_out (sparse)
 //   - index_k : Gemma-norm + rope -> in place in qkv, scatter into index_cache
@@ -36,6 +38,11 @@ namespace vllm {
 using bf16_t = sycl::ext::oneapi::bfloat16;
 
 static constexpr int M3_HEAD_DIM = 128;
+// One sub-group cooperatively processes one (token, head-slot): the 128-dim
+// head is split across the lanes. This launches num_tokens*total_slots
+// sub-groups (thousands of hardware threads) instead of one partial sub-group
+// per head, which is what restores occupancy on BMG/Xe2.
+static constexpr int M3_SG_SIZE = 16;
 
 // Head-slot section ids (in processing order along the packed qkv tensor).
 enum M3Section { SEC_Q = 0, SEC_K = 1, SEC_V = 2, SEC_IQ = 3, SEC_IK = 4 };
@@ -56,6 +63,7 @@ class fused_minimax_m3_qknorm_rope_kv_insert_kernel {
       bf16_t* __restrict__ index_cache,
       bf16_t* __restrict__ q_out,
       bf16_t* __restrict__ index_q_out,
+      int num_tokens,
       int num_heads,
       int num_kv_heads,
       int num_index_heads,
@@ -78,6 +86,7 @@ class fused_minimax_m3_qknorm_rope_kv_insert_kernel {
         index_cache_(index_cache),
         q_out_(q_out),
         index_q_out_(index_q_out),
+        num_tokens_(num_tokens),
         num_heads_(num_heads),
         num_kv_heads_(num_kv_heads),
         num_index_heads_(num_index_heads),
@@ -88,9 +97,10 @@ class fused_minimax_m3_qknorm_rope_kv_insert_kernel {
         cos_sin_row_stride_(cos_sin_row_stride),
         do_insert_(do_insert) {}
 
-  void operator()(sycl::nd_item<2> item) const {
-    const int token = item.get_global_id(0);
-    const int slot = item.get_global_id(1);
+  [[sycl::reqd_sub_group_size(M3_SG_SIZE)]] void
+  operator()(sycl::nd_item<1> item) const {
+    auto sg = item.get_sub_group();
+    const int lane = sg.get_local_linear_id();
 
     // Decode the head-slot -> (section, head index within section).
     const int q_end = num_heads_;
@@ -98,7 +108,14 @@ class fused_minimax_m3_qknorm_rope_kv_insert_kernel {
     const int v_end = k_end + num_kv_heads_;
     const int iq_end = v_end + num_index_heads_;
     const int ik_end = iq_end + (num_index_heads_ > 0 ? 1 : 0);
-    if (slot >= ik_end) return;
+    const int total_slots = ik_end;
+
+    // Global sub-group index -> (token, slot). Padding sub-groups (from
+    // rounding the global range up to the work-group size) fall out uniformly.
+    const int64_t head_idx = item.get_global_id(0) / M3_SG_SIZE;
+    if (head_idx >= (int64_t)num_tokens_ * total_slots) return;
+    const int token = head_idx / total_slots;
+    const int slot = head_idx % total_slots;
 
     int section, head;
     if (slot < q_end) {
@@ -124,11 +141,21 @@ class fused_minimax_m3_qknorm_rope_kv_insert_kernel {
     const int iq_cols = num_index_heads_ * M3_HEAD_DIM;
     int col;
     switch (section) {
-      case SEC_Q: col = head * M3_HEAD_DIM; break;
-      case SEC_K: col = q_cols + head * M3_HEAD_DIM; break;
-      case SEC_V: col = q_cols + kv_cols + head * M3_HEAD_DIM; break;
-      case SEC_IQ: col = q_cols + 2 * kv_cols + head * M3_HEAD_DIM; break;
-      default: col = q_cols + 2 * kv_cols + iq_cols; break;  // SEC_IK
+      case SEC_Q:
+        col = head * M3_HEAD_DIM;
+        break;
+      case SEC_K:
+        col = q_cols + head * M3_HEAD_DIM;
+        break;
+      case SEC_V:
+        col = q_cols + kv_cols + head * M3_HEAD_DIM;
+        break;
+      case SEC_IQ:
+        col = q_cols + 2 * kv_cols + head * M3_HEAD_DIM;
+        break;
+      default:
+        col = q_cols + 2 * kv_cols + iq_cols;
+        break;  // SEC_IK
     }
 
     bf16_t* __restrict__ src = qkv_ + token * qkv_row_stride_ + col;
@@ -136,42 +163,26 @@ class fused_minimax_m3_qknorm_rope_kv_insert_kernel {
     // V is raw: no norm/rope. Only (optionally) scatter into kv_cache[:,1].
     if (section == SEC_V) {
       if (do_insert_ && kv_cache_ != nullptr) {
-        insert_kv(token, src, head, /*kv_axis=*/1);
+        insert_kv(lane, token, src, head, /*kv_axis=*/1);
       }
       return;
     }
 
-    const bf16_t* __restrict__ weight =
-        section == SEC_Q ? q_norm_w_
-        : section == SEC_K ? k_norm_w_
-        : section == SEC_IQ ? iq_norm_w_ : ik_norm_w_;
+    const bf16_t* __restrict__ weight = section == SEC_Q    ? q_norm_w_
+                                        : section == SEC_K  ? k_norm_w_
+                                        : section == SEC_IQ ? iq_norm_w_
+                                                            : ik_norm_w_;
 
-    float buf[M3_HEAD_DIM];
-    float sumsq = 0.0f;
-#pragma unroll
-    for (int d = 0; d < M3_HEAD_DIM; ++d) {
-      float x = static_cast<float>(src[d]);
-      buf[d] = x;
-      sumsq += x * x;
+    // Pass 1: sum of squares, split across the sub-group's lanes.
+    float local_ss = 0.0f;
+    for (int d = lane; d < M3_HEAD_DIM; d += M3_SG_SIZE) {
+      const float x = static_cast<float>(src[d]);
+      local_ss += x * x;
     }
+    const float sumsq =
+        sycl::reduce_over_group(sg, local_ss, sycl::plus<float>());
     // Gemma RMSNorm: x * rsqrt(mean(x^2)+eps) * (1 + weight).
     const float rms = sycl::rsqrt(sumsq / M3_HEAD_DIM + eps_);
-#pragma unroll
-    for (int d = 0; d < M3_HEAD_DIM; ++d) {
-      buf[d] = buf[d] * rms * (1.0f + static_cast<float>(weight[d]));
-    }
-
-    // Partial NeoX RoPE on the leading rotary_dim dims; rest pass through.
-    const int half = rotary_dim_ / 2;
-    const bf16_t* cs = cos_sin_cache_ + positions_[token] * cos_sin_row_stride_;
-    for (int i = 0; i < half; ++i) {
-      const float cos = static_cast<float>(cs[i]);
-      const float sin = static_cast<float>(cs[half + i]);
-      const float x1 = buf[i];
-      const float x2 = buf[half + i];
-      buf[i] = x1 * cos - x2 * sin;
-      buf[half + i] = x2 * cos + x1 * sin;
-    }
 
     // Destination: q/index_q go to their gather buffers when provided
     // (sparse mode); k/index_k are rewritten in place; in dense mode q stays
@@ -186,22 +197,52 @@ class fused_minimax_m3_qknorm_rope_kv_insert_kernel {
     } else {
       dst = src;
     }
-#pragma unroll
-    for (int d = 0; d < M3_HEAD_DIM; ++d) {
-      dst[d] = static_cast<bf16_t>(buf[d]);
-    }
 
-    // Cache inserts (sparse mode only).
+    // Optional cache destination (sparse mode): K -> kv_cache[:,0],
+    // index_k -> index_cache. Computed once so pass 2 can write both at once.
+    bf16_t* __restrict__ cdst = nullptr;
     if (do_insert_) {
       if (section == SEC_K && kv_cache_ != nullptr) {
-        store_from_buf(buf, kv_slot_ptr(token, head, /*kv_axis=*/0));
+        cdst = kv_slot_ptr(token, head, /*kv_axis=*/0);
       } else if (section == SEC_IK && index_cache_ != nullptr) {
         const int64_t s = index_slot_mapping_[token];
-        if (s >= 0) {
-          bf16_t* dstc = index_cache_ + s * M3_HEAD_DIM;
-          store_from_buf(buf, dstc);
-        }
+        if (s >= 0) cdst = index_cache_ + s * M3_HEAD_DIM;
       }
+    }
+
+    // Pass 2: normalize + partial NeoX RoPE, streamed straight to dst (and the
+    // cache). Each lane owns a strided slice of the head; the rotary pairs
+    // (i, i+half) are both recomputed locally from src, so no cross-lane
+    // communication is needed beyond the sum-of-squares reduction above. Reads
+    // of src happen exactly as each index is written, so the in-place
+    // (dst==src) case has no read-after-write hazard. (Register-caching src
+    // between the two passes was tried and regressed ~19% — the second read is
+    // L1-resident and free, while the cache added register pressure; see
+    // opt_minimax-m3/OPTIMIZATION_LOG.md Phase 6.)
+    const int half = rotary_dim_ / 2;
+    const bf16_t* cs = cos_sin_cache_ + positions_[token] * cos_sin_row_stride_;
+    auto norm = [&](int d) {
+      return static_cast<float>(src[d]) * rms *
+             (1.0f + static_cast<float>(weight[d]));
+    };
+    for (int i = lane; i < half; i += M3_SG_SIZE) {
+      const float cos = static_cast<float>(cs[i]);
+      const float sin = static_cast<float>(cs[half + i]);
+      const float n1 = norm(i);
+      const float n2 = norm(half + i);
+      const bf16_t o1 = static_cast<bf16_t>(n1 * cos - n2 * sin);
+      const bf16_t o2 = static_cast<bf16_t>(n2 * cos + n1 * sin);
+      dst[i] = o1;
+      dst[half + i] = o2;
+      if (cdst != nullptr) {
+        cdst[i] = o1;
+        cdst[half + i] = o2;
+      }
+    }
+    for (int d = rotary_dim_ + lane; d < M3_HEAD_DIM; d += M3_SG_SIZE) {
+      const bf16_t v = static_cast<bf16_t>(norm(d));
+      dst[d] = v;
+      if (cdst != nullptr) cdst[d] = v;
     }
   }
 
@@ -214,23 +255,22 @@ class fused_minimax_m3_qknorm_rope_kv_insert_kernel {
     const int64_t pos = s % block_size_;
     const int64_t kv_block_stride =
         (int64_t)2 * block_size_ * num_kv_heads_ * M3_HEAD_DIM;
-    const int64_t kv_axis_stride = (int64_t)block_size_ * num_kv_heads_ * M3_HEAD_DIM;
+    const int64_t kv_axis_stride =
+        (int64_t)block_size_ * num_kv_heads_ * M3_HEAD_DIM;
     return kv_cache_ + block * kv_block_stride + kv_axis * kv_axis_stride +
            pos * (num_kv_heads_ * M3_HEAD_DIM) + head * M3_HEAD_DIM;
   }
 
-  void insert_kv(int token, const bf16_t* __restrict__ src, int head,
-                 int kv_axis) const {
+  void insert_kv(
+      int lane,
+      int token,
+      const bf16_t* __restrict__ src,
+      int head,
+      int kv_axis) const {
     bf16_t* dst = kv_slot_ptr(token, head, kv_axis);
     if (dst == nullptr) return;
-#pragma unroll
-    for (int d = 0; d < M3_HEAD_DIM; ++d) dst[d] = src[d];
-  }
-
-  static void store_from_buf(const float* buf, bf16_t* dst) {
-    if (dst == nullptr) return;
-#pragma unroll
-    for (int d = 0; d < M3_HEAD_DIM; ++d) dst[d] = static_cast<bf16_t>(buf[d]);
+    for (int d = lane; d < M3_HEAD_DIM; d += M3_SG_SIZE)
+      dst[d] = src[d];
   }
 
   // token id is passed explicitly to the cache-insert helpers.
@@ -247,6 +287,7 @@ class fused_minimax_m3_qknorm_rope_kv_insert_kernel {
   bf16_t* __restrict__ index_cache_;
   bf16_t* __restrict__ q_out_;
   bf16_t* __restrict__ index_q_out_;
+  int num_tokens_;
   int num_heads_;
   int num_kv_heads_;
   int num_index_heads_;
@@ -284,8 +325,9 @@ void fused_minimax_m3_qknorm_rope_kv_insert(
   TORCH_CHECK(qkv.dim() == 2, "qkv must be 2-D [num_tokens, packed]");
   TORCH_CHECK(positions.dtype() == torch::kInt64);
   TORCH_CHECK(rotary_dim % 2 == 0, "rotary_dim must be even");
-  TORCH_CHECK(cos_sin_cache.size(-1) == rotary_dim,
-              "cos_sin_cache last dim must equal rotary_dim");
+  TORCH_CHECK(
+      cos_sin_cache.size(-1) == rotary_dim,
+      "cos_sin_cache last dim must equal rotary_dim");
 
   const int64_t num_tokens = qkv.size(0);
   const bool do_insert = kv_cache.has_value() || index_cache.has_value();
@@ -303,12 +345,18 @@ void fused_minimax_m3_qknorm_rope_kv_insert(
                           (num_index_heads > 0 ? num_index_heads + 1 : 0);
 
   at::DeviceGuard dg(qkv.device());
-  sycl::range<2> global(num_tokens, total_slots);
+  // One sub-group (M3_SG_SIZE lanes) per (token, head-slot). Flatten to 1-D and
+  // round the global range up to the work-group size; padding sub-groups return
+  // early. WG = 8 sub-groups for good occupancy.
+  constexpr int kSgPerWg = 8;
+  const int64_t wg = (int64_t)kSgPerWg * vllm::M3_SG_SIZE;
+  const int64_t num_sg = (int64_t)num_tokens * total_slots;
+  const int64_t global_items = ((num_sg * vllm::M3_SG_SIZE + wg - 1) / wg) * wg;
 
   auto& queue = vllm::xpu::vllmGetQueue();
   queue.submit([&](sycl::handler& cgh) {
     cgh.parallel_for(
-        sycl::nd_range<2>(global, sycl::range<2>(1, total_slots)),
+        sycl::nd_range<1>(sycl::range<1>(global_items), sycl::range<1>(wg)),
         vllm::fused_minimax_m3_qknorm_rope_kv_insert_kernel(
             reinterpret_cast<vllm::bf16_t*>(qkv.data_ptr()),
             reinterpret_cast<const vllm::bf16_t*>(q_norm_weight.data_ptr()),
@@ -329,6 +377,7 @@ void fused_minimax_m3_qknorm_rope_kv_insert(
             bf16_ptr(index_cache),
             bf16_ptr(q_out),
             bf16_ptr(index_q_out),
+            static_cast<int>(num_tokens),
             static_cast<int>(num_heads),
             static_cast<int>(num_kv_heads),
             static_cast<int>(num_index_heads),

--- a/csrc/fused_minimax_m3_qknorm_rope_kv_insert.cpp
+++ b/csrc/fused_minimax_m3_qknorm_rope_kv_insert.cpp
@@ -1,0 +1,342 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+//
+// Horizontally-fused MiniMax-M3 attention pre-processing kernel (SYCL port of
+// csrc/libtorch_stable/fused_minimax_m3_qknorm_rope_kv_insert_kernel.cu from
+// vllm-project/vllm#45381, m3_release).
+//
+// Replaces the per-token Python sequence in the M3 attention forward:
+//     q = q_norm(q); k = k_norm(k); q,k = rope(pos, q,k)
+//     index_q = index_q_norm(index_q); index_k = index_k_norm(index_k)
+//     index_q,index_k = rope(pos, index_q,index_k)
+//     insert(k, v, index_k) into the paged caches
+//
+// All branches share head_dim=128 and the same partial-NeoX RoPE table
+// (``rotary_dim`` leading dims rotated, the trailing dims pass through). The
+// four norms are Gemma-style RMSNorm: ``x * rsqrt(mean(x^2)+eps) * (1+weight)``.
+//
+// The fused ``qkv`` packs, per token: [ q | k | v | index_q | index_k ] in the
+// sparse layer, or just [ q | k | v ] in the dense layer (no index, no insert).
+//
+//   - q       : Gemma-norm + rope -> q_out (sparse) or in place in qkv (dense)
+//   - k       : Gemma-norm + rope -> in place in qkv, scatter into kv_cache[:,0]
+//   - v       : untouched,                          scatter into kv_cache[:,1]
+//   - index_q : Gemma-norm + rope -> index_q_out (sparse)
+//   - index_k : Gemma-norm + rope -> in place in qkv, scatter into index_cache
+//
+// One work-item handles one (token, head-slot); it loops over the 128-dim head.
+
+#include <sycl/sycl.hpp>
+#include "utils.h"
+#include <torch/all.h>
+#include <optional>
+
+namespace vllm {
+
+using bf16_t = sycl::ext::oneapi::bfloat16;
+
+static constexpr int M3_HEAD_DIM = 128;
+
+// Head-slot section ids (in processing order along the packed qkv tensor).
+enum M3Section { SEC_Q = 0, SEC_K = 1, SEC_V = 2, SEC_IQ = 3, SEC_IK = 4 };
+
+class fused_minimax_m3_qknorm_rope_kv_insert_kernel {
+ public:
+  fused_minimax_m3_qknorm_rope_kv_insert_kernel(
+      bf16_t* __restrict__ qkv,
+      const bf16_t* __restrict__ q_norm_w,
+      const bf16_t* __restrict__ k_norm_w,
+      const bf16_t* __restrict__ iq_norm_w,
+      const bf16_t* __restrict__ ik_norm_w,
+      const bf16_t* __restrict__ cos_sin_cache,
+      const int64_t* __restrict__ positions,
+      const int64_t* __restrict__ slot_mapping,
+      const int64_t* __restrict__ index_slot_mapping,
+      bf16_t* __restrict__ kv_cache,
+      bf16_t* __restrict__ index_cache,
+      bf16_t* __restrict__ q_out,
+      bf16_t* __restrict__ index_q_out,
+      int num_heads,
+      int num_kv_heads,
+      int num_index_heads,
+      int rotary_dim,
+      float eps,
+      int block_size,
+      int64_t qkv_row_stride,
+      int64_t cos_sin_row_stride,
+      bool do_insert)
+      : qkv_(qkv),
+        q_norm_w_(q_norm_w),
+        k_norm_w_(k_norm_w),
+        iq_norm_w_(iq_norm_w),
+        ik_norm_w_(ik_norm_w),
+        cos_sin_cache_(cos_sin_cache),
+        positions_(positions),
+        slot_mapping_(slot_mapping),
+        index_slot_mapping_(index_slot_mapping),
+        kv_cache_(kv_cache),
+        index_cache_(index_cache),
+        q_out_(q_out),
+        index_q_out_(index_q_out),
+        num_heads_(num_heads),
+        num_kv_heads_(num_kv_heads),
+        num_index_heads_(num_index_heads),
+        rotary_dim_(rotary_dim),
+        eps_(eps),
+        block_size_(block_size),
+        qkv_row_stride_(qkv_row_stride),
+        cos_sin_row_stride_(cos_sin_row_stride),
+        do_insert_(do_insert) {}
+
+  void operator()(sycl::nd_item<2> item) const {
+    const int token = item.get_global_id(0);
+    const int slot = item.get_global_id(1);
+
+    // Decode the head-slot -> (section, head index within section).
+    const int q_end = num_heads_;
+    const int k_end = q_end + num_kv_heads_;
+    const int v_end = k_end + num_kv_heads_;
+    const int iq_end = v_end + num_index_heads_;
+    const int ik_end = iq_end + (num_index_heads_ > 0 ? 1 : 0);
+    if (slot >= ik_end) return;
+
+    int section, head;
+    if (slot < q_end) {
+      section = SEC_Q;
+      head = slot;
+    } else if (slot < k_end) {
+      section = SEC_K;
+      head = slot - q_end;
+    } else if (slot < v_end) {
+      section = SEC_V;
+      head = slot - k_end;
+    } else if (slot < iq_end) {
+      section = SEC_IQ;
+      head = slot - v_end;
+    } else {
+      section = SEC_IK;
+      head = 0;
+    }
+
+    // Column offset of this head inside the packed qkv row.
+    const int q_cols = num_heads_ * M3_HEAD_DIM;
+    const int kv_cols = num_kv_heads_ * M3_HEAD_DIM;
+    const int iq_cols = num_index_heads_ * M3_HEAD_DIM;
+    int col;
+    switch (section) {
+      case SEC_Q: col = head * M3_HEAD_DIM; break;
+      case SEC_K: col = q_cols + head * M3_HEAD_DIM; break;
+      case SEC_V: col = q_cols + kv_cols + head * M3_HEAD_DIM; break;
+      case SEC_IQ: col = q_cols + 2 * kv_cols + head * M3_HEAD_DIM; break;
+      default: col = q_cols + 2 * kv_cols + iq_cols; break;  // SEC_IK
+    }
+
+    bf16_t* __restrict__ src = qkv_ + token * qkv_row_stride_ + col;
+
+    // V is raw: no norm/rope. Only (optionally) scatter into kv_cache[:,1].
+    if (section == SEC_V) {
+      if (do_insert_ && kv_cache_ != nullptr) {
+        insert_kv(token, src, head, /*kv_axis=*/1);
+      }
+      return;
+    }
+
+    const bf16_t* __restrict__ weight =
+        section == SEC_Q ? q_norm_w_
+        : section == SEC_K ? k_norm_w_
+        : section == SEC_IQ ? iq_norm_w_ : ik_norm_w_;
+
+    float buf[M3_HEAD_DIM];
+    float sumsq = 0.0f;
+#pragma unroll
+    for (int d = 0; d < M3_HEAD_DIM; ++d) {
+      float x = static_cast<float>(src[d]);
+      buf[d] = x;
+      sumsq += x * x;
+    }
+    // Gemma RMSNorm: x * rsqrt(mean(x^2)+eps) * (1 + weight).
+    const float rms = sycl::rsqrt(sumsq / M3_HEAD_DIM + eps_);
+#pragma unroll
+    for (int d = 0; d < M3_HEAD_DIM; ++d) {
+      buf[d] = buf[d] * rms * (1.0f + static_cast<float>(weight[d]));
+    }
+
+    // Partial NeoX RoPE on the leading rotary_dim dims; rest pass through.
+    const int half = rotary_dim_ / 2;
+    const bf16_t* cs = cos_sin_cache_ + positions_[token] * cos_sin_row_stride_;
+    for (int i = 0; i < half; ++i) {
+      const float cos = static_cast<float>(cs[i]);
+      const float sin = static_cast<float>(cs[half + i]);
+      const float x1 = buf[i];
+      const float x2 = buf[half + i];
+      buf[i] = x1 * cos - x2 * sin;
+      buf[half + i] = x2 * cos + x1 * sin;
+    }
+
+    // Destination: q/index_q go to their gather buffers when provided
+    // (sparse mode); k/index_k are rewritten in place; in dense mode q stays
+    // in place too.
+    bf16_t* __restrict__ dst;
+    if (section == SEC_Q && q_out_ != nullptr) {
+      dst = q_out_ + token * (int64_t)(num_heads_ * M3_HEAD_DIM) +
+            head * M3_HEAD_DIM;
+    } else if (section == SEC_IQ && index_q_out_ != nullptr) {
+      dst = index_q_out_ + token * (int64_t)(num_index_heads_ * M3_HEAD_DIM) +
+            head * M3_HEAD_DIM;
+    } else {
+      dst = src;
+    }
+#pragma unroll
+    for (int d = 0; d < M3_HEAD_DIM; ++d) {
+      dst[d] = static_cast<bf16_t>(buf[d]);
+    }
+
+    // Cache inserts (sparse mode only).
+    if (do_insert_) {
+      if (section == SEC_K && kv_cache_ != nullptr) {
+        store_from_buf(buf, kv_slot_ptr(token, head, /*kv_axis=*/0));
+      } else if (section == SEC_IK && index_cache_ != nullptr) {
+        const int64_t s = index_slot_mapping_[token];
+        if (s >= 0) {
+          bf16_t* dstc = index_cache_ + s * M3_HEAD_DIM;
+          store_from_buf(buf, dstc);
+        }
+      }
+    }
+  }
+
+ private:
+  // Pointer into kv_cache[block, kv_axis, pos, head, :] for this token.
+  bf16_t* kv_slot_ptr(int token, int head, int kv_axis) const {
+    const int64_t s = slot_mapping_[token];
+    if (s < 0) return nullptr;
+    const int64_t block = s / block_size_;
+    const int64_t pos = s % block_size_;
+    const int64_t kv_block_stride =
+        (int64_t)2 * block_size_ * num_kv_heads_ * M3_HEAD_DIM;
+    const int64_t kv_axis_stride = (int64_t)block_size_ * num_kv_heads_ * M3_HEAD_DIM;
+    return kv_cache_ + block * kv_block_stride + kv_axis * kv_axis_stride +
+           pos * (num_kv_heads_ * M3_HEAD_DIM) + head * M3_HEAD_DIM;
+  }
+
+  void insert_kv(int token, const bf16_t* __restrict__ src, int head,
+                 int kv_axis) const {
+    bf16_t* dst = kv_slot_ptr(token, head, kv_axis);
+    if (dst == nullptr) return;
+#pragma unroll
+    for (int d = 0; d < M3_HEAD_DIM; ++d) dst[d] = src[d];
+  }
+
+  static void store_from_buf(const float* buf, bf16_t* dst) {
+    if (dst == nullptr) return;
+#pragma unroll
+    for (int d = 0; d < M3_HEAD_DIM; ++d) dst[d] = static_cast<bf16_t>(buf[d]);
+  }
+
+  // token id is passed explicitly to the cache-insert helpers.
+  bf16_t* __restrict__ qkv_;
+  const bf16_t* __restrict__ q_norm_w_;
+  const bf16_t* __restrict__ k_norm_w_;
+  const bf16_t* __restrict__ iq_norm_w_;
+  const bf16_t* __restrict__ ik_norm_w_;
+  const bf16_t* __restrict__ cos_sin_cache_;
+  const int64_t* __restrict__ positions_;
+  const int64_t* __restrict__ slot_mapping_;
+  const int64_t* __restrict__ index_slot_mapping_;
+  bf16_t* __restrict__ kv_cache_;
+  bf16_t* __restrict__ index_cache_;
+  bf16_t* __restrict__ q_out_;
+  bf16_t* __restrict__ index_q_out_;
+  int num_heads_;
+  int num_kv_heads_;
+  int num_index_heads_;
+  int rotary_dim_;
+  float eps_;
+  int block_size_;
+  int64_t qkv_row_stride_;
+  int64_t cos_sin_row_stride_;
+  bool do_insert_;
+};
+
+}  // namespace vllm
+
+void fused_minimax_m3_qknorm_rope_kv_insert(
+    torch::Tensor& qkv,
+    const torch::Tensor& q_norm_weight,
+    const torch::Tensor& k_norm_weight,
+    const torch::Tensor& cos_sin_cache,
+    const torch::Tensor& positions,
+    int64_t num_heads,
+    int64_t num_kv_heads,
+    int64_t rotary_dim,
+    double eps,
+    std::optional<torch::Tensor> index_q_norm_weight,
+    std::optional<torch::Tensor> index_k_norm_weight,
+    int64_t num_index_heads,
+    std::optional<torch::Tensor> slot_mapping,
+    std::optional<torch::Tensor> index_slot_mapping,
+    std::optional<torch::Tensor> kv_cache,
+    std::optional<torch::Tensor> index_cache,
+    int64_t block_size,
+    std::optional<torch::Tensor> q_out,
+    std::optional<torch::Tensor> index_q_out) {
+  TORCH_CHECK(qkv.dtype() == torch::kBFloat16, "qkv must be bf16");
+  TORCH_CHECK(qkv.dim() == 2, "qkv must be 2-D [num_tokens, packed]");
+  TORCH_CHECK(positions.dtype() == torch::kInt64);
+  TORCH_CHECK(rotary_dim % 2 == 0, "rotary_dim must be even");
+  TORCH_CHECK(cos_sin_cache.size(-1) == rotary_dim,
+              "cos_sin_cache last dim must equal rotary_dim");
+
+  const int64_t num_tokens = qkv.size(0);
+  const bool do_insert = kv_cache.has_value() || index_cache.has_value();
+
+  auto bf16_ptr = [](const std::optional<torch::Tensor>& t) -> vllm::bf16_t* {
+    if (!t.has_value()) return nullptr;
+    return reinterpret_cast<vllm::bf16_t*>(t->data_ptr());
+  };
+  auto i64_ptr = [](const std::optional<torch::Tensor>& t) -> int64_t* {
+    if (!t.has_value()) return nullptr;
+    return t->data_ptr<int64_t>();
+  };
+
+  const int total_slots = num_heads + 2 * num_kv_heads +
+                          (num_index_heads > 0 ? num_index_heads + 1 : 0);
+
+  at::DeviceGuard dg(qkv.device());
+  sycl::range<2> global(num_tokens, total_slots);
+
+  auto& queue = vllm::xpu::vllmGetQueue();
+  queue.submit([&](sycl::handler& cgh) {
+    cgh.parallel_for(
+        sycl::nd_range<2>(global, sycl::range<2>(1, total_slots)),
+        vllm::fused_minimax_m3_qknorm_rope_kv_insert_kernel(
+            reinterpret_cast<vllm::bf16_t*>(qkv.data_ptr()),
+            reinterpret_cast<const vllm::bf16_t*>(q_norm_weight.data_ptr()),
+            reinterpret_cast<const vllm::bf16_t*>(k_norm_weight.data_ptr()),
+            index_q_norm_weight.has_value()
+                ? reinterpret_cast<const vllm::bf16_t*>(
+                      index_q_norm_weight->data_ptr())
+                : nullptr,
+            index_k_norm_weight.has_value()
+                ? reinterpret_cast<const vllm::bf16_t*>(
+                      index_k_norm_weight->data_ptr())
+                : nullptr,
+            reinterpret_cast<const vllm::bf16_t*>(cos_sin_cache.data_ptr()),
+            positions.data_ptr<int64_t>(),
+            i64_ptr(slot_mapping),
+            i64_ptr(index_slot_mapping),
+            bf16_ptr(kv_cache),
+            bf16_ptr(index_cache),
+            bf16_ptr(q_out),
+            bf16_ptr(index_q_out),
+            static_cast<int>(num_heads),
+            static_cast<int>(num_kv_heads),
+            static_cast<int>(num_index_heads),
+            static_cast<int>(rotary_dim),
+            static_cast<float>(eps),
+            static_cast<int>(block_size),
+            qkv.stride(0),
+            cos_sin_cache.stride(0),
+            do_insert));
+  });
+}

--- a/csrc/fused_minimax_m3_qknorm_rope_kv_insert.cpp
+++ b/csrc/fused_minimax_m3_qknorm_rope_kv_insert.cpp
@@ -414,12 +414,26 @@ void fused_minimax_m3_qknorm_rope_kv_insert(
     CHECK_DEVICE(q_out.value());
     CHECK_CONTIGUOUS(q_out.value());
     TORCH_CHECK(q_out->dtype() == torch::kBFloat16, "q_out must be bf16");
+    TORCH_CHECK(
+        q_out->numel() == qkv.size(0) * (int64_t)num_heads * vllm::M3_HEAD_DIM,
+        "q_out must have num_tokens * num_heads * head_dim (= ",
+        qkv.size(0) * (int64_t)num_heads * vllm::M3_HEAD_DIM,
+        ") elements");
   }
   if (index_q_out.has_value()) {
+    TORCH_CHECK(
+        num_index_heads > 0,
+        "index_q_out must not be provided when num_index_heads == 0");
     CHECK_DEVICE(index_q_out.value());
     CHECK_CONTIGUOUS(index_q_out.value());
     TORCH_CHECK(
         index_q_out->dtype() == torch::kBFloat16, "index_q_out must be bf16");
+    TORCH_CHECK(
+        index_q_out->numel() ==
+            qkv.size(0) * (int64_t)num_index_heads * vllm::M3_HEAD_DIM,
+        "index_q_out must have num_tokens * num_index_heads * head_dim (= ",
+        qkv.size(0) * (int64_t)num_index_heads * vllm::M3_HEAD_DIM,
+        ") elements");
   }
 
   // Cache inserts need their matching slot maps (and a valid block_size for the
@@ -441,6 +455,18 @@ void fused_minimax_m3_qknorm_rope_kv_insert(
     TORCH_CHECK(
         block_size > 0,
         "block_size must be positive when kv_cache is provided");
+    // Kernel indexes kv_cache as [num_blocks, 2, block_size, num_kv_heads,
+    // head_dim]; a mismatched layout would scatter out of bounds.
+    TORCH_CHECK(
+        kv_cache->dim() == 5,
+        "kv_cache must be 5-D [num_blocks, 2, block_size, num_kv_heads, "
+        "head_dim]");
+    TORCH_CHECK(
+        kv_cache->size(1) == 2 && kv_cache->size(2) == block_size &&
+            kv_cache->size(3) == num_kv_heads &&
+            kv_cache->size(4) == vllm::M3_HEAD_DIM,
+        "kv_cache shape must be [num_blocks, 2, block_size, num_kv_heads, "
+        "head_dim]");
   }
   if (index_cache.has_value()) {
     TORCH_CHECK(
@@ -458,6 +484,13 @@ void fused_minimax_m3_qknorm_rope_kv_insert(
     TORCH_CHECK(
         index_slot_mapping->numel() == qkv.size(0),
         "index_slot_mapping length must match num_tokens");
+    // Kernel writes index_cache as a flattened [num_slots, head_dim] buffer
+    // (row = absolute slot); the trailing dim must be head_dim.
+    TORCH_CHECK(
+        index_cache->size(-1) == vllm::M3_HEAD_DIM,
+        "index_cache last dim must equal head_dim (",
+        vllm::M3_HEAD_DIM,
+        ")");
   }
 
   const int64_t num_tokens = qkv.size(0);

--- a/csrc/fused_minimax_m3_qknorm_rope_kv_insert.cpp
+++ b/csrc/fused_minimax_m3_qknorm_rope_kv_insert.cpp
@@ -31,6 +31,7 @@
 #include <sycl/sycl.hpp>
 #include "utils.h"
 #include <torch/all.h>
+#include <ATen/DeviceGuard.h>
 #include <optional>
 
 namespace vllm {
@@ -321,13 +322,143 @@ void fused_minimax_m3_qknorm_rope_kv_insert(
     int64_t block_size,
     std::optional<torch::Tensor> q_out,
     std::optional<torch::Tensor> index_q_out) {
+  CHECK_DEVICE(qkv);
+  CHECK_CONTIGUOUS(qkv);
+  CHECK_DEVICE(q_norm_weight);
+  CHECK_CONTIGUOUS(q_norm_weight);
+  CHECK_DEVICE(k_norm_weight);
+  CHECK_CONTIGUOUS(k_norm_weight);
+  CHECK_DEVICE(cos_sin_cache);
+  CHECK_CONTIGUOUS(cos_sin_cache);
+  CHECK_DEVICE(positions);
+  CHECK_CONTIGUOUS(positions);
+
   TORCH_CHECK(qkv.dtype() == torch::kBFloat16, "qkv must be bf16");
   TORCH_CHECK(qkv.dim() == 2, "qkv must be 2-D [num_tokens, packed]");
-  TORCH_CHECK(positions.dtype() == torch::kInt64);
+  TORCH_CHECK(
+      q_norm_weight.dtype() == torch::kBFloat16, "q_norm_weight must be bf16");
+  TORCH_CHECK(
+      k_norm_weight.dtype() == torch::kBFloat16, "k_norm_weight must be bf16");
+  TORCH_CHECK(
+      cos_sin_cache.dtype() == torch::kBFloat16, "cos_sin_cache must be bf16");
+  TORCH_CHECK(
+      q_norm_weight.numel() == vllm::M3_HEAD_DIM,
+      "q_norm_weight must have head_dim (",
+      vllm::M3_HEAD_DIM,
+      ") elements");
+  TORCH_CHECK(
+      k_norm_weight.numel() == vllm::M3_HEAD_DIM,
+      "k_norm_weight must have head_dim (",
+      vllm::M3_HEAD_DIM,
+      ") elements");
+  TORCH_CHECK(positions.dtype() == torch::kInt64, "positions must be int64");
+  TORCH_CHECK(positions.dim() == 1, "positions must be 1-D [num_tokens]");
+  TORCH_CHECK(
+      positions.size(0) == qkv.size(0),
+      "positions length must match num_tokens");
   TORCH_CHECK(rotary_dim % 2 == 0, "rotary_dim must be even");
+  TORCH_CHECK(
+      rotary_dim <= vllm::M3_HEAD_DIM,
+      "rotary_dim must be <= head_dim (",
+      vllm::M3_HEAD_DIM,
+      ")");
+  TORCH_CHECK(
+      cos_sin_cache.dim() == 2,
+      "cos_sin_cache must be 2-D [max_position, rotary_dim]");
   TORCH_CHECK(
       cos_sin_cache.size(-1) == rotary_dim,
       "cos_sin_cache last dim must equal rotary_dim");
+  TORCH_CHECK(
+      num_heads > 0 && num_kv_heads > 0,
+      "num_heads and num_kv_heads must be positive");
+  TORCH_CHECK(num_index_heads >= 0, "num_index_heads must be non-negative");
+
+  const int64_t expected_cols =
+      ((int64_t)num_heads + 2 * num_kv_heads +
+       (num_index_heads > 0 ? num_index_heads + 1 : 0)) *
+      vllm::M3_HEAD_DIM;
+  TORCH_CHECK(
+      qkv.size(1) == expected_cols,
+      "qkv packed dim (",
+      qkv.size(1),
+      ") must equal (num_heads + ",
+      "2*num_kv_heads + (num_index_heads>0 ? num_index_heads+1 : 0)) * ",
+      "head_dim (= ",
+      expected_cols,
+      ")");
+
+  // Index branches require their Gemma-norm weights; index_q_out stays optional
+  // (q/index_q fall back to in-place when no gather buffer is supplied).
+  if (num_index_heads > 0) {
+    TORCH_CHECK(
+        index_q_norm_weight.has_value() && index_k_norm_weight.has_value(),
+        "index_q_norm_weight and index_k_norm_weight are required when "
+        "num_index_heads > 0");
+    CHECK_DEVICE(index_q_norm_weight.value());
+    CHECK_CONTIGUOUS(index_q_norm_weight.value());
+    CHECK_DEVICE(index_k_norm_weight.value());
+    CHECK_CONTIGUOUS(index_k_norm_weight.value());
+    TORCH_CHECK(
+        index_q_norm_weight->dtype() == torch::kBFloat16 &&
+            index_k_norm_weight->dtype() == torch::kBFloat16,
+        "index norm weights must be bf16");
+    TORCH_CHECK(
+        index_q_norm_weight->numel() == vllm::M3_HEAD_DIM &&
+            index_k_norm_weight->numel() == vllm::M3_HEAD_DIM,
+        "index norm weights must have head_dim (",
+        vllm::M3_HEAD_DIM,
+        ") elements");
+  }
+
+  if (q_out.has_value()) {
+    CHECK_DEVICE(q_out.value());
+    CHECK_CONTIGUOUS(q_out.value());
+    TORCH_CHECK(q_out->dtype() == torch::kBFloat16, "q_out must be bf16");
+  }
+  if (index_q_out.has_value()) {
+    CHECK_DEVICE(index_q_out.value());
+    CHECK_CONTIGUOUS(index_q_out.value());
+    TORCH_CHECK(
+        index_q_out->dtype() == torch::kBFloat16, "index_q_out must be bf16");
+  }
+
+  // Cache inserts need their matching slot maps (and a valid block_size for the
+  // paged kv_cache); without them the kernel would dereference a null map.
+  if (kv_cache.has_value()) {
+    TORCH_CHECK(
+        slot_mapping.has_value(),
+        "slot_mapping is required when kv_cache is provided");
+    CHECK_DEVICE(kv_cache.value());
+    CHECK_CONTIGUOUS(kv_cache.value());
+    CHECK_DEVICE(slot_mapping.value());
+    CHECK_CONTIGUOUS(slot_mapping.value());
+    TORCH_CHECK(kv_cache->dtype() == torch::kBFloat16, "kv_cache must be bf16");
+    TORCH_CHECK(
+        slot_mapping->dtype() == torch::kInt64, "slot_mapping must be int64");
+    TORCH_CHECK(
+        slot_mapping->numel() == qkv.size(0),
+        "slot_mapping length must match num_tokens");
+    TORCH_CHECK(
+        block_size > 0,
+        "block_size must be positive when kv_cache is provided");
+  }
+  if (index_cache.has_value()) {
+    TORCH_CHECK(
+        index_slot_mapping.has_value(),
+        "index_slot_mapping is required when index_cache is provided");
+    CHECK_DEVICE(index_cache.value());
+    CHECK_CONTIGUOUS(index_cache.value());
+    CHECK_DEVICE(index_slot_mapping.value());
+    CHECK_CONTIGUOUS(index_slot_mapping.value());
+    TORCH_CHECK(
+        index_cache->dtype() == torch::kBFloat16, "index_cache must be bf16");
+    TORCH_CHECK(
+        index_slot_mapping->dtype() == torch::kInt64,
+        "index_slot_mapping must be int64");
+    TORCH_CHECK(
+        index_slot_mapping->numel() == qkv.size(0),
+        "index_slot_mapping length must match num_tokens");
+  }
 
   const int64_t num_tokens = qkv.size(0);
   const bool do_insert = kv_cache.has_value() || index_cache.has_value();

--- a/csrc/ops.h
+++ b/csrc/ops.h
@@ -1,8 +1,33 @@
 #pragma once
 
 #include <torch/all.h>
+#include <optional>
 
 torch::Tensor weak_ref_tensor(torch::Tensor& tensor);
+
+// Horizontally-fused MiniMax-M3 attention pre-processing: Gemma RMSNorm +
+// partial-NeoX RoPE on q/k (+ index_q/index_k in sparse mode), plus scatter of
+// k/v/index_k into the paged caches. head_dim == 128.
+void fused_minimax_m3_qknorm_rope_kv_insert(
+    torch::Tensor& qkv,
+    const torch::Tensor& q_norm_weight,
+    const torch::Tensor& k_norm_weight,
+    const torch::Tensor& cos_sin_cache,
+    const torch::Tensor& positions,
+    int64_t num_heads,
+    int64_t num_kv_heads,
+    int64_t rotary_dim,
+    double eps,
+    std::optional<torch::Tensor> index_q_norm_weight,
+    std::optional<torch::Tensor> index_k_norm_weight,
+    int64_t num_index_heads,
+    std::optional<torch::Tensor> slot_mapping,
+    std::optional<torch::Tensor> index_slot_mapping,
+    std::optional<torch::Tensor> kv_cache,
+    std::optional<torch::Tensor> index_cache,
+    int64_t block_size,
+    std::optional<torch::Tensor> q_out,
+    std::optional<torch::Tensor> index_q_out);
 
 void rms_norm(
     torch::Tensor& out,

--- a/csrc/ops.h
+++ b/csrc/ops.h
@@ -2,8 +2,33 @@
 
 #include <optional>
 #include <torch/all.h>
+#include <optional>
 
 torch::Tensor weak_ref_tensor(torch::Tensor& tensor);
+
+// Horizontally-fused MiniMax-M3 attention pre-processing: Gemma RMSNorm +
+// partial-NeoX RoPE on q/k (+ index_q/index_k in sparse mode), plus scatter of
+// k/v/index_k into the paged caches. head_dim == 128.
+void fused_minimax_m3_qknorm_rope_kv_insert(
+    torch::Tensor& qkv,
+    const torch::Tensor& q_norm_weight,
+    const torch::Tensor& k_norm_weight,
+    const torch::Tensor& cos_sin_cache,
+    const torch::Tensor& positions,
+    int64_t num_heads,
+    int64_t num_kv_heads,
+    int64_t rotary_dim,
+    double eps,
+    std::optional<torch::Tensor> index_q_norm_weight,
+    std::optional<torch::Tensor> index_k_norm_weight,
+    int64_t num_index_heads,
+    std::optional<torch::Tensor> slot_mapping,
+    std::optional<torch::Tensor> index_slot_mapping,
+    std::optional<torch::Tensor> kv_cache,
+    std::optional<torch::Tensor> index_cache,
+    int64_t block_size,
+    std::optional<torch::Tensor> q_out,
+    std::optional<torch::Tensor> index_q_out);
 
 void rms_norm(
     torch::Tensor& out,

--- a/csrc/torch_bindings.cpp
+++ b/csrc/torch_bindings.cpp
@@ -143,6 +143,24 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
       "int forced_token_heads_per_warp=-1) -> ()");
   ops.impl("fused_qk_norm_rope", torch::kXPU, &fused_qk_norm_rope);
 
+  // Fused MiniMax-M3 attention pre-processing (Gemma RMSNorm + partial-NeoX
+  // RoPE + paged K/V/index inserts). Registered under _C so the upstream
+  // vllm._custom_ops wrapper (torch.ops._C.*) works unchanged on XPU.
+  ops.def(
+      "fused_minimax_m3_qknorm_rope_kv_insert("
+      "Tensor! qkv, Tensor q_norm_weight, Tensor k_norm_weight, "
+      "Tensor cos_sin_cache, Tensor positions, int num_heads, "
+      "int num_kv_heads, int rotary_dim, float eps, "
+      "Tensor? index_q_norm_weight, Tensor? index_k_norm_weight, "
+      "int num_index_heads, "
+      "Tensor? slot_mapping, Tensor? index_slot_mapping, "
+      "Tensor!? kv_cache, Tensor!? index_cache, "
+      "int block_size, Tensor!? q_out, Tensor!? index_q_out) -> ()");
+  ops.impl(
+      "fused_minimax_m3_qknorm_rope_kv_insert",
+      torch::kXPU,
+      &fused_minimax_m3_qknorm_rope_kv_insert);
+
   // Compute FP8 quantized tensor for given scaling factor.
   ops.def(
       "static_scaled_fp8_quant(Tensor! result, Tensor input, Tensor scale, "

--- a/csrc/torch_bindings.cpp
+++ b/csrc/torch_bindings.cpp
@@ -161,6 +161,24 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
       "int forced_token_heads_per_warp=-1) -> ()");
   ops.impl("fused_qk_norm_rope", torch::kXPU, &fused_qk_norm_rope);
 
+  // Fused MiniMax-M3 attention pre-processing (Gemma RMSNorm + partial-NeoX
+  // RoPE + paged K/V/index inserts). Registered under _C so the upstream
+  // vllm._custom_ops wrapper (torch.ops._C.*) works unchanged on XPU.
+  ops.def(
+      "fused_minimax_m3_qknorm_rope_kv_insert("
+      "Tensor! qkv, Tensor q_norm_weight, Tensor k_norm_weight, "
+      "Tensor cos_sin_cache, Tensor positions, int num_heads, "
+      "int num_kv_heads, int rotary_dim, float eps, "
+      "Tensor? index_q_norm_weight, Tensor? index_k_norm_weight, "
+      "int num_index_heads, "
+      "Tensor? slot_mapping, Tensor? index_slot_mapping, "
+      "Tensor!? kv_cache, Tensor!? index_cache, "
+      "int block_size, Tensor!? q_out, Tensor!? index_q_out) -> ()");
+  ops.impl(
+      "fused_minimax_m3_qknorm_rope_kv_insert",
+      torch::kXPU,
+      &fused_minimax_m3_qknorm_rope_kv_insert);
+
   // Compute FP8 quantized tensor for given scaling factor.
   ops.def(
       "static_scaled_fp8_quant(Tensor! result, Tensor input, Tensor scale, "

--- a/tests/register_ops.py
+++ b/tests/register_ops.py
@@ -593,3 +593,54 @@ def topk_per_row_decode(
         logits.stride(1),
         top_k,
     )
+
+
+def fp32_router_gemm(
+    mat_a: torch.Tensor,
+    mat_b: torch.Tensor,
+) -> torch.Tensor:
+    return torch.ops._xpu_C.fp32_router_gemm(mat_a, mat_b)
+
+
+def fused_minimax_m3_qknorm_rope_kv_insert(
+    qkv: torch.Tensor,
+    q_norm_weight: torch.Tensor,
+    k_norm_weight: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    positions: torch.Tensor,
+    num_heads: int,
+    num_kv_heads: int,
+    rotary_dim: int,
+    eps: float,
+    index_q_norm_weight: torch.Tensor | None = None,
+    index_k_norm_weight: torch.Tensor | None = None,
+    num_index_heads: int = 0,
+    slot_mapping: torch.Tensor | None = None,
+    index_slot_mapping: torch.Tensor | None = None,
+    kv_cache: torch.Tensor | None = None,
+    index_cache: torch.Tensor | None = None,
+    block_size: int = 0,
+    q_out: torch.Tensor | None = None,
+    index_q_out: torch.Tensor | None = None,
+) -> None:
+    torch.ops._C.fused_minimax_m3_qknorm_rope_kv_insert(
+        qkv,
+        q_norm_weight,
+        k_norm_weight,
+        cos_sin_cache,
+        positions,
+        num_heads,
+        num_kv_heads,
+        rotary_dim,
+        eps,
+        index_q_norm_weight,
+        index_k_norm_weight,
+        num_index_heads,
+        slot_mapping,
+        index_slot_mapping,
+        kv_cache,
+        index_cache,
+        block_size,
+        q_out,
+        index_q_out,
+    )

--- a/tests/register_ops.py
+++ b/tests/register_ops.py
@@ -595,13 +595,6 @@ def topk_per_row_decode(
     )
 
 
-def fp32_router_gemm(
-    mat_a: torch.Tensor,
-    mat_b: torch.Tensor,
-) -> torch.Tensor:
-    return torch.ops._xpu_C.fp32_router_gemm(mat_a, mat_b)
-
-
 def fused_minimax_m3_qknorm_rope_kv_insert(
     qkv: torch.Tensor,
     q_norm_weight: torch.Tensor,

--- a/tests/register_ops.py
+++ b/tests/register_ops.py
@@ -712,13 +712,6 @@ def topk_per_row_decode(
     )
 
 
-def fp32_router_gemm(
-    mat_a: torch.Tensor,
-    mat_b: torch.Tensor,
-) -> torch.Tensor:
-    return torch.ops._xpu_C.fp32_router_gemm(mat_a, mat_b)
-
-
 def fused_minimax_m3_qknorm_rope_kv_insert(
     qkv: torch.Tensor,
     q_norm_weight: torch.Tensor,

--- a/tests/register_ops.py
+++ b/tests/register_ops.py
@@ -710,3 +710,54 @@ def topk_per_row_decode(
         logits.stride(1),
         top_k,
     )
+
+
+def fp32_router_gemm(
+    mat_a: torch.Tensor,
+    mat_b: torch.Tensor,
+) -> torch.Tensor:
+    return torch.ops._xpu_C.fp32_router_gemm(mat_a, mat_b)
+
+
+def fused_minimax_m3_qknorm_rope_kv_insert(
+    qkv: torch.Tensor,
+    q_norm_weight: torch.Tensor,
+    k_norm_weight: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    positions: torch.Tensor,
+    num_heads: int,
+    num_kv_heads: int,
+    rotary_dim: int,
+    eps: float,
+    index_q_norm_weight: torch.Tensor | None = None,
+    index_k_norm_weight: torch.Tensor | None = None,
+    num_index_heads: int = 0,
+    slot_mapping: torch.Tensor | None = None,
+    index_slot_mapping: torch.Tensor | None = None,
+    kv_cache: torch.Tensor | None = None,
+    index_cache: torch.Tensor | None = None,
+    block_size: int = 0,
+    q_out: torch.Tensor | None = None,
+    index_q_out: torch.Tensor | None = None,
+) -> None:
+    torch.ops._C.fused_minimax_m3_qknorm_rope_kv_insert(
+        qkv,
+        q_norm_weight,
+        k_norm_weight,
+        cos_sin_cache,
+        positions,
+        num_heads,
+        num_kv_heads,
+        rotary_dim,
+        eps,
+        index_q_norm_weight,
+        index_k_norm_weight,
+        num_index_heads,
+        slot_mapping,
+        index_slot_mapping,
+        kv_cache,
+        index_cache,
+        block_size,
+        q_out,
+        index_q_out,
+    )

--- a/tests/test_fused_minimax_m3_qknorm_rope_kv_insert.py
+++ b/tests/test_fused_minimax_m3_qknorm_rope_kv_insert.py
@@ -1,0 +1,187 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""XPU correctness test for the fused MiniMax-M3 attention pre-processing kernel
+``fused_minimax_m3_qknorm_rope_kv_insert``.
+
+Reference: Gemma RMSNorm ``x * rsqrt(mean(x^2)+eps) * (1+weight)`` followed by
+partial NeoX RoPE on the leading ``rotary_dim`` dims. Adapted from the upstream
+CUDA test in vllm-project/vllm#45381.
+"""
+
+import pytest
+import torch
+
+from tests.register_ops import fused_minimax_m3_qknorm_rope_kv_insert
+
+DEVICE = torch.device("xpu")
+HEAD_DIM = 128
+ROTARY_DIM = 64
+
+
+def make_cos_sin_cache(max_pos, rotary_dim, base, dtype, device):
+    inv_freq = 1.0 / (
+        base
+        ** (torch.arange(0, rotary_dim, 2, dtype=torch.float32, device=device)
+            / rotary_dim)
+    )
+    t = torch.arange(max_pos, dtype=torch.float32, device=device)
+    freqs = torch.einsum("i,j->ij", t, inv_freq)
+    cache = torch.cat((freqs.cos(), freqs.sin()), dim=-1)
+    return cache.to(dtype)
+
+
+def gemma_rmsnorm(x, weight, eps):
+    xf = x.float()
+    var = xf.pow(2).mean(dim=-1, keepdim=True)
+    out = xf * torch.rsqrt(var + eps)
+    out = out * (1.0 + weight.float())
+    return out.to(x.dtype)
+
+
+def apply_rope_neox_partial(x, positions, cos_sin_cache, rotary_dim):
+    half = rotary_dim // 2
+    cs = cos_sin_cache[positions].float()
+    cos = cs[..., :half].unsqueeze(1)
+    sin = cs[..., half:].unsqueeze(1)
+    rot = x[..., :rotary_dim].float()
+    x1 = rot[..., :half]
+    x2 = rot[..., half:]
+    o1 = x1 * cos - x2 * sin
+    o2 = x2 * cos + x1 * sin
+    out = x.clone()
+    out[..., :half] = o1.to(x.dtype)
+    out[..., half:rotary_dim] = o2.to(x.dtype)
+    return out
+
+
+def norm_rope_ref(x, weight, positions, cos_sin_cache, eps):
+    normed = gemma_rmsnorm(x, weight, eps)
+    return apply_rope_neox_partial(normed, positions, cos_sin_cache, ROTARY_DIM)
+
+
+@pytest.mark.parametrize("num_tokens", [1, 7, 64, 513])
+@pytest.mark.parametrize("num_heads,num_kv_heads", [(8, 2), (16, 4), (64, 4)])
+def test_dense_norm_rope(num_tokens, num_heads, num_kv_heads):
+    torch.manual_seed(0)
+    dtype, eps = torch.bfloat16, 1e-6
+    base, max_pos = 5_000_000.0, 4096
+
+    q_w = torch.randn(HEAD_DIM, dtype=dtype, device=DEVICE) * 0.1
+    k_w = torch.randn(HEAD_DIM, dtype=dtype, device=DEVICE) * 0.1
+    cos_sin = make_cos_sin_cache(max_pos, ROTARY_DIM, base, dtype, DEVICE)
+    positions = torch.randint(
+        0, max_pos, (num_tokens,), dtype=torch.int64, device=DEVICE
+    )
+
+    qsz, kvsz = num_heads * HEAD_DIM, num_kv_heads * HEAD_DIM
+    qkv = torch.randn(num_tokens, qsz + 2 * kvsz, dtype=dtype, device=DEVICE)
+    qkv_orig = qkv.clone()
+
+    fused_minimax_m3_qknorm_rope_kv_insert(
+        qkv, q_w, k_w, cos_sin, positions, num_heads, num_kv_heads,
+        ROTARY_DIM, eps
+    )
+    torch.xpu.synchronize()
+    q_out, k_out, v_out = qkv.split([qsz, kvsz, kvsz], dim=-1)
+
+    q_in, k_in, v_in = qkv_orig.split([qsz, kvsz, kvsz], dim=-1)
+    q_ref = norm_rope_ref(
+        q_in.view(num_tokens, num_heads, HEAD_DIM), q_w, positions, cos_sin, eps
+    ).view(num_tokens, qsz)
+    k_ref = norm_rope_ref(
+        k_in.view(num_tokens, num_kv_heads, HEAD_DIM),
+        k_w, positions, cos_sin, eps
+    ).view(num_tokens, kvsz)
+
+    torch.testing.assert_close(q_out, q_ref, rtol=1e-2, atol=1e-2)
+    torch.testing.assert_close(k_out, k_ref, rtol=1e-2, atol=1e-2)
+    torch.testing.assert_close(v_out, v_in, rtol=0, atol=0)  # V untouched
+
+
+@pytest.mark.parametrize("num_tokens", [1, 7, 64, 513])
+@pytest.mark.parametrize("block_size", [16, 64])
+def test_sparse_full(num_tokens, block_size):
+    torch.manual_seed(1)
+    dtype, eps = torch.bfloat16, 1e-6
+    base, max_pos = 5_000_000.0, 4096
+    num_heads, num_kv_heads, num_idx_heads = 16, 4, 4
+
+    q_w = torch.randn(HEAD_DIM, dtype=dtype, device=DEVICE) * 0.1
+    k_w = torch.randn(HEAD_DIM, dtype=dtype, device=DEVICE) * 0.1
+    iq_w = torch.randn(HEAD_DIM, dtype=dtype, device=DEVICE) * 0.1
+    ik_w = torch.randn(HEAD_DIM, dtype=dtype, device=DEVICE) * 0.1
+    cos_sin = make_cos_sin_cache(max_pos, ROTARY_DIM, base, dtype, DEVICE)
+    positions = torch.randint(
+        0, max_pos, (num_tokens,), dtype=torch.int64, device=DEVICE
+    )
+
+    qsz, kvsz = num_heads * HEAD_DIM, num_kv_heads * HEAD_DIM
+    iqsz, iksz = num_idx_heads * HEAD_DIM, HEAD_DIM
+    qkv = torch.randn(
+        num_tokens, qsz + 2 * kvsz + iqsz + iksz, dtype=dtype, device=DEVICE
+    )
+    qkv_orig = qkv.clone()
+    splits = [qsz, kvsz, kvsz, iqsz, iksz]
+
+    num_blocks = (num_tokens + block_size - 1) // block_size + 1
+    kv_cache = torch.zeros(
+        num_blocks, 2, block_size, num_kv_heads, HEAD_DIM,
+        dtype=dtype, device=DEVICE
+    )
+    index_cache = torch.zeros(
+        num_blocks, block_size, HEAD_DIM, dtype=dtype, device=DEVICE
+    )
+    slot_mapping = torch.randperm(
+        num_blocks * block_size, dtype=torch.int64, device=DEVICE
+    )[:num_tokens]
+    index_slot_mapping = torch.roll(slot_mapping, shifts=1)
+
+    q_out = torch.empty(num_tokens, qsz, dtype=dtype, device=DEVICE)
+    index_q = torch.empty(num_tokens, iqsz, dtype=dtype, device=DEVICE)
+
+    fused_minimax_m3_qknorm_rope_kv_insert(
+        qkv, q_w, k_w, cos_sin, positions, num_heads, num_kv_heads,
+        ROTARY_DIM, eps,
+        iq_w, ik_w, num_idx_heads, slot_mapping, index_slot_mapping,
+        kv_cache, index_cache, block_size, q_out, index_q,
+    )
+    torch.xpu.synchronize()
+
+    _, k_out, _, _, index_k = qkv.split(splits, dim=-1)
+    q_in, k_in, v_in, iq_orig, ik_orig = qkv_orig.split(splits, dim=-1)
+    q_ref = norm_rope_ref(
+        q_in.view(num_tokens, num_heads, HEAD_DIM), q_w, positions, cos_sin, eps
+    ).view(num_tokens, qsz)
+    k_ref = norm_rope_ref(
+        k_in.view(num_tokens, num_kv_heads, HEAD_DIM),
+        k_w, positions, cos_sin, eps
+    ).view(num_tokens, kvsz)
+    iq_ref = norm_rope_ref(
+        iq_orig.view(num_tokens, num_idx_heads, HEAD_DIM),
+        iq_w, positions, cos_sin, eps
+    ).view(num_tokens, iqsz)
+    ik_ref = norm_rope_ref(
+        ik_orig.view(num_tokens, 1, HEAD_DIM), ik_w, positions, cos_sin, eps
+    ).view(num_tokens, HEAD_DIM)
+
+    torch.testing.assert_close(q_out, q_ref, rtol=1e-2, atol=1e-2)
+    torch.testing.assert_close(k_out, k_ref, rtol=1e-2, atol=1e-2)
+    torch.testing.assert_close(index_q, iq_ref, rtol=1e-2, atol=1e-2)
+    torch.testing.assert_close(index_k, ik_ref, rtol=1e-2, atol=1e-2)
+
+    idx_flat = index_cache.view(num_blocks * block_size, HEAD_DIM)
+    k_ref_h = k_ref.view(num_tokens, num_kv_heads, HEAD_DIM)
+    v_ref_h = v_in.view(num_tokens, num_kv_heads, HEAD_DIM)
+    for t in range(num_tokens):
+        s = slot_mapping[t].item()
+        b, pos = s // block_size, s % block_size
+        torch.testing.assert_close(
+            kv_cache[b, 0, pos], k_ref_h[t], rtol=1e-2, atol=1e-2
+        )
+        torch.testing.assert_close(
+            kv_cache[b, 1, pos], v_ref_h[t], rtol=0, atol=0
+        )
+        index_s = index_slot_mapping[t].item()
+        torch.testing.assert_close(
+            idx_flat[index_s], ik_ref[t], rtol=1e-2, atol=1e-2
+        )


### PR DESCRIPTION
## Summary

Adds the **`fused_minimax_m3_qknorm_rope_kv_insert`** SYCL kernel — horizontally-fused MiniMax-M3 attention pre-processing (Gemma-RMSNorm + partial-NeoX RoPE + KV/index-cache insert) — and optimizes it for Intel BMG (Arc Pro B60).

Profile-guided (unitrace) optimization gives **~3.34× speedup**: 100,935 → 30,224 ns/call (pinned @ 2.4 GHz, min-of-7 device timing; MBU 18% → 56% of HBM).

## Kernel

SYCL port of the horizontally-fused M3 attention pre-processing kernel from vllm-project/vllm#45381 (`csrc/libtorch_stable/fused_minimax_m3_qknorm_rope_kv_insert_kernel.cu`), registered in the `_C` extension as `torch.ops._C.fused_minimax_m3_qknorm_rope_kv_insert` so the unchanged upstream `vllm._custom_ops` wrapper resolves it on XPU (no vllm-side dispatch shim).

Unlike DeepSeek-V4's `qnorm_rope_kv_insert` (head_dim 512, GPT-J interleaved rope, 2 standard RMSNorms, MLA layout), M3 uses head_dim 128, partial-NeoX rope (`rotary_dim` leading dims rotated, the rest pass through), four Gemma-style RMSNorms (`x * rsqrt(mean(x^2)+eps) * (1+weight)`), and the packed `[q|k|v|index_q|index_k]` layout:

- `q` → Gemma-norm + rope → `q_out` (sparse) / in place (dense)
- `k` → Gemma-norm + rope → in place + scatter `kv_cache[:,0]`
- `v` → raw → scatter `kv_cache[:,1]`
- `index_q` → Gemma-norm + rope → `index_q_out`
- `index_k` → Gemma-norm + rope → in place + scatter `index_cache`

## BMG optimization (~3.3×)

The initial port used a per-work-item `buf[128]` (16 KB private-memory spill) and a partial-sub-group launch geometry (~`num_tokens` threads) → 34% occupancy, 72% XVE stall. The optimized version:

- **Streaming two-pass norm+RoPE** — a sum-of-squares pass, then normalize+RoPE written straight to dst/cache. Removes `buf[128]`; private memory 16 KB → 0.
- **Cooperative sub-group per head** — one `M3_SG_SIZE`-lane sub-group per (token, head-slot) on a flat 1-D `nd_range`; lanes split the 128-dim head, sum-of-squares via `reduce_over_group`, rotary pairs computed lane-locally. Occupancy 34% → 92%, stall 72% → 31%.

A register-cache-of-`src` variant and a large-GRF build were both measured *worse* (occupancy-bound) and are not included.

## Commits

- `1066fe3` Add fused qknorm_rope_kv_insert SYCL kernel
- `770120b` Optimize fused qknorm/rope/kv-insert for BMG (~3.3x)
- `fe6926d` Add input validation and explicit DeviceGuard include
- `f0f5cc0` Drop stray unrelated fp32_router_gemm wrapper
- `a959bce` Validate cache/output tensor shapes in entrypoint

## Changes

| File | Change |
| --- | --- |
| `csrc/fused_minimax_m3_qknorm_rope_kv_insert.cpp` | new kernel + entrypoint |
| `csrc/ops.h` | op declaration |
| `csrc/torch_bindings.cpp` | schema + `kXPU` impl (next to `fused_qk_norm_rope`) |
| `CMakeLists.txt` | one source line in `VLLM_EXT_SRC` |
| `tests/register_ops.py` | Python wrapper |
| `tests/test_fused_minimax_m3_qknorm_rope_kv_insert.py` | correctness tests |

## Testing

Verified on Intel Arc Pro B60 (BMG) after the rebase:

- `pytest tests/test_fused_minimax_m3_qknorm_rope_kv_insert.py` — **20 passed** (dense norm+rope parity; sparse-full including the index branch and KV/index cache inserts) against an fp32 reference.
- Additional ad-hoc checks, all correct: `slot_mapping == -1` padding tokens (cache rows untouched), `rotary_dim == head_dim`, and sparse mode with `q_out=None` / `index_q_out=None` (in-place fallback).
- `pre-commit run` on all changed files — clean (clang-format, ruff, isort, cmake-format/lint, mypy, SPDX).
- `_C` builds cleanly with oneAPI `icpx -fsycl` against rebased `main` headers.
