### PR TITLE
[Bugfix] Fix FP8 W8A16 per-channel scale misrouted to block quant path

### DIFF
--- a/csrc/xpu/onednn/fp8_gemm_w8a16.h
+++ b/csrc/xpu/onednn/fp8_gemm_w8a16.h
@@ -26,9 +26,10 @@ static inline void dnnl_matmul_w8a16_fp8(
   const int n = o_sz.back();  // presume channel last format
   const int k = *(src_sz.end() - 1);
 
-  // block quant param: m2_sc is 2D with more than 1 element for block quant
-  // Weight scale layout: [k/group_size, n/group_size]
-  bool is_block_quant = (m2_sc.dim() == 2) && (m2_sc.numel() > 1);
+  // block quant: m2_sc is 2D with size(0) > 1, i.e. [k/group_size,
+  // n/group_size] Per-channel scale [1, N] has size(0)==1 and must NOT enter
+  // this branch.
+  bool is_block_quant = (m2_sc.dim() == 2) && (m2_sc.size(0) > 1);
   int64_t blk_group_size = -1;
   if (is_block_quant) {
     blk_group_size = k / m2_sc.size(0);

--- a/tests/test_fp8_gemm_onednn.py
+++ b/tests/test_fp8_gemm_onednn.py
@@ -257,6 +257,14 @@ def test_fp8_gemm_w8a16_per_channel(fp8_dtype, out_dtype, is_nt, is_mbk, batch,
 
     torch.testing.assert_close(output_fp8, output_ref, atol=5e-2, rtol=5e-2)
 
+    # [1, N] scale must use per-channel path, not block quant
+    scale_wei_2d = scale_wei_fp8.t().contiguous()  # [1, N]
+    output_fp8_2d = fp8_gemm_w8a16(input, weight_fp8_t, scale_wei_2d,
+                                   torch.Tensor())
+    output_fp8_2d = output_fp8_2d.transpose(0, 1) if is_mbk else output_fp8_2d
+    torch.testing.assert_close(output_fp8_2d, output_ref, atol=5e-2, rtol=5e-2,
+                               msg="2D scale [1, N]")
+
 
 def _convert_to_mxfp8_with_hp_ref(t):
     # Convert a tensor to mxfp8, returning:

--- a/tests/test_fp8_gemm_onednn.py
+++ b/tests/test_fp8_gemm_onednn.py
@@ -218,10 +218,11 @@ def test_fp8_gemm_per_channel(fp8_dtype, out_dtype, is_nt, batch, mnk_factors):
 @pytest.mark.parametrize("out_dtype", OUT_DTYPES)
 @pytest.mark.parametrize("is_nt", [True, False])
 @pytest.mark.parametrize("is_mbk", [True, False])
+@pytest.mark.parametrize("scale_layout", ["flat_1d", "row_2d"])
 @pytest.mark.parametrize("batch", BATCHES)
 @pytest.mark.parametrize("mnk_factors", MNK_FACTORS)
-def test_fp8_gemm_w8a16_per_channel(fp8_dtype, out_dtype, is_nt, is_mbk, batch,
-                                    mnk_factors):
+def test_fp8_gemm_w8a16_per_channel(fp8_dtype, out_dtype, is_nt, is_mbk,
+                                    scale_layout, batch, mnk_factors):
     seed = 1234
     torch.manual_seed(seed)
 
@@ -234,8 +235,10 @@ def test_fp8_gemm_w8a16_per_channel(fp8_dtype, out_dtype, is_nt, is_mbk, batch,
     weight_fp8, scale_wei_fp8 = scaled_fp8_quant(weight,
                                                  use_per_token_if_dynamic=True,
                                                  fp8_dtype=fp8_dtype)
-    # scale_wei_fp8 is [n, 1], flatten to [n] for per-channel scale
-    scale_wei_flat = scale_wei_fp8.flatten()
+    if scale_layout == "flat_1d":
+        scale_wei = scale_wei_fp8.flatten()
+    else:
+        scale_wei = scale_wei_fp8.t().contiguous()
 
     # reference: dequantize weight then fp16/bf16 matmul
     weight_dequant = weight_fp8.to(out_dtype) * scale_wei_fp8.to(out_dtype)
@@ -250,20 +253,18 @@ def test_fp8_gemm_w8a16_per_channel(fp8_dtype, out_dtype, is_nt, is_mbk, batch,
     output_fp8 = fp8_gemm_w8a16(
         input,
         weight_fp8_t,
-        scale_wei_flat,
+        scale_wei,
         torch.Tensor(),
     )
     output_fp8 = output_fp8.transpose(0, 1) if is_mbk else output_fp8
 
-    torch.testing.assert_close(output_fp8, output_ref, atol=5e-2, rtol=5e-2)
-
-    # [1, N] scale must use per-channel path, not block quant
-    scale_wei_2d = scale_wei_fp8.t().contiguous()  # [1, N]
-    output_fp8_2d = fp8_gemm_w8a16(input, weight_fp8_t, scale_wei_2d,
-                                   torch.Tensor())
-    output_fp8_2d = output_fp8_2d.transpose(0, 1) if is_mbk else output_fp8_2d
-    torch.testing.assert_close(output_fp8_2d, output_ref, atol=5e-2, rtol=5e-2,
-                               msg="2D scale [1, N]")
+    torch.testing.assert_close(
+        output_fp8,
+        output_ref,
+        atol=5e-2,
+        rtol=5e-2,
+        msg=f"scale_layout={scale_layout}",
+    )
 
 
 def _convert_to_mxfp8_with_hp_ref(t):


### PR DESCRIPTION
## Problem
Per-channel FP8 W8A16 GEMM produces completely wrong results , causing FP8-dynamic models (e.g. RedHatAI/Apertus-8B-Instruct-2509-FP8-dynamic) to output  meaningless results on XPU. 


## Fix                                                                                                                                                                                                                                                                                                                     
  Change the check to m2_sc.size(0) > 1:  
   bool is_block_quant = (m2_sc.dim() == 2) && (m2_sc.size(0) > 1);    
