### PR TITLE
Add xe2 block_fp8 grouped_gemm kernel

### DIFF
--- a/benchmark/benchmark_cutlass_fused_moe.py
+++ b/benchmark/benchmark_cutlass_fused_moe.py
@@ -95,9 +95,6 @@ def make_fused_moe_input(config):
             "block fp8 requires hidden_size and intermediate_size " \
             "divisible by 128"
 
-        w13_fp8 = w13.to(w_dtype)
-        w2_fp8 = w2.to(w_dtype)
-
         w13_blk_scales = torch.pow(
             2.0,
             torch.randint(-3,
@@ -111,14 +108,23 @@ def make_fused_moe_input(config):
                               intermediate_size // block_size),
                           device=DEVICE).float())
 
-        ref_w13 = torch.empty_like(w13_fp8, dtype=x_dtype)
-        ref_w2 = torch.empty_like(w2_fp8, dtype=x_dtype)
+        w13_fp8 = torch.empty_like(w13, dtype=w_dtype)
+        w2_fp8 = torch.empty_like(w2, dtype=w_dtype)
+        ref_w13 = torch.empty_like(w13, dtype=x_dtype)
+        ref_w2 = torch.empty_like(w2, dtype=x_dtype)
         for i in range(num_experts):
+            # Quantize by dividing each 128x128 block by its scale before the
+            # fp8 cast (mirroring the per-tensor scaled_fp8_quant path), so the
+            # dequantized weight (fp8 * scale) reconstructs the original weight
+            # and output magnitudes stay in the same range as the bf16 / per-
+            # tensor reference.
             s13 = w13_blk_scales[i].repeat_interleave(
                 block_size, dim=0).repeat_interleave(block_size, dim=1)
+            w13_fp8[i] = (w13[i] / s13).to(w_dtype)
             ref_w13[i] = w13_fp8[i].to(x_dtype) * s13
             s2 = w2_blk_scales[i].repeat_interleave(
                 block_size, dim=0).repeat_interleave(block_size, dim=1)
+            w2_fp8[i] = (w2[i] / s2).to(w_dtype)
             ref_w2[i] = w2_fp8[i].to(x_dtype) * s2
         w13 = w13_fp8
         w2 = w2_fp8

--- a/benchmark/benchmark_cutlass_fused_moe.py
+++ b/benchmark/benchmark_cutlass_fused_moe.py
@@ -45,7 +45,7 @@ def calculate_memory_usage(m, n, k, num_experts, x_dtype, w_dtype=None):
 
 
 def make_fused_moe_input(config):
-    mnk, e, topk, x_dtype, w_dtype, has_bias = config
+    mnk, e, topk, x_dtype, w_dtype, has_bias, is_block_fp8 = config
     m, n, k = mnk
     input_len = m
     hidden_size = k
@@ -83,7 +83,49 @@ def make_fused_moe_input(config):
     flat_expert_indices = expert_indices.view(-1)
     flat_expert_weights = expert_scores.view(-1, 1)
 
-    if w_dtype is not None:
+    if w_dtype is not None and is_block_fp8:
+        # 128x128 block-wise fp8 weights. Weights are laid out [E, N, K] here
+        # (natural orientation) and transposed to the kernel's [E, K, N] below,
+        # so the kernel scales are the transpose of the natural block grid
+        # [E, N // 128, K // 128] -> [E, K // 128, N // 128].
+        block_size = 128
+        n13 = 2 * intermediate_size
+        assert (hidden_size % block_size == 0
+                and intermediate_size % block_size == 0), \
+            "block fp8 requires hidden_size and intermediate_size " \
+            "divisible by 128"
+
+        w13_fp8 = w13.to(w_dtype)
+        w2_fp8 = w2.to(w_dtype)
+
+        w13_blk_scales = torch.pow(
+            2.0,
+            torch.randint(-3,
+                          4, (num_experts, n13 // block_size,
+                              hidden_size // block_size),
+                          device=DEVICE).float())
+        w2_blk_scales = torch.pow(
+            2.0,
+            torch.randint(-3,
+                          4, (num_experts, hidden_size // block_size,
+                              intermediate_size // block_size),
+                          device=DEVICE).float())
+
+        ref_w13 = torch.empty_like(w13_fp8, dtype=x_dtype)
+        ref_w2 = torch.empty_like(w2_fp8, dtype=x_dtype)
+        for i in range(num_experts):
+            s13 = w13_blk_scales[i].repeat_interleave(
+                block_size, dim=0).repeat_interleave(block_size, dim=1)
+            ref_w13[i] = w13_fp8[i].to(x_dtype) * s13
+            s2 = w2_blk_scales[i].repeat_interleave(
+                block_size, dim=0).repeat_interleave(block_size, dim=1)
+            ref_w2[i] = w2_fp8[i].to(x_dtype) * s2
+        w13 = w13_fp8
+        w2 = w2_fp8
+        # kernel scales: [E, K // 128, N // 128]
+        w13_scales = w13_blk_scales.transpose(1, 2).contiguous()
+        w2_scales = w2_blk_scales.transpose(1, 2).contiguous()
+    elif w_dtype is not None:
         w13_fp8 = torch.empty_like(w13, dtype=w_dtype)
         w2_fp8 = torch.empty_like(w2, dtype=w_dtype)
 
@@ -126,7 +168,7 @@ def make_fused_moe_input(config):
 
 
 def calculate_diff(config):
-    _, e, topk, x_dtype, w_dtype, _ = config
+    _, e, topk, x_dtype, w_dtype, _, is_block_fp8 = config
     ref_a, ref_w13, w13_bias, ref_w2, w2_bias, flat_expert_weights, \
         flat_expert_indices, a, w13, w13_scales, w2, w2_scales, \
             expert_scores, expert_indices = make_fused_moe_input(config)
@@ -147,7 +189,9 @@ def calculate_diff(config):
                            n_experts_per_token=topk,
                            activation="silu",
                            num_experts=e,
-                           is_fp8=(w_dtype is not None))
+                           is_fp8=(w_dtype is not None
+                                   and not is_block_fp8),
+                           is_block_fp8=is_block_fp8)
     if x_dtype == torch.float16:
         rtol = 1e-2
         atol = 1e-2
@@ -168,7 +212,7 @@ def get_benchmark(iterations):
         triton.testing.Benchmark(
             x_names=[
                 "m", "n", "k", "num_experts", "topk", "x_dtype", "w_dtype",
-                "has_bias"
+                "has_bias", "is_block_fp8"
             ],
             x_vals=[(*tuple(c)[0], *tuple(c)[1:]) for c in configs],
             line_arg="provider",
@@ -202,11 +246,12 @@ def get_benchmark(iterations):
                   x_dtype,
                   w_dtype,
                   has_bias,
+                  is_block_fp8,
                   provider,
                   iterations=iterations):
         print(f"Running config: {m, n, k, num_experts, topk, \
                                 x_dtype, w_dtype, \
-                                has_bias}, Provider: {provider}",
+                                has_bias, is_block_fp8}, Provider: {provider}",
               flush=True)
         total_latency = 0.0
         ms = 0.0
