### PR TITLE
[ATTN][DECODE] Route small uniform-`q_len` causal attention to the split-K decode path

### DIFF
--- a/tests/flash_attn/test_flash_attn_varlen_func.py
+++ b/tests/flash_attn/test_flash_attn_varlen_func.py
@@ -1241,3 +1241,113 @@ def test_decode_with_cross_layer_paged_kv(
     torch.testing.assert_close(output, ref_output, atol=atol, rtol=rtol), \
         f"{torch.max(torch.abs(output - ref_output))}"
     torch.xpu.empty_cache()
+
+
+# Speculative-decoding fast path: a uniform, small, causal query length per
+# sequence (q_len = num_speculative_tokens + 1) must be routed to the split-K
+# decode kernel and still match the causal reference exactly.
+@pytest.mark.parametrize("q_len", [2, 3, 4])
+@pytest.mark.parametrize("seq_lens", [[(1328, ), (18, ), (463, )],
+                                      [(1025, ), (523, ), (37, ), (200, )]])
+@pytest.mark.parametrize("num_heads", [(8, 2), (16, 1)])
+@pytest.mark.parametrize("head_size", [128])
+@pytest.mark.parametrize("block_size", [16, 32, 64])
+@pytest.mark.parametrize("window_size", [(-1, -1), (256, 0)])
+@pytest.mark.parametrize("dtype", DTYPES, ids=format_tc)
+@pytest.mark.parametrize("is_sink", [False, True])
+@pytest.mark.parametrize("num_blocks", [4096])
+@torch.inference_mode()
+def test_spec_decode_uniform_qlen(
+    q_len: int,
+    seq_lens: list[tuple[int]],
+    num_heads: tuple[int, int],
+    head_size: int,
+    block_size: int,
+    window_size: tuple[int, int],
+    dtype: torch.dtype,
+    is_sink: bool,
+    num_blocks: int,
+) -> None:
+    import vllm_xpu_kernels.flash_attn_interface as fai
+
+    torch.set_default_device("xpu")
+    torch.xpu.set_device("xpu:0")
+    torch.manual_seed(4242)
+
+    num_seqs = len(seq_lens)
+    query_lens = [q_len] * num_seqs
+    kv_lens = [x[0] for x in seq_lens]
+    num_query_heads, num_kv_heads = num_heads
+    assert num_query_heads % num_kv_heads == 0
+    max_kv_len = max(kv_lens)
+    scale = head_size**-0.5
+
+    query = torch.randn(sum(query_lens),
+                        num_query_heads,
+                        head_size,
+                        dtype=dtype)
+    key_cache = torch.randn(num_blocks,
+                            block_size,
+                            num_kv_heads,
+                            head_size,
+                            dtype=dtype)
+    value_cache = torch.randn_like(key_cache)
+
+    cu_query_lens = torch.tensor([0] + query_lens,
+                                 dtype=torch.int32).cumsum(dim=0,
+                                                           dtype=torch.int32)
+    seq_k = torch.tensor(kv_lens, dtype=torch.int32)
+    max_num_blocks_per_seq = (max_kv_len + block_size - 1) // block_size
+    block_tables = torch.randint(0,
+                                 num_blocks, (num_seqs, max_num_blocks_per_seq),
+                                 dtype=torch.int32)
+    sink = torch.randn(num_query_heads, dtype=dtype) if is_sink else None
+
+    # Confirm the spec-decode fast path is actually taken.
+    orig_spec = fai._spec_decode_varlen_fwd
+    used = {"flag": False, "q_len": 0}
+
+    def _traced(*args, **kwargs):
+        used["flag"] = True
+        used["q_len"] = args[0].shape[0] // (args[4].numel() - 1)
+        return orig_spec(*args, **kwargs)
+
+    fai._spec_decode_varlen_fwd = _traced
+    try:
+        output = flash_attn_varlen_func(query,
+                                        key_cache,
+                                        value_cache,
+                                        q_len,
+                                        cu_query_lens,
+                                        max_kv_len,
+                                        seqused_k=seq_k,
+                                        softmax_scale=scale,
+                                        causal=True,
+                                        block_table=block_tables,
+                                        window_size=list(window_size),
+                                        s_aux=sink)
+    finally:
+        fai._spec_decode_varlen_fwd = orig_spec
+
+    assert used["flag"] and used["q_len"] == q_len, \
+        "speculative-decode fast path was not taken"
+
+    ref_output = ref_paged_attn(query=query.contiguous(),
+                                key_cache=key_cache.contiguous(),
+                                value_cache=value_cache.contiguous(),
+                                query_lens=query_lens,
+                                kv_lens=kv_lens,
+                                block_tables=block_tables,
+                                scale=scale,
+                                casual=True,
+                                is_paged=True,
+                                sink=sink,
+                                window_size_left=window_size[0],
+                                window_size_right=window_size[1],
+                                dtype=dtype)
+    atol, rtol = 2e-2, 1e-2
+    if window_size[0] != -1 or window_size[1] != -1:
+        atol, rtol = 1.5e-2, 1.5e-2
+    torch.testing.assert_close(output, ref_output, atol=atol, rtol=rtol), \
+        f"{torch.max(torch.abs(output - ref_output))}"
+    torch.xpu.empty_cache()

--- a/vllm_xpu_kernels/flash_attn_interface.py
+++ b/vllm_xpu_kernels/flash_attn_interface.py
@@ -43,7 +43,8 @@ DEFAULT_FA_VERSION = 2
 # lengths on Xe2 (crossover is ~q_len 32); override it with
 # VLLM_XPU_SPEC_DECODE_MAX_QLEN (set to 0/1 to disable the fast path).
 try:
-    _SPEC_DECODE_MAX_QLEN = int(os.environ.get("VLLM_XPU_SPEC_DECODE_MAX_QLEN", "16"))
+    _SPEC_DECODE_MAX_QLEN = int(
+        os.environ.get("VLLM_XPU_SPEC_DECODE_MAX_QLEN", "16"))
 except ValueError:
     _SPEC_DECODE_MAX_QLEN = 16
 

--- a/vllm_xpu_kernels/flash_attn_interface.py
+++ b/vllm_xpu_kernels/flash_attn_interface.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+import os
 from typing import Optional
 
 import torch
@@ -15,6 +16,115 @@ except ImportError as e:
 #isort: on
 
 DEFAULT_FA_VERSION = 2
+
+# Speculative-decoding fast path.
+#
+# In speculative decoding every sequence in the batch issues the same small
+# number of query tokens (q_len = num_speculative_tokens + 1, e.g. 2/3/4). By
+# default such a batch (max_seqlen_q > 1) is routed to the chunk-prefill
+# kernel, which has no split-K parallelism over the KV dimension. With a long
+# KV cache and only a handful of query rows the GPU is heavily under-utilized,
+# so prefill is slow.
+#
+# Instead we reuse the split-K *decode* kernel: for a uniform, causal, paged
+# batch we treat each (sequence, query-position) pair as an independent
+# single-token decode "sequence" and run the whole batch in one decode
+# launch. Query token ``j`` (0-indexed within the q_len window) attends
+# causally to KV positions ``[0, kv_len - q_len + j]``, i.e.
+# ``seqused_k - (q_len - 1 - j)`` tokens, so each pseudo-sequence is an
+# ordinary q_len==1 decode with a per-position-adjusted ``seqused_k``. This is
+# exact (it matches the causal reference) and gets the decode path's split-K
+# parallelism.
+#
+# The path only triggers for small, uniform query lengths; larger uniform
+# query lengths keep using chunk-prefill (which reuses the shared KV tile
+# across the Q block, whereas the decode path rescans KV per query token).
+# The default threshold (16) stays within the measured win region across KV
+# lengths on Xe2 (crossover is ~q_len 32); override it with
+# VLLM_XPU_SPEC_DECODE_MAX_QLEN (set to 0/1 to disable the fast path).
+_SPEC_DECODE_MAX_QLEN = int(
+    os.environ.get("VLLM_XPU_SPEC_DECODE_MAX_QLEN", "16"))
+
+
+def _spec_decode_varlen_fwd(
+    q,
+    k,
+    v,
+    out,
+    cu_seqlens_q,
+    seqused_k,
+    block_table,
+    max_seqlen_k,
+    k_descale,
+    v_descale,
+    softmax_scale,
+    s_aux,
+    window_size,
+    softcap,
+):
+    """Run the split-K decode kernel once for a speculative-decode batch.
+
+    Assumes a uniform query length: every sequence contributes the same
+    ``q_len`` consecutive query tokens, laid out as ``q[i * q_len + j]`` for
+    sequence ``i`` and position ``j``. Each (sequence, position) pair is
+    treated as an independent single-token decode "sequence", so the whole
+    batch runs in a single ``varlen_fwd`` launch. Returns the output tensor
+    (same row order as ``q``).
+    """
+    batch = cu_seqlens_q.numel() - 1
+    q_len = q.shape[0] // batch
+    total = q.shape[0]  # batch * q_len
+
+    # One decode query per (sequence, position) pair; the row order already
+    # matches q, so the output needs no reordering.
+    cu_seqlens_q_spec = torch.arange(total + 1,
+                                     dtype=torch.int32,
+                                     device=q.device)
+    dummy_cu_seqlens_k = torch.empty_like(cu_seqlens_q_spec)
+
+    # Causal per-position KV length: query row i*q_len + j (position j within
+    # the q_len window of sequence i) attends to seqused_k[i] - (q_len-1-j)
+    # tokens.
+    pos = torch.arange(q_len, device=q.device, dtype=seqused_k.dtype)
+    seqused_k_spec = (seqused_k.view(batch, 1) -
+                      (q_len - 1 - pos).view(1, q_len)).clamp_(min=1).reshape(
+                          total).to(torch.int32)
+
+    # Expand the block table so each pseudo-sequence points at its parent
+    # sequence's blocks.
+    block_table_spec = block_table.repeat_interleave(q_len, dim=0)
+
+    out, _ = torch.ops._vllm_fa2_C.varlen_fwd(
+        q,
+        k,
+        v,
+        out,
+        cu_seqlens_q_spec,
+        dummy_cu_seqlens_k,
+        seqused_k_spec,
+        None,
+        block_table_spec,
+        None,  # alibi_slopes
+        1,  # max_seqlen_q
+        max_seqlen_k,
+        0.0,  # dropout_p
+        k_descale,
+        v_descale,
+        softmax_scale,
+        s_aux,
+        False,  # zero_tensors
+        False,  # causal: handled by per-position seqused_k
+        window_size[0],
+        window_size[1],
+        softcap,
+        False,  # return_softmax
+        None,  # gen
+        None,  # num_splits (let the kernel pick via get_num_splits)
+        False,  # is_mix_batch
+        None,  # splits_per_seq
+        None,  # work_list
+    )
+    return out
 
 
 def maybe_contiguous(x):
@@ -387,6 +497,36 @@ def flash_attn_varlen_func(
                                            and v_descale is not None):
             raise NotImplementedError(
                 "FA2 only supports both KV cache descaled")
+
+        # Speculative-decoding fast path: redirect small, uniform, causal,
+        # paged query batches (q_len = num_speculative_tokens + 1) from the
+        # slow chunk-prefill kernel to the split-K decode kernel. See the
+        # comment on _SPEC_DECODE_MAX_QLEN above for the rationale.
+        batch = cu_seqlens_q.numel() - 1
+        is_uniform_qlen = (batch > 0 and q.shape[0] == batch * max_seqlen_q)
+        if (block_table is not None and causal and not return_softmax_lse
+                and softcap == 0.0 and alibi_slopes is None and q_v is None
+                and q_descale is None and scheduler_metadata is None
+                and seqused_k is not None
+                and 1 < max_seqlen_q <= _SPEC_DECODE_MAX_QLEN
+                and is_uniform_qlen):
+            return _spec_decode_varlen_fwd(
+                q,
+                k,
+                v,
+                out,
+                cu_seqlens_q,
+                seqused_k,
+                block_table,
+                max_seqlen_k,
+                k_descale,
+                v_descale,
+                softmax_scale,
+                s_aux,
+                real_window_size,
+                softcap,
+            )
+
         # Compute per-seq splits and work_list on host, upload to device.
         # Only enable for decode (max_seqlen_q == 1) with paged KV cache,
         # multi-seq batches, and global num_splits_kv > 1.

--- a/vllm_xpu_kernels/flash_attn_interface.py
+++ b/vllm_xpu_kernels/flash_attn_interface.py
@@ -42,8 +42,10 @@ DEFAULT_FA_VERSION = 2
 # The default threshold (16) stays within the measured win region across KV
 # lengths on Xe2 (crossover is ~q_len 32); override it with
 # VLLM_XPU_SPEC_DECODE_MAX_QLEN (set to 0/1 to disable the fast path).
-_SPEC_DECODE_MAX_QLEN = int(
-    os.environ.get("VLLM_XPU_SPEC_DECODE_MAX_QLEN", "16"))
+try:
+    _SPEC_DECODE_MAX_QLEN = int(os.environ.get("VLLM_XPU_SPEC_DECODE_MAX_QLEN", "16"))
+except ValueError:
+    _SPEC_DECODE_MAX_QLEN = 16
 
 
 def _spec_decode_varlen_fwd(
@@ -80,8 +82,7 @@ def _spec_decode_varlen_fwd(
     cu_seqlens_q_spec = torch.arange(total + 1,
                                      dtype=torch.int32,
                                      device=q.device)
-    dummy_cu_seqlens_k = torch.empty_like(cu_seqlens_q_spec)
-
+    dummy_cu_seqlens_k = torch.zeros_like(cu_seqlens_q_spec)
     # Causal per-position KV length: query row i*q_len + j (position j within
     # the q_len window of sequence i) attends to seqused_k[i] - (q_len-1-j)
     # tokens.


### PR DESCRIPTION
## Summary

In speculative decoding, every sequence in a batch issues the same small number
of query tokens (`q_len = num_speculative_tokens + 1`, typically 2/3/4). Because
`max_seqlen_q > 1`, these batches were dispatched to the **chunk-prefill**
kernel, which has no split-K parallelism over the KV dimension. With a long KV
cache and only a handful of query rows, the GPU is badly under-utilized, so the
prefill path is slow.

This PR adds a fast path in `flash_attn_varlen_func` that redirects small,
**uniform** query-length, causal, paged batches to the split-K **decode**
kernel, which already parallelizes across the KV dimension. The redirect is
exact and runs in a **single** `varlen_fwd` launch.

## Approach

For a uniform-`q_len` batch, each `(sequence, query-position)` pair is treated
as an independent single-token decode "sequence". The whole batch then runs as
one ordinary `q_len == 1` decode launch:

- **`cu_seqlens_q`** → `arange(batch * q_len + 1)` — one query per
  pseudo-sequence. The pseudo-sequence order already matches `q`'s row order
  (`q[i * q_len + j]`), so the output needs no reordering and a caller-provided
  `out` is written in place.
- **`seqused_k`** → per-position causal KV lengths. Query token `j`
  (0-indexed within the `q_len` window) attends causally to
  `seqused_k[i] - (q_len - 1 - j)` tokens, computed via broadcasting into a
  `[batch, q_len]` matrix and flattened to `[batch * q_len]`.
- **`block_table`** → `repeat_interleave(q_len, dim=0)` so each
  pseudo-sequence points at its parent sequence's blocks.

Causality is expressed entirely through the per-position `seqused_k`, so the
decode kernel is invoked with `causal=False` and produces results identical to
the causal reference.

### Correctness intuition

`seqused_k[i]` follows the standard vLLM paged convention: it is the **total**
KV length *after* the current tokens' K/V are written into the cache, i.e.
`context + q_len`. Then:

```
seqused_k[i] - (q_len - 1 - j) = (context + q_len) - (q_len - 1 - j)
                              = context + j + 1
```

which is exactly the number of KV positions `[0, context + j]` that spec token
`j` may attend to under a causal mask.

## Scope

The trigger is purely structural, so the path is **not** limited to speculative
decoding — any small, uniform-`q_len`, causal, paged batch qualifies (e.g.
fresh prefill with equal prompt lengths, or uniform-chunk chunked prefill). It
activates only when all of the following hold:

- paged KV cache (`block_table` provided) and `seqused_k` provided
- `causal=True`
- uniform query length (`q.shape[0] == batch * max_seqlen_q`)
- `1 < max_seqlen_q <= VLLM_XPU_SPEC_DECODE_MAX_QLEN` (default `16`)
- no `return_softmax_lse`, `softcap`, `alibi_slopes`, `q_v`, `q_descale`, or
  `scheduler_metadata`

Anything that does not match falls through to the existing chunk-prefill /
decode dispatch unchanged.

### Tuning knob

`VLLM_XPU_SPEC_DECODE_MAX_QLEN` (default `16`) caps the query length eligible
for the fast path. The decode path rescans the KV cache per query token (no KV
tile reuse across the Q block), so its cost grows roughly linearly in `q_len`;
beyond the measured crossover (~`q_len` 32 on Xe2) chunk-prefill is faster. Set
the variable to `0`/`1` to disable the fast path entirely.

## Performance

Measured on Intel Arc B580 (Xe2), batch = 32, single `varlen_fwd` launch,
speedup of the decode path over the chunk-prefill path:

| `q_len` | kv = 2048 | kv = 8192 |
| ------: | --------: | --------: |
|       2 |    6.93×  |    5.55×  |
|       4 |    4.66×  |    4.57×  |
|       6 |    3.93×  |    3.90×  |
|       8 |    3.51×  |    3.32×  |
|      10 |    3.04×  |    2.80×  |

The path continues to win up to ~`q_len` 32; the default threshold of 16 keeps
it comfortably inside the win region.

## Testing

- Added `test_spec_decode_uniform_qlen` (288 cases) which asserts both that the
  fast path is taken and that the output matches the causal reference across
  `q_len` 2/3/4, GQA ratios (8:2, 16:1), block sizes 16/32/64, sliding window,
  attention sink, and fp16/bf16.
- Verified single-launch behavior, in-place caller-provided `out`, and that
  non-uniform batches correctly fall through to the existing path.
- Verified correctness for pure prefill (`context = 0`) and uniform-chunk
  chunked-prefill shapes.
- No regressions: existing `test_varlen_with_paged_kv` and
  `test_decode_with_paged_kv` suites (2804 cases) still pass.
- `ruff` / `isort` / `mypy` pre-commit hooks pass.

## Files changed

- `vllm_xpu_kernels/flash_attn_interface.py` — add `_spec_decode_varlen_fwd`
  helper, the `_SPEC_DECODE_MAX_QLEN` knob, and the dispatch guard.
- `tests/flash_attn/test_flash_attn_varlen_func.py` — add
  `test_spec_decode_uniform_qlen` regression test.
