### PR TITLE
fix concat_and_cache_mla fp8 kv cache dtype acc issue

### DIFF
--- a/csrc/cache.cpp
+++ b/csrc/cache.cpp
@@ -383,12 +383,18 @@ class concat_and_cache_mla_kernel {
         const int src_idx = token_idx * src_stride + i;
         const int dst_idx =
             block_idx * block_stride + block_offset * entry_stride + i + offset;
-        if constexpr (kv_dt == Fp8KVCacheDataType::kFp8E4M3) {
-          dst[dst_idx] = static_cast<at::Float8_e4m3fn>(src[src_idx] * *scale);
-        } else if constexpr (kv_dt == Fp8KVCacheDataType::kFp8E5M2) {
-          dst[dst_idx] = static_cast<at::Float8_e5m2>(src[src_idx] * *scale);
-        } else {
+        if constexpr (kv_dt == Fp8KVCacheDataType::kAuto) {
           dst[dst_idx] = src[src_idx];
+        } else {
+          using fp8_dtype = std::conditional_t<
+              kv_dt == Fp8KVCacheDataType::kFp8E5M2,
+              at::Float8_e5m2,
+              at::Float8_e4m3fn>;
+          const float fp8_max = vllm::fp8::quant_type_max_v<fp8_dtype>;
+          float x = static_cast<float>(src[src_idx]) / *scale;
+          x = sycl::fmax(-fp8_max, sycl::fmin(x, fp8_max));
+          auto fp8_val = static_cast<fp8_dtype>(x);
+          dst[dst_idx] = sycl::bit_cast<cache_t>(fp8_val);
         }
       }
     };

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -406,7 +406,7 @@ def _fill_mla_cache(cache: torch.Tensor, kv_cache_dtype: str):
 @pytest.mark.parametrize("dtype", DTYPES)
 @pytest.mark.parametrize("seed", SEEDS)
 @pytest.mark.parametrize("device", DEVICES)
-@pytest.mark.parametrize("kv_cache_dtype", KV_CACHE_DTYPE)
+@pytest.mark.parametrize("kv_cache_dtype", KV_CACHE_DTYPE_ALL)
 @torch.inference_mode()
 def test_concat_and_cache_mla(
     kv_lora_rank: int,


### PR DESCRIPTION
Fix JIRA https://jira.devtools.intel.com/browse/VLLMZ-2104

Root cause:

1. scale direction.
2. Wrong storage assigning a Float8_e4m3fn to a uint8_t cache.
3. No clamping to fp8_max .
