### PR TITLE
[LayerNorm] Support weightless RMSNorm in XPU kernels

### DIFF
--- a/csrc/layernorm.cpp
+++ b/csrc/layernorm.cpp
@@ -1,6 +1,7 @@
 #include <sycl/sycl.hpp>
 
 #include <algorithm>
+#include <optional>
 #include <ATen/DeviceGuard.h>
 #include "utils.h"
 #include "dispatch_utils.h"
@@ -8,7 +9,7 @@
 
 namespace vllm {
 
-template <typename scalar_t, int NUM_DIMS, int VEC_SIZE>
+template <typename scalar_t, int NUM_DIMS, int VEC_SIZE, bool HasWeight>
 class rms_norm_kernel {
  public:
   rms_norm_kernel(
@@ -101,11 +102,19 @@ class rms_norm_kernel {
          idx += item_ct1.get_local_range(2)) {
       vec_n_t<scalar_t, VEC_SIZE> dst;
       vec_n_t<scalar_t, VEC_SIZE> src1 = v_in[idx];
-      vec_n_t<scalar_t, VEC_SIZE> src2 = v_w[idx];
+      vec_n_t<scalar_t, VEC_SIZE> src2;
+      if constexpr (HasWeight) {
+        src2 = v_w[idx];
+      }
 #pragma unroll
       for (int j = 0; j < VEC_SIZE; j++) {
         float x = static_cast<float>(src1.val[j]);
-        dst.val[j] = ((scalar_t)(x * s_variance_val)) * src2.val[j];
+        scalar_t normalized = static_cast<scalar_t>(x * s_variance_val);
+        if constexpr (HasWeight) {
+          dst.val[j] = normalized * src2.val[j];
+        } else {
+          dst.val[j] = normalized;
+        }
       }
       v_out[idx] = dst;
     }
@@ -126,8 +135,8 @@ class rms_norm_kernel {
   sycl::local_accessor<float, 1> s_variance;
 };
 
-template <typename scalar_t, int NUM_DIMS>
-class rms_norm_kernel<scalar_t, NUM_DIMS, 0> {
+template <typename scalar_t, int NUM_DIMS, bool HasWeight>
+class rms_norm_kernel<scalar_t, NUM_DIMS, 0, HasWeight> {
  public:
   rms_norm_kernel(
       scalar_t* out_,
@@ -207,7 +216,12 @@ class rms_norm_kernel<scalar_t, NUM_DIMS, 0> {
     for (int idx = item_ct1.get_local_id(2); idx < hidden_size;
          idx += item_ct1.get_local_range(2)) {
       float x = (float)input_row[idx];
-      out_row[idx] = ((scalar_t)(x * (*s_variance_ptr))) * weight[idx];
+      scalar_t normalized = static_cast<scalar_t>(x * (*s_variance_ptr));
+      if constexpr (HasWeight) {
+        out_row[idx] = normalized * weight[idx];
+      } else {
+        out_row[idx] = normalized;
+      }
     }
   }
 
@@ -230,7 +244,12 @@ class rms_norm_kernel<scalar_t, NUM_DIMS, 0> {
 // The work-group is organized as (ROWS_PER_WG, 1, items_per_row).
 // Each "sub-row" uses dimension 0 to index which row it handles,
 // and dimension 2 for the column within that row.
-template <typename scalar_t, int NUM_DIMS, int VEC_SIZE, int ROWS_PER_WG>
+template <
+    typename scalar_t,
+    int NUM_DIMS,
+    int VEC_SIZE,
+    int ROWS_PER_WG,
+    bool HasWeight>
 class rms_norm_multi_row_kernel {
  public:
   rms_norm_multi_row_kernel(
@@ -337,11 +356,19 @@ class rms_norm_multi_row_kernel {
     for (int idx = col_id; idx < num_vec_elems; idx += col_range) {
       vec_n_t<scalar_t, VEC_SIZE> dst;
       vec_n_t<scalar_t, VEC_SIZE> src1 = v_in[idx];
-      vec_n_t<scalar_t, VEC_SIZE> src2 = v_w[idx];
+      vec_n_t<scalar_t, VEC_SIZE> src2;
+      if constexpr (HasWeight) {
+        src2 = v_w[idx];
+      }
 #pragma unroll
       for (int j = 0; j < VEC_SIZE; j++) {
         float x = static_cast<float>(src1.val[j]);
-        dst.val[j] = ((scalar_t)(x * s_var)) * src2.val[j];
+        scalar_t normalized = static_cast<scalar_t>(x * s_var);
+        if constexpr (HasWeight) {
+          dst.val[j] = normalized * src2.val[j];
+        } else {
+          dst.val[j] = normalized;
+        }
       }
       v_out[idx] = dst;
     }
@@ -362,11 +389,11 @@ class rms_norm_multi_row_kernel {
   sycl::local_accessor<float, 1> s_variance;
 };
 
-template <typename scalar_t>
+template <typename scalar_t, bool HasWeight>
 void call_rms_norm_kernel(
     torch::Tensor& out,
     torch::Tensor& input,
-    torch::Tensor& weight,
+    const scalar_t* weight_ptr,
     float epsilon) {
   using sycl_t = typename vllm::xpu::SyclTypeTrait<scalar_t>::Type;
   int hidden_size = input.size(-1);
@@ -380,7 +407,6 @@ void call_rms_norm_kernel(
 
   auto out_ptr = out.data_ptr<scalar_t>();
   auto input_ptr = input.data_ptr<scalar_t>();
-  auto weight_ptr = weight.data_ptr<scalar_t>();
 
   const int max_block_size = (num_tokens < 256) ? 1024 : 256;
   auto& queue = vllm::xpu::vllmGetQueue();
@@ -393,9 +419,10 @@ void call_rms_norm_kernel(
   auto wt_addr = reinterpret_cast<std::uintptr_t>(weight_ptr);
 
   // Base pointers must be aligned
-  bool ptrs_aligned = (inp_addr % req_alignment_bytes == 0) &&
-                      (out_addr % req_alignment_bytes == 0) &&
-                      (wt_addr % req_alignment_bytes == 0);
+  bool ptrs_aligned =
+      (inp_addr % req_alignment_bytes == 0) &&
+      (out_addr % req_alignment_bytes == 0) &&
+      (weight_ptr == nullptr || wt_addr % req_alignment_bytes == 0);
 
   // hidden_size must be divisible by vec_size (so vectorized loop covers all
   // elements)
@@ -432,7 +459,8 @@ void call_rms_norm_kernel(
                   sycl_t,
                   tensor_rank,
                   vec_size,
-                  ROWS_PER_WG>(
+                  ROWS_PER_WG,
+                  HasWeight>(
                   (sycl_t*)out_ptr,
                   (const sycl_t*)input_ptr,
                   input_stride_d2,
@@ -457,7 +485,7 @@ void call_rms_norm_kernel(
         sycl::local_accessor<float, 1> s_variance(sycl::range<1>(1), cgh);
         cgh.parallel_for(
             sycl::nd_range<3>(grid * block, block),
-            rms_norm_kernel<sycl_t, tensor_rank, vec_size>(
+            rms_norm_kernel<sycl_t, tensor_rank, vec_size, HasWeight>(
                 (sycl_t*)out_ptr,
                 (const sycl_t*)input_ptr,
                 input_stride_d2,
@@ -480,7 +508,7 @@ void call_rms_norm_kernel(
         sycl::local_accessor<float, 1> s_variance(sycl::range<1>(1), cgh);
         cgh.parallel_for(
             sycl::nd_range<3>(grid * block, block),
-            rms_norm_kernel<sycl_t, tensor_rank, 0>(
+            rms_norm_kernel<sycl_t, tensor_rank, 0, HasWeight>(
                 (sycl_t*)out_ptr,
                 (const sycl_t*)input_ptr,
                 input_stride_d2,
@@ -498,7 +526,7 @@ void call_rms_norm_kernel(
   }
 }
 
-template <typename scalar_t, int width>
+template <typename scalar_t, int width, bool HasWeight>
 class fused_add_rms_norm_kernel {
  public:
   fused_add_rms_norm_kernel(
@@ -566,12 +594,20 @@ class fused_add_rms_norm_kernel {
       int id = item_ct1.get_group(2) * vec_hidden_size + idx;
       int64_t strided_id = item_ct1.get_group(2) * vec_input_stride + idx;
       vec_t res = residual_v[id];
-      vec_t w = weight_v[idx];
+      vec_t w;
+      if constexpr (HasWeight) {
+        w = weight_v[idx];
+      }
       vec_t out;
 #pragma unroll
       for (int i = 0; i < width; i++) {
         float x = static_cast<float>(res.val[i]);
-        out.val[i] = static_cast<scalar_t>(x * s_var) * w.val[i];
+        scalar_t normalized = static_cast<scalar_t>(x * s_var);
+        if constexpr (HasWeight) {
+          out.val[i] = normalized * w.val[i];
+        } else {
+          out.val[i] = normalized;
+        }
       }
       input_v[strided_id] = out;
     }
@@ -588,8 +624,8 @@ class fused_add_rms_norm_kernel {
   sycl::local_accessor<float, 1> s_variance;  // local memory for variance
 };
 
-template <typename scalar_t>
-class fused_add_rms_norm_kernel<scalar_t, 0> {
+template <typename scalar_t, bool HasWeight>
+class fused_add_rms_norm_kernel<scalar_t, 0, HasWeight> {
  public:
   fused_add_rms_norm_kernel(
       scalar_t* __restrict__ input_,     // [..., hidden_size]
@@ -637,8 +673,13 @@ class fused_add_rms_norm_kernel<scalar_t, 0> {
     for (int idx = item_ct1.get_local_id(2); idx < hidden_size;
          idx += item_ct1.get_local_range(2)) {
       float x = (float)residual[item_ct1.get_group(2) * hidden_size + idx];
-      input[item_ct1.get_group(2) * input_stride + idx] =
-          ((scalar_t)(x * (*s_variance_ptr))) * weight[idx];
+      scalar_t normalized = static_cast<scalar_t>(x * (*s_variance_ptr));
+      if constexpr (HasWeight) {
+        input[item_ct1.get_group(2) * input_stride + idx] =
+            normalized * weight[idx];
+      } else {
+        input[item_ct1.get_group(2) * input_stride + idx] = normalized;
+      }
     }
   }
 
@@ -653,11 +694,11 @@ class fused_add_rms_norm_kernel<scalar_t, 0> {
   sycl::local_accessor<float, 1> s_variance;  // local memory for variance
 };
 
-template <typename scalar_t>
+template <typename scalar_t, bool HasWeight>
 void call_fused_add_rms_norm_kernel(
     torch::Tensor& input,
     torch::Tensor& residual,
-    torch::Tensor& weight,
+    const scalar_t* weight_ptr,
     float epsilon) {
   using sycl_t = typename vllm::xpu::SyclTypeTrait<scalar_t>::Type;
   int hidden_size = input.size(-1);
@@ -665,7 +706,6 @@ void call_fused_add_rms_norm_kernel(
   const int max_block_size = (num_tokens < 256) ? 1024 : 256;
   auto input_ptr = input.data_ptr<scalar_t>();
   auto residual_ptr = residual.data_ptr<scalar_t>();
-  auto weight_ptr = weight.data_ptr<scalar_t>();
   int64_t input_stride = input.stride(-2);
 
   constexpr int vector_width = (sizeof(scalar_t) == 2) ? 8 : 4;
@@ -673,9 +713,10 @@ void call_fused_add_rms_norm_kernel(
   auto inp_ptr = reinterpret_cast<std::uintptr_t>(input_ptr);
   auto res_ptr = reinterpret_cast<std::uintptr_t>(residual_ptr);
   auto wt_ptr = reinterpret_cast<std::uintptr_t>(weight_ptr);
-  bool ptrs_are_aligned = inp_ptr % req_alignment_bytes == 0 &&
-                          res_ptr % req_alignment_bytes == 0 &&
-                          wt_ptr % req_alignment_bytes == 0;
+  bool ptrs_are_aligned =
+      inp_ptr % req_alignment_bytes == 0 &&
+      res_ptr % req_alignment_bytes == 0 &&
+      (weight_ptr == nullptr || wt_ptr % req_alignment_bytes == 0);
   bool offsets_are_multiple_of_vector_width =
       hidden_size % vector_width == 0 && input_stride % vector_width == 0;
   bool can_vec = ptrs_are_aligned && offsets_are_multiple_of_vector_width;
@@ -690,7 +731,7 @@ void call_fused_add_rms_norm_kernel(
       sycl::local_accessor<float, 1> s_variance(sycl::range<1>(1), cgh);
       cgh.parallel_for(
           sycl::nd_range<3>(grid * block, block),
-          fused_add_rms_norm_kernel<sycl_t, vector_width>(
+          fused_add_rms_norm_kernel<sycl_t, vector_width, HasWeight>(
               (sycl_t*)input_ptr,
               (sycl_t*)residual_ptr,
               input_stride,
@@ -706,7 +747,7 @@ void call_fused_add_rms_norm_kernel(
       sycl::local_accessor<float, 1> s_variance(sycl::range<1>(1), cgh);
       cgh.parallel_for(
           sycl::nd_range<3>(grid * block, block),
-          fused_add_rms_norm_kernel<sycl_t, 0>(
+          fused_add_rms_norm_kernel<sycl_t, 0, HasWeight>(
               (sycl_t*)input_ptr,
               (sycl_t*)residual_ptr,
               input_stride,
@@ -724,7 +765,7 @@ void call_fused_add_rms_norm_kernel(
 void rms_norm(
     torch::Tensor& out,
     torch::Tensor& input,
-    torch::Tensor& weight,
+    std::optional<torch::Tensor> weight,
     double epsilon) {
   const at::DeviceGuard device_guard(input.device());
   TORCH_CHECK(out.is_contiguous());
@@ -732,25 +773,45 @@ void rms_norm(
     input = input.contiguous();
   }
   TORCH_CHECK(input.stride(-1) == 1);
-  TORCH_CHECK(weight.is_contiguous());
+  const bool has_weight = weight.has_value();
+  if (has_weight) {
+    TORCH_CHECK(weight->is_contiguous());
+  }
   VLLM_DISPATCH_FLOATING_TYPES(
       input.scalar_type(), "call_rms_norm_kernel", [&] {
-        vllm::call_rms_norm_kernel<scalar_t>(out, input, weight, epsilon);
+        const scalar_t* weight_ptr =
+            has_weight ? weight->data_ptr<scalar_t>() : nullptr;
+        if (has_weight) {
+          vllm::call_rms_norm_kernel<scalar_t, true>(
+              out, input, weight_ptr, epsilon);
+        } else {
+          vllm::call_rms_norm_kernel<scalar_t, false>(
+              out, input, weight_ptr, epsilon);
+        }
       });
 }
 
 void fused_add_rms_norm(
     torch::Tensor& input,
     torch::Tensor& residual,
-    torch::Tensor& weight,
+    std::optional<torch::Tensor> weight,
     double epsilon) {
   const at::DeviceGuard device_guard(input.device());
-  int hidden_size = input.size(-1);
-  int num_tokens = input.numel() / hidden_size;
+  const bool has_weight = weight.has_value();
+  if (has_weight) {
+    TORCH_CHECK(weight->is_contiguous());
+  }
 
   VLLM_DISPATCH_FLOATING_TYPES(
       input.scalar_type(), "call_fused_add_rms_norm_kernel", [&] {
-        vllm::call_fused_add_rms_norm_kernel<scalar_t>(
-            input, residual, weight, epsilon);
+        const scalar_t* weight_ptr =
+            has_weight ? weight->data_ptr<scalar_t>() : nullptr;
+        if (has_weight) {
+          vllm::call_fused_add_rms_norm_kernel<scalar_t, true>(
+              input, residual, weight_ptr, epsilon);
+        } else {
+          vllm::call_fused_add_rms_norm_kernel<scalar_t, false>(
+              input, residual, weight_ptr, epsilon);
+        }
       });
 }

--- a/csrc/ops.h
+++ b/csrc/ops.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <optional>
 #include <torch/all.h>
 
 torch::Tensor weak_ref_tensor(torch::Tensor& tensor);
@@ -7,13 +8,13 @@ torch::Tensor weak_ref_tensor(torch::Tensor& tensor);
 void rms_norm(
     torch::Tensor& out,
     torch::Tensor& input,
-    torch::Tensor& weight,
+    std::optional<torch::Tensor> weight,
     double epsilon);
 
 void fused_add_rms_norm(
     torch::Tensor& input,
     torch::Tensor& residual,
-    torch::Tensor& weight,
+    std::optional<torch::Tensor> weight,
     double epsilon);
 
 // Fused RMSNorm + dynamic per-token quantization (FP8 or INT8 output).

--- a/csrc/torch_bindings.cpp
+++ b/csrc/torch_bindings.cpp
@@ -24,14 +24,14 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
   // FIXME: torch op check consider input & weight is mutable in some ut
   // cases. so we make it mutable here.
   ops.def(
-      "rms_norm(Tensor! result, Tensor input, Tensor weight, float epsilon) "
+      "rms_norm(Tensor! result, Tensor input, Tensor? weight, float epsilon) "
       "-> "
       "()");
   ops.impl("rms_norm", torch::kXPU, &rms_norm);
 
   // In-place fused Add and RMS Normalization.
   ops.def(
-      "fused_add_rms_norm(Tensor! input, Tensor! residual, Tensor weight, "
+      "fused_add_rms_norm(Tensor! input, Tensor! residual, Tensor? weight, "
       "float epsilon) -> ()");
   ops.impl("fused_add_rms_norm", torch::kXPU, &fused_add_rms_norm);
 

--- a/tests/ops/layernorm_op.py
+++ b/tests/ops/layernorm_op.py
@@ -10,7 +10,8 @@ from tests.ops.custom_ops import CustomOp
 
 
 def fused_add_rms_norm(
-        x: torch.Tensor, residual: torch.Tensor, weight: torch.Tensor,
+        x: torch.Tensor, residual: torch.Tensor,
+        weight: Optional[torch.Tensor],
         variance_epsilon: float) -> tuple[torch.Tensor, torch.Tensor]:
     import tests.register_ops as ops
     ops.fused_add_rms_norm(
@@ -22,7 +23,7 @@ def fused_add_rms_norm(
     return x, residual
 
 
-def rms_norm(x: torch.Tensor, weight: torch.Tensor,
+def rms_norm(x: torch.Tensor, weight: Optional[torch.Tensor],
              variance_epsilon: float) -> torch.Tensor:
     import tests.register_ops as ops
     out = torch.empty_like(x)
@@ -118,12 +119,12 @@ class RMSNorm(CustomOp):
 
         add_residual = residual is not None
         norm_func = dispatch_cuda_rmsnorm_func(add_residual)
+        weight = self.weight.data if self.has_weight else None
 
         if add_residual:
-            return norm_func(x, residual, self.weight.data,
-                             self.variance_epsilon)
+            return norm_func(x, residual, weight, self.variance_epsilon)
         else:
-            return norm_func(x, self.weight.data, self.variance_epsilon)
+            return norm_func(x, weight, self.variance_epsilon)
 
     def forward_xpu(
         self,
@@ -133,6 +134,6 @@ class RMSNorm(CustomOp):
         return self.forward_cuda(x, residual)
 
     def extra_repr(self) -> str:
-        s = f"hidden_size={self.weight.data.size(0)}"
+        s = f"hidden_size={self.hidden_size}"
         s += f", eps={self.variance_epsilon}"
         return s

--- a/tests/register_ops.py
+++ b/tests/register_ops.py
@@ -9,8 +9,8 @@ import vllm_xpu_kernels._xpu_C  # noqa: F401
 
 
 # layer norm ops
-def rms_norm(out: torch.Tensor, input: torch.Tensor, weight: torch.Tensor,
-             epsilon: float) -> None:
+def rms_norm(out: torch.Tensor, input: torch.Tensor,
+             weight: Optional[torch.Tensor], epsilon: float) -> None:
     # TODO: Remove this contiguous call when the kernel is updated to support
     # non-contiguous input
     input_contiguous = input.contiguous()
@@ -18,7 +18,8 @@ def rms_norm(out: torch.Tensor, input: torch.Tensor, weight: torch.Tensor,
 
 
 def fused_add_rms_norm(input: torch.Tensor, residual: torch.Tensor,
-                       weight: torch.Tensor, epsilon: float) -> None:
+                       weight: Optional[torch.Tensor],
+                       epsilon: float) -> None:
     torch.ops._C.fused_add_rms_norm(input, residual, weight, epsilon)
 
 

--- a/tests/test_layernorm.py
+++ b/tests/test_layernorm.py
@@ -16,6 +16,7 @@ HEAD_DIMS = [128, 64]
 NUM_Q_HEADS = [32, 40, 64]
 NUM_KV_HEADS = [8, 32]
 ADD_RESIDUAL = [False, True]
+HAS_WEIGHT = [False, True]
 SEEDS = [0]
 XPU_DEVICES = [
     f"xpu:{i}" for i in range(1 if torch.xpu.device_count() == 1 else 2)
@@ -33,6 +34,7 @@ MINI_PYTEST_PARAMS = {
 @pytest.mark.parametrize("num_tokens", NUM_TOKENS)
 @pytest.mark.parametrize("hidden_size", HIDDEN_SIZES)
 @pytest.mark.parametrize("add_residual", ADD_RESIDUAL)
+@pytest.mark.parametrize("has_weight", HAS_WEIGHT)
 @pytest.mark.parametrize("dtype", DTYPES)
 @pytest.mark.parametrize("seed", SEEDS)
 @pytest.mark.parametrize("device", XPU_DEVICES)
@@ -42,6 +44,7 @@ def test_rms_norm(
     num_tokens: int,
     hidden_size: int,
     add_residual: bool,
+    has_weight: bool,
     dtype: torch.dtype,
     seed: int,
     device: str,
@@ -50,8 +53,9 @@ def test_rms_norm(
     # Note: torch.set_default_device("xpu:1") not works.
     torch.set_default_device("xpu")
     torch.xpu.set_device(device)
-    layer = RMSNorm(hidden_size).to(dtype=dtype)
-    layer.weight.data.normal_(mean=1.0, std=0.1)
+    layer = RMSNorm(hidden_size, has_weight=has_weight).to(dtype=dtype)
+    if has_weight:
+        layer.weight.data.normal_(mean=1.0, std=0.1)
     scale = 1 / (2 * hidden_size)
     last_dim = 2 * hidden_size if strided_input else hidden_size
     x = torch.randn(num_tokens, last_dim, dtype=dtype)
@@ -75,12 +79,13 @@ def test_rms_norm(
     else:
         torch.testing.assert_close(out, ref_out, atol=1e-2, rtol=1e-2)
 
+    weight = layer.weight.data if has_weight else None
     if residual is not None:
         opcheck(torch.ops._C.fused_add_rms_norm,
-                (x, residual, layer.weight.data, layer.variance_epsilon))
+                (x, residual, weight, layer.variance_epsilon))
     else:
         opcheck(torch.ops._C.rms_norm,
-                (out, x, layer.weight.data, layer.variance_epsilon))
+                (out, x, weight, layer.variance_epsilon))
 
 
 @pytest.mark.parametrize("num_tokens", NUM_TOKENS)


### PR DESCRIPTION
# [LayerNorm] Support weightless RMSNorm in XPU kernels

This PR adds native weightless RMSNorm support (`has_weight=False`) in `vllm-xpu-kernels`, aligning the XPU op interface with the upstream vLLM CUDA change ([`93bbe94`](https://github.com/vllm-project/vllm/commit/93bbe94d3a3a49bc5a845edfa8ac75ada54614e1), PR [#44109](https://github.com/vllm-project/vllm/pull/44109)).

The upstream commit added a weightless RMSNorm path for CUDA only. On the XPU side, models that use weightless RMSNorm (e.g. `Gemma4Router.norm`, `Gemma4Attention.v_norm`) now fall back to the unfused `aten::pow → aten::mean → aten::rsqrt → aten::mul` chain, causing:

* **Performance regression** — the unfused chain introduces extra kernel launches and redundant memory traffic compared to the fused kernel.

This PR adds weight-optional rms_norm support to `vllm-xpu-kernels`:

- A compile-time `bool HasWeight` template parameter is added to all RMS norm kernel classes (`rms_norm_kernel`, `rms_norm_multi_row_kernel`, `fused_add_rms_norm_kernel` and their scalar-fallback specializations). Weight loads and multiplies are guarded by `if constexpr (HasWeight)` and compiled out entirely for the weightless case.
- The public op signatures (`rms_norm`, `fused_add_rms_norm`) change from `Tensor weight` to `Tensor? weight` / `std::optional<torch::Tensor>`, following the PyTorch/vLLM optional-tensor convention.
- Tests are extended with `has_weight ∈ {False, True}` parametrization. All existing and new tests pass, including `opcheck` validation for both variants.

## Related PRs

| PR | Repo | Role |
|---|---|---|
| [#47121](https://github.com/vllm-project/vllm/pull/47121) | vllm-project/vllm | vLLM side: Routes weightless RMSNorm to `_C` dispatch on XPU |
| This PR | vllm-project/vllm-xpu-kernels | XPU kernel side: Support weightless RMSNorm in XPU kernels |

## Impact

We verified on **Gemma4-26B-it** serving benchmarks (B60, isl/osl=4k/1k, TP=4, concurrency=16, bf16, enforce-eager) with three configurations:

- **baseline**: Current vllm commit [`6e3a983`](https://github.com/vllm-project/vllm/commit/6e3a983cf3c533c6f7b3c2906a1d1483609413b8), — weightless RMSNorm falls back to unfused `aten` chain.
- **WA**: Python-level workaround — construct all-ones weight tensor, force fused path.
- **This PR**: Native weightless kernel support, 

| Metric | baseline | WA | This PR | This PR vs<br>WA | This PR vs<br>baseline |
|---|---:|---:|---:|---:|---:|
| Output token throughput (tok/s) | **265.61** | **301.16** | **312.53** | **+3.78%** | **+17.67%** |
| Mean TTFT (ms) | **3,418.59** | **3,223.69** | **3,222.73** | **-0.03%** | **-5.73%** |
| Median TTFT (ms) | **3,617.73** | **3,407.06** | **3,406.21** | **-0.02%** | **-5.85%** |
| P99 TTFT (ms) | **9,619.43** | **9,063.02** | **9,061.84** | **-0.01%** | **-5.80%** |
| Mean TPOT (ms) | **56.92** | **50.00** | **48.07** | **-3.86%** | **-15.55%** |
| Median TPOT (ms) | **56.74** | **49.89** | **47.92** | **-3.94%** | **-15.54%** |
| P99 TPOT (ms) | **59.64** | **52.68** | **50.77** | **-3.62%** | **-14.86%** |

This PR support weightless RMSNorm in `vllm-xpu-kernels`. Both `WA` and this PR eliminate the unfused fallback, but this PR further reduces TPOT by ~4% over `WA` by avoiding the dummy-weight allocation, memory load, and identity-multiply in the inner loop.

Another comparative experiment was conducted on **Qwen3-30B-A3B** (B60, isl/osl=4k/1k, TP=4, concurrency=32, bf16, enforce-eager) as an example of non-weightless-RMS model; No end-to-end performance regression was observed.

| Metric | baseline | This PR | This PR vs<br> baseline |
|---|---:|---:|---:|
| Output token throughput (tok/s) | 589.78 | 594.37 | +0.78% |
| Mean TTFT (ms) | 3328.48 | 3311.58 | -0.51% |
| Mean TPOT (ms) | 51.03 | 50.62 | -0.80% |

## Co-authors

* Yintong Lu (@yintong-lu )

