### PR TITLE
fix: use int64 for kv_stride in fp8_paged_mqa_logits to prevent overflow

### DIFF
--- a/csrc/xpu/mqa_logits/xe_2/mqa_logits_xe2.cpp
+++ b/csrc/xpu/mqa_logits/xe_2/mqa_logits_xe2.cpp
@@ -301,8 +301,8 @@ class fp8_paged_mqa_logits_kernel_t {
     int64_t block_size;
     int64_t max_blocks;
     int64_t max_model_len;
-    int32_t kv_stride0;
-    int32_t scale_stride0;
+    int64_t kv_stride0;
+    int64_t scale_stride0;
   };
 
   CUTLASS_DEVICE
@@ -613,11 +613,11 @@ torch::Tensor fp8_paged_mqa_logits_xe2(
   const int32_t* block_tables_ptr = block_tables.data_ptr<int32_t>();
   float* out_ptr = logits.data_ptr<float>();
 
-  const int32_t kv_stride0 = kv.stride(0);
-  const int32_t kv_stride1 = kv.stride(1);
-  const int32_t kv_stride3 = kv.stride(3);
-  const int32_t scale_stride0 = kv_scales.stride(0);
-  const int32_t scale_stride1 = kv_scales.stride(1);
+  const int64_t kv_stride0 = kv.stride(0);
+  const int64_t kv_stride1 = kv.stride(1);
+  const int64_t kv_stride3 = kv.stride(3);
+  const int64_t scale_stride0 = kv_scales.stride(0);
+  const int64_t scale_stride1 = kv_scales.stride(1);
 
   TORCH_CHECK(kv_stride1 == index_dim, "kv index_dim stride mismatch");
   TORCH_CHECK(kv_stride3 == 1, "kv last dim stride mismatch");


### PR DESCRIPTION
## Summary

Fix GPU segfault (page fault) in `fp8_paged_mqa_logits_xe2` caused by `int32_t` stride overflow in the packed multi-layer KV cache layout.

## Problem

With vLLM's unified KV cache allocation, all attention layers share one allocation. Each page contains data for ALL layers, making `stride(0)` very large (e.g., `1,039,680` for DeepSeek-V4-Flash).

The kernel stored `kv_stride0` and `scale_stride0` as `int32_t`. When computing the memory offset `physical_block_index × stride`, the product overflows `INT32_MAX` for block indices > 2065:

```
stride(0) = 1,039,680
INT32_MAX  = 2,147,483,647
Overflow at: INT32_MAX / 1,039,680 ≈ 2065

block 2066 × 1,039,680 = 2,147,978,880 > INT32_MAX
→ wraps to negative offset → GPU reads unmapped memory → page fault
```

The crash manifests as:
```
Segmentation fault from GPU at 0xff00000b65ba2000, ctx_id: 1 (CCS)
  type: 0 (NotPresent), level: 2 (PDP), access: 0 (Read), banned: 1, aborting.
```

## Fix

Change `kv_stride0` and `scale_stride0` from `int32_t` to `int64_t` in:
1. `fp8_paged_mqa_logits_kernel_t::Params` struct
2. `fp8_paged_mqa_logits_xe2()` launch function local variables

## Testing

Tested with DeepSeek-V4-Flash, TP=4, INPUT_LEN=8192:
- **Before**: 100% crash at first decode step after prefill
- **After**: Inference completes successfully with coherent output