@@ -218,7 +263,7 @@ def get_benchmark(iterations):
             _, a, w13, w13_scales, w2, w2_scales, \
                 expert_scores, expert_indices = make_fused_moe_input(
                     config=((m, n, k), num_experts,
-                            topk, x_dtype, w_dtype, has_bias))
+                            topk, x_dtype, w_dtype, has_bias, is_block_fp8))
 
         if provider == "vllm":
             start_event = torch.xpu.Event(enable_timing=True)
@@ -236,7 +281,9 @@ def get_benchmark(iterations):
                               n_experts_per_token=topk,
                               activation="silu",
                               num_experts=num_experts,
-                              is_fp8=(w_dtype is not None))
+                              is_fp8=(w_dtype is not None
+                                      and not is_block_fp8),
+                              is_block_fp8=is_block_fp8)
             start_event.record()
             for index in range(5, iterations):
                 xpu_fused_moe(hidden_states=a,
@@ -251,7 +298,9 @@ def get_benchmark(iterations):
                               n_experts_per_token=topk,
                               activation="silu",
                               num_experts=num_experts,
-                              is_fp8=(w_dtype is not None))
+                              is_fp8=(w_dtype is not None
+                                      and not is_block_fp8),
+                              is_block_fp8=is_block_fp8)
             end_event.record()
             torch.xpu.synchronize()
             total_latency = start_event.elapsed_time(end_event)
@@ -297,7 +346,8 @@ def get_benchmark(iterations):
                     n_experts_per_token=topk,
                     activation="silu",
                     num_experts=num_experts,
-                    is_fp8=(w_dtype is not None),
+                    is_fp8=(w_dtype is not None and not is_block_fp8),
+                    is_block_fp8=is_block_fp8,
                     start_event_remap=remap_se[i] if i is not None else None,
                     end_event_remap=remap_ee[i] if i is not None else None,
                     start_event_gemm1=gemm1_se[i] if i is not None else None,

--- a/benchmark/src/fused_moe_interface_.py
+++ b/benchmark/src/fused_moe_interface_.py
@@ -28,6 +28,7 @@ def xpu_fused_moe_CalKernelTime(hidden_states,
                                 is_fp8=False,
                                 is_int4=False,
                                 is_mxfp4=False,
+                                is_block_fp8=False,
                                 start_event_remap=None,
                                 end_event_remap=None,
                                 start_event_gemm1=None,
@@ -107,7 +108,7 @@ def xpu_fused_moe_CalKernelTime(hidden_states,
                                dtype=hidden_states.dtype,
                                device=hidden_states.device)
 
-    if not is_fp8 and not is_int4 and not is_mxfp4:
+    if not is_fp8 and not is_int4 and not is_mxfp4 and not is_block_fp8:
         gemm1_scales = None
         gemm2_scales = None
     else:
@@ -172,7 +173,8 @@ def xpu_fused_moe_CalKernelTime(hidden_states,
         K=hidden_size,
         num_experts=num_experts,
         is_B_int4=is_int4,
-        is_B_mxfp4=is_mxfp4)
+        is_B_mxfp4=is_mxfp4,
+        is_B_fp8block=is_block_fp8)
     if end_event_gemm1 is not None:
         end_event_gemm1.record()
     active_experts1 = (rows_per_expert > 0).sum().item()
@@ -212,7 +214,8 @@ def xpu_fused_moe_CalKernelTime(hidden_states,
         K=inter_size,
         num_experts=num_experts,
         is_B_int4=is_int4,
-        is_B_mxfp4=is_mxfp4)
+        is_B_mxfp4=is_mxfp4,
+        is_B_fp8block=is_block_fp8)
 
     if end_event_gemm2 is not None:
         end_event_gemm2.record()

--- a/benchmark/src/get_model_config.py
+++ b/benchmark/src/get_model_config.py
@@ -27,9 +27,16 @@ def gen_cutlass_fused_moe_correctness_configs():
     x_dtype = [torch.float16, torch.bfloat16]
     w_dtype = [torch.float8_e5m2, torch.float8_e4m3fn, None]
     has_bias = [True, False]
+    # block_fp8 = True uses 128x128 block-wise fp8 weight scales instead of a
+    # single per-expert (per-tensor) scale. It is only valid for fp8 weights
+    # whose N and K are both divisible by 128.
+    is_block = [False, True]
 
-    configs = list(
-        itertools.product(mnk, experts, topk, x_dtype, w_dtype, has_bias))
+    configs = [
+        (m, e, t, x, w, b, blk) for m, e, t, x, w, b, blk in itertools.product(
+            mnk, experts, topk, x_dtype, w_dtype, has_bias, is_block)
+        if not (blk and (w is None or m[1] % 128 != 0 or m[2] % 128 != 0))
+    ]
     return configs
 
 
@@ -38,6 +45,9 @@ def gen_cutlass_fused_moe_perf_configs():
     x_dtype = [torch.float16, torch.bfloat16]
     w_dtype = [torch.float8_e5m2, torch.float8_e4m3fn, None]
     has_bias = [True, False]
+    # block_fp8 = True uses 128x128 block-wise fp8 weight scales; only valid for
+    # fp8 weights with N and K both divisible by 128.
+    is_block = [False, True]
     input_lens = [1, 4, 16, 1024, 8192]
 
     for model in model_lists:
@@ -53,9 +63,13 @@ def gen_cutlass_fused_moe_perf_configs():
 
         moe_top_k = model_config["moe_config"]["moe_top_k"]
         num_experts = model_config["num_groups"]
-        configs += list(
-            itertools.product(mnk, [num_experts],
-                              [moe_top_k], x_dtype, w_dtype, has_bias))
+        configs += [
+            (mk, ne, tk, x, w, b, blk)
+            for mk, ne, tk, x, w, b, blk in itertools.product(
+                mnk, [num_experts], [moe_top_k], x_dtype, w_dtype, has_bias,
+                is_block)
+            if not (blk and (w is None or mk[1] % 128 != 0 or mk[2] % 128 != 0))
+        ]
 
     # Hardcoded model shapes (n, k, num_experts, topk) for various TP sizes.
     # Config tuple (m, n, k) produces:
@@ -99,16 +113,21 @@ def gen_cutlass_fused_moe_perf_configs():
     for n, k, num_experts, topk in hardcoded_model_shapes:
         mnk = list(zip(input_lens, [n] * len(input_lens),
                        [k] * len(input_lens)))
