### PR TITLE
[MoE] update moe_sum op

### DIFF
--- a/csrc/moe/moe_align_sum_kernels.cpp
+++ b/csrc/moe/moe_align_sum_kernels.cpp
@@ -582,27 +582,65 @@ class count_and_sort_expert_tokens_kernel {
   }
 };
 
-template <typename scalar_t, int TOPK>
+// Decide whether the k-th expert slot of a token contributes to the reduction.
+template <typename idx_t>
+inline bool moe_sum_slot_active(
+    const idx_t* topk_ids, const int32_t* expert_map, int64_t slot) {
+  if (topk_ids == nullptr) {
+    return true;
+  }
+  const int64_t expert_id = static_cast<int64_t>(topk_ids[slot]);
+  if (expert_id < 0) {
+    return false;
+  }
+  if (expert_map != nullptr && expert_map[expert_id] < 0) {
+    return false;
+  }
+  return true;
+}
+
+template <typename scalar_t, typename idx_t, int TOPK>
 class moe_sum_kernel {
  private:
   scalar_t* output;       // [..., d]
   const scalar_t* input;  // [..., topk, d]
   int d;
+  const idx_t* topk_ids;      // [num_tokens, topk] or nullptr
+  const int32_t* expert_map;  // [num_experts] or nullptr
 
  public:
-  moe_sum_kernel(scalar_t* output, const scalar_t* input, int d)
-      : output(output), input(input), d(d) {}
+  moe_sum_kernel(
+      scalar_t* output,
+      const scalar_t* input,
+      int d,
+      const idx_t* topk_ids,
+      const int32_t* expert_map)
+      : output(output),
+        input(input),
+        d(d),
+        topk_ids(topk_ids),
+        expert_map(expert_map) {}
 
   void operator()(sycl::nd_item<1> item) const {
     const int64_t token_idx = item.get_group(0);
+
+    bool active[TOPK];
+#pragma unroll
+    for (int k = 0; k < TOPK; ++k) {
+      active[k] = moe_sum_slot_active<idx_t>(
+          topk_ids, expert_map, token_idx * TOPK + k);
+    }
+
     for (int64_t idx = item.get_local_id(0); idx < d;
          idx += item.get_local_range(0)) {
-      scalar_t x = 0.0;
+      float x = 0.f;
 #pragma unroll
       for (int k = 0; k < TOPK; ++k) {
-        x += input[token_idx * TOPK * d + k * d + idx];
+        if (active[k]) {
+          x += static_cast<float>(input[token_idx * TOPK * d + k * d + idx]);
+        }
       }
-      output[token_idx * d + idx] = x;
+      output[token_idx * d + idx] = static_cast<scalar_t>(x);
     }
   }
 };
