### PR TITLE
fix low accuracy of Qwen3.5-27B/Qwen3.6-27B

### DIFF
--- a/csrc/xpu/gdn_attn/causal_conv1d.hpp
+++ b/csrc/xpu/gdn_attn/causal_conv1d.hpp
@@ -455,8 +455,10 @@ struct update_states_kernel {
     for (int i = elems_start_offset_group + local_id;
          i < (local_group_id + 1) * elems_per_group;
          i += group_size) {
-      conv_states_ptr[width_id * conv_elems + i] =
-          conv_states_tmp_ptr[width_id * conv_elems + i];
+      if (i < conv_elems) {
+        conv_states_ptr[width_id * conv_elems + i] =
+            conv_states_tmp_ptr[width_id * conv_elems + i];
+      }
     }
   }
 

--- a/csrc/xpu/gdn_attn/xe_2/chunk_causal_conv1d_tiled_xe2.hpp
+++ b/csrc/xpu/gdn_attn/xe_2/chunk_causal_conv1d_tiled_xe2.hpp
@@ -336,24 +336,24 @@ struct chunk_causal_conv1d_tiled_kernel {
     // ========================================================================
     // Phase 2: Each item computes conv1d for its own feature lanes
     // ========================================================================
+    if (!feat_valid) return;
+
     bool is_q = (feat < q_dim);
     bool is_k = (!is_q && feat < q_dim + k_dim);
 
     // Load weights from global (only Width * elems_per_item = 16 values)
     T local_weights[Width * elems_per_item];
-    if (feat_valid) {
 #pragma unroll
-      for (int w = 0; w < Width; ++w) {
+    for (int w = 0; w < Width; ++w) {
 #pragma unroll
-        for (int e = 0; e < elems_per_item; ++e) {
-          local_weights[w * elems_per_item + e] =
-              conv_weights[(reordered_feat + e) * Width + w];
-        }
+      for (int e = 0; e < elems_per_item; ++e) {
+        local_weights[w * elems_per_item + e] =
+            conv_weights[(reordered_feat + e) * Width + w];
       }
     }
 
     float local_bias[elems_per_item];
-    if (conv_bias != nullptr && feat_valid) {
+    if (conv_bias != nullptr) {
 #pragma unroll
       for (int e = 0; e < elems_per_item; ++e) {
         local_bias[e] = conv_bias[reordered_feat + e];
@@ -363,40 +363,38 @@ struct chunk_causal_conv1d_tiled_kernel {
     // Conv1d: for each output token t, read SLM slots [t, t+Width)
     for (int t = 0; t < tile_tokens; ++t) {
       float res[elems_per_item];
-      if (feat_valid) {
+#pragma unroll
+      for (int e = 0; e < elems_per_item; ++e) {
+        res[e] = 0.0f;
+      }
+
+#pragma unroll
+      for (int w = 0; w < Width; ++w) {
+        int slot = t + w;
 #pragma unroll
         for (int e = 0; e < elems_per_item; ++e) {
-          res[e] = 0.0f;
+          res[e] += static_cast<float>(
+                        slm_input[slot * feats_per_wg + local_feat + e]) *
+                    static_cast<float>(local_weights[w * elems_per_item + e]);
         }
+      }
 
+      if (conv_bias != nullptr) {
 #pragma unroll
-        for (int w = 0; w < Width; ++w) {
-          int slot = t + w;
-#pragma unroll
-          for (int e = 0; e < elems_per_item; ++e) {
-            res[e] += static_cast<float>(
-                          slm_input[slot * feats_per_wg + local_feat + e]) *
-                      static_cast<float>(local_weights[w * elems_per_item + e]);
-          }
+        for (int e = 0; e < elems_per_item; ++e) {
+          res[e] += local_bias[e];
         }
+      }
 
-        if (conv_bias != nullptr) {
+      if (act_mode == ActMode::silu) {
 #pragma unroll
-          for (int e = 0; e < elems_per_item; ++e) {
-            res[e] += local_bias[e];
-          }
+        for (int e = 0; e < elems_per_item; ++e) {
+          act_silu(res[e]);
         }
-
-        if (act_mode == ActMode::silu) {
+      } else if (act_mode == ActMode::swish) {
 #pragma unroll
-          for (int e = 0; e < elems_per_item; ++e) {
-            act_silu(res[e]);
-          }
-        } else if (act_mode == ActMode::swish) {
-#pragma unroll
-          for (int e = 0; e < elems_per_item; ++e) {
-            act_swish(res[e]);
-          }
+        for (int e = 0; e < elems_per_item; ++e) {
+          act_swish(res[e]);
         }
       }
 
@@ -409,17 +407,15 @@ struct chunk_causal_conv1d_tiled_kernel {
 
         float q_local_sq = 0.0f;
         float k_local_sq = 0.0f;
-        if (feat_valid) {
-          if (is_q) {
+        if (is_q) {
 #pragma unroll
-            for (int e = 0; e < elems_per_item; ++e)
-              q_local_sq += res[e] * res[e];
-          }
-          if (is_k) {
+          for (int e = 0; e < elems_per_item; ++e)
+            q_local_sq += res[e] * res[e];
+        }
+        if (is_k) {
 #pragma unroll
-            for (int e = 0; e < elems_per_item; ++e)
-              k_local_sq += res[e] * res[e];
-          }
+          for (int e = 0; e < elems_per_item; ++e)
+            k_local_sq += res[e] * res[e];
         }
 
         // Subgroup reduce
@@ -446,50 +442,46 @@ struct chunk_causal_conv1d_tiled_kernel {
         }
         sycl::group_barrier(item.get_group());  // protect SLM for next token
 
-        if (feat_valid) {
-          float q_inv = sycl::rsqrt(q_total + l2norm_eps) *
-                        sycl::rsqrt(static_cast<float>(q_dim));
-          float k_inv = sycl::rsqrt(k_total + l2norm_eps);
+        float q_inv = sycl::rsqrt(q_total + l2norm_eps) *
+                      sycl::rsqrt(static_cast<float>(q_dim));
+        float k_inv = sycl::rsqrt(k_total + l2norm_eps);
 
-          if (is_q) {
+        if (is_q) {
 #pragma unroll
-            for (int e = 0; e < elems_per_item; ++e)
-              res[e] *= q_inv;
-          }
-          if (is_k) {
+          for (int e = 0; e < elems_per_item; ++e)
+            res[e] *= q_inv;
+        }
+        if (is_k) {
 #pragma unroll
-            for (int e = 0; e < elems_per_item; ++e)
-              res[e] *= k_inv;
-          }
+          for (int e = 0; e < elems_per_item; ++e)
+            res[e] *= k_inv;
         }
       }
 
       // Write output
-      if (feat_valid) {
-        int token_in_seq = tile_start_in_seq + t;
-        int out_token_id = pre_chunks * chunk_size_xe2 + token_in_seq;
+      int token_in_seq = tile_start_in_seq + t;
+      int out_token_id = pre_chunks * chunk_size_xe2 + token_in_seq;
 
-        if (is_q) {
+      if (is_q) {
 #pragma unroll
-          for (int e = 0; e < elems_per_item; ++e) {
-            q_out
-                [out_token_id * num_k_heads * q_dim + k_head_id * q_dim + feat +
-                 e] = res[e];
-          }
-        } else if (is_k) {
+        for (int e = 0; e < elems_per_item; ++e) {
+          q_out
+              [out_token_id * num_k_heads * q_dim + k_head_id * q_dim + feat +
+               e] = res[e];
+        }
+      } else if (is_k) {
 #pragma unroll
-          for (int e = 0; e < elems_per_item; ++e) {
-            k_out
-                [out_token_id * num_k_heads * k_dim + k_head_id * k_dim + feat -
-                 q_dim + e] = res[e];
-          }
-        } else {
+        for (int e = 0; e < elems_per_item; ++e) {
+          k_out
+              [out_token_id * num_k_heads * k_dim + k_head_id * k_dim + feat -
+               q_dim + e] = res[e];
+        }
+      } else {
 #pragma unroll
-          for (int e = 0; e < elems_per_item; ++e) {
-            v_out
-                [out_token_id * num_k_heads * v_dim + k_head_id * v_dim + feat -
-                 (q_dim + k_dim) + e] = res[e];
-          }
+        for (int e = 0; e < elems_per_item; ++e) {
+          v_out
+              [out_token_id * num_k_heads * v_dim + k_head_id * v_dim + feat -
+               (q_dim + k_dim) + e] = res[e];
         }
       }
     }
@@ -576,30 +568,28 @@ struct chunk_causal_conv1d_tiled_kernel {
     // ========================================================================
     // Phase 3: Save conv_state for the last tile of each sequence
     // ========================================================================
-    if (feat_valid) {
-      if (tile_start_in_seq + TileT >= seq_len && seq_len > 1) {
-        int last_slot = (tile_tokens - 1) + (Width - 1);
+    if (tile_start_in_seq + TileT >= seq_len && seq_len > 1) {
+      int last_slot = (tile_tokens - 1) + (Width - 1);
 #pragma unroll
-        for (int i = 0; i < Width - 1; ++i) {
-          int slot = last_slot - (Width - 2) + i;
+      for (int i = 0; i < Width - 1; ++i) {
+        int slot = last_slot - (Width - 2) + i;
 #pragma unroll
-          for (int e = 0; e < elems_per_item; ++e) {
-            conv_states_tmp
-                [batch_id * (Width - 1) * conv_elems + i * conv_elems +
-                 reordered_feat + e] =
-                    slm_input[slot * feats_per_wg + local_feat + e];
-          }
+        for (int e = 0; e < elems_per_item; ++e) {
+          conv_states_tmp
+              [batch_id * (Width - 1) * conv_elems + i * conv_elems +
+               reordered_feat + e] =
+                  slm_input[slot * feats_per_wg + local_feat + e];
         }
-      } else if (seq_len == 1) {
-        T* st = conv_states + states_id * conv_states_stride_0;
+      }
+    } else if (seq_len == 1) {
+      T* st = conv_states + states_id * conv_states_stride_0;
 #pragma unroll
-        for (int i = 0; i < Width - 1; ++i) {
-          int slot = i + 1;
+      for (int i = 0; i < Width - 1; ++i) {
+        int slot = i + 1;
 #pragma unroll
-          for (int e = 0; e < elems_per_item; ++e) {
-            st[i * conv_elems + reordered_feat + e] =
-                slm_input[slot * feats_per_wg + local_feat + e];
-          }
+        for (int e = 0; e < elems_per_item; ++e) {
+          st[i * conv_elems + reordered_feat + e] =
+              slm_input[slot * feats_per_wg + local_feat + e];
         }
       }
     }

--- a/csrc/xpu/gdn_attn/xe_2/chunk_causal_conv1d_tiled_xe2.hpp
+++ b/csrc/xpu/gdn_attn/xe_2/chunk_causal_conv1d_tiled_xe2.hpp
@@ -336,24 +336,24 @@ struct chunk_causal_conv1d_tiled_kernel {
     // ========================================================================
     // Phase 2: Each item computes conv1d for its own feature lanes
     // ========================================================================
-    if (!feat_valid) return;
-
     bool is_q = (feat < q_dim);
     bool is_k = (!is_q && feat < q_dim + k_dim);
 
     // Load weights from global (only Width * elems_per_item = 16 values)
     T local_weights[Width * elems_per_item];
+    if (feat_valid) {
 #pragma unroll
-    for (int w = 0; w < Width; ++w) {
+      for (int w = 0; w < Width; ++w) {
 #pragma unroll
-      for (int e = 0; e < elems_per_item; ++e) {
-        local_weights[w * elems_per_item + e] =
-            conv_weights[(reordered_feat + e) * Width + w];
+        for (int e = 0; e < elems_per_item; ++e) {
+          local_weights[w * elems_per_item + e] =
+              conv_weights[(reordered_feat + e) * Width + w];
+        }
       }
     }
 
     float local_bias[elems_per_item];
-    if (conv_bias != nullptr) {
+    if (conv_bias != nullptr && feat_valid) {
 #pragma unroll
       for (int e = 0; e < elems_per_item; ++e) {
         local_bias[e] = conv_bias[reordered_feat + e];
@@ -363,38 +363,40 @@ struct chunk_causal_conv1d_tiled_kernel {
     // Conv1d: for each output token t, read SLM slots [t, t+Width)
     for (int t = 0; t < tile_tokens; ++t) {
       float res[elems_per_item];
+      if (feat_valid) {
 #pragma unroll
-      for (int e = 0; e < elems_per_item; ++e) {
-        res[e] = 0.0f;
-      }
+        for (int e = 0; e < elems_per_item; ++e) {
+          res[e] = 0.0f;
+        }
 
 #pragma unroll
-      for (int w = 0; w < Width; ++w) {
-        int slot = t + w;
+        for (int w = 0; w < Width; ++w) {
+          int slot = t + w;
 #pragma unroll
-        for (int e = 0; e < elems_per_item; ++e) {
-          res[e] += static_cast<float>(
-                        slm_input[slot * feats_per_wg + local_feat + e]) *
-                    static_cast<float>(local_weights[w * elems_per_item + e]);
+          for (int e = 0; e < elems_per_item; ++e) {
+            res[e] += static_cast<float>(
+                          slm_input[slot * feats_per_wg + local_feat + e]) *
+                      static_cast<float>(local_weights[w * elems_per_item + e]);
+          }
         }
-      }
 
-      if (conv_bias != nullptr) {
+        if (conv_bias != nullptr) {
 #pragma unroll
-        for (int e = 0; e < elems_per_item; ++e) {
-          res[e] += local_bias[e];
+          for (int e = 0; e < elems_per_item; ++e) {
+            res[e] += local_bias[e];
+          }
         }
-      }
 
-      if (act_mode == ActMode::silu) {
+        if (act_mode == ActMode::silu) {
 #pragma unroll
-        for (int e = 0; e < elems_per_item; ++e) {
-          act_silu(res[e]);
-        }
-      } else if (act_mode == ActMode::swish) {
+          for (int e = 0; e < elems_per_item; ++e) {
+            act_silu(res[e]);
+          }
+        } else if (act_mode == ActMode::swish) {
 #pragma unroll
-        for (int e = 0; e < elems_per_item; ++e) {
-          act_swish(res[e]);
+          for (int e = 0; e < elems_per_item; ++e) {
+            act_swish(res[e]);
+          }
         }
       }
 
@@ -407,15 +409,17 @@ struct chunk_causal_conv1d_tiled_kernel {
 
         float q_local_sq = 0.0f;
         float k_local_sq = 0.0f;
-        if (is_q) {
+        if (feat_valid) {
+          if (is_q) {
 #pragma unroll
-          for (int e = 0; e < elems_per_item; ++e)
-            q_local_sq += res[e] * res[e];
-        }
-        if (is_k) {
+            for (int e = 0; e < elems_per_item; ++e)
+              q_local_sq += res[e] * res[e];
+          }
+          if (is_k) {
 #pragma unroll
-          for (int e = 0; e < elems_per_item; ++e)
-            k_local_sq += res[e] * res[e];
+            for (int e = 0; e < elems_per_item; ++e)
+              k_local_sq += res[e] * res[e];
+          }
         }
 
         // Subgroup reduce
@@ -442,46 +446,50 @@ struct chunk_causal_conv1d_tiled_kernel {
         }
         sycl::group_barrier(item.get_group());  // protect SLM for next token
 
-        float q_inv = sycl::rsqrt(q_total + l2norm_eps) *
-                      sycl::rsqrt(static_cast<float>(q_dim));
-        float k_inv = sycl::rsqrt(k_total + l2norm_eps);
+        if (feat_valid) {
+          float q_inv = sycl::rsqrt(q_total + l2norm_eps) *
+                        sycl::rsqrt(static_cast<float>(q_dim));
+          float k_inv = sycl::rsqrt(k_total + l2norm_eps);
 
-        if (is_q) {
+          if (is_q) {
 #pragma unroll
-          for (int e = 0; e < elems_per_item; ++e)
-            res[e] *= q_inv;
-        }
-        if (is_k) {
+            for (int e = 0; e < elems_per_item; ++e)
+              res[e] *= q_inv;
+          }
+          if (is_k) {
 #pragma unroll
-          for (int e = 0; e < elems_per_item; ++e)
-            res[e] *= k_inv;
+            for (int e = 0; e < elems_per_item; ++e)
+              res[e] *= k_inv;
+          }
         }
       }
 
       // Write output
-      int token_in_seq = tile_start_in_seq + t;
-      int out_token_id = pre_chunks * chunk_size_xe2 + token_in_seq;
+      if (feat_valid) {
+        int token_in_seq = tile_start_in_seq + t;
+        int out_token_id = pre_chunks * chunk_size_xe2 + token_in_seq;
 
-      if (is_q) {
+        if (is_q) {
 #pragma unroll
-        for (int e = 0; e < elems_per_item; ++e) {
-          q_out
-              [out_token_id * num_k_heads * q_dim + k_head_id * q_dim + feat +
-               e] = res[e];
-        }
-      } else if (is_k) {
+          for (int e = 0; e < elems_per_item; ++e) {
+            q_out
+                [out_token_id * num_k_heads * q_dim + k_head_id * q_dim + feat +
+                 e] = res[e];
+          }
+        } else if (is_k) {
 #pragma unroll
-        for (int e = 0; e < elems_per_item; ++e) {
-          k_out
-              [out_token_id * num_k_heads * k_dim + k_head_id * k_dim + feat -
-               q_dim + e] = res[e];
-        }
-      } else {
+          for (int e = 0; e < elems_per_item; ++e) {
+            k_out
+                [out_token_id * num_k_heads * k_dim + k_head_id * k_dim + feat -
+                 q_dim + e] = res[e];
+          }
+        } else {
 #pragma unroll
-        for (int e = 0; e < elems_per_item; ++e) {
-          v_out
-              [out_token_id * num_k_heads * v_dim + k_head_id * v_dim + feat -
-               (q_dim + k_dim) + e] = res[e];
+          for (int e = 0; e < elems_per_item; ++e) {
+            v_out
+                [out_token_id * num_k_heads * v_dim + k_head_id * v_dim + feat -
+                 (q_dim + k_dim) + e] = res[e];
+          }
         }
       }
     }
@@ -568,28 +576,30 @@ struct chunk_causal_conv1d_tiled_kernel {
     // ========================================================================
     // Phase 3: Save conv_state for the last tile of each sequence
     // ========================================================================
-    if (tile_start_in_seq + TileT >= seq_len && seq_len > 1) {
-      int last_slot = (tile_tokens - 1) + (Width - 1);
+    if (feat_valid) {
+      if (tile_start_in_seq + TileT >= seq_len && seq_len > 1) {
+        int last_slot = (tile_tokens - 1) + (Width - 1);
 #pragma unroll
-      for (int i = 0; i < Width - 1; ++i) {
-        int slot = last_slot - (Width - 2) + i;
+        for (int i = 0; i < Width - 1; ++i) {
+          int slot = last_slot - (Width - 2) + i;
 #pragma unroll
-        for (int e = 0; e < elems_per_item; ++e) {
-          conv_states_tmp
-              [batch_id * (Width - 1) * conv_elems + i * conv_elems +
-               reordered_feat + e] =
-                  slm_input[slot * feats_per_wg + local_feat + e];
+          for (int e = 0; e < elems_per_item; ++e) {
+            conv_states_tmp
+                [batch_id * (Width - 1) * conv_elems + i * conv_elems +
+                 reordered_feat + e] =
+                    slm_input[slot * feats_per_wg + local_feat + e];
+          }
         }
-      }
-    } else if (seq_len == 1) {
-      T* st = conv_states + states_id * conv_states_stride_0;
+      } else if (seq_len == 1) {
+        T* st = conv_states + states_id * conv_states_stride_0;
 #pragma unroll
-      for (int i = 0; i < Width - 1; ++i) {
-        int slot = i + 1;
+        for (int i = 0; i < Width - 1; ++i) {
+          int slot = i + 1;
 #pragma unroll
-        for (int e = 0; e < elems_per_item; ++e) {
-          st[i * conv_elems + reordered_feat + e] =
-              slm_input[slot * feats_per_wg + local_feat + e];
+          for (int e = 0; e < elems_per_item; ++e) {
+            st[i * conv_elems + reordered_feat + e] =
+                slm_input[slot * feats_per_wg + local_feat + e];
+          }
         }
       }
     }

--- a/csrc/xpu/gdn_attn/xe_2/chunk_causal_conv1d_xe2.hpp
+++ b/csrc/xpu/gdn_attn/xe_2/chunk_causal_conv1d_xe2.hpp
@@ -630,8 +630,10 @@ struct chunk_update_states_kernel {
     for (int i = elems_start_offset_group + local_id;
          i < (local_group_id + 1) * elems_per_group;
          i += group_size) {
-      conv_states_ptr[width_id * conv_elems + i] =
-          conv_states_tmp_ptr[width_id * conv_elems + i];
+      if (i < conv_elems) {
+        conv_states_ptr[width_id * conv_elems + i] =
+            conv_states_tmp_ptr[width_id * conv_elems + i];
+      }
     }
   }
 

--- a/csrc/xpu/gdn_attn/xe_2/chunk_gated_delta_rule_kernels_xe2.hpp
+++ b/csrc/xpu/gdn_attn/xe_2/chunk_gated_delta_rule_kernels_xe2.hpp
@@ -51,7 +51,7 @@ act_softplus(float& x, float beta = 1.0f, float threshold = 20.0f) {
 
 template <typename T>
 CUTE_DEVICE void chunk_prepare_kernel(
-    const float* a,
+    float* a,
     const float* A_log,
     const T* dt_bias,
     const int* query_start_loc,
@@ -119,9 +119,8 @@ CUTE_DEVICE void chunk_prepare_kernel(
           sycl::inclusive_scan_over_group(sg, g_local_sum, sycl::plus<float>());
       CUTE_UNROLL
       for (int c = local_num - 1; c >= 0; --c) {
-        const_cast<float*>(a)
-            [(chunk_start_offset + sg_local_id * local_num + c) +
-             v_head_id * total_virtual_seqlen] = g_local_sum;
+        a[(chunk_start_offset + sg_local_id * local_num + c) +
+          v_head_id * total_virtual_seqlen] = g_local_sum;
         g_local_sum -= g_local[c];
       }
 
@@ -1260,7 +1259,7 @@ void kernel_launcher(
     T* w,
     T* u,
     const float* b,
-    const float* a,
+    float* a,
     const float* A_log,
     const T* dt_bias,
     StateT* ssm_state,

--- a/tests/gdn_attn/test_gdn_attn.py
+++ b/tests/gdn_attn/test_gdn_attn.py
@@ -1027,3 +1027,100 @@ def test_chunk_prepare_vhead_oob_guard(dtype):
     torch.testing.assert_close(z, ref_z, atol=atol, rtol=rtol)
     torch.testing.assert_close(core_attn_out, ref_core_attn_out, atol=atol,
                                rtol=rtol)
+
+
+# chunk_update_states_kernel conv_elems guard coverage. When total conv_elems
+# is not a multiple of elems_per_group (1024), the last work-group is 
+# over-provisioned and requires an upper bound check to prevent out-of-bounds
+# memory writes. Qwen3.6-27B at TP=4 (local num_k_heads=4, num_v_heads=12) 
+# forces conv_elems = 2560. 2560 % 1024 != 0, exercising this guard.
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16],
+                         ids=format_tc)
+@torch.inference_mode()
+def test_causal_conv1d_conv_elems_oob_guard(dtype):
+    device = "xpu"
+    random.seed(0)
+    torch.manual_seed(0)
+
+    # Qwen-27B global heads: K=16, V=48. 
+    # At TP=4, local heads are K=4 and V=12. 
+    tp_size = 4
+    num_k_heads = 16 // tp_size  # -> 4
+    num_v_heads = 48 // tp_size  # -> 12
+    head_k_dim = 128
+    head_v_dim = 128 
+    
+    width = 4
+    activation = "silu"
+    num_actual_tokens = 64  # single prefill
+    num_prefills, num_decodes = 1, 0
+    cache_batch_size = 4
+
+    mixed_qkvz_size = num_k_heads * (
+        2 * head_k_dim + 2 * head_v_dim * num_v_heads // num_k_heads)
+    mixed_ba_size = num_k_heads * (2 * num_v_heads // num_k_heads)
+    
+    # conv_elems will equal mixed_qkv_size (2560 here)
+    mixed_qkv_size = num_k_heads * (
+        2 * head_k_dim + head_v_dim * num_v_heads // num_k_heads)
+
+    projected_states_qkvz = torch.randn((num_actual_tokens, mixed_qkvz_size),
+                                        dtype=dtype, device=device)
+    projected_states_ba = torch.randn((num_actual_tokens, mixed_ba_size),
+                                      dtype=dtype, device=device)
+                                      
+    conv_state = torch.randn((cache_batch_size, width - 1, mixed_qkv_size),
+                             dtype=dtype, device=device)
+    ref_conv_state = conv_state.clone()
+    ssm_state = torch.randn(
+        (cache_batch_size, num_v_heads, head_v_dim, head_k_dim),
+        dtype=dtype, device=device)
+    ref_ssm_state = ssm_state.clone()
+        
+    conv_weights = torch.randn((mixed_qkv_size, width), dtype=dtype, device=device)
+    conv_bias = torch.randn((mixed_qkv_size), dtype=dtype, device=device)
+    A_log = torch.randn((num_v_heads), dtype=torch.float32, device=device)
+    dt_bias = torch.randn((num_v_heads), dtype=dtype, device=device)
+
+    non_spec_query_start_loc = torch.tensor([0, num_actual_tokens],
+                                            dtype=torch.int32, device=device)
+    has_initial_state = torch.tensor([True], dtype=torch.bool, device=device)
+    non_spec_state_indices_tensor = torch.tensor([0], dtype=torch.int32, device=device)
+
+    core_attn_out = torch.zeros((num_actual_tokens, num_v_heads, head_v_dim),
+                                dtype=dtype, device=device)
+    z = torch.empty_like(core_attn_out)
+
+    torch.ops._xpu_C.gdn_attention(
+        core_attn_out, z, projected_states_qkvz, projected_states_ba,
+        num_k_heads, num_v_heads, head_k_dim, head_v_dim,
+        conv_state=conv_state, ssm_state=ssm_state, conv_weights=conv_weights,
+        conv_bias=conv_bias, activation=activation, A_log=A_log,
+        dt_bias=dt_bias, num_prefills=num_prefills, num_decodes=num_decodes,
+        num_spec_decodes=0, has_initial_state=has_initial_state,
+        non_spec_query_start_loc=non_spec_query_start_loc,
+        non_spec_token_indx=None,
+        non_spec_state_indices_tensor=non_spec_state_indices_tensor,
+        spec_query_start_loc=None, spec_token_indx=None,
+        spec_state_indices_tensor=None, num_accepted_tokens=None,
+        num_actual_tokens=num_actual_tokens, tp_size=tp_size,
+        reorder_input=False)
+
+    ref_core_attn_out = torch.zeros_like(core_attn_out)
+    ref_z = torch.empty_like(core_attn_out)
+    ref_gdn_attention(
+        ref_core_attn_out, ref_z, projected_states_qkvz, projected_states_ba,
+        num_k_heads, num_v_heads, head_k_dim, head_v_dim,
+        conv_state=ref_conv_state, ssm_state=ref_ssm_state,
+        conv_weights=conv_weights, conv_bias=conv_bias, activation=activation,
+        A_log=A_log, dt_bias=dt_bias, num_prefills=num_prefills,
+        num_decodes=num_decodes, has_initial_state=has_initial_state,
+        non_spec_query_start_loc=non_spec_query_start_loc,
+        non_spec_state_indices_tensor=non_spec_state_indices_tensor,
+        num_actual_tokens=num_actual_tokens, tp_size=tp_size,
+        reorder_input=False)
+
+    atol = rtol = 5e-2
+    torch.testing.assert_close(z, ref_z, atol=atol, rtol=rtol)
+    torch.testing.assert_close(core_attn_out, ref_core_attn_out, atol=atol,
+                               rtol=rtol)

--- a/tests/gdn_attn/test_gdn_attn.py
+++ b/tests/gdn_attn/test_gdn_attn.py
@@ -1045,8 +1045,9 @@ def test_causal_conv1d_conv_elems_oob_guard(dtype):
     # Qwen-27B global heads: K=16, V=48. 
     # At TP=4, local heads are K=4 and V=12. 
     tp_size = 4
-    num_k_heads = 16 // tp_size  # -> 4
-    num_v_heads = 48 // tp_size  # -> 12
+    num_k_heads = 16
+    num_v_heads = 48
+    # local heads will be K=4, V=12 internally
     head_k_dim = 128
     head_v_dim = 128 
     
@@ -1056,13 +1057,18 @@ def test_causal_conv1d_conv_elems_oob_guard(dtype):
     num_prefills, num_decodes = 1, 0
     cache_batch_size = 4
 
-    mixed_qkvz_size = num_k_heads * (
-        2 * head_k_dim + 2 * head_v_dim * num_v_heads // num_k_heads)
-    mixed_ba_size = num_k_heads * (2 * num_v_heads // num_k_heads)
+    local_num_k_heads = num_k_heads // tp_size
+    local_num_v_heads = num_v_heads // tp_size
+    
+    mixed_qkvz_size = local_num_k_heads * (
+        2 * head_k_dim + 2 * head_v_dim * \
+        local_num_v_heads // local_num_k_heads)
+    mixed_ba_size = local_num_k_heads * (
+        2 * local_num_v_heads // local_num_k_heads)
     
     # conv_elems will equal mixed_qkv_size (2560 here)
-    mixed_qkv_size = num_k_heads * (
-        2 * head_k_dim + head_v_dim * num_v_heads // num_k_heads)
+    mixed_qkv_size = local_num_k_heads * (
+        2 * head_k_dim + head_v_dim * local_num_v_heads // local_num_k_heads)
 
     projected_states_qkvz = torch.randn((num_actual_tokens, mixed_qkvz_size),
                                         dtype=dtype, device=device)
@@ -1073,21 +1079,24 @@ def test_causal_conv1d_conv_elems_oob_guard(dtype):
                              dtype=dtype, device=device)
     ref_conv_state = conv_state.clone()
     ssm_state = torch.randn(
-        (cache_batch_size, num_v_heads, head_v_dim, head_k_dim),
+        (cache_batch_size, local_num_v_heads, head_v_dim, head_k_dim),
         dtype=dtype, device=device)
     ref_ssm_state = ssm_state.clone()
         
-    conv_weights = torch.randn((mixed_qkv_size, width), dtype=dtype, device=device)
+    conv_weights = torch.randn(
+        (mixed_qkv_size, width), dtype=dtype, device=device)
     conv_bias = torch.randn((mixed_qkv_size), dtype=dtype, device=device)
-    A_log = torch.randn((num_v_heads), dtype=torch.float32, device=device)
-    dt_bias = torch.randn((num_v_heads), dtype=dtype, device=device)
+    A_log = torch.randn((local_num_v_heads), dtype=torch.float32, device=device)
+    dt_bias = torch.randn((local_num_v_heads), dtype=dtype, device=device)
 
     non_spec_query_start_loc = torch.tensor([0, num_actual_tokens],
                                             dtype=torch.int32, device=device)
     has_initial_state = torch.tensor([True], dtype=torch.bool, device=device)
-    non_spec_state_indices_tensor = torch.tensor([0], dtype=torch.int32, device=device)
+    non_spec_state_indices_tensor = torch.tensor(
+        [0], dtype=torch.int32, device=device)
 
-    core_attn_out = torch.zeros((num_actual_tokens, num_v_heads, head_v_dim),
+    core_attn_out = torch.zeros(
+        (num_actual_tokens, local_num_v_heads, head_v_dim),
                                 dtype=dtype, device=device)
     z = torch.empty_like(core_attn_out)
 


### PR DESCRIPTION
This PR is to fix low accuracy of Qwen3.5-27B on B60. [VLLMZ-1515](https://jira.devtools.intel.com/browse/VLLMZ-1515)

There are two accuracy issues in the 27B model: 
1. We observed lower gsm8k for 27B model compared to CUDA.
2. When max_model_len >= 32K, the gsm8k score is ~0.


**Before:**  GSM8k score ~= 0 when max_model_len >= 32K (vllm-xpu-kernels 0.1.10.1)

vllm ({'pretrained': '/hf_models/Qwen3.5-27B/', 'enforce_eager': True, 'tensor_parallel_size': 4, 'add_bos_token': True, 'max_model_len': 32768}), gen_kwargs: ({'max_gen_toks': 4096}), limit: 200.0, num_fewshot: 5, batch_size: auto
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.085|±  |0.0198|
|     |       |strict-match    |     5|exact_match|↑  |0.080|±  |0.0192|

vllm ({'pretrained': '/hf_models/Qwen3.6-27B/', 'enforce_eager': True, 'tensor_parallel_size': 4, 'add_bos_token': True}), gen_kwargs: ({'max_gen_toks': 4096}), limit: 200.0, num_fewshot: 5, batch_size: auto
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |    0|±  |     0|
|     |       |strict-match    |     5|exact_match|↑  |    0|±  |     0|

**After:**
vllm ({'pretrained': '/hf_models/Qwen3.5-27B/', 'enforce_eager': True, 'tensor_parallel_size': 4, 'add_bos_token': True}), gen_kwargs: ({'max_gen_toks': 4096}), limit: 200.0, num_fewshot: 5, batch_size: auto
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.865|±  |0.0242|
|     |       |strict-match    |     5|exact_match|↑  |0.915|±  |0.0198|

vllm ({'pretrained': '/hf_models/Qwen3.6-27B/', 'enforce_eager': True, 'tensor_parallel_size': 4, 'add_bos_token': True}), gen_kwargs: ({'max_gen_toks': 4096}), limit: 200.0, num_fewshot: 5, batch_size: auto
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.665|±  |0.0335|
|     |       |strict-match    |     5|exact_match|↑  |0.670|±  |0.0333|


**FULL GSM8K** with this PR
vllm ({'pretrained': '/hf_models/Qwen3.5-27B/', 'enforce_eager': True, 'tensor_parallel_size': 4, 'add_bos_token': True}), gen_kwargs: ({'max_gen_toks': 4096}), limit: None, num_fewshot: 5, batch_size: auto
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.8673|±  |0.0093|
|     |       |strict-match    |     5|exact_match|↑  |0.8848|±  |0.0088|

vllm ({'pretrained': '/hf_models/Qwen3.6-27B/', 'enforce_eager': True, 'tensor_parallel_size': 4, 'add_bos_token': True}), gen_kwargs: ({'max_gen_toks': 4096}), limit: None, num_fewshot: 5, batch_size: auto
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.6785|±  |0.0129|
|     |       |strict-match    |     5|exact_match|↑  |0.6763|±  |0.0129|

vllm ({'pretrained': '/hf_models/Qwen3.5-9B/', 'enforce_eager': True, 'tensor_parallel_size': 2, 'add_bos_token': True}), gen_kwargs: ({'max_gen_toks': 4096}), limit: None, num_fewshot: 5, batch_size: auto
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.8848|±  |0.0088|
|     |       |strict-match    |     5|exact_match|↑  |0.8886|±  |0.0087|