### PR TITLE
Make XPU flash cache writes stride-aware

### DIFF
--- a/csrc/cache.cpp
+++ b/csrc/cache.cpp
@@ -169,10 +169,32 @@ class reshape_and_cache_flash_kernel {
 
     fp8::CopyWithScaleOp<cache_t, scalar_t, kv_dt> k_op{k_scale_val};
     fp8::CopyWithScaleOp<cache_t, scalar_t, kv_dt> v_op{v_scale_val};
-    vectorize_with_alignment<VEC_SIZE>(
-        key_src, key_dst, n, local_idx, local_range, k_op);
-    vectorize_with_alignment<VEC_SIZE>(
-        value_src, value_dst, n, local_idx, local_range, v_op);
+    if (head_stride_ == head_size_) {
+      vectorize_with_alignment<VEC_SIZE>(
+          key_src, key_dst, n, local_idx, local_range, k_op);
+      vectorize_with_alignment<VEC_SIZE>(
+          value_src, value_dst, n, local_idx, local_range, v_op);
+      return;
+    }
+
+    for (int head_idx = 0; head_idx < num_heads_; ++head_idx) {
+      const int64_t src_offset = head_idx * head_size_;
+      const int64_t cache_offset = head_idx * head_stride_;
+      vectorize_with_alignment<VEC_SIZE>(
+          key_src + src_offset,
+          key_dst + cache_offset,
+          head_size_,
+          local_idx,
+          local_range,
+          k_op);
+      vectorize_with_alignment<VEC_SIZE>(
+          value_src + src_offset,
+          value_dst + cache_offset,
+          head_size_,
+          local_idx,
+          local_range,
+          v_op);
+    }
   }
 
  private:


### PR DESCRIPTION
## Summary
- keep the existing vectorized reshape_and_cache_flash path for compact K/V cache rows
- use per-head destination indexing when the cache view has a larger head stride
- fixes writes into content-dim packed FlashAttention K/V views, where K/V heads are separated by 2 * head_size stride

## Context
This came up while validating vllm-project/vllm#44455, which packs K/V into the content dimension. The XPU FlashAttention read path already consumes cache strides, but reshape_and_cache_flash was bulk-copying num_heads * head_size contiguous elements for each token row, which corrupts packed K/V split views.

## Tests
- git diff --check origin/main...HEAD -- csrc/cache.cpp
- /home/LucasWilkinson/local/vllm2/.venv/bin/pre-commit run clang-format --files csrc/cache.cpp

AI assistance was used to inspect the vLLM failure mode and draft this patch.