### PR TITLE
Replace oneDNN git submodule with CMake FetchContent

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "third_party/oneDNN"]
-	path = third_party/oneDNN
-	url = https://github.com/uxlfoundation/oneDNN.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,15 @@ set(TORCH_SUPPORTED_VERSION_XPU "2.12.0")
 set(BUILD_SYCL_TLA_KERNELS
     ON
     CACHE BOOL "Build SYCL-TLA based kernels for XPU")
+
+set(ONEDNN_GIT_REPO
+    "https://github.com/uxlfoundation/oneDNN.git"
+    CACHE STRING "oneDNN git repository URL")
+
+# rls-v3.12
+set(ONEDNN_GIT_TAG
+    "80afa71049cd69a3df32adcccb623b12cd7baa22"
+    CACHE STRING "oneDNN git commit hash or tag")
 # ARCHITECTURE OPTIONS
 option(VLLM_XPU_ENABLE_XE2 "Enable XE2 architecture kernels" ON)
 option(VLLM_XPU_ENABLE_XE_DEFAULT "Enable XE Default architecture kernels" ON)
@@ -122,6 +131,8 @@ if(NOT VLLM_CHUNK_PREFILL_CONFIG OR "${VLLM_CHUNK_PREFILL_CONFIG}" STREQUAL "")
 endif()
 
 message(STATUS "Kernel build configuration:")
+message(STATUS "  ONEDNN_GIT_REPO              = ${ONEDNN_GIT_REPO}")
+message(STATUS "  ONEDNN_GIT_TAG               = ${ONEDNN_GIT_TAG}")
 message(STATUS "  BUILD_SYCL_TLA_KERNELS       = ${BUILD_SYCL_TLA_KERNELS}")
 message(STATUS "  VLLM_XPU_ENABLE_XE2          = ${VLLM_XPU_ENABLE_XE2}")
 message(STATUS "  VLLM_XPU_ENABLE_XE_DEFAULT   = ${VLLM_XPU_ENABLE_XE_DEFAULT}")
@@ -626,8 +637,7 @@ if(XPU_SPECIFIC_KERNELS_ENABLED)
     include_directories(${ONEDNN_INCLUDE_DIR})
     link_libraries(${ONEDNN_LIBRARY})
   else()
