### PR TITLE
Allow bfloat16/float16 descale tensors for FP8 KV cache

### DIFF
--- a/vllm_xpu_kernels/flash_attn_interface.py
+++ b/vllm_xpu_kernels/flash_attn_interface.py
@@ -27,6 +27,26 @@ def _as_int32_device_tensor(x, device: torch.device) -> torch.Tensor:
     return torch.tensor(x, device=device, dtype=torch.int32)
 
 
+def _normalize_descale_tensor(
+    descale: Optional[torch.Tensor],
+    name: str,
+) -> Optional[torch.Tensor]:
+    if descale is None:
+        return None
+
+    assert descale.dtype in (torch.float32, torch.bfloat16, torch.float16), \
+        f"{name} must be a float32 or bfloat16 or float16 scalar tensor view"
+    assert descale.untyped_storage().nbytes() == descale.element_size(), \
+        f"{name} must be view of single scalar tensor"
+
+    if descale.dtype == torch.float32:
+        return descale
+
+    descale_scalar = descale.flatten()[0].to(dtype=torch.float32)
+    return descale_scalar if descale.ndim == 0 else descale_scalar.expand(
+        descale.shape)
+
+
 def _kv_tile_from_block_size(block_size: int) -> int:
     # Mirror of flash_api.cpp get_num_splits() / TileShapeQK<1>.
     if block_size == 16:
@@ -336,14 +356,8 @@ def flash_attn_varlen_func(
 
     if softmax_scale is None:
         softmax_scale = q.shape[-1]**(-0.5)
-    if k_descale is not None:
-        assert k_descale.untyped_storage().nbytes() == 4 and \
-            k_descale.dtype == torch.float32, \
-            "k_descale must be view of single float32 scalar tensor"
-    if v_descale is not None:
-        assert v_descale.untyped_storage().nbytes() == 4 and \
-            v_descale.dtype == torch.float32, \
-            "v_descale must be view of single float32 scalar tensor"
+    k_descale = _normalize_descale_tensor(k_descale, "k_descale")
+    v_descale = _normalize_descale_tensor(v_descale, "v_descale")
     # custom op does not support non-tuple input
     real_window_size: tuple[int, int]
     if window_size is None:


### PR DESCRIPTION
# Essential Elements of an Effective PR Description Checklist

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.

PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS ABOVE HAVE BEEN CONSIDERED.

## Purpose
`k_descale` and `v_descale` passed by vLLM are not always `torch.float32`, with error pops like:
```
(EngineCore pid=33674) ERROR 06-16 09:28:31 [core.py:1204]   File "/workspace/vllm/vllm/model_executor/layers/attention/kv_transfer_utils.py", line 40, in wrapper
(EngineCore pid=33674) ERROR 06-16 09:28:31 [core.py:1204]     return func(*args, **kwargs)
(EngineCore pid=33674) ERROR 06-16 09:28:31 [core.py:1204]            ^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=33674) ERROR 06-16 09:28:31 [core.py:1204]   File "/workspace/vllm/vllm/model_executor/layers/attention/attention.py", line 753, in unified_attention_with_output
(EngineCore pid=33674) ERROR 06-16 09:28:31 [core.py:1204]     self.impl.forward(
(EngineCore pid=33674) ERROR 06-16 09:28:31 [core.py:1204]   File "/workspace/vllm/vllm/v1/attention/backends/flash_attn.py", line 870, in forward
(EngineCore pid=33674) ERROR 06-16 09:28:31 [core.py:1204]     flash_attn_varlen_func(
(EngineCore pid=33674) ERROR 06-16 09:28:31 [core.py:1204]   File "/workspace/vllm/vllm/_xpu_ops.py", line 824, in flash_attn_varlen_func
(EngineCore pid=33674) ERROR 06-16 09:28:31 [core.py:1204]     return flash_attn_varlen_func(
(EngineCore pid=33674) ERROR 06-16 09:28:31 [core.py:1204]            ^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=33674) ERROR 06-16 09:28:31 [core.py:1204]   File "/opt/venv/lib/python3.12/site-packages/vllm_xpu_kernels/flash_attn_interface.py", line 233, in flash_attn_varlen_func
(EngineCore pid=33674) ERROR 06-16 09:28:31 [core.py:1204]     assert sum(k_descale.stride()) == 0 and \
(EngineCore pid=33674) ERROR 06-16 09:28:31 [core.py:1204]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=33674) ERROR 06-16 09:28:31 [core.py:1204] AssertionError: k_descale must be view of single float32 scalar tensor

```
## Test Plan

## Test Result

## (Optional) Documentation Update

**BEFORE SUBMITTING, PLEASE READ <https://docs.vllm.ai/en/latest/contributing>** (anything written below this line will be removed by GitHub Actions)
