### PR TITLE
[MoE] Add a bf16xfp32 gemm kernel for router gemm

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -398,6 +398,7 @@ set(GROUPED_GEMM_LIB_NAME "")
 set(GDN_ATTN_LIB_NAME "")
 set(MQA_LOGITS_LIB_NAME "")
 set(MHC_LIB_NAME "")
+set(GEMM_BF16XFP32_LIB_NAME "")
 
 if(BUILD_SYCL_TLA_KERNELS)
 
@@ -441,6 +442,8 @@ if(BUILD_SYCL_TLA_KERNELS)
       add_subdirectory(csrc/xpu/mhc/xe_2)
       list(APPEND MHC_LIB_NAME "mhc_kernels_xe_2")
     endif()
+    add_subdirectory(csrc/xpu/gemm_bf16xfp32/xe_2)
+    list(APPEND GEMM_BF16XFP32_LIB_NAME "gemm_bf16xfp32_xe_2")
     list(APPEND SYCL_TLA_COMPILE_OPTIONS -DVLLM_XPU_ENABLE_XE2)
   endif()
   list(APPEND VLLM_GPU_COMPILE_FLAGS ${SYCL_TLA_COMPILE_OPTIONS})
@@ -637,6 +640,8 @@ if(XPU_SPECIFIC_KERNELS_ENABLED)
     list(APPEND VLLM_EXT_XPU_SRC
          "csrc/xpu/grouped_gemm/grouped_gemm_interface.cpp")
   endif()
+  list(APPEND VLLM_EXT_XPU_SRC
+       "csrc/xpu/gemm_bf16xfp32/gemm_bf16xfp32_interface.cpp")
   if(GDN_KERNELS_ENABLED)
     list(APPEND VLLM_EXT_XPU_SRC "csrc/xpu/gdn_attn/gdn_attn_interface.cpp")
   endif()
@@ -674,7 +679,7 @@ if(XPU_SPECIFIC_KERNELS_ENABLED)
     INCLUDE_DIRECTORIES
     ${VLLM_XPU_INCLUDE_DIR}
     LIBRARIES
-    ${GROUPED_GEMM_LIB_NAME};${GDN_ATTN_LIB_NAME};${MQA_LOGITS_LIB_NAME};${MHC_LIB_NAME}
+    ${GROUPED_GEMM_LIB_NAME};${GDN_ATTN_LIB_NAME};${MQA_LOGITS_LIB_NAME};${MHC_LIB_NAME};${GEMM_BF16XFP32_LIB_NAME}
     USE_SABI
     3
     WITH_SOABI)