-    message(
-      FATAL_ERROR "onednn not found but xpu specific kernels are enabled.")
+    message(FATAL_ERROR "oneDNN not found!")
   endif()
 
   define_gpu_extension_target(

--- a/cmake/Modules/FindoneDNN.cmake
+++ b/cmake/Modules/FindoneDNN.cmake
@@ -12,33 +12,21 @@ if(NOT ONEDNN_FOUND)
   set(ONEDNN_INCLUDE_DIR)
   set(DNNL_INCLUDES)
 
-  set(THIRD_PARTY_DIR "${PROJECT_SOURCE_DIR}/third_party")
-  set(ONEDNN_DIR "oneDNN")
-  set(ONEDNN_ROOT "${THIRD_PARTY_DIR}/${ONEDNN_DIR}")
+  include(FetchContent)
 
-  find_path(
-    ONEDNN_INCLUDE_DIR dnnl.hpp dnnl.h
-    PATHS ${ONEDNN_ROOT}
-    PATH_SUFFIXES include
-    NO_DEFAULT_PATH)
-  if(NOT ONEDNN_INCLUDE_DIR)
-    find_package(Git)
-    if(NOT Git_FOUND)
-      message(FATAL_ERROR "Can not find Git executable!")
-    endif()
-    execute_process(
-      COMMAND ${GIT_EXECUTABLE} submodule update --init ${ONEDNN_DIR}
-      WORKING_DIRECTORY ${THIRD_PARTY_DIR} COMMAND_ERROR_IS_FATAL ANY)
-    find_path(
-      ONEDNN_INCLUDE_DIR dnnl.hpp dnnl.h
-      PATHS ${ONEDNN_ROOT}
-      PATH_SUFFIXES include
-      NO_DEFAULT_PATH)
-  endif(NOT ONEDNN_INCLUDE_DIR)
+  if(POLICY CMP0169)
+    cmake_policy(SET CMP0169 OLD)
+  endif()
 
-  if(NOT ONEDNN_INCLUDE_DIR)
-    message(FATAL_ERROR "oneDNN source files not found!")
-  endif(NOT ONEDNN_INCLUDE_DIR)
+  message(
+    STATUS
+      "oneDNN: fetching from ${ONEDNN_GIT_REPO} (commit: ${ONEDNN_GIT_TAG})")
+  FetchContent_Declare(
+    oneDNN
+    GIT_REPOSITORY ${ONEDNN_GIT_REPO}
+    GIT_TAG ${ONEDNN_GIT_TAG}
+    GIT_PROGRESS TRUE
+    GIT_SHALLOW FALSE)
 
   set(DNNL_ENABLE_PRIMITIVE_CACHE
       TRUE
@@ -67,7 +55,9 @@ if(NOT ONEDNN_FOUND)
       TRUE
       CACHE BOOL "use one pass for oneDNN BatchNorm" FORCE)
 
-  add_subdirectory(${ONEDNN_ROOT} oneDNN EXCLUDE_FROM_ALL)
+  FetchContent_Populate(oneDNN)
+  add_subdirectory(${onednn_SOURCE_DIR} ${onednn_BINARY_DIR} EXCLUDE_FROM_ALL)
+
   set(ONEDNN_LIBRARY ${DNNL_LIBRARY_NAME})
   if(NOT TARGET ${ONEDNN_LIBRARY})
     message(FATAL_ERROR "Failed to include oneDNN target")
@@ -84,8 +74,7 @@ if(NOT ONEDNN_FOUND)
   list(APPEND ONEDNN_INCLUDE_DIR ${DNNL_INCLUDES})
 
   # Upper level targets should not load header files from oneDNN's third party.
-  list(FILTER ONEDNN_INCLUDE_DIR EXCLUDE REGEX
-       ".*third_party/oneDNN/third_party.*")
+  list(FILTER ONEDNN_INCLUDE_DIR EXCLUDE REGEX ".*/third_party.*")
 
   set(ONEDNN_FOUND ON)
   message(STATUS "Found oneDNN: TRUE")

--- a/csrc/xpu/onednn/onednn_runtime.cpp
+++ b/csrc/xpu/onednn/onednn_runtime.cpp
@@ -1,5 +1,15 @@
 #include "onednn_runtime.h"
 
+std::string get_onednn_version() {
+  std::ostringstream ss;
+  {
+    const dnnl_version_t* ver = dnnl_version();
+    ss << ver->major << '.' << ver->minor << '.' << ver->patch << "."
+       << ver->hash;
+  }
+  return ss.str();
+}
+
 namespace oneDNN {
 
 GpuEngineManager& GpuEngineManager::Instance() {

--- a/csrc/xpu/onednn/onednn_runtime.h
+++ b/csrc/xpu/onednn/onednn_runtime.h
@@ -4,10 +4,13 @@
 #include <c10/xpu/XPUFunctions.h>
 #include <c10/xpu/XPUStream.h>
 #include <memory>
+#include <sstream>
 
 #include <oneapi/dnnl/dnnl.h>
 #include <oneapi/dnnl/dnnl.hpp>
 #include <oneapi/dnnl/dnnl_sycl.hpp>
+
+std::string get_onednn_version();
 
 namespace oneDNN {
 

--- a/csrc/xpu/ops.h
+++ b/csrc/xpu/ops.h
@@ -166,3 +166,5 @@ torch::Tensor fp8_paged_mqa_logits(
     const c10::optional<at::Tensor>& schedule_metadata,
     int64_t max_model_len);
 #endif
+
+std::string get_onednn_version();

--- a/csrc/xpu/torch_bindings.cpp
+++ b/csrc/xpu/torch_bindings.cpp
@@ -148,6 +148,9 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, xpu_ops) {
       "schedule_metadata, int max_model_len) -> Tensor");
   xpu_ops.impl("fp8_paged_mqa_logits", torch::kXPU, &fp8_paged_mqa_logits);
 #endif
+
+  xpu_ops.def("get_onednn_version() -> str");
+  xpu_ops.impl("get_onednn_version", &get_onednn_version);
 }
 
 REGISTER_EXTENSION(TORCH_EXTENSION_NAME)


### PR DESCRIPTION
## Summary
- Replace oneDNN git submodule with CMake FetchContent for flexible branch/commit management across platforms
- Add `ONEDNN_GIT_REPO` and `ONEDNN_GIT_TAG` CMake options to configure the oneDNN source at build time
- Add `get_onednn_version()` utility to query oneDNN runtime version (cherry-picked from #146)
- Default to rls-v3.12 (commit 80afa71049cd69a3df32adcccb623b12cd7baa22)

## Test plan
- [x] Build with default settings and verify oneDNN is fetched and compiled
- [x] Run `test_onednn_version` to verify runtime version matches expected 3.12.0
- [x] Verify no level_zero header conflicts from oneDNN's third_party