### PR TITLE
Run mqa logits test only for ci and full scope

### DIFF
--- a/tests/mqa_logits/test_mqa_logits.py
+++ b/tests/mqa_logits/test_mqa_logits.py
@@ -1,10 +1,23 @@
 # SPDX-License-Identifier: Apache-2.0
+import os
 import random
 
 import pytest
 import torch
 
 import vllm_xpu_kernels._xpu_C  # noqa: F401
+
+_test_scope = os.getenv("XPU_KERNEL_TEST_SCOPE", "").strip().lower()
+_allowed_scopes = {
+    "",
+    "ci",
+    "full",
+}
+if _test_scope not in _allowed_scopes:
+    pytest.skip(
+        f"mqa logits tests are disabled for scope: {_test_scope}",
+        allow_module_level=True,
+    )
 
 DEVICES = ["xpu:0"]
 


### PR DESCRIPTION
This pull request introduces a mechanism to conditionally skip the `mqa_logits` test suite based on the `XPU_KERNEL_TEST_SCOPE` environment variable. This allows for more flexible and targeted test execution, especially useful in different CI or local development environments.

Test suite conditional execution:

* [`tests/mqa_logits/test_mqa_logits.py`](diffhunk://#diff-2612ec7584d68f885894e1cc1e99f01fea82aa91e7b93d094a6019b8ea935365R2-R21): Added logic to check the `XPU_KERNEL_TEST_SCOPE` environment variable and skip the entire test module if the scope is not in the allowed set (`"", "ci", "full"`). This helps control when the tests are run, such as in CI pipelines or full test runs.# Essential Elements of an Effective PR Description Checklist

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.

PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS ABOVE HAVE BEEN CONSIDERED.

## Purpose

## Test Plan

## Test Result

## (Optional) Documentation Update

**BEFORE SUBMITTING, PLEASE READ <https://docs.vllm.ai/en/latest/contributing>** (anything written below this line will be removed by GitHub Actions)