--- a/benchmark/benchmark_gemm_bf16xfp32.py
+++ b/benchmark/benchmark_gemm_bf16xfp32.py
@@ -1,0 +1,170 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Benchmark the BF16xFP32 emulated-FP32 router GEMM on XPU.
+
+The kernel emulates an FP32-precision GEMM (BF16 activation x FP32 weight) with
+two BF16 DPAS ops (DualGemm), targeting the Hunyuan-V3 MoE router shape
+(N = num_experts, K = hidden_size, M = num_tokens). It is compared against the
+correctness-equivalent FP32 ``F.linear`` baseline.
+
+  python benchmark/benchmark_gemm_bf16xfp32.py
+  python benchmark/benchmark_gemm_bf16xfp32.py --iters 200 --warmup 50 --check
+  python benchmark/benchmark_gemm_bf16xfp32.py --n 192 --k 4096 --m 2,64,1024
+"""
+
+import os
+from argparse import ArgumentParser
+
+# Silence libkineto INFO spam; must be set before importing torch.
+os.environ.setdefault("KINETO_LOG_LEVEL", "5")
+
+import torch
+import torch.nn.functional as F
+from torch.profiler import ProfilerActivity, profile
+
+import vllm_xpu_kernels._xpu_C  # noqa: F401
+from vllm_xpu_kernels.gemm_bf16xfp32 import gemm_bf16xfp32, split_fp32_weight
+
+SCALE = 1.0 / 256.0
+
+M_LIST = [2, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384]
+N_LIST = [128, 192, 256]
+K_LIST = [3072, 4096, 6144]
+
+
+def _make_inputs(m, n, k, seed=1234):
+    torch.manual_seed(seed)
+    x_bf16 = torch.randn(m, k, dtype=torch.bfloat16, device="xpu") / 8.0
+    w_fp32 = torch.randn(n, k, dtype=torch.float32, device="xpu") / 8.0
+    return x_bf16, w_fp32
+
+
+def _bench_wall(fn, warmup, iters):
+    for _ in range(warmup):
+        fn()
+    torch.xpu.synchronize()
+    start = torch.xpu.Event(enable_timing=True)
+    end = torch.xpu.Event(enable_timing=True)
+    start.record()
+    for _ in range(iters):
+        fn()
+    end.record()
+    torch.xpu.synchronize()
+    return start.elapsed_time(end) * 1e3 / iters  # ms -> us
+
+
+def _bench_device(fn, warmup, iters):
+    for _ in range(warmup):
+        fn()
+    torch.xpu.synchronize()
+    with profile(activities=[ProfilerActivity.XPU]) as prof:
+        for _ in range(iters):
+            fn()
+        torch.xpu.synchronize()
+
+    def _self_us(evt):
+        for attr in ("self_device_time_total", "self_xpu_time_total"):
+            val = getattr(evt, attr, None)
+            if val:
+                return val
+        return 0.0
+
+    return sum(_self_us(e) for e in prof.key_averages()) / iters
+
+
+def benchmark_gemm_bf16xfp32(shapes, peaks, warmup, iters, check):
+    peak_bf16, peak_fp32, peak_bw = peaks
+
+    print(f"torch={torch.__version__}, scale={SCALE}, "
+          f"iters/warmup={iters}/{warmup}")
+    print(f"peaks: bf16 XMX {peak_bf16} TFLOP/s | fp32 vector {peak_fp32} "
+          f"TFLOP/s | BW {peak_bw} GB/s")
+    print()
+
+    hdr = (f"{'M':>6}{'N':>5}{'K':>6} | "
+           f"{'ker dev':>8} {'ker wall':>9} | "
+           f"{'TFLOP/s':>9} {'MFU':>7} {'GB/s':>9} {'MBU':>7} | "
+           f"{'fp32 dev':>9} {'fp32 wall':>10} | "
+           f"{'dev speedup':>11} {'wall speedup':>12}")
+    print(hdr)
+    print("-" * len(hdr))
+
+    prev_nk = None
+    for (m, n, k) in shapes:
+        if prev_nk is not None and (n, k) != prev_nk:
+            print()
+        prev_nk = (n, k)
+
+        x_bf16, w_fp32 = _make_inputs(m, n, k)
+        w_high, w_low = split_fp32_weight(w_fp32, SCALE)  # -> [K, N] bf16
+
+        def run_kernel(x=x_bf16, wh=w_high, wl=w_low):
+            return gemm_bf16xfp32(x, wh, wl, SCALE)
+
+        def run_fp32(x=x_bf16, w=w_fp32):
+            return F.linear(x.float(), w)
+
+        if check:
+            out = run_kernel().float()
+            ref = run_fp32()
+            torch.xpu.synchronize()
+            denom = ref.abs().max().item() + 1e-6
+            rel = (out - ref).abs().max().item() / denom
+            assert rel < 2e-2, (
+                f"correctness failed at {(m, n, k)}: rel={rel:.3e}")
+
+        dev_k = _bench_device(run_kernel, warmup, iters)
+        dev_f = _bench_device(run_fp32, warmup, iters)
+        wall_k = _bench_wall(run_kernel, warmup, iters)
+        wall_f = _bench_wall(run_fp32, warmup, iters)
+
+        tflops = (4.0 * m * n * k) / (dev_k * 1e-6) / 1e12
+        gbps = (m * k * 2 + 2 * (k * n * 2) + m * n * 4) / (dev_k * 1e-6) / 1e9
+
+        print(f"{m:>6}{n:>5}{k:>6} | "
+              f"{dev_k:>8.2f} {wall_k:>9.2f} | "
+              f"{tflops:>9.2f} {tflops / peak_bf16 * 100:>6.1f}% "
+              f"{gbps:>9.1f} {gbps / peak_bw * 100:>6.1f}% | "
+              f"{dev_f:>9.2f} {wall_f:>10.2f} | "
+              f"{dev_f / dev_k:>10.2f}x {wall_f / wall_k:>11.2f}x")
+
+
+if __name__ == "__main__":
+    parser = ArgumentParser(
+        description="Benchmark the BF16xFP32 router GEMM kernel on XPU.")
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--warmup", type=int, default=20)
+    parser.add_argument("--iters", type=int, default=100)
+    parser.add_argument("--check", action="store_true",
+                        help="verify kernel output vs FP32 F.linear per shape")
+    parser.add_argument("--m", type=str, default=None,
+                        help="comma-separated M values (overrides the sweep)")
+    parser.add_argument("--n", type=str, default=None,
+                        help="comma-separated N values (overrides the sweep)")
+    parser.add_argument("--k", type=str, default=None,
+                        help="comma-separated K values (overrides the sweep)")
+
+    # Hardware peaks for MFU/MBU roofline (defaults: Intel Arc Pro B60 / BMG).
+    parser.add_argument("--peak-bf16-tflops", type=float, default=98.5)
+    parser.add_argument("--peak-fp32-tflops", type=float, default=12.28)
+    parser.add_argument("--peak-bw-gbps", type=float, default=456.0)
+
+    args = parser.parse_args()
+
+    torch.manual_seed(args.seed)
+    torch.set_default_device("xpu")
+
+    def _parse(arg, default):
+        return [int(x) for x in arg.split(",")] if arg else default
+
+    m_list = _parse(args.m, M_LIST)
+    n_list = _parse(args.n, N_LIST)
+    k_list = _parse(args.k, K_LIST)
+    shapes = [(m, n, k) for n in n_list for k in k_list for m in m_list]
+
+    benchmark_gemm_bf16xfp32(
+        shapes,
+        (args.peak_bf16_tflops, args.peak_fp32_tflops, args.peak_bw_gbps),
+        args.warmup,
+        args.iters,
+        args.check,
+    )

--- a/csrc/xpu/gemm_bf16xfp32/gemm_bf16xfp32_interface.cpp
+++ b/csrc/xpu/gemm_bf16xfp32/gemm_bf16xfp32_interface.cpp
@@ -1,0 +1,22 @@
+/***************************************************************************************************
+ * Copyright (C) 2025 - 2026 Intel Corporation, All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ **************************************************************************************************/
+#include "csrc/utils.h"
+#include "gemm_bf16xfp32_interface.h"
+
+#ifdef VLLM_XPU_ENABLE_XE2
+  #include "xe_2/gemm_bf16xfp32_xe2.h"
+#endif
+
+at::Tensor gemm_bf16xfp32(
+    at::Tensor A, at::Tensor B_high, at::Tensor B_low, double scale) {
+#ifdef VLLM_XPU_ENABLE_XE2
+  if (vllm::xpu::is_xe2_arch()) {
+    // Pass by lvalue reference to xe2 impl
+    return gemm_bf16xfp32_xe2(A, B_high, B_low, scale);
+  }
+#endif
+  TORCH_CHECK(false, "gemm_bf16xfp32: requires XE2 architecture (BMG/LNL)");
+  return at::Tensor();
+}

--- a/csrc/xpu/gemm_bf16xfp32/gemm_bf16xfp32_interface.h
+++ b/csrc/xpu/gemm_bf16xfp32/gemm_bf16xfp32_interface.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <torch/all.h>
+
+at::Tensor gemm_bf16xfp32(
+    at::Tensor A,       // [M, K] bf16
+    at::Tensor B_high,  // [N, K] bf16
+    at::Tensor B_low,   // [N, K] bf16
+    double scale);

--- a/csrc/xpu/gemm_bf16xfp32/gemm_bf16xfp32_interface.h
+++ b/csrc/xpu/gemm_bf16xfp32/gemm_bf16xfp32_interface.h
@@ -4,6 +4,6 @@
 
 at::Tensor gemm_bf16xfp32(
     at::Tensor A,       // [M, K] bf16
-    at::Tensor B_high,  // [N, K] bf16
-    at::Tensor B_low,   // [N, K] bf16
+    at::Tensor B_high,  // [K, N] bf16 (transposed weight)
+    at::Tensor B_low,   // [K, N] bf16 (transposed weight)
     double scale);

--- a/csrc/xpu/gemm_bf16xfp32/xe_2/CMakeLists.txt
+++ b/csrc/xpu/gemm_bf16xfp32/xe_2/CMakeLists.txt
@@ -1,0 +1,3 @@
+cmake_minimum_required(VERSION 3.18)
+
+add_xe2_kernel_library(gemm_bf16xfp32_xe_2 INCLUDE_CMAKE_SOURCE_DIR)

--- a/csrc/xpu/gemm_bf16xfp32/xe_2/bf16xfp32_epilogue.hpp
+++ b/csrc/xpu/gemm_bf16xfp32/xe_2/bf16xfp32_epilogue.hpp
@@ -1,0 +1,254 @@
+/***************************************************************************************************
+ * Copyright (C) 2025 - 2026 Intel Corporation, All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * BF16xFP32 GEMM Epilogue: combines two accumulator results into one output.
+ *   D = acc_high + acc_low * scale
+ *
+ * Based on xe_dual_gemm_epilogue_elementwise_activation.hpp
+ **************************************************************************************************/
+#pragma once
+
+#include <sycl/sycl.hpp>
+#include "cutlass/cutlass.h"
+#include "cutlass/epilogue/dispatch_policy.hpp"
+#include "cutlass/epilogue/collective/collective_epilogue.hpp"
+#include "cutlass/epilogue/collective/detail.hpp"
+#include "cutlass/detail/layout.hpp"
+
+#include "cute/tensor.hpp"
+
+namespace cutlass {
+namespace epilogue {
+namespace collective {
+
+template <
+    class DispatchPolicy,
+    class CtaTileMNK_,
+    class ElementC_,
+    class StrideC_,
+    class ElementD_,
+    class StrideD_,
+    class CopyOpG2R_,
+    class CopyOpR2G_>
+class BF16xFP32Epilogue;
+
+template <
+    class CtaTileMNK_,
+    class ElementC_,
+    class StrideC_,
+    class ElementD_,
+    class StrideD_,
+    class CopyOpG2R_,
+    class CopyOpR2G_>
+class BF16xFP32Epilogue<
+    IntelXeXMX16,
+    CtaTileMNK_,
+    ElementC_,
+    StrideC_,
+    ElementD_,
+    StrideD_,
+    CopyOpG2R_,
+    CopyOpR2G_> {
+ public:
+  using DispatchPolicy = IntelXeXMX16;
+  using CtaTileMNK = CtaTileMNK_;
+  using ElementC = ElementC_;
+  using ElementAccumulator = ElementD_;
+  using StrideC = StrideC_;
+  using ElementD = ElementD_;
+  using StrideD = StrideD_;
+  using CopyOpG2R = CopyOpG2R_;
+  using CopyOpR2G = CopyOpR2G_;
+
+  using GmemTiledCopyC = CopyOpG2R;
+  using GmemTiledCopyD = cute::conditional_t<
+      not cute::is_void_v<ElementD> && not cute::is_void_v<CopyOpR2G>,
+      CopyOpR2G,
+      XE_2D_U32x8x16_ST_N>;
+  using ElementOutput = ElementAccumulator;
+  using ElementCompute = ElementAccumulator;
+
+  static constexpr int SubgroupSize = DispatchPolicy::SubgroupSize;
+
+  static_assert(
+      cute::rank(CtaTileMNK{}) == 3,
+      "CtaTileMNK must be rank-3: [CTA_M, CTA_N, CTA_K]");
+  static_assert(
+      cute::rank(StrideD{}) == 3, "StrideD must be rank-3: [M, N, L]");
+
+  static_assert(std::is_same_v<ElementC, void>, "No Source memory needed");
+  static_assert(
+      std::is_same_v<CopyOpG2R, void>, "No Source Copy operation required");
+
+  using CopyThreadShape = cute::Shape<cute::_1, cute::Int<SubgroupSize>>;
+  using Trait_D = cute::Copy_Traits<GmemTiledCopyD, StrideD>;
+  using XE_Copy_D = decltype(cute::make_tiled_copy(
+      cute::Copy_Atom<Trait_D, ElementD>{},
+      cute::Layout<CopyThreadShape>{},
+      cute::make_layout(
+          cute::shape_div(typename Trait_D::BlockShape{}, CopyThreadShape{}))));
+
+ private:
+  constexpr static bool is_destination_supported =
+      not cute::is_void_v<ElementD> && not cute::is_void_v<CopyOpR2G>;
+
+ public:
+  // Host side epilogue arguments
+  struct Arguments {
+    ElementD* ptr_D;
+    StrideD dD;
+    float scale;  // The scale factor for BF16xFP32 reconstruction
+  };
+
+  // Device side epilogue params
+  struct Params {
+    XE_Copy_D xe_store_d;
+    float scale;
+  };
+
+  template <class ProblemShape>
+  static constexpr Params to_underlying_arguments(
+      ProblemShape const& problem_shape,
+      Arguments const& args,
+      [[maybe_unused]] void* workspace) {
+    auto problem_shape_MNKL = cute::append<4>(problem_shape, 1);
+    auto [M, N, K, L] = problem_shape_MNKL;
+
+    XE_Copy_D xe_store_d = {};
+    if constexpr (is_destination_supported) {
+      auto mD = cute::make_tensor(
+          cute::make_gmem_ptr(static_cast<ElementD const*>(args.ptr_D)),
+          cute::make_layout(cute::make_shape(M, N, L), args.dD));
+      xe_store_d = cute::make_tiled_copy(
+          cute::Copy_Atom<Trait_D, ElementD>{}.with(mD),
+          cute::Layout<CopyThreadShape>{},
+          cute::make_layout(
+              cute::shape_div(
+                  typename Trait_D::BlockShape{}, CopyThreadShape{})));
+    }
+
+    return {xe_store_d, args.scale};
+  }
+
+  template <class ProblemShape>
+  static size_t
+  get_workspace_size(ProblemShape const& problem_shape, Arguments const& args) {
+    return 0;
+  }
+
+  template <class ProblemShape>
+  static cutlass::Status initialize_workspace(
+      ProblemShape const& problem_shape,
+      Arguments const& args,
+      void* workspace,
+      cudaStream_t stream,
+      CudaHostAdapter* cuda_adapter = nullptr) {
+    return Status::kSuccess;
+  }
+
+  template <class ProblemShape>
+  CUTLASS_HOST_DEVICE static bool
+  can_implement(ProblemShape const& problem_shape, Arguments const& args) {
+    return true;
+  }
+
+  CUTLASS_HOST_DEVICE
+  BF16xFP32Epilogue(Params const& params_) : params(params_) {}
+
+  CUTLASS_DEVICE
+  bool is_producer_load_needed() const { return false; }
+
+  template <
+      class ProblemShapeMNKL,
+      class TileShapeMNK,
+      class TileCoordMNKL,
+      class Accumulator0,
+      class Accumulator1,
+      class TiledMma,
+      class ResidueMNK>
+  CUTLASS_DEVICE void operator()(
+      ProblemShapeMNKL problem_shape_mnkl,
+      TileShapeMNK tile_shape_MNK,
+      TileCoordMNKL tile_coord_mnkl,
+      Accumulator0 accumulators0,  // acc_high = X * W_high
+      Accumulator1 accumulators1,  // acc_low  = X * W_low
+      TiledMma tiled_mma,
+      ResidueMNK residue_mnk,
+      int thread_idx,
+      char* smem) {
+    (void)tiled_mma;
+    (void)residue_mnk;
+    (void)smem;
+    using namespace cute;
+
+    using MmaAtomShape = typename TiledMma::AtomShape_MNK;
+    static constexpr auto BLK_M = get<0>(CtaTileMNK{});
+    static constexpr auto BLK_N = get<1>(CtaTileMNK{});
+    static constexpr auto BLK_K = get<2>(CtaTileMNK{});
+
+    static constexpr auto ATOM_M =
+        get<1>(typename TiledMma::ThrLayoutVMNK{}.shape());
+    static constexpr auto ATOM_N =
+        get<2>(typename TiledMma::ThrLayoutVMNK{}.shape());
+    static constexpr auto ATOM_K =
+        get<3>(typename TiledMma::ThrLayoutVMNK{}.shape());
+
+    static constexpr auto SG_M = BLK_M / ATOM_M;
+    static constexpr auto SG_N = BLK_N / ATOM_N;
+    static constexpr auto SG_K = BLK_K / ATOM_K;
+    using SubgroupTileShape =
+        Shape<decltype(SG_M), decltype(SG_N), decltype(SG_K)>;
+
+    static constexpr int FragsM =
+        get<0>(SubgroupTileShape{}) / get<0>(MmaAtomShape());
+    static constexpr int FragsN =
+        get<1>(SubgroupTileShape{}) / get<1>(MmaAtomShape());
+    static constexpr int FragmentSize =
+        (get<0>(MmaAtomShape()) * get<1>(MmaAtomShape())) / SubgroupSize;
+
+    auto [M, N, K, L] = problem_shape_mnkl;
+    auto [m_coord, n_coord, k_coord, l_coord] = tile_coord_mnkl;
+    auto m_sg = get_sub_group_id() / ATOM_N;
+    auto n_sg = get_sub_group_id() % ATOM_N;
+
+    Tensor mD_mnl = cute::get_xe_tensor(make_shape(M, N, L));
+    Tensor g_wg_D = local_tile(
+        mD_mnl,
+        take<0, 2>(CtaTileMNK{}),
+        make_coord(m_coord, n_coord, l_coord));
+    Tensor gD = local_tile(
+        g_wg_D, take<0, 2>(SubgroupTileShape{}), make_coord(m_sg, n_sg));
+
+    auto thread_xe_store_d = params.xe_store_d.get_thread_slice(thread_idx);
+    Tensor tCgD = thread_xe_store_d.partition_D(gD);
+
+    float scale = params.scale;
+
+    CUTLASS_PRAGMA_UNROLL
+    for (int epi_n = 0; epi_n < FragsN; epi_n++) {
+      CUTLASS_PRAGMA_UNROLL
+      for (int epi_m = 0; epi_m < FragsM; epi_m++) {
+        Tensor trD =
+            make_tensor<ElementAccumulator>(Shape<Int<FragmentSize>>{});
+        CUTLASS_PRAGMA_UNROLL
+        for (int epi_v = 0; epi_v < FragmentSize; epi_v++) {
+          // D = acc_high + acc_low * scale
+          trD(epi_v) = accumulators0(epi_v, epi_m, epi_n) +
+                       accumulators1(epi_v, epi_m, epi_n) * scale;
+        }
+
+        if constexpr (is_destination_supported) {
+          copy(params.xe_store_d, trD, tCgD(_, epi_m, epi_n));
+        }
+      }
+    }
+  }
+
+ private:
+  Params const& params;
+};
+
+}  // namespace collective
+}  // namespace epilogue
+}  // namespace cutlass

--- a/csrc/xpu/gemm_bf16xfp32/xe_2/bf16xfp32_epilogue.hpp
+++ b/csrc/xpu/gemm_bf16xfp32/xe_2/bf16xfp32_epilogue.hpp
@@ -118,7 +118,7 @@ class BF16xFP32Epilogue<
     XE_Copy_D xe_store_d = {};
     if constexpr (is_destination_supported) {
       auto mD = cute::make_tensor(
-          cute::make_gmem_ptr(static_cast<ElementD const*>(args.ptr_D)),
+          cute::make_gmem_ptr(static_cast<ElementD*>(args.ptr_D)),
           cute::make_layout(cute::make_shape(M, N, L), args.dD));
       xe_store_d = cute::make_tiled_copy(
           cute::Copy_Atom<Trait_D, ElementD>{}.with(mD),

--- a/csrc/xpu/gemm_bf16xfp32/xe_2/gemm_bf16xfp32_xe2.cpp
+++ b/csrc/xpu/gemm_bf16xfp32/xe_2/gemm_bf16xfp32_xe2.cpp
@@ -1,0 +1,12 @@
+/***************************************************************************************************
+ * Copyright (C) 2025 - 2026 Intel Corporation, All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ **************************************************************************************************/
+#include <torch/all.h>
+#include "gemm_bf16xfp32_xe2.h"
+#include "gemm_bf16xfp32_xe2_impl.hpp"
+
+at::Tensor gemm_bf16xfp32_xe2(
+    at::Tensor& A, at::Tensor& B_high, at::Tensor& B_low, double scale) {
+  return gemm_bf16xfp32::gemm_bf16xfp32_xe2_impl(A, B_high, B_low, scale);
+}

--- a/csrc/xpu/gemm_bf16xfp32/xe_2/gemm_bf16xfp32_xe2.h
+++ b/csrc/xpu/gemm_bf16xfp32/xe_2/gemm_bf16xfp32_xe2.h
@@ -4,6 +4,6 @@
 
 at::Tensor gemm_bf16xfp32_xe2(
     at::Tensor& A,       // [M, K] bf16
-    at::Tensor& B_high,  // [N, K] bf16
-    at::Tensor& B_low,   // [N, K] bf16
+    at::Tensor& B_high,  // [K, N] bf16 (transposed weight)
+    at::Tensor& B_low,   // [K, N] bf16 (transposed weight)
     double scale);

--- a/csrc/xpu/gemm_bf16xfp32/xe_2/gemm_bf16xfp32_xe2.h
+++ b/csrc/xpu/gemm_bf16xfp32/xe_2/gemm_bf16xfp32_xe2.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <torch/all.h>
+
+at::Tensor gemm_bf16xfp32_xe2(
+    at::Tensor& A,       // [M, K] bf16
+    at::Tensor& B_high,  // [N, K] bf16
+    at::Tensor& B_low,   // [N, K] bf16
+    double scale);

--- a/csrc/xpu/gemm_bf16xfp32/xe_2/gemm_bf16xfp32_xe2_impl.hpp
+++ b/csrc/xpu/gemm_bf16xfp32/xe_2/gemm_bf16xfp32_xe2_impl.hpp
@@ -1,0 +1,426 @@
+/***************************************************************************************************
+ * Copyright (C) 2025 - 2026 Intel Corporation, All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * BF16xFP32 GEMM implementation using DualGemm infrastructure from sycl-tla.
+ *
+ * Emulates FP32-precision GEMM using two BF16 DPAS operations:
+ *   result = X * W_high + (X * W_low) * scale
+ *
+ * where W_high and W_low are BF16 decompositions of an FP32 weight matrix W.
+ **************************************************************************************************/
+#pragma once
+
+#include <torch/all.h>
+#include "csrc/utils.h"
+
+#include <cute/tensor.hpp>
+#include <cute/util/compat.hpp>
+#include <sycl/ext/intel/experimental/grf_size_properties.hpp>
+#include <sycl/sycl.hpp>
+
+#include "cutlass/cutlass.h"
+#include "cutlass/kernel_hardware_info.h"
+#include "cutlass/gemm/dispatch_policy.hpp"
+#include "cutlass/epilogue/dispatch_policy.hpp"
+#include "cutlass/epilogue/collective/default_epilogue.hpp"
+#include "cutlass/epilogue/fusion/xe_callbacks.hpp"
+#include "cutlass/gemm/device/gemm_universal_adapter.h"
+#include "cutlass/util/packed_stride.hpp"
+
+// DualGemm infrastructure from applications/
+#include "dual_gemm/kernel/xe_dual_gemm.hpp"
+#include "dual_gemm/collective/xe_dual_gemm_mma.hpp"
+#include "dual_gemm/collective/xe_dual_gemm_epilogue.hpp"
+
+// Local epilogue
+#include "bf16xfp32_epilogue.hpp"
+
+#pragma clang diagnostic ignored "-Wpass-failed"
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+
+namespace gemm_bf16xfp32 {
+using namespace cute;
+
+// Default policy: good for medium/large M (prefill).
+struct policy_default {
+  using TileShape = Shape<_128, _64, _64>;
+  using TiledMma = typename TiledMMAHelper<
+      MMA_Atom<XE_8x16x16_F32BF16BF16F32_TT>,
+      Layout<TileShape>,
+      Layout<Shape<_8, _2, _1>, Stride<_2, _1, _0>>>::TiledMMA;
+  static constexpr int PipelineStages = 2;
+};
+
+// Small M policy: for decode (M=1~32)
+struct policy_small_m {
+  using TileShape = Shape<_32, _64, _64>;
+  using TiledMma = typename TiledMMAHelper<
+      MMA_Atom<XE_8x16x16_F32BF16BF16F32_TT>,
+      Layout<TileShape>,
+      Layout<Shape<_2, _2, _1>, Stride<_2, _1, _0>>>::TiledMMA;
+  static constexpr int PipelineStages = 2;
+};
+
+// Medium M policy: for small batch prefill (M=17~64)
+struct policy_medium_m {
+  using TileShape = Shape<_64, _64, _64>;
+  using TiledMma = typename TiledMMAHelper<
+      MMA_Atom<XE_8x16x16_F32BF16BF16F32_TT>,
+      Layout<TileShape>,
+      Layout<Shape<_4, _2, _1>, Stride<_2, _1, _0>>>::TiledMMA;
+  static constexpr int PipelineStages = 2;
+};
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+// Kernel type assembly
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+template <class Policy>
+struct DualGemmKernelType {
+  using ElementA = bfloat16_t;
+  using ElementB = bfloat16_t;
+  using ElementAccumulator = float;
+  using ElementOutput = float;
+
+  using LayoutA = cutlass::layout::RowMajor;
+  using LayoutB = cutlass::layout::RowMajor;
+  using LayoutC = cutlass::layout::RowMajor;
+  using LayoutD = cutlass::layout::RowMajor;
+
+  using StrideA = cutlass::gemm::TagToStrideA_t<LayoutA>;
+  using StrideB = cutlass::gemm::TagToStrideB_t<LayoutB>;
+  using StrideC = cutlass::gemm::TagToStrideC_t<LayoutC>;
+  using StrideD = cutlass::gemm::TagToStrideC_t<LayoutD>;
+
+  using TileShape = typename Policy::TileShape;
+  using TiledMma = typename Policy::TiledMma;
+  static constexpr int PipelineStages = Policy::PipelineStages;
+
+  using GmemTiledCopyA = XE_2D_U16x16x32_LD_N;
+  using GmemTiledCopyB = XE_2D_U16x32x32_LD_V;
+
+  using GEMMDispatchPolicy =
+      cutlass::gemm::MainloopIntelXeXMX16<PipelineStages>;
+  using EpilogueDispatchPolicy = cutlass::epilogue::IntelXeXMX16;
+
+  // Individual epilogues (pass-through, do NOT write output)
+  using EpilogueOp = cutlass::epilogue::fusion::LinCombEltAct<
+      cutlass::epilogue::thread::Identity,
+      ElementOutput,
+      float,
+      ElementAccumulator,
+      ElementAccumulator,
+      cutlass::FloatRoundStyle::round_to_nearest>;
+
+  using FusionCallBacks = cutlass::epilogue::fusion::FusionCallbacks<
+      EpilogueDispatchPolicy,
+      EpilogueOp,
+      TileShape,
+      decltype(tile_shape(TiledMma()))>;
+
+  static constexpr bool WriteEpilogueOutput = false;
+
+  using CollectiveEpilogue = cutlass::epilogue::collective::DualGemmEpilogue<
+      EpilogueDispatchPolicy,
+      TileShape,
+      ElementAccumulator,
+      StrideC,
+      ElementOutput,
+      StrideD,
+      FusionCallBacks,
+      XE_2D_U32x8x16_LD_N,
+      XE_2D_U32x8x16_ST_N,
+      WriteEpilogueOutput>;
+
+  // BF16xFP32 combining epilogue: D = acc_high + acc_low * scale
+  using CollectiveBF16xFP32Epilogue =
+      cutlass::epilogue::collective::BF16xFP32Epilogue<
+          EpilogueDispatchPolicy,
+          TileShape,
+          void,  // No source C
+          StrideC,
+          ElementOutput,
+          StrideD,
+          void,  // No load op
+          XE_2D_U32x8x16_ST_N>;
+
+  // Mainloop: shared A, dual B (W_high, W_low)
+  using CollectiveMainloop = cutlass::gemm::collective::DualGemmMma<
+      GEMMDispatchPolicy,
+      TileShape,
+      ElementA,
+      StrideA,
+      ElementB,
+      StrideB,
+      TiledMma,
+      GmemTiledCopyA,
+      GmemTiledCopyB>;
+
+  // Full kernel
+  using GemmKernel = cutlass::gemm::kernel::DualGemm<
+      Shape<int, int, int, int>,
+      CollectiveMainloop,
+      CollectiveEpilogue,
+      CollectiveEpilogue,
+      CollectiveBF16xFP32Epilogue>;
+};
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+// SYCL kernel name tags
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+template <class Policy>
+class GemmBF16xFP32KernelName;
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+// Launch function
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+template <class Policy>
+void launch_gemm_bf16xfp32(
+    sycl::queue& queue,
+    const bfloat16_t* A,       // [M, K]
+    const bfloat16_t* B_high,  // [K, N]
+    const bfloat16_t* B_low,   // [K, N]
+    float* D,                  // [M, N] (or [splits, M, N] when splits > 1)
+    int M,
+    int N,
+    int K,
+    float scale,
+    int splits = 1) {
+  using Kernel = typename DualGemmKernelType<Policy>::GemmKernel;
+  using StrideA = typename DualGemmKernelType<Policy>::StrideA;
+  using StrideB = typename DualGemmKernelType<Policy>::StrideB;
+  using StrideD = typename DualGemmKernelType<Policy>::StrideD;
+
+  const int Kp = K / splits;
+
+  // A [M, K] as (M, Kp, L): row stride = K, L step advances Kp along K.
+  StrideA stride_A;
+  cute::get<0>(stride_A) = static_cast<int64_t>(K);
+  cute::get<2>(stride_A) = static_cast<int64_t>(Kp);
+
+  // B [K, N] as (N, Kp, L): N contiguous, K stride = N, L step = Kp * N.
+  StrideB stride_B;
+  cute::get<1>(stride_B) = static_cast<int64_t>(N);
+  cute::get<2>(stride_B) = static_cast<int64_t>(Kp) * N;
+
+  // D [L, M, N] as (M, N, L): N contiguous, M stride = N, L step = M * N.
+  StrideD stride_D;
+  cute::get<0>(stride_D) = static_cast<int64_t>(N);
+  cute::get<2>(stride_D) = static_cast<int64_t>(M) * N;
+
+  using EpilogueArguments = typename Kernel::EpilogueArguments0;
+  EpilogueArguments epilogue_args0{
+      {1.0f, 0.0f}, nullptr, stride_D, nullptr, stride_D};
+  EpilogueArguments epilogue_args1{
+      {1.0f, 0.0f}, nullptr, stride_D, nullptr, stride_D};
+
+  using BF16xFP32EpilogueArguments =
+      typename Kernel::DualGemmElemActEpilogueArguments;
+  BF16xFP32EpilogueArguments bf16xfp32_args{D, stride_D, scale};
+
+  cutlass::KernelHardwareInfo hw_info;
+  hw_info.sm_count =
+      cutlass::KernelHardwareInfo::query_device_multiprocessor_count(
+          hw_info.device_id);
+
+  const auto mode = (splits > 1) ? cutlass::gemm::GemmUniversalMode::kBatched
+                                 : cutlass::gemm::GemmUniversalMode::kGemm;
+
+  typename Kernel::Arguments arguments{
+      mode,
+      {M, N, Kp, splits},
+      {A, stride_A, B_high, stride_B, B_low, stride_B},
+      epilogue_args0,
+      epilogue_args1,
+      bf16xfp32_args,
+      hw_info};
+
+  TORCH_CHECK(
+      Kernel::can_implement(arguments),
+      "gemm_bf16xfp32: problem size not supported by kernel. "
+      "M=",
+      M,
+      " N=",
+      N,
+      " K=",
+      K,
+      " splits=",
+      splits);
+
+  size_t workspace_size = Kernel::get_workspace_size(arguments);
+  TORCH_CHECK(
+      workspace_size == 0, "gemm_bf16xfp32: unexpected workspace requirement");
+
+  typename Kernel::Params params =
+      Kernel::to_underlying_arguments(arguments, nullptr);
+
+  dim3 block = Kernel::get_block_shape();
+  dim3 grid = Kernel::get_grid_shape(params);
+
+  sycl::range<3> local(1, 1, block.x);
+  sycl::range<3> global(grid.z, grid.y, grid.x);
+
+  namespace syclex = sycl::ext::oneapi::experimental;
+  namespace intelex = sycl::ext::intel::experimental;
+  syclex::properties kernel_props{
+      syclex::sub_group_size<Kernel::DispatchPolicy::SubgroupSize>,
+      intelex::grf_size<256>};
+
+  queue.submit([&](sycl::handler& cgh) {
+    cgh.parallel_for<GemmBF16xFP32KernelName<Policy>>(
+        sycl::nd_range<3>{global * local, local}, kernel_props, [=](auto) {
+          // SharedStorageSize is 0 for DualGemm
+          char* smem_buf = nullptr;
+          Kernel kernel_op;
+          kernel_op(params, smem_buf);
+        });
+  });
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+// Split-K partial reduction
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+class ReduceSplitsKernelName;
+
+inline void launch_reduce_splits(
+    sycl::queue& queue,
+    const float* partials,  // [splits, M, N]
+    float* D,               // [M, N]
+    int splits,
+    int M,
+    int N) {
+  const int64_t mn = static_cast<int64_t>(M) * N;
+  constexpr int kWg = 256;
+  const int64_t n_groups = (mn + kWg - 1) / kWg;
+
+  queue.submit([&](sycl::handler& cgh) {
+    cgh.parallel_for<ReduceSplitsKernelName>(
+        sycl::nd_range<1>{
+            sycl::range<1>(static_cast<size_t>(n_groups) * kWg),
+            sycl::range<1>(kWg)},
+        [=](sycl::nd_item<1> item) {
+          const int64_t idx = static_cast<int64_t>(item.get_global_linear_id());
+          if (idx >= mn) {
+            return;
+          }
+          float acc = 0.0f;
+          const float* p = partials + idx;
+          for (int s = 0; s < splits; ++s) {
+            acc += p[static_cast<int64_t>(s) * mn];
+          }
+          D[idx] = acc;
+        });
+  });
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+// Top-level dispatch (selects tile policy based on M)
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+inline at::Tensor gemm_bf16xfp32_xe2_impl(
+    at::Tensor& A,       // [M, K] bf16
+    at::Tensor& B_high,  // [K, N] bf16 (transposed weight)
+    at::Tensor& B_low,   // [K, N] bf16 (transposed weight)
+    double scale) {
+  TORCH_CHECK(A.dim() == 2, "A must be 2D [M, K]");
+  TORCH_CHECK(B_high.dim() == 2, "B_high must be 2D [K, N]");
+  TORCH_CHECK(B_low.dim() == 2, "B_low must be 2D [K, N]");
+  TORCH_CHECK(A.dtype() == at::kBFloat16, "A must be BF16");
+  TORCH_CHECK(B_high.dtype() == at::kBFloat16, "B_high must be BF16");
+  TORCH_CHECK(B_low.dtype() == at::kBFloat16, "B_low must be BF16");
+  TORCH_CHECK(A.is_contiguous(), "A must be contiguous");
+  TORCH_CHECK(B_high.is_contiguous(), "B_high must be contiguous");
+  TORCH_CHECK(B_low.is_contiguous(), "B_low must be contiguous");
+
+  int M = A.size(0);
+  int K = A.size(1);
+  int N = B_high.size(1);
+
+  TORCH_CHECK(B_high.size(0) == K, "B_high.size(0) must match A.size(1) (K)");
+  TORCH_CHECK(B_low.size(0) == K, "B_low.size(0) must match A.size(1) (K)");
+  TORCH_CHECK(
+      B_low.size(1) == N, "B_low.size(1) must match B_high.size(1) (N)");
+  TORCH_CHECK(N % 4 == 0, "N must be divisible by 4");
+
+  // Allocate output [M, N] fp32
+  auto D = at::empty({M, N}, A.options().dtype(at::kFloat));
+
+  auto& queue = at::xpu::getCurrentXPUStream(A.device().index()).queue();
+
+  const bfloat16_t* ptr_A = reinterpret_cast<const bfloat16_t*>(A.data_ptr());
+  const bfloat16_t* ptr_B_high =
+      reinterpret_cast<const bfloat16_t*>(B_high.data_ptr());
+  const bfloat16_t* ptr_B_low =
+      reinterpret_cast<const bfloat16_t*>(B_low.data_ptr());
+  float* ptr_D = reinterpret_cast<float*>(D.data_ptr());
+
+  float scale_f = static_cast<float>(scale);
+
+  constexpr int kEusPerXeCore = 8;  // Xe2 (BMG): 8 XVEs per Xe-core
+  int n_eus = static_cast<int>(
+      queue.get_device().get_info<sycl::info::device::max_compute_units>());
+  int n_cores = n_eus / kEusPerXeCore;
+  if (n_cores < 1) {
+    n_cores = 1;
+  }
+
+  const int fill_threshold = (n_cores + 1) / 2;
+  const int grid_n = (N + 63) / 64;
+  auto num_wgs = [&](int blk_m) { return ((M + blk_m - 1) / blk_m) * grid_n; };
+
+  if (num_wgs(128) >= fill_threshold) {
+    launch_gemm_bf16xfp32<policy_default>(
+        queue, ptr_A, ptr_B_high, ptr_B_low, ptr_D, M, N, K, scale_f);
+  } else if (num_wgs(64) >= fill_threshold) {
+    launch_gemm_bf16xfp32<policy_medium_m>(
+        queue, ptr_A, ptr_B_high, ptr_B_low, ptr_D, M, N, K, scale_f);
+  } else {
+    const int base_wgs = num_wgs(32);
+    const int max_wgs = 2 * n_cores;
+    int splits = 1;
+    int fill_wgs = base_wgs;  // best occupancy so far (splits == 1)
+    for (int s = 2; base_wgs * s <= max_wgs; ++s) {
+      if (K % s != 0 || (K / s) % 64 != 0) {
+        continue;
+      }
+      const int wgs = base_wgs * s;
+      if (wgs >= n_cores) {  // first split that fully occupies -> take it
+        splits = s;
+        fill_wgs = wgs;
+        break;
+      }
+      if (wgs > fill_wgs) {  // otherwise keep the most-filling split
+        splits = s;
+        fill_wgs = wgs;
+      }
+    }
+
+    if (splits > 1) {
+      auto D_ws = at::empty({splits, M, N}, A.options().dtype(at::kFloat));
+      float* ptr_D_ws = reinterpret_cast<float*>(D_ws.data_ptr());
+      launch_gemm_bf16xfp32<policy_small_m>(
+          queue,
+          ptr_A,
+          ptr_B_high,
+          ptr_B_low,
+          ptr_D_ws,
+          M,
+          N,
+          K,
+          scale_f,
+          splits);
+      launch_reduce_splits(queue, ptr_D_ws, ptr_D, splits, M, N);
+    } else {
+      launch_gemm_bf16xfp32<policy_small_m>(
+          queue, ptr_A, ptr_B_high, ptr_B_low, ptr_D, M, N, K, scale_f);
+    }
+  }
+
+  return D;
+}
+
+}  // namespace gemm_bf16xfp32

--- a/csrc/xpu/gemm_bf16xfp32/xe_2/gemm_bf16xfp32_xe2_impl.hpp
+++ b/csrc/xpu/gemm_bf16xfp32/xe_2/gemm_bf16xfp32_xe2_impl.hpp
@@ -72,10 +72,7 @@ struct policy_medium_m {
   static constexpr int PipelineStages = 2;
 };
 
-///////////////////////////////////////////////////////////////////////////////////////////////////
 // Kernel type assembly
-///////////////////////////////////////////////////////////////////////////////////////////////////
-
 template <class Policy>
 struct DualGemmKernelType {
   using ElementA = bfloat16_t;
@@ -166,16 +163,8 @@ struct DualGemmKernelType {
       CollectiveBF16xFP32Epilogue>;
 };
 
-///////////////////////////////////////////////////////////////////////////////////////////////////
-// SYCL kernel name tags
-///////////////////////////////////////////////////////////////////////////////////////////////////
-
 template <class Policy>
 class GemmBF16xFP32KernelName;
-
-///////////////////////////////////////////////////////////////////////////////////////////////////
-// Launch function
-///////////////////////////////////////////////////////////////////////////////////////////////////
 
 template <class Policy>
 void launch_gemm_bf16xfp32(
@@ -280,10 +269,7 @@ void launch_gemm_bf16xfp32(
   });
 }
 
-///////////////////////////////////////////////////////////////////////////////////////////////////
 // Split-K partial reduction
-///////////////////////////////////////////////////////////////////////////////////////////////////
-
 class ReduceSplitsKernelName;
 
 inline void launch_reduce_splits(
@@ -317,10 +303,82 @@ inline void launch_reduce_splits(
   });
 }
 
-///////////////////////////////////////////////////////////////////////////////////////////////////
-// Top-level dispatch (selects tile policy based on M)
-///////////////////////////////////////////////////////////////////////////////////////////////////
+// Split-K factor selection
+inline int choose_splits_fill(int base_wgs, int K, int n_cores) {
+  int splits = 1;
+  int fill_wgs = base_wgs;
+  for (int s = 2; base_wgs * s <= 2 * n_cores; ++s) {
+    if (K % s != 0 || (K / s) % 64 != 0) {
+      continue;
+    }
+    const int wgs = base_wgs * s;
+    if (wgs >= n_cores) {  // first split that fully occupies -> take it
+      splits = s;
+      break;
+    }
+    if (wgs > fill_wgs) {  // otherwise keep the most-filling split
+      splits = s;
+      fill_wgs = wgs;
+    }
+  }
+  return splits;
+}
 
+inline int choose_splits_net(int base_wgs, int K, int n_cores) {
+  int splits = 1;
+  int best_net = 0;  // net for splits == 1
+  for (int s = 2; base_wgs * s <= 2 * n_cores; ++s) {
+    if (K % s != 0 || (K / s) % 64 != 0) {
+      continue;
+    }
+    const int wgs = base_wgs * s;
+    const int gain = (wgs < n_cores ? wgs : n_cores) - base_wgs;
+    const int waste = (wgs > n_cores) ? (wgs - n_cores) : 0;
+    const int net = gain - waste;
+    if (net > best_net) {
+      best_net = net;
+      splits = s;
+    }
+  }
+  return splits;
+}
+
+// Launch a policy with a given Split-K factor (splits == 1 -> single kernel)
+template <class Policy>
+inline void launch_with_splitk(
+    sycl::queue& queue,
+    const at::Tensor& D,
+    const bfloat16_t* ptr_A,
+    const bfloat16_t* ptr_B_high,
+    const bfloat16_t* ptr_B_low,
+    float* ptr_D,
+    int M,
+    int N,
+    int K,
+    float scale_f,
+    int splits) {
+  if (splits > 1) {
+    auto D_ws = at::empty({splits, M, N}, D.options());
+    float* ptr_D_ws = reinterpret_cast<float*>(D_ws.data_ptr());
+    launch_gemm_bf16xfp32<Policy>(
+        queue,
+        ptr_A,
+        ptr_B_high,
+        ptr_B_low,
+        ptr_D_ws,
+        M,
+        N,
+        K,
+        scale_f,
+        splits);
+    launch_reduce_splits(queue, ptr_D_ws, ptr_D, splits, M, N);
+  } else {
+    launch_gemm_bf16xfp32<Policy>(
+        queue, ptr_A, ptr_B_high, ptr_B_low, ptr_D, M, N, K, scale_f);
+  }
+}
+
+// Top-level dispatch (selects tile policy based on M)
 inline at::Tensor gemm_bf16xfp32_xe2_impl(
     at::Tensor& A,       // [M, K] bf16
     at::Tensor& B_high,  // [K, N] bf16 (transposed weight)
@@ -379,51 +437,40 @@ inline at::Tensor gemm_bf16xfp32_xe2_impl(
   auto num_wgs = [&](int blk_m) { return ((M + blk_m - 1) / blk_m) * grid_n; };
 
   if (num_wgs(128) >= fill_threshold) {
+    // Prefill: the BLK_M=128 grid already fills the machine (splits == 1).
     launch_gemm_bf16xfp32<policy_default>(
         queue, ptr_A, ptr_B_high, ptr_B_low, ptr_D, M, N, K, scale_f);
-  } else if (num_wgs(64) >= fill_threshold) {
-    launch_gemm_bf16xfp32<policy_medium_m>(
-        queue, ptr_A, ptr_B_high, ptr_B_low, ptr_D, M, N, K, scale_f);
+  } else if (num_wgs(64) >= fill_threshold || (M >= 128 && M % 64 == 0)) {
+    // Mid M (compute-bound): split only when the occupancy gained beats the
+    // work-groups that spill into an extra wave.
+    launch_with_splitk<policy_medium_m>(
+        queue,
+        D,
+        ptr_A,
+        ptr_B_high,
+        ptr_B_low,
+        ptr_D,
+        M,
+        N,
+        K,
+        scale_f,
+        choose_splits_net(num_wgs(64), K, n_cores));
   } else {
-    const int base_wgs = num_wgs(32);
-    const int max_wgs = 2 * n_cores;
-    int splits = 1;
-    int fill_wgs = base_wgs;  // best occupancy so far (splits == 1)
-    for (int s = 2; base_wgs * s <= max_wgs; ++s) {
-      if (K % s != 0 || (K / s) % 64 != 0) {
-        continue;
-      }
-      const int wgs = base_wgs * s;
-      if (wgs >= n_cores) {  // first split that fully occupies -> take it
-        splits = s;
-        fill_wgs = wgs;
-        break;
-      }
-      if (wgs > fill_wgs) {  // otherwise keep the most-filling split
-        splits = s;
-        fill_wgs = wgs;
-      }
-    }
-
-    if (splits > 1) {
-      auto D_ws = at::empty({splits, M, N}, A.options().dtype(at::kFloat));
-      float* ptr_D_ws = reinterpret_cast<float*>(D_ws.data_ptr());
-      launch_gemm_bf16xfp32<policy_small_m>(
-          queue,
-          ptr_A,
-          ptr_B_high,
-          ptr_B_low,
-          ptr_D_ws,
-          M,
-          N,
-          K,
-          scale_f,
-          splits);
-      launch_reduce_splits(queue, ptr_D_ws, ptr_D, splits, M, N);
-    } else {
-      launch_gemm_bf16xfp32<policy_small_m>(
-          queue, ptr_A, ptr_B_high, ptr_B_low, ptr_D, M, N, K, scale_f);
-    }
+    // Decode (memory-bound small M): split aggressively to put more cores to
+    // work streaming weights; spilled waves are nearly free at these tiny
+    // tiles.
+    launch_with_splitk<policy_small_m>(
+        queue,
+        D,
+        ptr_A,
+        ptr_B_high,
+        ptr_B_low,
+        ptr_D,
+        M,
+        N,
+        K,
+        scale_f,
+        choose_splits_fill(num_wgs(32), K, n_cores));
   }
 
   return D;

--- a/csrc/xpu/gemm_bf16xfp32/xe_2/gemm_bf16xfp32_xe2_impl.hpp
+++ b/csrc/xpu/gemm_bf16xfp32/xe_2/gemm_bf16xfp32_xe2_impl.hpp
@@ -332,6 +332,12 @@ inline at::Tensor gemm_bf16xfp32_xe2_impl(
   TORCH_CHECK(A.dtype() == at::kBFloat16, "A must be BF16");
   TORCH_CHECK(B_high.dtype() == at::kBFloat16, "B_high must be BF16");
   TORCH_CHECK(B_low.dtype() == at::kBFloat16, "B_low must be BF16");
+  TORCH_CHECK(A.is_xpu(), "A must be on XPU");
+  TORCH_CHECK(B_high.is_xpu(), "B_high must be on XPU");
+  TORCH_CHECK(B_low.is_xpu(), "B_low must be on XPU");
+  TORCH_CHECK(
+      A.device() == B_high.device() && A.device() == B_low.device(),
+      "A, B_high, and B_low must be on the same XPU device");
   TORCH_CHECK(A.is_contiguous(), "A must be contiguous");
   TORCH_CHECK(B_high.is_contiguous(), "B_high must be contiguous");
   TORCH_CHECK(B_low.is_contiguous(), "B_low must be contiguous");

--- a/csrc/xpu/torch_bindings.cpp
+++ b/csrc/xpu/torch_bindings.cpp
@@ -3,6 +3,7 @@
 #ifdef VLLM_MOE_ENABLED
   #include "xpu/grouped_gemm/grouped_gemm_interface.h"
 #endif
+#include "xpu/gemm_bf16xfp32/gemm_bf16xfp32_interface.h"
 #include "xpu/lora/lora_ops.h"
 
 #include <torch/library.h>
@@ -52,6 +53,11 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, xpu_ops) {
       torch::kXPU,
       &cutlass_grouped_gemm_interface);
 #endif
+
+  xpu_ops.def(
+      "gemm_bf16xfp32(Tensor A, Tensor B_high, Tensor B_low, float scale) -> "
+      "Tensor");
+  xpu_ops.impl("gemm_bf16xfp32", torch::kXPU, &gemm_bf16xfp32);
 
   xpu_ops.def(
       "deepseek_scaling_rope(Tensor! positions, Tensor! query, Tensor! key, "

--- a/setup.py
+++ b/setup.py
@@ -564,6 +564,9 @@ if _is_enabled("BUILD_SYCL_TLA_KERNELS"):
         if _is_enabled("MOE_KERNELS_ENABLED"):
             additional_libraries["grouped_gemm_xe_2"] = (
                 "/csrc/xpu/grouped_gemm/xe_2")
+        # Router BF16xFP32 GEMM: independent of MoE, only needs XE2.
+        additional_libraries["gemm_bf16xfp32_xe_2"] = (
+            "/csrc/xpu/gemm_bf16xfp32/xe_2")
     if _is_enabled("VLLM_XPU_ENABLE_XE_DEFAULT") and _is_enabled(
             "MOE_KERNELS_ENABLED"):
         additional_libraries["grouped_gemm_xe_default"] = (

--- a/tests/register_ops.py
+++ b/tests/register_ops.py
@@ -425,6 +425,11 @@ def fp8_gemm_w8a16(input: torch.Tensor, weight: torch.Tensor,
     return torch.ops._xpu_C.fp8_gemm_w8a16(input, weight, scale_wei, scale_act)
 
 
+def gemm_bf16xfp32(A: torch.Tensor, B_high: torch.Tensor,
+                   B_low: torch.Tensor, scale: float = 256.0):
+    return torch.ops._xpu_C.gemm_bf16xfp32(A, B_high, B_low, scale)
+
+
 # moe
 def moe_sum(input: torch.Tensor, output: torch.Tensor) -> None:
     torch.ops._moe_C.moe_sum(input, output)

--- a/tests/register_ops.py
+++ b/tests/register_ops.py
@@ -426,7 +426,7 @@ def fp8_gemm_w8a16(input: torch.Tensor, weight: torch.Tensor,
 
 
 def gemm_bf16xfp32(A: torch.Tensor, B_high: torch.Tensor,
-                   B_low: torch.Tensor, scale: float = 256.0):
+                   B_low: torch.Tensor, scale: float = 1.0 / 256.0):
     return torch.ops._xpu_C.gemm_bf16xfp32(A, B_high, B_low, scale)
 
 

--- a/tests/test_gemm_bf16xfp32.py
+++ b/tests/test_gemm_bf16xfp32.py
@@ -4,7 +4,9 @@
 The kernel emulates an FP32-precision GEMM (BF16 activation x FP32 weight)
 by decomposing the FP32 weight into two BF16 matrices and running a DualGemm:
 
-    out = A @ B_high.T + (A @ B_low.T) * scale
+    out = A @ B_high + (A @ B_low) * scale
+
+(B_high/B_low are already transposed to [K, N], see _split_fp32_weight.)
 
 This mirrors the way the Hunyuan-V3 MoE router (GateLinear) is computed on
 XPU today.  The result is compared against the reference ``F.linear`` path

--- a/tests/test_gemm_bf16xfp32.py
+++ b/tests/test_gemm_bf16xfp32.py
@@ -1,0 +1,102 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Correctness test for the BF16xFP32 emulated-FP32 GEMM.
+
+The kernel emulates an FP32-precision GEMM (BF16 activation x FP32 weight)
+by decomposing the FP32 weight into two BF16 matrices and running a DualGemm:
+
+    out = A @ B_high.T + (A @ B_low.T) * scale
+
+This mirrors the way the Hunyuan-V3 MoE router (GateLinear) is computed on
+XPU today.  The result is compared against the reference ``F.linear`` path
+that vLLM currently uses on XPU:
+
+        x_fp32 = x_bf16.float()
+        out    = F.linear(x_fp32, W_fp32)      # FP32 x FP32 GEMM
+
+Run:
+    pytest -q tests/test_gemm_bf16xfp32.py
+"""
+
+import pytest
+import torch
+
+from tests.register_ops import gemm_bf16xfp32
+
+DEVICE = "xpu"
+SCALE = 1.0 / 256.0
+
+NUM_TOKENS = [1, 4, 8, 16, 32, 64, 256, 1024, 4096, 8192]
+NUM_EXPERTS = [128, 192, 256]
+HIDDEN_SIZES = [3072, 4096, 6144]
+
+
+def _split_fp32_weight(weight: torch.Tensor, scale: float = SCALE):
+    """FP32 weight [N, K] -> (W_high, W_low) BF16 decomposition.
+
+    The kernel computes ``Y[m,n] = sum_k A[m,k] * B[k,n]`` (i.e. F.linear),
+    so the components are returned transposed to ``[K, N]`` (N-contiguous),
+    matching the layout the kernel expects.
+
+    Reconstruction: weight ~= fp32(W_high.T) + fp32(W_low.T) * scale
+    """
+    assert weight.dtype == torch.float32
+    W_high = weight.to(torch.bfloat16)
+    residual = weight - W_high.float()
+    W_low = (residual / scale).to(torch.bfloat16)
+    return W_high.t().contiguous(), W_low.t().contiguous()
+
+
+def _make_inputs(m, n, k, seed=1234):
+    torch.manual_seed(seed)
+    x_bf16 = (torch.randn(m, k, dtype=torch.bfloat16, device=DEVICE) / 8.0)
+    w_fp32 = (torch.randn(n, k, dtype=torch.float32, device=DEVICE) / 8.0)
+    return x_bf16, w_fp32
+
+
+def _ref_flinear(x_bf16, w_fp32):
+    return torch.nn.functional.linear(x_bf16.float(), w_fp32)
+
+
+def _ref_bf16_naive(x_bf16, w_fp32):
+    w_high = w_fp32.to(torch.bfloat16)
+    return torch.nn.functional.linear(x_bf16, w_high).float()
+
+
+@pytest.mark.parametrize("k", HIDDEN_SIZES)
+@pytest.mark.parametrize("n", NUM_EXPERTS)
+@pytest.mark.parametrize("m", NUM_TOKENS)
+def test_gemm_bf16xfp32_correctness(m, n, k):
+    x_bf16, w_fp32 = _make_inputs(m, n, k)
+
+    ref = _ref_flinear(x_bf16, w_fp32)
+
+    w_high, w_low = _split_fp32_weight(w_fp32, SCALE)
+    out = gemm_bf16xfp32(x_bf16, w_high, w_low, SCALE)
+    torch.xpu.synchronize()
+
+    assert out.dtype == torch.float32
+    assert out.shape == ref.shape
+
+    abs_err = (out - ref).abs()
+    rel_err = abs_err / (ref.abs() + 1e-6)
+    max_abs = abs_err.max().item()
+    mean_rel = rel_err.mean().item()
+
+    naive = _ref_bf16_naive(x_bf16, w_fp32)
+    naive_max_rel = ((naive - ref).abs() / (ref.abs() + 1e-6)).max().item()
+    dual_max_rel = rel_err.max().item()
+
+    torch.testing.assert_close(out, ref, rtol=1e-3, atol=1e-4)
+
+    assert max_abs < 1e-4, f"max abs err {max_abs:.2e} exceeds 1e-4"
+    assert mean_rel < 1e-4, f"mean rel err {mean_rel:.2e} exceeds 1e-4"
+
+    assert dual_max_rel <= naive_max_rel + 1e-3, (
+        f"dual-bf16 rel err {dual_max_rel:.4e} worse than "
+        f"naive bf16 {naive_max_rel:.4e}")
+
+if __name__ == "__main__":
+    import itertools
+    for m, n, k in itertools.product(NUM_TOKENS, NUM_EXPERTS, HIDDEN_SIZES):
+        test_gemm_bf16xfp32_correctness(m, n, k)
+    print("\nAll gemm_bf16xfp32 correctness tests passed.")

