### PR TITLE
 [wip]Fix low accuracy of Qwen3.5-27B

### DIFF
--- a/csrc/xpu/gdn_attn/causal_conv1d.hpp
+++ b/csrc/xpu/gdn_attn/causal_conv1d.hpp
@@ -455,8 +455,10 @@ struct update_states_kernel {
     for (int i = elems_start_offset_group + local_id;
          i < (local_group_id + 1) * elems_per_group;
          i += group_size) {
-      conv_states_ptr[width_id * conv_elems + i] =
-          conv_states_tmp_ptr[width_id * conv_elems + i];
+      if (i < conv_elems) {
+        conv_states_ptr[width_id * conv_elems + i] =
+            conv_states_tmp_ptr[width_id * conv_elems + i];
+      }
     }
   }
 

--- a/csrc/xpu/gdn_attn/xe_2/chunk_causal_conv1d_tiled_xe2.hpp
+++ b/csrc/xpu/gdn_attn/xe_2/chunk_causal_conv1d_tiled_xe2.hpp
@@ -336,24 +336,24 @@ struct chunk_causal_conv1d_tiled_kernel {
     // ========================================================================
     // Phase 2: Each item computes conv1d for its own feature lanes
     // ========================================================================
-    if (!feat_valid) return;
-
     bool is_q = (feat < q_dim);
     bool is_k = (!is_q && feat < q_dim + k_dim);
 
     // Load weights from global (only Width * elems_per_item = 16 values)
     T local_weights[Width * elems_per_item];
+    if (feat_valid) {
 #pragma unroll
-    for (int w = 0; w < Width; ++w) {
+      for (int w = 0; w < Width; ++w) {
 #pragma unroll
-      for (int e = 0; e < elems_per_item; ++e) {
-        local_weights[w * elems_per_item + e] =
-            conv_weights[(reordered_feat + e) * Width + w];
+        for (int e = 0; e < elems_per_item; ++e) {
+          local_weights[w * elems_per_item + e] =
+              conv_weights[(reordered_feat + e) * Width + w];
+        }
       }
     }
 
     float local_bias[elems_per_item];
-    if (conv_bias != nullptr) {
+    if (conv_bias != nullptr && feat_valid) {
 #pragma unroll
       for (int e = 0; e < elems_per_item; ++e) {
         local_bias[e] = conv_bias[reordered_feat + e];
@@ -363,38 +363,40 @@ struct chunk_causal_conv1d_tiled_kernel {
     // Conv1d: for each output token t, read SLM slots [t, t+Width)
     for (int t = 0; t < tile_tokens; ++t) {
       float res[elems_per_item];
+      if (feat_valid) {
 #pragma unroll
-      for (int e = 0; e < elems_per_item; ++e) {
-        res[e] = 0.0f;
-      }
+        for (int e = 0; e < elems_per_item; ++e) {
+          res[e] = 0.0f;
+        }
 
 #pragma unroll
-      for (int w = 0; w < Width; ++w) {
-        int slot = t + w;
+        for (int w = 0; w < Width; ++w) {
+          int slot = t + w;
 #pragma unroll
-        for (int e = 0; e < elems_per_item; ++e) {
-          res[e] += static_cast<float>(
-                        slm_input[slot * feats_per_wg + local_feat + e]) *
-                    static_cast<float>(local_weights[w * elems_per_item + e]);
+          for (int e = 0; e < elems_per_item; ++e) {
+            res[e] += static_cast<float>(
+                          slm_input[slot * feats_per_wg + local_feat + e]) *
+                      static_cast<float>(local_weights[w * elems_per_item + e]);
+          }
         }
-      }
 
-      if (conv_bias != nullptr) {
+        if (conv_bias != nullptr) {
 #pragma unroll
-        for (int e = 0; e < elems_per_item; ++e) {
-          res[e] += local_bias[e];
+          for (int e = 0; e < elems_per_item; ++e) {
+            res[e] += local_bias[e];
+          }
         }
-      }
 
-      if (act_mode == ActMode::silu) {
+        if (act_mode == ActMode::silu) {
 #pragma unroll
-        for (int e = 0; e < elems_per_item; ++e) {
-          act_silu(res[e]);
-        }
-      } else if (act_mode == ActMode::swish) {
+          for (int e = 0; e < elems_per_item; ++e) {
+            act_silu(res[e]);
+          }
+        } else if (act_mode == ActMode::swish) {
 #pragma unroll
-        for (int e = 0; e < elems_per_item; ++e) {
-          act_swish(res[e]);
+          for (int e = 0; e < elems_per_item; ++e) {
+            act_swish(res[e]);
+          }
         }
       }
 
@@ -407,15 +409,17 @@ struct chunk_causal_conv1d_tiled_kernel {
 
         float q_local_sq = 0.0f;
         float k_local_sq = 0.0f;
-        if (is_q) {
+        if (feat_valid) {
+          if (is_q) {
 #pragma unroll
-          for (int e = 0; e < elems_per_item; ++e)
-            q_local_sq += res[e] * res[e];
-        }
-        if (is_k) {
+            for (int e = 0; e < elems_per_item; ++e)
+              q_local_sq += res[e] * res[e];
+          }
+          if (is_k) {
 #pragma unroll
-          for (int e = 0; e < elems_per_item; ++e)
-            k_local_sq += res[e] * res[e];
+            for (int e = 0; e < elems_per_item; ++e)
+              k_local_sq += res[e] * res[e];
+          }
         }
 
         // Subgroup reduce
@@ -442,46 +446,50 @@ struct chunk_causal_conv1d_tiled_kernel {
         }
         sycl::group_barrier(item.get_group());  // protect SLM for next token
 
-        float q_inv = sycl::rsqrt(q_total + l2norm_eps) *
-                      sycl::rsqrt(static_cast<float>(q_dim));
-        float k_inv = sycl::rsqrt(k_total + l2norm_eps);
+        if (feat_valid) {
+          float q_inv = sycl::rsqrt(q_total + l2norm_eps) *
+                        sycl::rsqrt(static_cast<float>(q_dim));
+          float k_inv = sycl::rsqrt(k_total + l2norm_eps);
 
-        if (is_q) {
+          if (is_q) {
 #pragma unroll
-          for (int e = 0; e < elems_per_item; ++e)
-            res[e] *= q_inv;
-        }
-        if (is_k) {
+            for (int e = 0; e < elems_per_item; ++e)
+              res[e] *= q_inv;
+          }
+          if (is_k) {
 #pragma unroll
-          for (int e = 0; e < elems_per_item; ++e)
-            res[e] *= k_inv;
+            for (int e = 0; e < elems_per_item; ++e)
+              res[e] *= k_inv;
+          }
         }
       }
 
       // Write output
-      int token_in_seq = tile_start_in_seq + t;
-      int out_token_id = pre_chunks * chunk_size_xe2 + token_in_seq;
+      if (feat_valid) {
+        int token_in_seq = tile_start_in_seq + t;
+        int out_token_id = pre_chunks * chunk_size_xe2 + token_in_seq;
 
-      if (is_q) {
+        if (is_q) {
 #pragma unroll
-        for (int e = 0; e < elems_per_item; ++e) {
-          q_out
-              [out_token_id * num_k_heads * q_dim + k_head_id * q_dim + feat +
-               e] = res[e];
-        }
-      } else if (is_k) {
+          for (int e = 0; e < elems_per_item; ++e) {
+            q_out
+                [out_token_id * num_k_heads * q_dim + k_head_id * q_dim + feat +
+                 e] = res[e];
+          }
+        } else if (is_k) {
 #pragma unroll
-        for (int e = 0; e < elems_per_item; ++e) {
-          k_out
-              [out_token_id * num_k_heads * k_dim + k_head_id * k_dim + feat -
-               q_dim + e] = res[e];
-        }
-      } else {
+          for (int e = 0; e < elems_per_item; ++e) {
+            k_out
+                [out_token_id * num_k_heads * k_dim + k_head_id * k_dim + feat -
+                 q_dim + e] = res[e];
+          }
+        } else {
 #pragma unroll
-        for (int e = 0; e < elems_per_item; ++e) {
-          v_out
-              [out_token_id * num_k_heads * v_dim + k_head_id * v_dim + feat -
-               (q_dim + k_dim) + e] = res[e];
+          for (int e = 0; e < elems_per_item; ++e) {
+            v_out
+                [out_token_id * num_k_heads * v_dim + k_head_id * v_dim + feat -
+                 (q_dim + k_dim) + e] = res[e];
+          }
         }
       }
     }
@@ -568,28 +576,30 @@ struct chunk_causal_conv1d_tiled_kernel {
     // ========================================================================
     // Phase 3: Save conv_state for the last tile of each sequence
     // ========================================================================
-    if (tile_start_in_seq + TileT >= seq_len && seq_len > 1) {
-      int last_slot = (tile_tokens - 1) + (Width - 1);
+    if (feat_valid) {
+      if (tile_start_in_seq + TileT >= seq_len && seq_len > 1) {
+        int last_slot = (tile_tokens - 1) + (Width - 1);
 #pragma unroll
-      for (int i = 0; i < Width - 1; ++i) {
-        int slot = last_slot - (Width - 2) + i;
+        for (int i = 0; i < Width - 1; ++i) {
+          int slot = last_slot - (Width - 2) + i;
 #pragma unroll
-        for (int e = 0; e < elems_per_item; ++e) {
-          conv_states_tmp
-              [batch_id * (Width - 1) * conv_elems + i * conv_elems +
-               reordered_feat + e] =
-                  slm_input[slot * feats_per_wg + local_feat + e];
+          for (int e = 0; e < elems_per_item; ++e) {
+            conv_states_tmp
+                [batch_id * (Width - 1) * conv_elems + i * conv_elems +
+                 reordered_feat + e] =
+                    slm_input[slot * feats_per_wg + local_feat + e];
+          }
         }
-      }
-    } else if (seq_len == 1) {
-      T* st = conv_states + states_id * conv_states_stride_0;
+      } else if (seq_len == 1) {
+        T* st = conv_states + states_id * conv_states_stride_0;
 #pragma unroll
-      for (int i = 0; i < Width - 1; ++i) {
-        int slot = i + 1;
+        for (int i = 0; i < Width - 1; ++i) {
+          int slot = i + 1;
 #pragma unroll
-        for (int e = 0; e < elems_per_item; ++e) {
-          st[i * conv_elems + reordered_feat + e] =
-              slm_input[slot * feats_per_wg + local_feat + e];
+          for (int e = 0; e < elems_per_item; ++e) {
+            st[i * conv_elems + reordered_feat + e] =
+                slm_input[slot * feats_per_wg + local_feat + e];
+          }
         }
       }
     }

--- a/csrc/xpu/gdn_attn/xe_2/chunk_causal_conv1d_xe2.hpp
+++ b/csrc/xpu/gdn_attn/xe_2/chunk_causal_conv1d_xe2.hpp
@@ -630,8 +630,10 @@ struct chunk_update_states_kernel {
     for (int i = elems_start_offset_group + local_id;
          i < (local_group_id + 1) * elems_per_group;
          i += group_size) {
-      conv_states_ptr[width_id * conv_elems + i] =
-          conv_states_tmp_ptr[width_id * conv_elems + i];
+      if (i < conv_elems) {
+        conv_states_ptr[width_id * conv_elems + i] =
+            conv_states_tmp_ptr[width_id * conv_elems + i];
+      }
     }
   }
 

--- a/csrc/xpu/gdn_attn/xe_2/chunk_gated_delta_rule_kernels_xe2.hpp
+++ b/csrc/xpu/gdn_attn/xe_2/chunk_gated_delta_rule_kernels_xe2.hpp
@@ -378,6 +378,7 @@ CUTE_DEVICE void chunk_inverse_kernel(
                 static_cast<T>(A_ptr_save[m_idx * chunk_size + n_idx]);
           }
         }
+        item.barrier(sycl::access::fence_space::local_space);
       }
       chunk_id += global_chunk_range;
     }


### PR DESCRIPTION
This PR is to fix low accuracy of Qwen3.5-27B on B60. [VLLMZ-1515](https://jira.devtools.intel.com/browse/VLLMZ-1515)

Before:
vllm ({'pretrained': '/hf_models/Qwen3.5-27B/', 'enforce_eager': True, 'tensor_parallel_size': 4, 'add_bos_token': True, 'max_model_len': 32768}), gen_kwargs: ({'max_gen_toks': 4096}), limit: 200.0, num_fewshot: 5, batch_size: auto
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.085|±  |0.0198|
|     |       |strict-match    |     5|exact_match|↑  |0.080|±  |0.0192|

vllm ({'pretrained': '/hf_models/Qwen3.6-27B/', 'enforce_eager': True, 'tensor_parallel_size': 4, 'add_bos_token': True}), gen_kwargs: ({'max_gen_toks': 4096}), limit: 200.0, num_fewshot: 5, batch_size: auto
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |    0|±  |     0|
|     |       |strict-match    |     5|exact_match|↑  |    0|±  |     0|

After:
vllm ({'pretrained': '/hf_models/Qwen3.5-27B/', 'enforce_eager': True, 'tensor_parallel_size': 4, 'add_bos_token': True}), gen_kwargs: ({'max_gen_toks': 4096}), limit: 200.0, num_fewshot: 5, batch_size: auto
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.865|±  |0.0242|
|     |       |strict-match    |     5|exact_match|↑  |0.880|±  |0.0230|

vllm ({'pretrained': '/hf_models/Qwen3.6-27B/', 'enforce_eager': True, 'tensor_parallel_size': 4, 'add_bos_token': True}), gen_kwargs: ({'max_gen_toks': 4096}), limit: 200.0, num_fewshot: 5, batch_size: auto
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.700|±  |0.0325|
|     |       |strict-match    |     5|exact_match|↑  |0.705|±  |0.0323|

FULL GSM8K Test Result:
vllm ({'pretrained': '/hf_models/Qwen3.5-27B/', 'enforce_eager': True, 'tensor_parallel_size': 4, 'add_bos_token': True}), gen_kwargs: ({'max_gen_toks': 4096}), limit: None, num_fewshot: 5, batch_size: auto
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.8696|±  |0.0093|
|     |       |strict-match    |     5|exact_match|↑  |0.8878|±  |0.0087|