@@ -1166,12 +1204,23 @@ void batched_moe_align_block_size(
 }
 
 void moe_sum(
-    torch::Tensor& input,   // [num_tokens, topk, hidden_size]
-    torch::Tensor& output)  // [num_tokens, hidden_size]
+    torch::Tensor& input,                          // [num_tokens, topk, hidden]
+    torch::Tensor& output,                         // [num_tokens, hidden]
+    const std::optional<torch::Tensor>& topk_ids,  // [num_tokens, topk]
+    const std::optional<torch::Tensor>& expert_map)  // [num_experts]
 {
   const int hidden_size = input.size(-1);
   const auto num_tokens = output.numel() / hidden_size;
   const int topk = input.size(1);
+
+  // Pad-aware reduction is required whenever topk_ids is supplied: slots whose
+  // (global) expert id is negative are padding/invalid, and -- when an
+  // expert_map is given -- experts that map off this device (value < 0) must
+  // also be skipped. Without topk_ids we take the plain fast path.
+  const bool pad_aware = topk_ids.has_value();
+  const int32_t* expert_map_ptr = (pad_aware && expert_map.has_value())
+                                      ? expert_map->data_ptr<int32_t>()
+                                      : nullptr;
 
   at::Device curDevice = at::Device(at::kXPU, at::xpu::current_device());
   at::DeviceGuard device_guard(curDevice);
@@ -1182,50 +1231,83 @@ void moe_sum(
   sycl::range<1> global_range(global_size);
   sycl::range<1> local_range(local_size);
 
+  // Dispatch over the topk_ids index dtype (int32 or int64); when there is no
+  // pad-aware masking we use int32 with a null pointer so the mask is a no-op.
+#define VLLM_MOE_SUM_LAUNCH(TOPK_VAL)                                       \
+  VLLM_DISPATCH_FLOATING_TYPES(input.scalar_type(), "moe_sum_kernel", [&] { \
+    auto* out_ptr = output.data_ptr<scalar_t>();                            \
+    auto* in_ptr = input.data_ptr<scalar_t>();                              \
+    if (pad_aware) {                                                        \
+      AT_DISPATCH_INDEX_TYPES(topk_ids->scalar_type(), "moe_sum_idx", [&] { \
+        const auto* tk_ptr = topk_ids->data_ptr<index_t>();                 \
+        queue.submit([&](sycl::handler& cgh) {                              \
+          cgh.parallel_for(                                                 \
+              sycl::nd_range<1>(global_range, local_range),                 \
+              vllm::moe::moe_sum_kernel<scalar_t, index_t, TOPK_VAL>(       \
+                  out_ptr, in_ptr, hidden_size, tk_ptr, expert_map_ptr));   \
+        });                                                                 \
+      });                                                                   \
+    } else {                                                                \
+      queue.submit([&](sycl::handler& cgh) {                                \
+        cgh.parallel_for(                                                   \
+            sycl::nd_range<1>(global_range, local_range),                   \
+            vllm::moe::moe_sum_kernel<scalar_t, int32_t, TOPK_VAL>(         \
+                out_ptr,                                                    \
+                in_ptr,                                                     \
+                hidden_size,                                                \
+                static_cast<const int32_t*>(nullptr),                       \
+                nullptr));                                                  \
+      });                                                                   \
+    }                                                                       \
+  })
+
   switch (topk) {
+    case 1:
+      VLLM_MOE_SUM_LAUNCH(1);
+      break;
+
     case 2:
-      VLLM_DISPATCH_FLOATING_TYPES(input.scalar_type(), "moe_sum_kernel", [&] {
-        queue.submit([&](sycl::handler& cgh) {
-          cgh.parallel_for(
-              sycl::nd_range<1>(global_range, local_range),
-              vllm::moe::moe_sum_kernel<scalar_t, 2>(
-                  output.data_ptr<scalar_t>(),
-                  input.data_ptr<scalar_t>(),
-                  hidden_size));
-        });
-      });
+      VLLM_MOE_SUM_LAUNCH(2);
       break;
 
     case 3:
-      VLLM_DISPATCH_FLOATING_TYPES(input.scalar_type(), "moe_sum_kernel", [&] {
-        queue.submit([&](sycl::handler& cgh) {
-          cgh.parallel_for(
-              sycl::nd_range<1>(global_range, local_range),
-              vllm::moe::moe_sum_kernel<scalar_t, 3>(
-                  output.data_ptr<scalar_t>(),
-                  input.data_ptr<scalar_t>(),
-                  hidden_size));
-        });
-      });
+      VLLM_MOE_SUM_LAUNCH(3);
       break;
 
     case 4:
-      VLLM_DISPATCH_FLOATING_TYPES(input.scalar_type(), "moe_sum_kernel", [&] {
-        queue.submit([&](sycl::handler& cgh) {
-          cgh.parallel_for(
-              sycl::nd_range<1>(global_range, local_range),
-              vllm::moe::moe_sum_kernel<scalar_t, 4>(
-                  output.data_ptr<scalar_t>(),
-                  input.data_ptr<scalar_t>(),
-                  hidden_size));
-        });
-      });
+      VLLM_MOE_SUM_LAUNCH(4);
+      break;
+
+    case 6:
+      VLLM_MOE_SUM_LAUNCH(6);
+      break;
+
+    case 8:
+      VLLM_MOE_SUM_LAUNCH(8);
+      break;
+
+    case 9:
+      VLLM_MOE_SUM_LAUNCH(9);
       break;
 
     default:
-      at::sum_out(output, input, 1);
+      if (pad_aware) {
+        auto ids = topk_ids.value();
+        auto valid = ids.ge(0);  // drop padding/invalid slots
+        if (expert_map.has_value()) {
+          auto clamped = ids.clamp_min(0).to(torch::kLong);
+          auto local = expert_map->index_select(0, clamped.reshape({-1}))
+                           .reshape(ids.sizes());
+          valid = valid.logical_and(local.ge(0));
+        }
+        auto masked = input.mul(valid.unsqueeze(-1).to(input.scalar_type()));
+        at::sum_out(output, masked, 1);
+      } else {
+        at::sum_out(output, input, 1);
+      }
       break;
   }
+#undef VLLM_MOE_SUM_LAUNCH
 }
 
 void moe_lora_align_block_size(

--- a/csrc/moe/moe_align_sum_kernels.cpp
+++ b/csrc/moe/moe_align_sum_kernels.cpp
@@ -599,7 +599,12 @@ inline bool moe_sum_slot_active(
   return true;
 }
 
-template <typename scalar_t, typename idx_t, int TOPK>
+// PAD_AWARE selects, at compile time, between the plain reduction fast path
+// (no topk_ids/expert_map, no per-slot branch) and the pad-aware masked path.
+// The fast path is instantiated for ordinary tensor-parallel MoE where every
+// slot contributes; it keeps the tight, fully-unrolled fp32 accumulation
+// (matching the pre-masking kernel codegen) while preserving fp32 precision.
+template <typename scalar_t, typename idx_t, int TOPK, bool PAD_AWARE>
 class moe_sum_kernel {
  private:
   scalar_t* output;       // [..., d]
@@ -624,23 +629,36 @@ class moe_sum_kernel {
   void operator()(sycl::nd_item<1> item) const {
     const int64_t token_idx = item.get_group(0);
 
-    bool active[TOPK];
+    if constexpr (!PAD_AWARE) {
+      // Fast path: every slot is active. No mask, no branch in the hot loop.
+      for (int64_t idx = item.get_local_id(0); idx < d;
+           idx += item.get_local_range(0)) {
+        float x = 0.f;
 #pragma unroll
-    for (int k = 0; k < TOPK; ++k) {
-      active[k] = moe_sum_slot_active<idx_t>(
-          topk_ids, expert_map, token_idx * TOPK + k);
-    }
-
-    for (int64_t idx = item.get_local_id(0); idx < d;
-         idx += item.get_local_range(0)) {
-      float x = 0.f;
-#pragma unroll
-      for (int k = 0; k < TOPK; ++k) {
-        if (active[k]) {
+        for (int k = 0; k < TOPK; ++k) {
           x += static_cast<float>(input[token_idx * TOPK * d + k * d + idx]);
         }
+        output[token_idx * d + idx] = static_cast<scalar_t>(x);
       }
-      output[token_idx * d + idx] = static_cast<scalar_t>(x);
+    } else {
+      bool active[TOPK];
+#pragma unroll
+      for (int k = 0; k < TOPK; ++k) {
+        active[k] = moe_sum_slot_active<idx_t>(
+            topk_ids, expert_map, token_idx * TOPK + k);
+      }
+
+      for (int64_t idx = item.get_local_id(0); idx < d;
+           idx += item.get_local_range(0)) {
+        float x = 0.f;
+#pragma unroll
+        for (int k = 0; k < TOPK; ++k) {
+          if (active[k]) {
+            x += static_cast<float>(input[token_idx * TOPK * d + k * d + idx]);
+          }
+        }
+        output[token_idx * d + idx] = static_cast<scalar_t>(x);
+      }
     }
   }
 };
@@ -1286,7 +1304,7 @@ void moe_sum(
         queue.submit([&](sycl::handler& cgh) {                              \
           cgh.parallel_for(                                                 \
               sycl::nd_range<1>(global_range, local_range),                 \
-              vllm::moe::moe_sum_kernel<scalar_t, index_t, TOPK_VAL>(       \
+              vllm::moe::moe_sum_kernel<scalar_t, index_t, TOPK_VAL, true>( \
                   out_ptr, in_ptr, hidden_size, tk_ptr, expert_map_ptr));   \
         });                                                                 \
       });                                                                   \
@@ -1294,7 +1312,7 @@ void moe_sum(
       queue.submit([&](sycl::handler& cgh) {                                \
         cgh.parallel_for(                                                   \
             sycl::nd_range<1>(global_range, local_range),                   \
-            vllm::moe::moe_sum_kernel<scalar_t, int32_t, TOPK_VAL>(         \
+            vllm::moe::moe_sum_kernel<scalar_t, int32_t, TOPK_VAL, false>(  \
                 out_ptr,                                                    \
                 in_ptr,                                                     \
                 hidden_size,                                                \

--- a/csrc/moe/moe_align_sum_kernels.cpp
+++ b/csrc/moe/moe_align_sum_kernels.cpp
@@ -1213,10 +1213,53 @@ void moe_sum(
   const auto num_tokens = output.numel() / hidden_size;
   const int topk = input.size(1);
 
+  // This kernel indexes input/output with a contiguous linear layout (it does
+  // not use per-dim strides like the CUDA reference), so both must be
+  // contiguous, share dtype/device, and have matching element counts.
+  TORCH_CHECK(
+      input.scalar_type() == output.scalar_type(),
+      "moe_sum: input and output must have the same dtype");
+  TORCH_CHECK(
+      input.device() == output.device(),
+      "moe_sum: input and output must be on the same device");
+  TORCH_CHECK(
+      input.is_contiguous() && output.is_contiguous(),
+      "moe_sum expects contiguous input and output");
+  TORCH_CHECK(
+      input.numel() == output.numel() * topk,
+      "moe_sum: input shape must be [num_tokens, topk, hidden] matching output "
+      "[num_tokens, hidden]");
+
   // Pad-aware reduction is required whenever topk_ids is supplied: slots whose
   // (global) expert id is negative are padding/invalid, and -- when an
   // expert_map is given -- experts that map off this device (value < 0) must
   // also be skipped. Without topk_ids we take the plain fast path.
+  // An expert_map without topk_ids has no effect and almost certainly signals a
+  // caller bug, so reject it explicitly rather than silently ignoring it.
+  TORCH_CHECK(
+      !(expert_map.has_value() && !topk_ids.has_value()),
+      "moe_sum: expert_map requires topk_ids to be provided");
+
+  if (topk_ids.has_value()) {
+    const auto& tk = topk_ids.value();
+    TORCH_CHECK(tk.is_contiguous(), "moe_sum: topk_ids must be contiguous");
+    TORCH_CHECK(
+        tk.device() == input.device(),
+        "moe_sum: topk_ids must be on the same device as input");
+    TORCH_CHECK(
+        tk.dim() == 2 && tk.size(0) == num_tokens && tk.size(1) == topk,
+        "moe_sum: topk_ids must have shape [num_tokens, topk]");
+    if (expert_map.has_value()) {
+      const auto& em = expert_map.value();
+      TORCH_CHECK(
+          em.scalar_type() == at::kInt, "moe_sum: expert_map must be int32");
+      TORCH_CHECK(em.is_contiguous(), "moe_sum: expert_map must be contiguous");
+      TORCH_CHECK(
+          em.device() == input.device(),
+          "moe_sum: expert_map must be on the same device as input");
+    }
+  }
+
   const bool pad_aware = topk_ids.has_value();
   const int32_t* expert_map_ptr = (pad_aware && expert_map.has_value())
                                       ? expert_map->data_ptr<int32_t>()

--- a/csrc/moe/moe_ops.h
+++ b/csrc/moe/moe_ops.h
@@ -2,7 +2,11 @@
 
 #include <torch/all.h>
 
-void moe_sum(torch::Tensor& input, torch::Tensor& output);
+void moe_sum(
+    torch::Tensor& input,
+    torch::Tensor& output,
+    const std::optional<torch::Tensor>& topk_ids,
+    const std::optional<torch::Tensor>& expert_map);
 
 void moe_align_block_size(
     torch::Tensor topk_ids,

--- a/csrc/moe/torch_bindings.cpp
+++ b/csrc/moe/torch_bindings.cpp
@@ -4,7 +4,9 @@
 TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, m) {
   // Calculate the result of moe by summing up the partial results
   // from all selected experts.
-  m.def("moe_sum(Tensor input, Tensor! output) -> ()");
+  m.def(
+      "moe_sum(Tensor input, Tensor! output, Tensor? topk_ids, "
+      "Tensor? expert_map) -> ()");
   m.impl("moe_sum", torch::kXPU, &moe_sum);
 
   // Aligning the number of tokens to be processed by each expert such

--- a/tests/register_ops.py
+++ b/tests/register_ops.py
@@ -426,8 +426,13 @@ def fp8_gemm_w8a16(input: torch.Tensor, weight: torch.Tensor,
 
 
 # moe
-def moe_sum(input: torch.Tensor, output: torch.Tensor) -> None:
-    torch.ops._moe_C.moe_sum(input, output)
+def moe_sum(
+    input: torch.Tensor,
+    output: torch.Tensor,
+    topk_ids: Optional[torch.Tensor] = None,
+    expert_map: Optional[torch.Tensor] = None,
+) -> None:
+    torch.ops._moe_C.moe_sum(input, output, topk_ids, expert_map)
 
 
 def moe_lora_align_block_size(

--- a/tests/test_moe_sum.py
+++ b/tests/test_moe_sum.py
@@ -36,4 +36,66 @@ def test_moe_sum(m: int, topk: int, k: int, dtype: torch.dtype):
 
     torch.testing.assert_close(actual, expected, atol=2e-2, rtol=0)
 
-    opcheck(torch.ops._moe_C.moe_sum, (input, actual))
+    opcheck(torch.ops._moe_C.moe_sum, (input, actual, None, None))
+
+
+@pytest.mark.parametrize("m", [1, 33, 64])
+@pytest.mark.parametrize("topk", TOP_KS)
+@pytest.mark.parametrize("k", [128, 1024])
+@pytest.mark.parametrize("dtype",
+                         [torch.float32, torch.float16, torch.bfloat16],
+                         ids=format_tc)
+def test_moe_sum_expert_map(m: int, topk: int, k: int, dtype: torch.dtype):
+    num_experts = 8
+    input = torch.randn((m, topk, k), device="xpu", dtype=dtype)
+    actual = torch.empty((m, k), device="xpu", dtype=dtype)
+
+    topk_ids = torch.randint(0,
+                             num_experts, (m, topk),
+                             device="xpu",
+                             dtype=torch.int32)
+    # Mark half of the experts as non-local (mapped to -1).
+    expert_map = torch.arange(num_experts, device="xpu", dtype=torch.int32)
+    expert_map[num_experts // 2:] = -1
+
+    # Reference: zero out contributions from non-local experts.
+    local_mask = (expert_map[topk_ids.long()] >= 0)  # [m, topk]
+    expected = (input *
+                local_mask.unsqueeze(-1).to(input.dtype)).sum(dim=1)
+
+    moe_sum(input, actual, topk_ids, expert_map)
+
+    torch.testing.assert_close(actual, expected, atol=2e-2, rtol=0)
+
+    opcheck(torch.ops._moe_C.moe_sum, (input, actual, topk_ids, expert_map))
+
+
+@pytest.mark.parametrize("m", [1, 33, 64])
+@pytest.mark.parametrize("topk", TOP_KS)
+@pytest.mark.parametrize("k", [128, 1024])
+@pytest.mark.parametrize("dtype",
+                         [torch.float32, torch.float16, torch.bfloat16],
+                         ids=format_tc)
+def test_moe_sum_padded_topk_ids(m: int, topk: int, k: int,
+                                 dtype: torch.dtype):
+    # topk_ids may contain -1 padding slots (no expert_map). Those slots must
+    # be skipped without indexing expert_map out of bounds.
+    num_experts = 8
+    input = torch.randn((m, topk, k), device="xpu", dtype=dtype)
+    actual = torch.empty((m, k), device="xpu", dtype=dtype)
+
+    topk_ids = torch.randint(0,
+                             num_experts, (m, topk),
+                             device="xpu",
+                             dtype=torch.int32)
+    # Mark the last slot of every token as padding.
+    topk_ids[:, -1] = -1
+
+    valid = (topk_ids >= 0)  # [m, topk]
+    expected = (input * valid.unsqueeze(-1).to(input.dtype)).sum(dim=1)
+
+    moe_sum(input, actual, topk_ids, None)
+
+    torch.testing.assert_close(actual, expected, atol=2e-2, rtol=0)
+
+    opcheck(torch.ops._moe_C.moe_sum, (input, actual, topk_ids, None))

--- a/tests/test_moe_sum.py
+++ b/tests/test_moe_sum.py
@@ -99,3 +99,35 @@ def test_moe_sum_padded_topk_ids(m: int, topk: int, k: int,
     torch.testing.assert_close(actual, expected, atol=2e-2, rtol=0)
 
     opcheck(torch.ops._moe_C.moe_sum, (input, actual, topk_ids, None))
+
+
+def test_moe_sum_input_validation():
+    m, topk, k = 32, 4, 128
+    input = torch.randn((m, topk, k), device="xpu", dtype=torch.float32)
+    output = torch.empty((m, k), device="xpu", dtype=torch.float32)
+    topk_ids = torch.zeros((m, topk), device="xpu", dtype=torch.int32)
+    expert_map = torch.arange(8, device="xpu", dtype=torch.int32)
+
+    # expert_map without topk_ids must be rejected rather than silently ignored.
+    with pytest.raises(RuntimeError, match="expert_map requires topk_ids"):
+        moe_sum(input, output, None, expert_map)
+
+    # dtype mismatch between input and output.
+    bad_out = torch.empty((m, k), device="xpu", dtype=torch.float16)
+    with pytest.raises(RuntimeError, match="same dtype"):
+        moe_sum(input, bad_out)
+
+    # non-contiguous input (a strided slice along hidden).
+    wide = torch.randn((m, topk, k * 2), device="xpu", dtype=torch.float32)
+    noncontig = wide[:, :, ::2]  # shape [m, topk, k], non-contiguous
+    assert not noncontig.is_contiguous()
+    with pytest.raises(RuntimeError, match="contiguous"):
+        moe_sum(noncontig, output)
+
+    # topk_ids with a wrong shape.
+    with pytest.raises(RuntimeError, match="num_tokens, topk"):
+        moe_sum(input, output, topk_ids[:, :topk - 1].contiguous(), None)
+
+    # expert_map with a non-int32 dtype.
+    with pytest.raises(RuntimeError, match="expert_map must be int32"):
+        moe_sum(input, output, topk_ids, expert_map.to(torch.int64))


### PR DESCRIPTION
This pull request extends the `moe_sum` operator to support pad-aware summation, enabling it to skip contributions from padding slots and non-local experts. It also updates the kernel implementation, Python bindings, and tests to handle these new features.

## Performance

Measured on XPU, bf16, `warmup=20 rep=200`, cold-cache (rotating buffer sets so
every iteration touches cold HBM; otherwise small working sets stay resident in
L2/LLC and report bandwidth well above the HBM peak). `before` = prior `moe_sum`
(before this PR); `after` = this PR. avg time in us (lower is better).

### TP scenario (plain `moe_sum`, no masking, num_tokens=2048)

The plain tensor-parallel path is unchanged in semantics. A compile-time
`PAD_AWARE` specialization keeps its hot loop free of the masking branch, so
there is no regression versus `before` (topk=6/8 are faster thanks to new
topk specializations), while fp32 accumulation is preserved for precision.

| topk | k    | before (us) | after (us) |
|-----:|-----:|------------:|-----------:|
| 2    | 128  |        8.75 |       8.93 |
| 2    | 512  |       22.95 |      22.96 |
| 2    | 1024 |       44.78 |      44.78 |
| 2    | 4096 |      164.73 |     165.07 |
| 6    | 128  |       26.02 |      11.80 |
| 6    | 512  |       47.19 |      42.19 |
| 6    | 1024 |       91.81 |      83.89 |
| 6    | 4096 |      335.95 |     321.10 |
| 8    | 128  |       27.19 |      14.38 |
| 8    | 512  |       55.56 |      51.51 |
| 8    | 1024 |      106.32 |     102.03 |
| 8    | 4096 |      408.39 |     395.14 |

### EP scenario (pad-aware `moe_sum` with `expert_map`, topk=8, k=4096)

New capability added by this PR (no `before` baseline, since the old op had no
`topk_ids`/`expert_map` interface).

| num_tokens | after (us) | BW (GB/s) |
|-----------:|-----------:|----------:|
| 128        |       30.3 |       312 |
| 512        |       99.8 |       378 |
| 2048       |      376.1 |       401 |
| 8192       |     1477.4 |       409 |