--- a/vllm_xpu_kernels/gemm_bf16xfp32.py
+++ b/vllm_xpu_kernels/gemm_bf16xfp32.py
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: Apache-2.0
+"""BF16xFP32 GEMM: emulated FP32-precision GEMM using two BF16 DPAS operations.
+
+  result = A @ B_high.T + (A @ B_low.T) * scale
+
+where B_high, B_low are BF16 decompositions of an FP32 weight matrix B:
+  B_high = bf16(B)
+  B_low  = bf16((B - fp32(B_high)) / scale)
+"""
+
+import torch
+
+import vllm_xpu_kernels._xpu_C  # noqa: F401  (registers torch.ops._xpu_C.*)
+
+
+def split_fp32_weight(
+    weight: torch.Tensor, scale: float = 1.0 / 256.0
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Split FP32 weight into two BF16 components for DualGemm.
+
+    The kernel computes ``Y = X @ W.T`` (F.linear semantics) as
+    ``Y[m,n] = sum_k A[m,k] * B[k,n]``, so the returned components are
+    transposed to ``[K, N]`` (N-contiguous) as the kernel expects.
+
+    Args:
+        weight: [N, K] FP32 weight tensor (nn.Linear layout: out x in)
+        scale: Fixed scale factor (default 1/256 = 2^-8, matches CUDA hpc-ops;
+            W_low stores the amplified residual, reconstructed as W_low * scale)
+
+    Returns:
+        (W_high, W_low): both [K, N] BF16 tensors (transposed & contiguous)
+        Reconstruction: weight ≈ fp32(W_high) + fp32(W_low) * scale
+    """
+    assert weight.dtype == torch.float32, "weight must be FP32"
+    W_high = weight.to(torch.bfloat16)
+    residual = weight - W_high.float()
+    W_low = (residual / scale).to(torch.bfloat16)
+    # Transpose to [K, N] contiguous for the kernel's B layout.
+    return W_high.t().contiguous(), W_low.t().contiguous()
+
+
+def gemm_bf16xfp32(
+    A: torch.Tensor,
+    B_high: torch.Tensor,
+    B_low: torch.Tensor,
+    scale: float = 1.0 / 256.0,
+) -> torch.Tensor:
+    """BF16xFP32 GEMM via DualGemm.
+
+    Computes ``Y = A @ (W_high + W_low * scale)`` where ``B_high``/``B_low``
+    are the [K, N] transposed BF16 decompositions of an FP32 weight
+    (see :func:`split_fp32_weight`). This equals ``F.linear(A, W)`` for the
+    original [N, K] weight ``W``.
+
+    Args:
+        A: [M, K] BF16 activation tensor
+        B_high: [K, N] BF16 (high bits of FP32 weight, transposed)
+        B_low: [K, N] BF16 (low bits of FP32 weight, normalized by scale)
+        scale: The scale factor used during weight splitting
+
+    Returns:
+        [M, N] FP32 output tensor
+    """
+    return torch.ops._xpu_C.gemm_bf16xfp32(A, B_high, B_low, scale)

--- a/vllm_xpu_kernels/gemm_bf16xfp32.py
+++ b/vllm_xpu_kernels/gemm_bf16xfp32.py
@@ -1,9 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 """BF16xFP32 GEMM: emulated FP32-precision GEMM using two BF16 DPAS operations.
 
-  result = A @ B_high.T + (A @ B_low.T) * scale
+  result = A @ B_high + (A @ B_low) * scale
 
-where B_high, B_low are BF16 decompositions of an FP32 weight matrix B:
+where B_high, B_low are BF16 decompositions of an FP32 weight matrix B.
+The kernel expects B_high/B_low in transposed [K, N] layout (see
+:func:`split_fp32_weight`):
   B_high = bf16(B)
   B_low  = bf16((B - fp32(B_high)) / scale)
 """
@@ -29,9 +31,12 @@ def split_fp32_weight(
 
     Returns:
         (W_high, W_low): both [K, N] BF16 tensors (transposed & contiguous)
-        Reconstruction: weight ≈ fp32(W_high) + fp32(W_low) * scale
+        Reconstruction: weight ≈ fp32(W_high.T) + fp32(W_low.T) * scale
     """
-    assert weight.dtype == torch.float32, "weight must be FP32"
+    if weight.dtype != torch.float32:
+        raise ValueError(f"weight must be FP32 (got {weight.dtype})")
+    if scale == 0.0:
+        raise ValueError("scale must be non-zero")
     W_high = weight.to(torch.bfloat16)
     residual = weight - W_high.float()
     W_low = (residual / scale).to(torch.bfloat16)


### PR DESCRIPTION

### Purpose
Add an XPU operator `gemm_bf16xfp32` that emulates an FP32-precision GEMM (BF16 activation × FP32 weight) using two BF16 GEMM passes (DualGemm). It targets the MoE router GateLinear in models such as Hunyuan-V3 and MiniMax-M3, where the gate weight is kept in FP32 for the numerical stability of routing. Currently this runs as FP32 `F.linear`: the BF16 activation is upcast to FP32 and fed to a oneDNN FP32 matmul. The execution on the FP32 pipe (~12.3 TFLOP/s on B60) is much slower than the BF16 (~98.5 TFLOP/s on B60). `gemm_bf16xfp32`  decomposes the FP32 weight into two BF16 components and combines them in the epilogue, recovering FP32-class accuracy (absolute error ~1e-5) while cutting latency (4–7.7×) on prefill; 

### How it works
The FP32 weight `W` is split into two BF16 tensors:
- `W_high = bf16(W)`
- `W_low  = bf16((W - fp32(W_high)) / scale)`   (default `scale = 1/256`)

**DualGemm** The kernel computes `D = X @ W_high + (X @ W_low) * scale`, sharing the `A` (activation) load and fusing the correction in the epilogue. The DualGemm collective is adapted from the `dual_gemm` example in sycl-tla: it runs the two BF16 GEMMs from a single kernel so `A` is loaded once and the `W_low` correction is applied in the shared epilogue. `W_high + W_low * scale` reproduces `W` to ~FP32 precision, so the result can match FP32 `F.linear` to FP32-class accuracy.

**Split-K for decode** At small M (decode) the default tile leaves most Xe-cores idle. For those shapes the kernel splits the K  — each slice computes a partial `[M,N]`, and a small fused kernel sums the partials. 

### Code Changes
- `csrc/xpu/gemm_bf16xfp32/` — kernel interface + implementation (three tile policies: small-M / medium-M / default, dispatched by M; Split-K + fused reduction for decode).
- `vllm_xpu_kernels/gemm_bf16xfp32.py` — Python API: `split_fp32_weight`, `gemm_bf16xfp32`.
- `tests/test_gemm_bf16xfp32.py` — correctness vs FP32 `F.linear`.
- `benchmark/benchmark_gemm_bf16xfp32.py` — latency / roofline benchmark vs FP32 `F.linear`.
- `CMakeLists.txt` / `setup.py` — build wiring for `gemm_bf16xfp32_xe_2`.

### Usage
```python
from vllm_xpu_kernels.gemm_bf16xfp32 import split_fp32_weight, gemm_bf16xfp32

w_high, w_low = split_fp32_weight(weight_fp32)          # [N,K] -> two [K,N] bf16 
out = gemm_bf16xfp32(x_bf16, w_high, w_low)             # == F.linear(x, weight)
```

Note: Weight preparation is a one-time, offline step.`split_fp32_weight` decomposes the FP32 router weight into the two BF16 components (`W_high`, `W_low`);  If integrated into upstream vLLM, this will run once at load time in the layer's `process_weights_after_loading` — the FP32 router weight will split there and `W_high` / `W_low` be cached.

## Test Plan

- Correctness: `pytest tests/test_gemm_bf16xfp32.py` — compares kernel output against FP32 `F.linear` over the M × N × K sweep. Element-wise `assert_close(rtol=1e-3, atol=1e-4)` plus aggregate bounds (`max_abs < 1e-4`, `mean_rel < 1e-4`) and a `dual-bf16 ≤ naive-bf16` invariant.
- Performance: `python benchmark/benchmark_gemm_bf16xfp32.py` on Intel Arc Pro B60 (BMG / Xe2) — reports device + wall latency, TFLOP/s / MFU / GB/s / MBU, and speedup vs FP32.
**Hardware:** Intel Arc Pro B60 (BMG, Xe2). Peaks: BF16 98.5 TFLOP/s, FP32 vector 12.28 TFLOP/s,  BW 456 GB/s.
**Baseline:** FP32 `F.linear` (oneDNN) — the correctness-equivalent op this kernel replaces.
**Sweep:** M ∈ {2 … 16384}, N ∈ {128, 192, 256}, K ∈ {3072, 4096, 6144}. 100 iters / 20 warmup.
**Measurement:** `ker dev` / `fp32 dev` are on-device kernel time; `ker wall` / `fp32 wall` are end-to-end eager wall-clock; `dev speedup` / `wall speedup` are `fp32 / kernel`. TFLOP/s counts both BF16 passes (`4·M·N·K`); MFU vs BF16 peak; GB/s / MBU from IO traffic (A + W_high + W_low + D) vs BW peak.

## Test Result
- `pytest tests/test_gemm_bf16xfp32.py`: **all pass** 
Accuracy is measured against the **FP32 (oneDNN) baseline** across the full sweep: **absolute error ~1e-5 (worst 2.5e-5), mean relative ~2e-5**.
- Benchmark vs FP32 `F.linear` (see tables below)

Representative MNK—  Hunyuan-V3 router gemm shape (N = 192 experts, K = 4096 hidden), full M sweep:

```
     M    N     K |  ker dev  ker wall |   TFLOP/s     MFU      GB/s     MBU |  fp32 dev  fp32 wall | dev speedup wall speedup
--------------------------------------------------------------------------------------------------------------------------------
     2  192  4096 |     6.77     15.53 |      0.93    0.9%     467.2  102.4% |      7.92      42.09 |       1.17x        2.71x
     8  192  4096 |     6.70     15.40 |      3.76    3.8%     480.6  105.4% |     18.43      39.85 |       2.75x        2.59x
    16  192  4096 |     6.64     15.65 |      7.58    7.7%     495.4  108.7% |     18.87      40.16 |       2.84x        2.57x
    32  192  4096 |     6.67     15.47 |     15.09   15.3%     514.5  112.8% |     19.31      40.30 |       2.90x        2.61x
    64  192  4096 |     9.33     15.31 |     21.58   21.9%     398.7   87.4% |     21.34      39.44 |       2.29x        2.58x
   128  192  4096 |    12.07     15.37 |     33.36   33.9%     355.6   78.0% |     29.50      42.18 |       2.44x        2.74x
   256  192  4096 |    20.51     21.25 |     39.26   39.9%     265.2   58.2% |     54.43      57.78 |       2.65x        2.72x
   512  192  4096 |    31.20     31.86 |     51.61   52.4%     247.8   54.3% |    107.51     110.42 |       3.45x        3.47x
  1024  192  4096 |    60.14     64.00 |     53.56   54.4%     204.9   44.9% |    218.61     221.87 |       3.64x        3.47x
  2048  192  4096 |   126.81    124.54 |     50.80   51.6%     169.5   37.2% |    438.95     442.29 |       3.46x        3.55x
  4096  192  4096 |   176.12    176.40 |     73.16   74.3%     226.2   49.6% |    877.21     880.30 |       4.98x        4.99x
  8192  192  4096 |   297.13    295.30 |     86.73   88.0%     257.6   56.5% |   1748.78    1750.21 |       5.89x        5.93x
 16384  192  4096 |   587.07    584.28 |     87.79   89.1%     255.4   56.0% |   3489.41    3487.94 |       5.94x        5.97x

```

Representative MNK — MiniMax-M3 router shape (N = 128 experts, K = 6144 hidden), full M sweep:

```
     M    N     K |  ker dev  ker wall |   TFLOP/s     MFU      GB/s     MBU |  fp32 dev  fp32 wall | dev speedup wall speedup
--------------------------------------------------------------------------------------------------------------------------------
     2  128  6144 |     7.27     15.44 |      0.87    0.9%     436.5   95.7% |      8.34      42.63 |       1.15x        2.76x
     8  128  6144 |     7.17     15.46 |      3.51    3.6%     453.3   99.4% |     11.65      41.74 |       1.63x        2.70x
    16  128  6144 |     7.17     15.42 |      7.02    7.1%     467.6  102.5% |     11.95      41.61 |       1.67x        2.70x
    32  128  6144 |     7.25     15.84 |     13.88   14.1%     490.2  107.5% |     17.27      44.22 |       2.38x        2.79x
    64  128  6144 |    10.07     15.39 |     20.00   20.3%     393.9   86.4% |     23.07      41.63 |       2.29x        2.71x
   128  128  6144 |    11.91     15.57 |     33.80   34.3%     401.6   88.1% |     32.74      41.77 |       2.75x        2.68x
   256  128  6144 |    21.24     22.25 |     37.92   38.5%     302.4   66.3% |     61.81      65.49 |       2.91x        2.94x
   512  128  6144 |    38.27     38.90 |     42.09   42.7%     253.5   55.6% |    128.84     132.33 |       3.37x        3.40x
  1024  128  6144 |    46.60     47.07 |     69.12   70.2%     348.7   76.5% |    279.65     283.43 |       6.00x        6.02x
  2048  128  6144 |   142.01    142.97 |     45.37   46.1%     206.7   45.3% |    577.69     581.25 |       4.07x        4.07x
  4096  128  6144 |   341.38    337.97 |     37.74   38.3%     162.8   35.7% |   1411.30    1415.87 |       4.13x        4.19x
  8192  128  6144 |   536.50    533.94 |     48.03   48.8%     201.3   44.1% |   2333.43    2334.42 |       4.35x        4.37x
 16384  128  6144 |   915.95    907.54 |     56.27   57.1%     232.4   51.0% |   4533.84    4528.51 |       4.95x        4.99x

```

Benchmark Results Summary
- **Prefill (large M) — compute-bound.** The kernel runs on the BF16 pipe (98.5 TFLOP/s) while FP32 `F.linear` is stuck on the FP32 vector pipe (12.28 TFLOP/s). Result: **4–7.7× device speedup**, reaching up to **~89% MFU**.
- **Decode (small M) — bandwidth-bound.** Two BF16 weight passes move the same bytes as one FP32 weight, so the device-time floor is FP32 parity. 
