### PR TITLE
test: avoid broken XPU torch.topk in topk reference impls

### DIFF
--- a/tests/ops/grouped_topk_op.py
+++ b/tests/ops/grouped_topk_op.py
@@ -22,6 +22,16 @@ def grouped_topk(
 
     assert hidden_states.size(0) == gating_output.size(0), (
         "Number of tokens mismatch")
+    # NOTE: torch.topk on XPU (torch 2.13.0+xpu) can return incorrect indices.
+    # Compute this reference implementation on CPU and move results back to the
+    # original device to avoid the broken XPU topk. Also upcast to float32 to
+    # match the fused kernel's internal precision; otherwise low-precision
+    # (e.g. bfloat16) rounding can create spurious ties in the group/expert
+    # selection that differ from the kernel.
+    ref_device = gating_output.device
+    gating_output = gating_output.cpu().float()
+    if e_score_correction_bias is not None:
+        e_score_correction_bias = e_score_correction_bias.cpu().float()
     if scoring_func == "softmax":
         scores = torch.softmax(gating_output, dim=-1)
     elif scoring_func == "sigmoid":
@@ -61,7 +71,8 @@ def grouped_topk(
         topk_weights = topk_weights / topk_weights.sum(dim=-1, keepdim=True)
 
     topk_weights = topk_weights * routed_scaling_factor
-    return topk_weights.to(torch.float32), topk_ids.to(torch.int32)
+    return (topk_weights.to(device=ref_device, dtype=torch.float32),
+            topk_ids.to(device=ref_device, dtype=torch.int32))
 
 
 def fused_grouped_topk(

--- a/tests/test_topk_softplus_sqrt.py
+++ b/tests/test_topk_softplus_sqrt.py
@@ -36,7 +36,11 @@ def _torch_topk_softplus_sqrt(
             scores_for_choice = scores + e_score_correction_bias.unsqueeze(0)
         else:
             scores_for_choice = scores
-        topk_ids = torch.topk(scores_for_choice, k=topk, dim=-1, sorted=True)[1]
+        # NOTE: torch.topk on XPU (torch 2.13.0+xpu) can return incorrect
+        # indices, so compute reference top-k selection on CPU.
+        topk_ids = torch.topk(
+            scores_for_choice.cpu(), k=topk, dim=-1, sorted=True
+        )[1].to(scores_for_choice.device)
 
     topk_weights = original_scores.gather(1, topk_ids.long())
     if renormalize:


### PR DESCRIPTION
torch.topk on XPU (torch 2.13.0+xpu) can return incorrect indices, causing the reference implementations in test_topk_softplus_sqrt and grouped_topk to disagree with the correct fused kernels.

Compute the reference top-k selection on CPU to avoid the broken XPU topk. For grouped_topk, also upcast the gating output and correction bias to float32 so the reference matches the fused kernel internal precision; otherwise bfloat16 rounding creates spurious ties in the group/expert selection.