-        configs += list(
-            itertools.product(mnk, [num_experts],
-                              [topk], x_dtype, w_dtype, has_bias))
+        configs += [
+            (mk, ne, tk, x, w, b, blk)
+            for mk, ne, tk, x, w, b, blk in itertools.product(
+                mnk, [num_experts], [topk], x_dtype, w_dtype, has_bias,
+                is_block)
+            if not (blk and (w is None or mk[1] % 128 != 0 or mk[2] % 128 != 0))
+        ]
 
     configs = set(configs)  # remove duplicates
 
     def sort_key(x):
-        (m, n, k), moe_topk, topk_, x_dtype_, w_dtype_, bias_ = x
+        (m, n, k), moe_topk, topk_, x_dtype_, w_dtype_, bias_, blk_ = x
 
-        return (m, n, k, moe_topk, topk_, str(x_dtype_), str(w_dtype_), bias_)
+        return (m, n, k, moe_topk, topk_, str(x_dtype_), str(w_dtype_), bias_,
+                blk_)
 
     configs = sorted(configs, key=sort_key)
     return configs

--- a/csrc/xpu/grouped_gemm/grouped_gemm_interface.cpp
+++ b/csrc/xpu/grouped_gemm/grouped_gemm_interface.cpp
@@ -23,7 +23,7 @@ torch::Tensor cutlass_grouped_gemm_interface(
   const auto B_dtype = ptr_B.dtype();
   const bool is_B_fp8block =
       (B_dtype == at::kFloat8_e4m3fn || B_dtype == at::kFloat8_e5m2) &&
-      ptr_scales.has_value() && ptr_scales->dim() == 3;
+      ptr_B_scale.has_value() && ptr_B_scale->dim() == 3;
   if (vllm::xpu::force_xe_default_kernel()) {
 #ifdef VLLM_XPU_ENABLE_XE_DEFAULT
     TORCH_CHECK(

--- a/csrc/xpu/grouped_gemm/grouped_gemm_interface.cpp
+++ b/csrc/xpu/grouped_gemm/grouped_gemm_interface.cpp
@@ -19,8 +19,16 @@ torch::Tensor cutlass_grouped_gemm_interface(
     int64_t N,
     int64_t K,
     int64_t num_experts) {
+  const auto B_dtype = ptr_B.dtype();
+  const bool is_B_fp8block =
+      (B_dtype == at::kFloat8_e4m3fn || B_dtype == at::kFloat8_e5m2) &&
+      ptr_scales.has_value() && ptr_scales->dim() == 3;
   if (vllm::xpu::force_xe_default_kernel()) {
 #ifdef VLLM_XPU_ENABLE_XE_DEFAULT
+    TORCH_CHECK(
+        !is_B_fp8block,
+        "Block-wise FP8 grouped gemm is not supported by the XE default "
+        "kernel.");
     int64_t groups = num_experts;
     return cutlass_grouped_gemm_xe_default(
         ptr_A, ptr_B, ptr_bias, ptr_D, rows_per_expert, N, K, groups);
@@ -48,6 +56,10 @@ torch::Tensor cutlass_grouped_gemm_interface(
 #endif
   } else {
 #ifdef VLLM_XPU_ENABLE_XE_DEFAULT
+    TORCH_CHECK(
+        !is_B_fp8block,
+        "Block-wise FP8 grouped gemm is not supported by the XE default "
+        "kernel.");
     int64_t groups = num_experts;
     return cutlass_grouped_gemm_xe_default(
         ptr_A, ptr_B, ptr_bias, ptr_D, rows_per_expert, N, K, groups);

--- a/csrc/xpu/grouped_gemm/xe_2/gemm_xe2.hpp
+++ b/csrc/xpu/grouped_gemm/xe_2/gemm_xe2.hpp
@@ -233,6 +233,244 @@ CUTE_DEVICE void xe_gemm(
   copy(copy_c, tCrC_out, tCgC);
 }
 
+// Weight-only block-wise FP8 (W8A16) grouped GEMM.
+// Weights are FP8 with one FP32 scale per 128x128 (K x N) block.
+// Activations remain BF16/FP16. The scale is applied to the dequantized
+// weight fragment per 128-element K block before MMA accumulation. Because
+// every supported policy has tile_n <= 128 (and divides 128), the N-block
+// index is constant for a given output tile, so the scale is a scalar per
+// 128-K block.
+template <
+    class GmemTiledCopyA,
+    class GmemTiledCopyB,
+    class GmemTiledCopyC,
+    class ATensor,
+    class BTensor,
+    class DTensor,
+    class TiledMMA,
+    typename ElementS,
+    typename ElementBI>
+CUTE_DEVICE void xe_gemm_blockfp8(
+    ATensor const& A,  // (M,K)
+    BTensor const& B,  // (N,K)
+    const ElementS* Scales,
+    const ElementBI* Bias,
+    DTensor& C,  // (M,N)
+    Coord<int, int, cute::Underscore, int> blk_coord,
+    TiledMMA const& mma,
+    const int gemm_n) {
+  using TA = typename ATensor::element_type;
+  using TB = typename BTensor::element_type;
+  auto item = sycl::ext::oneapi::this_work_item::get_nd_item<3>();
+  auto wg_m = get<0>(blk_coord);
+  auto wg_n = get<1>(blk_coord);
+  int local_id = item.get_local_linear_id();
+
+  Tensor cA = make_identity_tensor(A.shape());
+  Tensor cB = make_identity_tensor(B.shape());
+  Tensor cC = make_identity_tensor(C.shape());
+
+  auto wg_tile = mma.tile_mnk();
+  auto wg_coord = make_coord(wg_m, wg_n, 0);
+
+  Tensor gA = local_tile(
+      cA, select<0, 2>(wg_tile), make_coord(wg_m, _));  // (BLK_M,BLK_K,k)
+  Tensor gB = local_tile(
+      cB, select<1, 2>(wg_tile), make_coord(wg_n, _));  // (BLK_N,BLK_K,k)
+  Tensor gC =
+      local_tile(cC, wg_tile, wg_coord, Step<_1, _1, X>{});  // (BLK_M,BLK_N)
+
+  auto copy_a = get_block_2d_copy_A<GmemTiledCopyA>(mma, A);
+  auto copy_b = get_block_2d_copy_B<GmemTiledCopyB>(mma, B);
+  auto copy_c = get_block_2d_copy_D<GmemTiledCopyC>(mma, C);
+
+  auto thr_mma = mma.get_slice(local_id);
+  auto thr_copy_a = copy_a.get_slice(local_id);
+  auto thr_copy_b = copy_b.get_slice(local_id);
+  auto thr_copy_c = copy_c.get_slice(local_id);
+
+  auto tCrA = thr_mma.partition_sg_fragment_A(gA(_, _, 0));
+  auto tCrB = thr_mma.partition_sg_fragment_B(gB(_, _, 0));
+
+  auto tArA = thr_copy_a.partition_sg_fragment_D(gA(_, _, 0));
+  auto tBrB = thr_copy_b.partition_sg_fragment_D(gB(_, _, 0));
+
+  Tensor tAgA = thr_copy_a.partition_S(gA);
+  Tensor tBgB = thr_copy_b.partition_S(gB);
+
+  /* Partition C */
+  auto tCrC = thr_mma.partition_sg_fragment_C(gC);
+  auto tCrC_out = thr_copy_c.partition_sg_fragment_S(gC);
+  auto tCgC = thr_copy_c.partition_D(gC);
+
+  auto prefetch_a = make_block_2d_prefetch(copy_a);
+  auto prefetch_b = make_block_2d_prefetch(copy_b);
+
+  auto thr_prefetch_A = prefetch_a.get_slice(local_id);
+  auto thr_prefetch_B = prefetch_b.get_slice(local_id);
+
+  auto pAgA = thr_prefetch_A.partition_S(gA);
+  auto pBgB = thr_prefetch_B.partition_S(gB);
+
+  const int prefetch_dist = 3;
+
+  constexpr int barrier_scope = 2;
+
+  static constexpr int block_size = 128;
+  static constexpr auto tile_m = get<0>(wg_tile);
+  static constexpr auto tile_n = get<1>(wg_tile);
+  static constexpr auto tile_k = get<2>(wg_tile);
+  int num_n_blocks = gemm_n / block_size;
+  int n_block = (wg_n * tile_n) / block_size;
+
+  int k_tile_count = ceil_div(shape<1>(A), get<2>(wg_tile));
+  int k_tile_prefetch = 0;
+
+  // The block scale is a single scalar for this output tile's N-block (tile_n <=
+  // 128), so it only depends on the K-block. The scale loads are software-
+  // pipelined either way: the next K-block's scale is loaded one block
+  // (block_size / tile_k k-tiles) before it is consumed, so its global-memory
+  // latency overlaps the intervening MMAs instead of stalling the inner loop.
+  //
+  // Two schemes are selected at compile time by the workgroup M tile:
+  //  * Small M (tile_m <= 32: decode / MoE small-batch, the latency-critical and
+  //    memory-bound regime where weight-only fp8 wins most): a second C
+  //    accumulator holds the unscaled partial sum of the current 128-K block,
+  //    and the scale is folded into the final accumulator only at each 128-K
+  //    boundary. The inner MMA loop is then identical to the unscaled/per-tensor
+  //    path (no per-k-tile scaling). The small per-sub-group C fragment lets both
+  //    accumulators stay in registers without spilling.
+  //  * Large M (tile_m == 128: prefill, compute-bound): a second 128x128 C
+  //    accumulator would spill, so the scale is instead folded into the
+  //    activation fragment A in place each k-tile (scale_b * (A.B) ==
+  //    (scale_b * A).B) using a single accumulator.
+  static constexpr bool use_block_accum = (tile_m <= 32);
+  using TAScale = typename ATensor::element_type;
+  int num_k_blocks = ceil_div(static_cast<int>(shape<1>(A)), block_size);
+  float next_raw_scale =
+      (num_k_blocks > 0) ? Scales[n_block] : 1.0f;  // K-block 0
+
+  clear(tCrC);
+
+  CUTE_UNROLL
+  for (; k_tile_prefetch < prefetch_dist; k_tile_prefetch++) {
+    prefetch(prefetch_a, pAgA(_, _, _, k_tile_prefetch));
+    prefetch(prefetch_b, pBgB(_, _, _, k_tile_prefetch));
+  }
+
+  if constexpr (use_block_accum) {
+    // Small-M path: clean inner loop, fold the block scale at each 128-K
+    // boundary using a second (register-resident) accumulator.
+    auto tCrC_blk = thr_mma.partition_sg_fragment_C(gC);
+    clear(tCrC_blk);
+    float cur_scale = 1.0f;
+
+    for (int k_tile = 0; k_tile < k_tile_count; k_tile++, k_tile_prefetch++) {
+      barrier_arrive(barrier_scope);
+
+      copy(copy_a, tAgA(_, _, _, k_tile), tArA);
+      copy(copy_b, tBgB(_, _, _, k_tile), tBrB);
+
+      if (k_tile_prefetch < k_tile_count) {
+        prefetch(prefetch_a, pAgA(_, _, _, k_tile_prefetch));
+        prefetch(prefetch_b, pBgB(_, _, _, k_tile_prefetch));
+      }
+
+      if ((k_tile * tile_k) % block_size == 0) {
+        cur_scale = next_raw_scale;
+        int next_k_block = (k_tile * tile_k) / block_size + 1;
+        if (next_k_block < num_k_blocks) {
+          next_raw_scale = Scales[next_k_block * num_n_blocks + n_block];
+        }
+      }
+
+      reorder(tArA, tCrA);
+      reorder(tBrB, tCrB);
+
+      cute::gemm(mma, tCrA, tCrB, tCrC_blk);
+
+      // At the end of each 128-K block, fold the unscaled partial sum into the
+      // final accumulator with this block's scale, then reset. K is divisible by
+      // 128, so the final block always folds.
+      if (((k_tile + 1) * tile_k) % block_size == 0) {
+        CUTLASS_PRAGMA_UNROLL
+        for (int i = 0; i < tCrC.size(); ++i) {
+          tCrC(i) += cur_scale * tCrC_blk(i);
+        }
+        clear(tCrC_blk);
+      }
+
+      barrier_wait(barrier_scope);
+    }
+  } else {
+    // Large-M path: single accumulator, fold the block scale into A each k-tile.
+    TAScale cur_scale = static_cast<TAScale>(1);
+
+    for (int k_tile = 0; k_tile < k_tile_count; k_tile++, k_tile_prefetch++) {
+      barrier_arrive(barrier_scope);
+
+      copy(copy_a, tAgA(_, _, _, k_tile), tArA);
+      copy(copy_b, tBgB(_, _, _, k_tile), tBrB);
+
+      if (k_tile_prefetch < k_tile_count) {
+        prefetch(prefetch_a, pAgA(_, _, _, k_tile_prefetch));
+        prefetch(prefetch_b, pBgB(_, _, _, k_tile_prefetch));
+      }
+
+      if ((k_tile * tile_k) % block_size == 0) {
+        cur_scale = static_cast<TAScale>(next_raw_scale);
+        int next_k_block = (k_tile * tile_k) / block_size + 1;
+        if (next_k_block < num_k_blocks) {
+          next_raw_scale = Scales[next_k_block * num_n_blocks + n_block];
+        }
+      }
+
+      reorder(tArA, tCrA);
+      reorder(tBrB, tCrB);
+
+      CUTLASS_PRAGMA_UNROLL
+      for (int i = 0; i < tCrA.size(); ++i) {
+        tCrA(i) = tCrA(i) * cur_scale;
+      }
+
+      cute::gemm(mma, tCrA, tCrB, tCrC);
+
+      barrier_wait(barrier_scope);
+    }
+  }
+
+  if (Bias != nullptr) {
+    static constexpr auto ATOM_M =
+        get<1>(typename TiledMMA::ThrLayoutVMNK{}.shape());
+    static constexpr auto ATOM_N =
+        get<2>(typename TiledMMA::ThrLayoutVMNK{}.shape());
+
+    auto sg_local_n_coord = cutlass::get_sub_group_id() % ATOM_N;
+
+    static constexpr auto SG_M = tile_m / ATOM_M;  // BLK_M / ATOM_M;
+    static constexpr auto SG_N = tile_n / ATOM_N;  // BLK_N / ATOM_N;
+
+    int sg_local_id = cutlass::get_sub_group_local_id();
+    static constexpr int sg_local_range = 16;
+
+    int n_tile_start = wg_n * tile_n;
+    int n_sg_start = sg_local_n_coord * SG_N;
+
+    CUTLASS_PRAGMA_UNROLL
+    for (int sn = 0; sn < SG_N / sg_local_range; ++sn) {
+      int sg_local_n = sn * sg_local_range + sg_local_id;
+      float b_float = Bias[n_tile_start + n_sg_start + sg_local_n];
+      CUTLASS_PRAGMA_UNROLL
+      for (int sm = 0; sm < SG_M; ++sm) {
+        tCrC(sn * SG_M + sm) += b_float;
+      }
+    }
+  }
+
+  reorder(tCrC, tCrC_out);
+  copy(copy_c, tCrC_out, tCgC);
+}
+
 template <
     class GmemTiledCopyA,
     class GmemTiledCopyB,

--- a/csrc/xpu/grouped_gemm/xe_2/gemm_xe2.hpp
+++ b/csrc/xpu/grouped_gemm/xe_2/gemm_xe2.hpp
@@ -234,12 +234,8 @@ CUTE_DEVICE void xe_gemm(
 }
 
 // Weight-only block-wise FP8 (W8A16) grouped GEMM.
-// Weights are FP8 with one FP32 scale per 128x128 (K x N) block.
-// Activations remain BF16/FP16. The scale is applied to the dequantized
-// weight fragment per 128-element K block before MMA accumulation. Because
-// every supported policy has tile_n <= 128 (and divides 128), the N-block
-// index is constant for a given output tile, so the scale is a scalar per
-// 128-K block.
+// FP8 weights with one FP32 scale per 128x128 (K x N) block.
+// Activations remain BF16/FP16.
 template <
     class GmemTiledCopyA,
     class GmemTiledCopyB,
@@ -326,24 +322,14 @@ CUTE_DEVICE void xe_gemm_blockfp8(
   int k_tile_count = ceil_div(shape<1>(A), get<2>(wg_tile));
   int k_tile_prefetch = 0;
 
-  // The block scale is a single scalar for this output tile's N-block (tile_n <=
-  // 128), so it only depends on the K-block. The scale loads are software-
-  // pipelined either way: the next K-block's scale is loaded one block
-  // (block_size / tile_k k-tiles) before it is consumed, so its global-memory
-  // latency overlaps the intervening MMAs instead of stalling the inner loop.
-  //
-  // Two schemes are selected at compile time by the workgroup M tile:
-  //  * Small M (tile_m <= 32: decode / MoE small-batch, the latency-critical and
-  //    memory-bound regime where weight-only fp8 wins most): a second C
-  //    accumulator holds the unscaled partial sum of the current 128-K block,
-  //    and the scale is folded into the final accumulator only at each 128-K
-  //    boundary. The inner MMA loop is then identical to the unscaled/per-tensor
-  //    path (no per-k-tile scaling). The small per-sub-group C fragment lets both
-  //    accumulators stay in registers without spilling.
-  //  * Large M (tile_m == 128: prefill, compute-bound): a second 128x128 C
-  //    accumulator would spill, so the scale is instead folded into the
-  //    activation fragment A in place each k-tile (scale_b * (A.B) ==
-  //    (scale_b * A).B) using a single accumulator.
+  // One scalar block scale per output tile (tile_n <= 128), depending only on
+  // the K-block; the next block's scale is prefetched a block ahead so its load
+  // overlaps the MMAs. Two compile-time schemes by M tile:
+  //  * Small M (tile_m <= 32): a second C accumulator sums each 128-K block
+  //    unscaled and is folded in (scaled) at the block boundary, keeping the
+  //    inner loop scale-free. Both accumulators fit in registers at small M.
+  //  * Large M (tile_m == 128): a second 128x128 accumulator would spill, so
+  //    the scale is folded into A each k-tile (scale_b*(A.B) == (scale_b*A).B).
   static constexpr bool use_block_accum = (tile_m <= 32);
   using TAScale = typename ATensor::element_type;
   int num_k_blocks = ceil_div(static_cast<int>(shape<1>(A)), block_size);
@@ -359,8 +345,8 @@ CUTE_DEVICE void xe_gemm_blockfp8(
   }
 
   if constexpr (use_block_accum) {
-    // Small-M path: clean inner loop, fold the block scale at each 128-K
-    // boundary using a second (register-resident) accumulator.
+    // Small-M path: scale-free inner loop, folding each 128-K block into the
+    // final accumulator via a second register-resident accumulator.
     auto tCrC_blk = thr_mma.partition_sg_fragment_C(gC);
     clear(tCrC_blk);
     float cur_scale = 1.0f;
@@ -389,9 +375,8 @@ CUTE_DEVICE void xe_gemm_blockfp8(
 
       cute::gemm(mma, tCrA, tCrB, tCrC_blk);
 
-      // At the end of each 128-K block, fold the unscaled partial sum into the
-      // final accumulator with this block's scale, then reset. K is divisible by
-      // 128, so the final block always folds.
+      // Fold this block's unscaled sum (scaled) into tCrC at each 128-K
+      // boundary, then reset. K % 128 == 0, so the last block always folds.
       if (((k_tile + 1) * tile_k) % block_size == 0) {
         CUTLASS_PRAGMA_UNROLL
         for (int i = 0; i < tCrC.size(); ++i) {

--- a/csrc/xpu/grouped_gemm/xe_2/gemm_xe2.hpp
+++ b/csrc/xpu/grouped_gemm/xe_2/gemm_xe2.hpp
@@ -388,7 +388,7 @@ CUTE_DEVICE void xe_gemm_blockfp8(
       barrier_wait(barrier_scope);
     }
   } else {
-    // Large-M path: single accumulator, fold the block scale into A each k-tile.
+    // Large-M path: single accumulator, fold block scale into A each k-tile.
     TAScale cur_scale = static_cast<TAScale>(1);
 
     for (int k_tile = 0; k_tile < k_tile_count; k_tile++, k_tile_prefetch++) {

--- a/csrc/xpu/grouped_gemm/xe_2/grouped_gemm_xe2.hpp
+++ b/csrc/xpu/grouped_gemm/xe_2/grouped_gemm_xe2.hpp
@@ -150,7 +150,8 @@ CUTE_DEVICE void MoEGEMM(
     } else if constexpr (IsBlockScale) {
       int64_t num_k_blocks = static_cast<int64_t>(gemm_k) / 128;
       int64_t num_n_blocks = static_cast<int64_t>(gemm_n) / 128;
-      ptr_Scales_curr_batch = const_cast<ElementS*>(Scales) +
+      ptr_Scales_curr_batch =
+          const_cast<ElementS*>(Scales) +
           static_cast<int64_t>(expert_id) * num_k_blocks * num_n_blocks;
     }
     ElementBI* ptr_Bias_curr_batch = nullptr;

--- a/csrc/xpu/grouped_gemm/xe_2/grouped_gemm_xe2.hpp
+++ b/csrc/xpu/grouped_gemm/xe_2/grouped_gemm_xe2.hpp
@@ -65,6 +65,7 @@ template <
     char LayoutKindA,
     char LayoutKindB,
     char LayoutKindD,
+    bool IsBlockScale,
     class TiledMMA,
     typename ElementA,
     typename ElementB,
@@ -146,6 +147,11 @@ CUTE_DEVICE void MoEGEMM(
     if constexpr (is_B_4bits) {
       ptr_Scales_curr_batch =
           const_cast<ElementS*>(Scales) + B_offset * 2 / group_size;
+    } else if constexpr (IsBlockScale) {
+      int64_t num_k_blocks = static_cast<int64_t>(gemm_k) / 128;
+      int64_t num_n_blocks = static_cast<int64_t>(gemm_n) / 128;
+      ptr_Scales_curr_batch = const_cast<ElementS*>(Scales) +
+          static_cast<int64_t>(expert_id) * num_k_blocks * num_n_blocks;
     }
     ElementBI* ptr_Bias_curr_batch = nullptr;
     if (Bias != static_cast<ElementBI*>(nullptr)) {
@@ -194,6 +200,16 @@ CUTE_DEVICE void MoEGEMM(
           XE_GEMM_4BITS_CALLER(256)
         }
 #undef XE_GEMM_4BITS_CALLER
+      } else if constexpr (IsBlockScale) {
+        xe_gemm_blockfp8<GmemTiledCopyA, GmemTiledCopyB, GmemTiledCopyD>(
+            A_tensor,
+            B_tensor,
+            ptr_Scales_curr_batch,
+            ptr_Bias_curr_batch,
+            D_tensor,
+            tile_coord,
+            mma,
+            gemm_n);
       } else {
         xe_gemm<GmemTiledCopyA, GmemTiledCopyB, GmemTiledCopyD>(
             A_tensor,

--- a/csrc/xpu/grouped_gemm/xe_2/grouped_gemm_xe2_interface.hpp
+++ b/csrc/xpu/grouped_gemm/xe_2/grouped_gemm_xe2_interface.hpp
@@ -64,13 +64,14 @@ namespace MoE {
 using namespace cute;
 
 // type tag to define a unique sycl kernel name
-template <typename, typename, typename, typename, char, char, class>
+template <typename, typename, typename, typename, char, char, class, bool>
 class GemmCuteName;
 
 template <
     char layoutA,
     char layoutB,
     class policy,
+    bool IsBlockScale = false,
     typename ElementA,
     typename ElementB,
     typename ElementS,
@@ -133,7 +134,8 @@ void MoEGEMMLauncher(
         ElementD,
         layoutA,
         layoutB,
-        policy>>(
+        policy,
+        IsBlockScale>>(
         sycl::nd_range<3>{global * local, local}, kernel_props, [=](auto) {
           MoE::MoEGEMM<
               GmemTiledCopyA,
@@ -141,7 +143,8 @@ void MoEGEMMLauncher(
               GmemTiledCopyD,
               layoutA,
               layoutB,
-              'R'>(
+              'R',
+              IsBlockScale>(
               activations,
               weights,
               scales,
@@ -178,6 +181,8 @@ at::Tensor cutlass_grouped_gemm_xe2_impl(
   bool is_B_int4 = (B_dtype == at::kChar) && ptr_scales.has_value();
   bool is_B_mxfp4 =
       (B_dtype == at::kFloat4_e2m1fn_x2) && ptr_scales.has_value();
+  bool is_B_fp8block =
+      is_weight_fp8 && ptr_scales.has_value() && ptr_scales->dim() == 3;
 
   TORCH_CHECK(N % 8 == 0, "N must be divisible by 8");
 
@@ -228,6 +233,25 @@ at::Tensor cutlass_grouped_gemm_xe2_impl(
 #define MoEGEMMLauncherCallER(                                                 \
     LayoutA, LayoutB, Policy, ElementA, ElementB, ElementS)                    \
   MoEGEMMLauncher<LayoutA, LayoutB, Policy>(                                   \
+      dpcpp_queue,                                                             \
+      reinterpret_cast<ElementA*>(ptr_A.data_ptr()),                           \
+      reinterpret_cast<ElementB*>(ptr_B.data_ptr()),                           \
+      ptr_scales.has_value()                                                   \
+          ? reinterpret_cast<ElementS*>(ptr_scales->data_ptr())                \
+          : static_cast<ElementS*>(nullptr),                                   \
+      ptr_bias.has_value() ? reinterpret_cast<ElementA*>(ptr_bias->data_ptr()) \
+                           : static_cast<ElementA*>(nullptr),                  \
+      reinterpret_cast<ElementA*>(ptr_D.data_ptr()),                           \
+      N,                                                                       \
+      K,                                                                       \
+      reinterpret_cast<int*>(rows_per_expert.data_ptr()),                      \
+      num_experts,                                                             \
+      group_size,                                                              \
+      static_cast<int*>(atomic_buffer.data_ptr()));
+
+#define MoEGEMMBlockLauncherCallER(                                            \
+    LayoutA, LayoutB, Policy, ElementA, ElementB, ElementS)                    \
+  MoEGEMMLauncher<LayoutA, LayoutB, Policy, /*IsBlockScale=*/true>(            \
       dpcpp_queue,                                                             \
       reinterpret_cast<ElementA*>(ptr_A.data_ptr()),                           \
       reinterpret_cast<ElementB*>(ptr_B.data_ptr()),                           \
@@ -299,6 +323,61 @@ at::Tensor cutlass_grouped_gemm_xe2_impl(
       W4A16LauncherCallER(policy);
     }
 #undef W4A16LauncherCallER
+  } else if (is_B_fp8block) {
+    TORCH_CHECK(
+        is_weight_fp8, "block fp8 grouped gemm must have fp8 weights");
+    TORCH_CHECK(
+        ptr_scales.has_value(), "block fp8 grouped gemm must have scales");
+    TORCH_CHECK(ptr_scales->is_contiguous(), "ptr_scales must be contiguous");
+    TORCH_CHECK(ptr_scales->dtype() == at::kFloat, "ptr_scales must be float");
+    TORCH_CHECK(
+        ptr_scales->dim() == 3,
+        "ptr_scales of block fp8 must be 3D [num_experts, K / 128, N / 128]");
+    TORCH_CHECK(
+        ptr_scales->size(0) == num_experts,
+        "ptr_scales.size(0) of block fp8 must match num_experts");
+    TORCH_CHECK(
+        K % 128 == 0, "K must be divisible by 128 for block fp8 grouped gemm");
+    TORCH_CHECK(
+        N % 128 == 0, "N must be divisible by 128 for block fp8 grouped gemm");
+    TORCH_CHECK(
+        ptr_scales->size(1) == K / 128,
+        "ptr_scales.size(1) of block fp8 must be K / 128");
+    TORCH_CHECK(
+        ptr_scales->size(2) == N / 128,
+        "ptr_scales.size(2) of block fp8 must be N / 128");
+    group_size = 128;
+
+#define W8A16BlockLauncherCallER(policy)                                   \
+  if (B_dtype == at::kFloat8_e4m3fn && A_dtype == at::kHalf) {             \
+    using scalar_t = half_t;                                               \
+    MoEGEMMBlockLauncherCallER(                                            \
+        'R', 'R', policy, scalar_t, float_e4m3_t, float);                 \
+  } else if (B_dtype == at::kFloat8_e5m2 && A_dtype == at::kHalf) {        \
+    using scalar_t = half_t;                                               \
+    MoEGEMMBlockLauncherCallER(                                            \
+        'R', 'R', policy, scalar_t, float_e5m2_t, float);                 \
+  } else if (B_dtype == at::kFloat8_e4m3fn && A_dtype == at::kBFloat16) {  \
+    using scalar_t = bfloat16_t;                                           \
+    MoEGEMMBlockLauncherCallER(                                            \
+        'R', 'R', policy, scalar_t, float_e4m3_t, float);                 \
+  } else if (B_dtype == at::kFloat8_e5m2 && A_dtype == at::kBFloat16) {    \
+    using scalar_t = bfloat16_t;                                           \
+    MoEGEMMBlockLauncherCallER(                                            \
+        'R', 'R', policy, scalar_t, float_e5m2_t, float);                 \
+  }
+
+    if (A_avg_M <= 8) {
+      using policy = w8a16_policy_m_16;
+      W8A16BlockLauncherCallER(policy);
+    } else if (A_avg_M <= 32) {
+      using policy = w8a16_policy_m_32;
+      W8A16BlockLauncherCallER(policy);
+    } else {
+      using policy = w8a16_policy;
+      W8A16BlockLauncherCallER(policy);
+    }
+#undef W8A16BlockLauncherCallER
   } else if (is_weight_fp8) {
     TORCH_CHECK(ptr_scales.has_value(), "w8a16 grouped gemm must have scales");
     TORCH_CHECK(ptr_scales->is_contiguous(), "ptr_scales must be contiguous");
@@ -368,6 +447,7 @@ at::Tensor cutlass_grouped_gemm_xe2_impl(
     }
 #undef W16A16LauncherCallER
   }
+#undef MoEGEMMBlockLauncherCallER
 #undef MoEGEMMLauncherCallER
   return ptr_D;
 }

--- a/csrc/xpu/grouped_gemm/xe_2/grouped_gemm_xe2_interface.hpp
+++ b/csrc/xpu/grouped_gemm/xe_2/grouped_gemm_xe2_interface.hpp
@@ -324,8 +324,7 @@ at::Tensor cutlass_grouped_gemm_xe2_impl(
     }
 #undef W4A16LauncherCallER
   } else if (is_B_fp8block) {
-    TORCH_CHECK(
-        is_weight_fp8, "block fp8 grouped gemm must have fp8 weights");
+    TORCH_CHECK(is_weight_fp8, "block fp8 grouped gemm must have fp8 weights");
     TORCH_CHECK(
         ptr_scales.has_value(), "block fp8 grouped gemm must have scales");
     TORCH_CHECK(ptr_scales->is_contiguous(), "ptr_scales must be contiguous");
@@ -348,22 +347,22 @@ at::Tensor cutlass_grouped_gemm_xe2_impl(
         "ptr_scales.size(2) of block fp8 must be N / 128");
     group_size = 128;
 
-#define W8A16BlockLauncherCallER(policy)                                   \
-  if (B_dtype == at::kFloat8_e4m3fn && A_dtype == at::kHalf) {             \
-    using scalar_t = half_t;                                               \
-    MoEGEMMBlockLauncherCallER(                                            \
+#define W8A16BlockLauncherCallER(policy)                                  \
+  if (B_dtype == at::kFloat8_e4m3fn && A_dtype == at::kHalf) {            \
+    using scalar_t = half_t;                                              \
+    MoEGEMMBlockLauncherCallER(                                           \
         'R', 'R', policy, scalar_t, float_e4m3_t, float);                 \
-  } else if (B_dtype == at::kFloat8_e5m2 && A_dtype == at::kHalf) {        \
-    using scalar_t = half_t;                                               \
-    MoEGEMMBlockLauncherCallER(                                            \
+  } else if (B_dtype == at::kFloat8_e5m2 && A_dtype == at::kHalf) {       \
+    using scalar_t = half_t;                                              \
+    MoEGEMMBlockLauncherCallER(                                           \
         'R', 'R', policy, scalar_t, float_e5m2_t, float);                 \
-  } else if (B_dtype == at::kFloat8_e4m3fn && A_dtype == at::kBFloat16) {  \
-    using scalar_t = bfloat16_t;                                           \
-    MoEGEMMBlockLauncherCallER(                                            \
+  } else if (B_dtype == at::kFloat8_e4m3fn && A_dtype == at::kBFloat16) { \
+    using scalar_t = bfloat16_t;                                          \
+    MoEGEMMBlockLauncherCallER(                                           \
         'R', 'R', policy, scalar_t, float_e4m3_t, float);                 \
-  } else if (B_dtype == at::kFloat8_e5m2 && A_dtype == at::kBFloat16) {    \
-    using scalar_t = bfloat16_t;                                           \
-    MoEGEMMBlockLauncherCallER(                                            \
+  } else if (B_dtype == at::kFloat8_e5m2 && A_dtype == at::kBFloat16) {   \
+    using scalar_t = bfloat16_t;                                          \
+    MoEGEMMBlockLauncherCallER(                                           \
         'R', 'R', policy, scalar_t, float_e5m2_t, float);                 \
   }
 

--- a/tests/fused_moe/test_grouped_gemm.py
+++ b/tests/fused_moe/test_grouped_gemm.py
@@ -220,6 +220,74 @@ def test_xe_grouped_gemm_fp8(m, n, k, e, topk, dtype, fp8_dtype, has_bias):
     torch.testing.assert_close(output, ref, rtol=1e-2, atol=1e-2)
 
 
+@pytest.mark.parametrize("m,n,k", FUSED_MOE_MNK_FACTORS)
+@pytest.mark.parametrize("e", NUM_EXPERTS)
+@pytest.mark.parametrize("topk", TOP_KS)
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16],
+                         ids=format_tc)
+@pytest.mark.parametrize("fp8_dtype", [torch.float8_e5m2, torch.float8_e4m3fn],
+                         ids=format_tc)
+@pytest.mark.parametrize("has_bias", [False, True])
+def test_xe_grouped_gemm_block_fp8(m, n, k, e, topk, dtype, fp8_dtype,
+                                   has_bias):
+    seed_everything(7)
+    block_size = 128
+    if n % block_size != 0 or k % block_size != 0:
+        pytest.skip("block fp8 requires N and K divisible by 128")
+    num_experts = e
+    total_m = m * topk
+    num_k_blocks = k // block_size
+    num_n_blocks = n // block_size
+    # input
+    input_A = torch.randn((total_m, k), dtype=dtype,
+                          device=DEVICE).contiguous()
+    ref_A = input_A
+    # weight: fp8 [num_experts, K, N]
+    input_B_fp8 = torch.randn(
+        (num_experts, k, n), dtype=dtype, device=DEVICE).to(fp8_dtype)
+    # 128x128 block scales [num_experts, K // 128, N // 128]
+    random_exponents = torch.randint(
+        -3, 4, (num_experts, num_k_blocks, num_n_blocks), device=DEVICE)
+    scale_B = torch.pow(2.0, random_exponents.float()).contiguous()
+
+    if has_bias:
+        bias = torch.randn((num_experts, n), dtype=dtype, device=DEVICE) * 100
+    else:
+        bias = None
+
+    # output offset
+    num_rows_per_expert = torch.zeros(num_experts,
+                                      device=DEVICE,
+                                      dtype=torch.int32)
+    init_rows_for_experts(m, topk, num_rows_per_expert)
+    output = torch.empty((total_m, n), dtype=dtype, device=DEVICE)
+
+    cutlass_grouped_gemm_xe2(input_A, input_B_fp8, scale_B, bias, output,
+                             num_rows_per_expert, n, k, num_experts)
+    # ref gg
+    ref = []
+    pre_token_sum = 0
+    for i in range(num_experts):
+        cur_token_num = num_rows_per_expert[i]
+        if cur_token_num == 0:
+            continue
+        # mma uses fp32 as calculate dtype
+        # so here use fp32 to avoid accuracy error
+        input = ref_A[pre_token_sum:pre_token_sum + cur_token_num, :].to(
+            torch.float32)
+        scale_full = scale_B[i].repeat_interleave(
+            block_size, dim=0).repeat_interleave(block_size, dim=1)
+        weight = input_B_fp8[i].to(torch.float32) * scale_full
+        expert_output_fp32 = input @ weight
+        if has_bias:
+            expert_output_fp32 += bias[i]
+        ref.append(expert_output_fp32.to(dtype))
+        pre_token_sum += cur_token_num
+    ref = torch.cat(ref, dim=0)
+
+    torch.testing.assert_close(output, ref, rtol=1e-2, atol=1e-1)
+
+
 def dequantize_uint4(qweight, scales, group_size):
     import numpy as np
     k = qweight.shape[1] * 2

--- a/vllm_xpu_kernels/fused_moe_interface.py
+++ b/vllm_xpu_kernels/fused_moe_interface.py
@@ -209,7 +209,6 @@ class XpuFusedMoe:
         else:
             self.gemm1_scales = w13_scales
             self.gemm2_scales = w2_scales
-
         self.w13_bias = w13_bias
         self.w2_bias = w2_bias
 

--- a/vllm_xpu_kernels/fused_moe_interface.py
+++ b/vllm_xpu_kernels/fused_moe_interface.py
@@ -209,6 +209,7 @@ class XpuFusedMoe:
         else:
             self.gemm1_scales = w13_scales
             self.gemm2_scales = w2_scales
+
         self.w13_bias = w13_bias
         self.w2_bias = w2_bias
 

--- a/vllm_xpu_kernels/fused_moe_interface.py
+++ b/vllm_xpu_kernels/fused_moe_interface.py
@@ -24,7 +24,7 @@ def _is_env_enabled(env_name: str, default: str = "0") -> bool:
 
 
 def _should_use_ref_fused_moe(is_mxfp8: bool, is_block_fp8: bool) -> bool:  
-    if is_mxfp8 or is_block_fp8:
+    if is_mxfp8 or (is_block_fp8 and not torch.ops._xpu_C.is_xe2_arch()):
         return True
     return _is_env_enabled(REF_FUSED_MOE_ENV)
 


### PR DESCRIPTION

## Purpose

Add **block-wise FP8 (W8A16)** weight quantization support to the Xe2 grouped GEMM that backs the fused-MoE op. Weights are stored in FP8 (`e4m3`/`e5m2`) with a **128×128 block scale grid** and dequantized on the fly against BF16/FP16 activations, complementing the existing per-tensor FP8 path. This matches the block-scaled FP8 checkpoints in DeepSeek-V2/V3, Qwen3-MoE, etc.

## Test Plan

- **Correctness** — block-FP8 output vs a dequantized (`fp8 → x_dtype × scale`) reference MoE:
  ```bash
  pytest tests/fused_moe/test_grouped_gemm.py
  ```
  Also exercised via the benchmark's `calculate_diff` against `ref_fused_moe` across model shapes, both activation dtypes (`bf16`/`fp16`), both weight dtypes (`e4m3`/`e5m2`), and with/without bias.
- **Performance** — per-stage (remap / gemm1 / gemm2 / gather) latency + TFLOPS sweep over representative MoE shapes:
  ```bash
  python benchmark/benchmark_cutlass_fused_moe.py
  ```

## Test Result
Tests were executed on PVC Max 1550.

- **Correctness:** all configs pass `torch.testing.assert_close` within the per-dtype `rtol/atol` (block-FP8, per-tensor FP8, and BF16 baselines).
- **Performance:** block-FP8 is ~10% slower than per-tensor FP8, with the worst gap at large M, and is within a few percent of per-tensor at small/decode M.
<img width="1690" height="650" alt="image" src="https://github.com/user-attachments/assets/337d7e67-2d83-4012-ab83-d7e21ca940a5" />

### DeepSeek-V3
My objective is to improve DSv3 performance. For those kernels specifically, we achieve a mean of 1.04x

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vllm-project/codesmith/vllm-xpu-kernels/pr/436"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785013675&installation_id=142609222&pr_number=436&repository=vllm-project%2Fvllm-xpu-kernels&return_to=https%3A%2F%2Fgithub.com%2Fvllm-project%2Fvllm-xpu-kernels%2Fpull%2F436&signature=0f25be1fbfb0473234883368b727c7c97e769169f552c1d7d63cb271b366ebfa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->