### PR TITLE
[XPU][FMHA] Fix sliding-window prefill K-loop right boundary

### DIFF
--- a/benchmark/benchmark_cutlass_flash_attn_window.py
+++ b/benchmark/benchmark_cutlass_flash_attn_window.py
@@ -39,13 +39,13 @@ BASE = dict(
     kv_dtype=None,
 )
 
-WINDOWS = [(64, 0), (128, 0), (256, 0), (512, 0), (1024, 0), (2048, 0),(-1, -1)]
+WINDOWS = [(64, 0), (128, 0), (256, 0), (512, 0), (1024, 0), (2048, 0), (-1, -1)]
 ITERS = 20
 
 
 def main():
     torch.set_default_device("xpu")
-    torch.xpu.set_device("xpu:0")
+    torch.xpu.set_device(0)
     print(f"device={torch.xpu.get_device_name()}")
     print(f"shape: q=k={BASE['query_lens']} heads={BASE['num_heads']} "
           f"head_size={BASE['head_size']} causal={BASE['is_causal']} "

--- a/benchmark/benchmark_cutlass_flash_attn_window.py
+++ b/benchmark/benchmark_cutlass_flash_attn_window.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Temporary PR before/after perf driver for the local-window (sliding window)
+# right-boundary fix in chunk_prefill_kernel.hpp.
+#
+# Reuses the OFFICIAL measurement function `benchmark_varlen_with_paged_kv`
+# (XPU-event kernel timing + FLOPS) from benchmark_cutlass_flash_attn_varlen.py,
+# but drives it for local-window configs that the official `filter_configs`
+# otherwise skips. Numbers are directly comparable across builds.
+#
+# Run inside container, from the benchmark/ directory:
+#   ZE_AFFINITY_MASK=2 python3 benchmark_cutlass_flash_attn_window.py
+import torch
+
+# Importing the official module sets up sys.path (bootstrap_benchmark_env) and
+# pulls in the kernel-time benchmark machinery.
+from benchmark_cutlass_flash_attn_varlen import benchmark_varlen_with_paged_kv
+
+DTYPE = torch.bfloat16
+
+# Representative long-sequence prefill shape (q == k), GQA 32/8, head_size 128.
+# window_size is given as the raw (left, right) flash-attn convention; the host
+# normalizes local+causal into right=0 local-only internally.
+BASE = dict(
+    num_seqs=1,
+    query_lens="4096",
+    kv_lens="4096",
+    num_heads=(32, 8),
+    head_size=128,
+    block_size=64,
+    output_dtype=DTYPE,
+    soft_cap=None,
+    num_blocks=2048,
+    fa_versions=2,
+    q_dtype=None,
+    is_sink=False,
+    is_causal=True,
+    is_paged=True,
+    kv_dtype=None,
+)
+
+WINDOWS = [(64, 0), (128, 0), (256, 0), (512, 0), (1024, 0), (2048, 0),(-1, -1)]
+ITERS = 20
+
+
+def main():
+    torch.set_default_device("xpu")
+    torch.xpu.set_device("xpu:0")
+    print(f"device={torch.xpu.get_device_name()}")
+    print(f"shape: q=k={BASE['query_lens']} heads={BASE['num_heads']} "
+          f"head_size={BASE['head_size']} causal={BASE['is_causal']} "
+          f"paged={BASE['is_paged']} dtype={DTYPE}")
+    print()
+    print(f"{'window':>10} | {'kernel_time(us)':>16} | {'TFLOPS':>10}")
+    print("-" * 44)
+    for w in WINDOWS:
+        cfg = dict(BASE, window_size=w)
+        kt = benchmark_varlen_with_paged_kv(provider="flash_kernel_time",
+                                            iterations=ITERS, **cfg)
+        tf = benchmark_varlen_with_paged_kv(provider="flash_kernel_TFLOPS",
+                                            iterations=ITERS, **cfg)
+        print(f"{str(list(w)):>10} | {kt:>16.3f} | {tf:>10.3f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/csrc/xpu/attn/xe_2/kernel/chunk_prefill_kernel.hpp
+++ b/csrc/xpu/attn/xe_2/kernel/chunk_prefill_kernel.hpp
@@ -271,17 +271,7 @@ class XeFMHAFwdKernel {
       int seq_coord =
           cute::min(seq_len_qo, (blk_q * get<0>(TileShapeQK{}) + q_offset_sg));
 
-      // calc sg level seq_len_kv
-      // The right K-boundary must shrink whenever a local (sliding-window)
-      // mask is active, regardless of whether causal masking is also on.
-      // The host converts local+causal into local-only (CausalMask=false,
-      // LocalMask=true); in that case the right edge is still bounded by
-      // row + local_right, so we must clamp seq_len here too. Otherwise
-      // seq_len degenerates to seq_len_kv and every Q block iterates all K
-      // blocks, computing GEMM1 for tiles that the local mask then sets to
-      // -inf (pure wasted work). This clamp matches the per-element local
-      // right-mask test (col > row + local_right) used in the mainloop, so
-      // results are unchanged.
+      // calc sg level seq_len_kv(clamped right K-boundary)
       const int seq_len =
           LocalMask
               ? cute::min(

--- a/csrc/xpu/attn/xe_2/kernel/chunk_prefill_kernel.hpp
+++ b/csrc/xpu/attn/xe_2/kernel/chunk_prefill_kernel.hpp
@@ -272,16 +272,26 @@ class XeFMHAFwdKernel {
           cute::min(seq_len_qo, (blk_q * get<0>(TileShapeQK{}) + q_offset_sg));
 
       // calc sg level seq_len_kv
+      // The right K-boundary must shrink whenever a local (sliding-window)
+      // mask is active, regardless of whether causal masking is also on.
+      // The host converts local+causal into local-only (CausalMask=false,
+      // LocalMask=true); in that case the right edge is still bounded by
+      // row + local_right, so we must clamp seq_len here too. Otherwise
+      // seq_len degenerates to seq_len_kv and every Q block iterates all K
+      // blocks, computing GEMM1 for tiles that the local mask then sets to
+      // -inf (pure wasted work). This clamp matches the per-element local
+      // right-mask test (col > row + local_right) used in the mainloop, so
+      // results are unchanged.
       const int seq_len =
-          CausalMask
-              ? LocalMask
+          LocalMask
+              ? cute::min(
+                    seq_len_kv,
+                    full_tile_offset + seq_coord + q_sg_tile +
+                        params.mainloop.local_right)
+              : CausalMask
                     ? cute::min(
-                          seq_len_kv,
-                          full_tile_offset + seq_coord + q_sg_tile +
-                              params.mainloop.local_right)
-                    : cute::min(
                           seq_len_kv, full_tile_offset + seq_coord + q_sg_tile)
-              : seq_len_kv;
+                    : seq_len_kv;
       const int sg_k_block0 =
           LocalMask
               ? cute::max(


### PR DESCRIPTION

### Summary
The chunk-prefill FMHA kernel did not shrink the right K-boundary for **local (sliding-window) attention** unless causal masking was also active. As a result, sliding-window prefill iterated over **every** K block, ran GEMM1 on tiles that the local mask immediately set to `-inf`, and wasted most of its compute. This PR moves the local-window clamp to the outermost branch so the K-loop bound respects the window. Results are bit-for-bit unchanged; narrow-window prefill is **~5× faster**.

### Root cause
The host normalizes `local + causal` into **local-only**:

```cpp
// fmha_xe2.cpp
if (is_local && is_causal) { window_size_right = 0; is_causal = false; }
// -> LocalMask = true, CausalMask = false
```

But the kernel's right-boundary (`seq_len`) was gated on `CausalMask` first:

```cpp
// before
const int seq_len =
    CausalMask
        ? LocalMask ? min(seq_len_kv, row + local_right)
                    : min(seq_len_kv, row)
        : seq_len_kv;            // <-- local-only falls here
```

Since the host had cleared `CausalMask`, a sliding-window run fell into the `seq_len_kv` branch — the right edge never shrank. Every Q block then iterated all K blocks (e.g. 128 of them for seq=4096), computing GEMM1 for tiles that the per-element local mask (`col > row + local_right`) discards anyway.

### Fix
Make `LocalMask` the outermost condition so the right edge is clamped whenever a local window is active, matching the mainloop's per-element right-mask test:

```cpp
// after
const int seq_len =
    LocalMask
        ? min(seq_len_kv, row + local_right)
        : CausalMask ? min(seq_len_kv, row)
                     : seq_len_kv;
```

This only skips K blocks that are **entirely** masked, so numerics are identical to before.

### Performance: sliding-window prefill (before vs after)

Intel Arc Pro B60 Graphics · `q = k = 4096` · heads = (32, 8) · `head_size = 128` ·
causal · paged · bf16. Kernel time measured with the official
`benchmark_varlen_with_paged_kv` (XPU-event timing).

| window (left, right) | before (μs) | after (μs) | speedup |
|----------------------|------------:|-----------:|--------:|
| `[64, 0]`            |    2833.868 |    512.321 |  5.53×  |
| `[128, 0]`           |    2906.134 |    579.745 |  5.01×  |
| `[256, 0]`           |    3046.319 |    722.308 |  4.22×  |
| `[512, 0]`           |    3297.830 |    978.366 |  3.37×  |
| `[1024, 0]`          |    3768.724 |   1457.862 |  2.59×  |
| `[2048, 0]`          |    4482.663 |   2193.346 |  2.04×  |
| `[-1, -1]` (full)    |    2423.817 |   2418.627 |  ~1.0×  |

**Before the fix**, every sliding window was *slower* than full attention and got worse as the window grew.

**After the fix**, kernel time scales monotonically with window size — narrow windows are far faster and wide windows approach full attention. The full-attention path is unchanged, confirming only the local branch is affected.

### Testing
- Accuracy: targeted sliding-window correctness check passes (output matches the pre-fix kernel and the reference), since the fix only skips fully-masked K blocks.
- Perf reproduction: added `benchmark/benchmark_cutlass_flash_attn_window.py`, a standalone before/after driver that **reuses the official** `benchmark_varlen_with_paged_kv` measurement to cover local-window configs (which the official `filter_configs` skips by default):
  ```bash
  python benchmark/benchmark_cutlass_flash_attn_window.py
  ```

