### PR TITLE
act_and_mul: round work-group size to power of two

### DIFF
--- a/csrc/activation.cpp
+++ b/csrc/activation.cpp
@@ -444,8 +444,13 @@ class swiglustep_and_mul_kernel {
     }                                                                    \
   }                                                                      \
   if (d % vec_size != 0) vec_size = 1;                                   \
-  int64_t wg_size = std::min(                                            \
+  int64_t wg_cap = std::min(                                             \
       static_cast<int64_t>(d / vec_size), static_cast<int64_t>(1024));   \
+  /* Round work-group size down to a power of two, as XPU produces       \
+     wrong results / NaNs for non power-of-two local sizes. The strided  \
+     loop below still covers all elements for any wg_size. */            \
+  int64_t wg_size = 1;                                                   \
+  while ((wg_size << 1) <= wg_cap) wg_size <<= 1;                        \
   switch (vec_size) {                                                    \
     VEC_LAUNCH_ACT_AND_MUL(KERNEL, ACT_FIRST, 1);                        \
     VEC_LAUNCH_ACT_AND_MUL(KERNEL, ACT_FIRST, 2);                        \
@@ -477,8 +482,13 @@ class swiglustep_and_mul_kernel {
     }                                                                    \
   }                                                                      \
   if (d % vec_size != 0) vec_size = 1;                                   \
-  int64_t wg_size = std::min(                                            \
+  int64_t wg_cap = std::min(                                             \
       static_cast<int64_t>(d / vec_size), static_cast<int64_t>(1024));   \
+  /* Round work-group size down to a power of two, as XPU produces       \
+     wrong results / NaNs for non power-of-two local sizes. The strided  \
+     loop below still covers all elements for any wg_size. */            \
+  int64_t wg_size = 1;                                                   \
+  while ((wg_size << 1) <= wg_cap) wg_size <<= 1;                        \
   switch (vec_size) {                                                    \
     VEC_LAUNCH_ACT_AND_MUL_WITH_PARAM(KERNEL, 1);                        \
     VEC_LAUNCH_ACT_AND_MUL_WITH_PARAM(KERNEL, 2);                        \

--- a/tests/test_activation.py
+++ b/tests/test_activation.py
@@ -12,7 +12,10 @@ from tests.utils import opcheck, seed_everything
 
 DTYPES = [torch.half, torch.bfloat16, torch.float]
 NUM_TOKENS = [7, 83, 2048]  # Arbitrary values for testing
-D = [512, 13824]  # Arbitrary values for testing
+# 640/1408/2816 are regression sizes: the *_and_mul vec launch previously
+# picked a non-power-of-two work-group size for these widths and returned
+# wrong values / NaN
+D = [512, 640, 1408, 2816, 13824]
 SEEDS = [0]
 XPU_DEVICES = [
     f"xpu:{i}" for i in range(1 if torch.xpu.device_count() == 1 else 2)


### PR DESCRIPTION
### checklist:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.

### Purpose:

Fix `silu_and_mul` / `gelu_and_mul` / `mul_and_silu` returning **wrong values or NaN** on XPU for many intermediate widths.

The vectorized launch (`LAUNCH_ACTIVATION_GATE_KERNEL_VEC` in `csrc/activation.cpp`) computes `wg_size = min(d / vec_size, 1024)`, which is frequently **not** a power of two. This device mis-executes such work-group sizes, so the kernel produces garbage for the affected `d` (e.g. 320, 640, **1408**, **2816**, 5632) while power-of-two widths (512/1024/2048) happen to work.

Impact: any MoE whose expert intermediate width is in the broken set is corrupted on XPU and produces wrong outputs during inference — e.g. **DeepSeek-V2/V3-Lite** (`moe_intermediate=1408`, shared `2816`) generates only repeated/gibberish tokens, while GraniteMoE (`512`) works. Both the shared expert (`SiluAndMul`) and routed experts (`XpuFusedMoe`) call this op, so all MoE backends are affected. Present in **v0.1.10 through current `main`** (the vectorized launch is unchanged across these).

**Fix:** round `wg_size` down to a power of two. `vec_size` (vectorization) is unchanged → no throughput regression; the  kernel's strided loop already covers all elements for any `wg_size`.

### Test Plan

```bash
# Unit (existing test, extended with regression widths 640/1408/2816):
pytest tests/test_activation.py -k "silu_and_mul"

# Direct op check across many widths vs a torch reference:
python - <<'PY'
import torch, torch.nn.functional as F, vllm_xpu_kernels, vllm_xpu_kernels._C
for d in [320, 640, 1408, 2816, 5632, 512, 2048]:
    x = torch.randn(4, 2*d, device="xpu", dtype=torch.bfloat16)
    out = torch.empty(4, d, device="xpu", dtype=torch.bfloat16)
    torch.ops._C.silu_and_mul(out, x)
    ref = F.silu(x[:, :d].float()) * x[:, d:].float()
    rel = (out.float()-ref).abs().max().item() / ref.abs().max().item()
    print(f"d={d:5d} rel_err={rel:.4f} {'OK' if rel<0.05 else 'WRONG'}")
PY

# End-to-end: serve DeepSeek-V2-Lite on XPU and check generation.
vllm serve deepseek-ai/DeepSeek-V2-Lite --data-parallel-size 2 --enable-expert-parallel \
  --dtype bfloat16 --enforce-eager --trust-remote-code
```

### Test Result

**Direct op check (bf16), before vs after:**

| d | before | after |
|---|---|---|
| 320  | WRONG (rel 1.16) | OK (3e-3) |
| 640  | NaN | OK |
| 1408 | NaN (rel 1.02) | OK |
| 2816 | WRONG (rel 0.90) | OK |
| 5632 | NaN | OK |
| 512 / 2048 | OK | OK |

fp16/fp32 at d=1408 also fixed (rel → 0). `pytest tests/test_activation.py -k silu_and_mul` → **90 passed** (fails at the new sizes before the fix).

**End-to-end (DeepSeek-V2-Lite, 2× Arc B70), before vs after:**

| prompt | before | after |
|---|---|---|
| "The capital of France is" | `should should should …` | ` Paris.` |
| "Question: What is 5 times 6? Answer:" | `should should …` | ` 5 x 6 = 30` |

No docs update required.