### PR TITLE
[XE2][GDN] Optimization for Gated Delta Rule in gdn

### DIFF
--- a/csrc/xpu/gdn_attn/gdn_attn_interface.cpp
+++ b/csrc/xpu/gdn_attn/gdn_attn_interface.cpp
@@ -619,6 +619,12 @@ void gated_delta_rule(
           non_spec_token_indx.has_value()
               ? reinterpret_cast<const int*>(non_spec_token_indx->data_ptr())
               : nullptr;
+      TORCH_CHECK(
+          has_initial_state.has_value(),
+          "XE2 decode path requires has_initial_state");
+      TORCH_CHECK(
+          has_initial_state->numel() == num_decodes,
+          "XE2 decode path requires has_initial_state size to match num_decodes");
 
       gated_delta_rule_decode_xe2(
           queue,
@@ -632,7 +638,6 @@ void gated_delta_rule(
           dt_bias,
           ssm_state,
           *non_spec_state_indices_tensor,
-          has_initial_state,
           num_decodes,
           q.size(1),
           q.size(2),

--- a/csrc/xpu/gdn_attn/gdn_attn_interface.cpp
+++ b/csrc/xpu/gdn_attn/gdn_attn_interface.cpp
@@ -11,6 +11,7 @@
   #include "xe_2/chunk_causal_conv1d_tiled_xe2.hpp"
   #include "xe_2/l2norm.h"
   #include "xe_2/chunk_gated_delta_rule_xe2.h"
+  #include "xe_2/gated_delta_rule_decode_xe2.h"
 #endif
 
 // Conv stage of GatedDeltaNet linear attention. Runs the causal conv1d (plus
@@ -612,6 +613,31 @@ void gated_delta_rule(
           has_initial_state,
           num_prefills,
           num_decodes,
+          token_indx_ptr);
+    } else if (num_spec_decodes == 0 && num_decodes > 0) {
+      const int* token_indx_ptr =
+          non_spec_token_indx.has_value()
+              ? reinterpret_cast<const int*>(non_spec_token_indx->data_ptr())
+              : nullptr;
+
+      gated_delta_rule_decode_xe2(
+          queue,
+          core_attn_out_active,
+          q,
+          k,
+          v,
+          b,
+          a,
+          A_log,
+          dt_bias,
+          ssm_state,
+          *non_spec_state_indices_tensor,
+          has_initial_state,
+          num_decodes,
+          q.size(1),
+          q.size(2),
+          v.size(1),
+          v.size(2),
           token_indx_ptr);
     } else {
       gdn::gated_delta_rule(

--- a/csrc/xpu/gdn_attn/gdn_attn_interface.cpp
+++ b/csrc/xpu/gdn_attn/gdn_attn_interface.cpp
@@ -568,6 +568,34 @@ void gated_delta_rule(
   std::optional<torch::Tensor> empty_tensor{std::nullopt};
 
   if (spec_token > 0) {
+#ifdef VLLM_XPU_ENABLE_XE2
+    const int num_spec_tokens = spec_state_indices_tensor->size(1);
+    const int* spec_token_indx_ptr =
+        spec_token_indx.has_value()
+            ? reinterpret_cast<const int*>(spec_token_indx->data_ptr())
+            : nullptr;
+
+    gated_delta_rule_decode_xe2_spec(
+        queue,
+        core_attn_out_active,
+        q,
+        k,
+        v,
+        b,
+        a,
+        A_log,
+        dt_bias,
+        ssm_state,
+        *spec_state_indices_tensor,
+        *num_accepted_tokens,
+        num_spec_decodes,
+        num_spec_tokens,
+        q.size(1),
+        q.size(2),
+        v.size(1),
+        v.size(2),
+        spec_token_indx_ptr);
+#else
     gdn::gated_delta_rule(
         queue,
         core_attn_out_active,
@@ -587,6 +615,7 @@ void gated_delta_rule(
         num_prefills,
         num_decodes,
         num_spec_decodes);
+    #endif
   }
 
   if (non_spec_token > 0) {

--- a/csrc/xpu/gdn_attn/xe_2/gated_delta_rule_decode_xe2.cpp
+++ b/csrc/xpu/gdn_attn/xe_2/gated_delta_rule_decode_xe2.cpp
@@ -112,3 +112,139 @@ void gated_delta_rule_decode_xe2(
         k_bucket_size);
   }
 }
+
+    void gated_delta_rule_decode_xe2_spec(
+      sycl::queue& queue,
+      torch::Tensor& core_attn_out,
+      const torch::Tensor& q,
+      const torch::Tensor& k,
+      const torch::Tensor& v,
+      const torch::Tensor& b,
+      const torch::Tensor& a,
+      const torch::Tensor& A_log,
+      const torch::Tensor& dt_bias,
+      torch::Tensor& ssm_state,
+      const torch::Tensor& cache_indices,
+      const torch::Tensor& num_accepted_tokens,
+      const int num_spec_decodes,
+      const int num_spec_tokens,
+      const int num_k_heads,
+      const int head_k_dim,
+      const int num_v_heads,
+      const int head_v_dim,
+      const int* token_indx) {
+      TORCH_CHECK(cache_indices.is_contiguous(), "cache_indices must be contiguous");
+      TORCH_CHECK(cache_indices.dtype() == torch::kInt32, "cache_indices must be int32");
+      TORCH_CHECK(cache_indices.dim() == 2, "cache_indices must be 2D");
+      TORCH_CHECK(cache_indices.size(0) == num_spec_decodes, "cache_indices size(0) must match num_spec_decodes");
+      TORCH_CHECK(
+        cache_indices.size(1) == num_spec_tokens,
+        "cache_indices size(1) must match num_spec_tokens");
+      TORCH_CHECK(
+        num_accepted_tokens.is_contiguous(),
+        "num_accepted_tokens must be contiguous");
+      TORCH_CHECK(
+        num_accepted_tokens.dtype() == torch::kInt32,
+        "num_accepted_tokens must be int32");
+      TORCH_CHECK(num_accepted_tokens.dim() == 1, "num_accepted_tokens must be 1D");
+      TORCH_CHECK(
+        num_accepted_tokens.size(0) == num_spec_decodes,
+        "num_accepted_tokens size must match num_spec_decodes");
+      TORCH_CHECK(num_v_heads % num_k_heads == 0, "num_v_heads must be divisible by num_k_heads");
+      TORCH_CHECK(
+        A_log.scalar_type() == at::kFloat,
+        "A_log dtype must be float32, but got ",
+        A_log.scalar_type());
+      TORCH_CHECK(
+        dt_bias.scalar_type() == core_attn_out.scalar_type(),
+        "dt_bias dtype must match core_attn_out dtype, but got dt_bias=",
+        dt_bias.scalar_type(),
+        ", core_attn_out=",
+        core_attn_out.scalar_type());
+      TORCH_CHECK(head_k_dim % gdn::xe2::decode_sub_group_size == 0);
+
+      const int ssm_state_stride_0 = ssm_state.stride(0);
+      const int cache_indices_stride_0 = cache_indices.stride(0);
+      const int* cache_indices_ptr =
+        reinterpret_cast<const int*>(cache_indices.data_ptr());
+      const int* num_accepted_tokens_ptr =
+        reinterpret_cast<const int*>(num_accepted_tokens.data_ptr());
+      const int k_bucket_size = head_k_dim / gdn::xe2::decode_sub_group_size;
+
+      if (core_attn_out.scalar_type() == at::kBFloat16) {
+      using scalar_t = sycl::ext::oneapi::bfloat16;
+      gdn::xe2::dispatch_state_dtype_decode_xe2_spec<scalar_t>(
+        queue,
+        core_attn_out,
+        q,
+        k,
+        v,
+        b,
+        a,
+        A_log,
+        dt_bias,
+        ssm_state,
+        ssm_state_stride_0,
+        token_indx,
+        cache_indices_ptr,
+        cache_indices_stride_0,
+        num_accepted_tokens_ptr,
+        num_spec_decodes,
+        num_spec_tokens,
+        num_k_heads,
+        head_k_dim,
+        num_v_heads,
+        head_v_dim,
+        k_bucket_size);
+      } else if (core_attn_out.scalar_type() == at::kHalf) {
+      using scalar_t = sycl::half;
+      gdn::xe2::dispatch_state_dtype_decode_xe2_spec<scalar_t>(
+        queue,
+        core_attn_out,
+        q,
+        k,
+        v,
+        b,
+        a,
+        A_log,
+        dt_bias,
+        ssm_state,
+        ssm_state_stride_0,
+        token_indx,
+        cache_indices_ptr,
+        cache_indices_stride_0,
+        num_accepted_tokens_ptr,
+        num_spec_decodes,
+        num_spec_tokens,
+        num_k_heads,
+        head_k_dim,
+        num_v_heads,
+        head_v_dim,
+        k_bucket_size);
+      } else {
+      using scalar_t = float;
+      gdn::xe2::dispatch_state_dtype_decode_xe2_spec<scalar_t>(
+        queue,
+        core_attn_out,
+        q,
+        k,
+        v,
+        b,
+        a,
+        A_log,
+        dt_bias,
+        ssm_state,
+        ssm_state_stride_0,
+        token_indx,
+        cache_indices_ptr,
+        cache_indices_stride_0,
+        num_accepted_tokens_ptr,
+        num_spec_decodes,
+        num_spec_tokens,
+        num_k_heads,
+        head_k_dim,
+        num_v_heads,
+        head_v_dim,
+        k_bucket_size);
+      }
+    }

--- a/csrc/xpu/gdn_attn/xe_2/gated_delta_rule_decode_xe2.cpp
+++ b/csrc/xpu/gdn_attn/xe_2/gated_delta_rule_decode_xe2.cpp
@@ -1,0 +1,122 @@
+#include <sycl/sycl.hpp>
+#include <torch/all.h>
+
+#include "gated_delta_rule_decode_xe2.h"
+#include "gated_delta_rule_decode_xe2.hpp"
+
+void gated_delta_rule_decode_xe2(
+    sycl::queue& queue,
+    torch::Tensor& core_attn_out,
+    const torch::Tensor& q,
+    const torch::Tensor& k,
+    const torch::Tensor& v,
+    const torch::Tensor& b,
+    const torch::Tensor& a,
+    const torch::Tensor& A_log,
+    const torch::Tensor& dt_bias,
+    torch::Tensor& ssm_state,
+    const torch::Tensor& cache_indices,
+    const std::optional<torch::Tensor>& has_initial_state,
+    const int batch_size,
+    const int num_k_heads,
+    const int head_k_dim,
+    const int num_v_heads,
+    const int head_v_dim,
+    const int* token_indx) {
+  TORCH_CHECK(cache_indices.is_contiguous(), "cache_indices must be contiguous");
+  TORCH_CHECK(cache_indices.dtype() == torch::kInt32, "cache_indices must be int32");
+  TORCH_CHECK(cache_indices.dim() == 1, "cache_indices must be 1D");
+  TORCH_CHECK(cache_indices.size(0) == batch_size, "cache_indices size must match batch_size");
+  TORCH_CHECK(num_v_heads % num_k_heads == 0, "num_v_heads must be divisible by num_k_heads");
+  TORCH_CHECK(
+      A_log.scalar_type() == at::kFloat,
+      "A_log dtype must be float32, but got ",
+      A_log.scalar_type());
+  TORCH_CHECK(
+      dt_bias.scalar_type() == core_attn_out.scalar_type(),
+      "dt_bias dtype must match core_attn_out dtype, but got dt_bias=",
+      dt_bias.scalar_type(),
+      ", core_attn_out=",
+      core_attn_out.scalar_type());
+  TORCH_CHECK(head_k_dim % gdn::xe2::decode_sub_group_size == 0);
+
+  const int ssm_state_stride_0 = ssm_state.stride(0);
+  const bool* has_initial_state_ptr =
+      has_initial_state.has_value()
+          ? reinterpret_cast<bool*>(has_initial_state->data_ptr())
+          : nullptr;
+    const int* cache_indices_ptr =
+      reinterpret_cast<const int*>(cache_indices.data_ptr());
+  const int k_bucket_size = head_k_dim / gdn::xe2::decode_sub_group_size;
+
+  if (core_attn_out.scalar_type() == at::kBFloat16) {
+    using scalar_t = sycl::ext::oneapi::bfloat16;
+    gdn::xe2::dispatch_state_dtype_decode_xe2<scalar_t>(
+        queue,
+        core_attn_out,
+        q,
+        k,
+        v,
+        b,
+        a,
+        A_log,
+        dt_bias,
+        ssm_state,
+        ssm_state_stride_0,
+        token_indx,
+        cache_indices_ptr,
+        has_initial_state_ptr,
+        batch_size,
+        num_k_heads,
+        head_k_dim,
+        num_v_heads,
+        head_v_dim,
+        k_bucket_size);
+  } else if (core_attn_out.scalar_type() == at::kHalf) {
+    using scalar_t = sycl::half;
+    gdn::xe2::dispatch_state_dtype_decode_xe2<scalar_t>(
+        queue,
+        core_attn_out,
+        q,
+        k,
+        v,
+        b,
+        a,
+        A_log,
+        dt_bias,
+        ssm_state,
+        ssm_state_stride_0,
+        token_indx,
+        cache_indices_ptr,
+        has_initial_state_ptr,
+        batch_size,
+        num_k_heads,
+        head_k_dim,
+        num_v_heads,
+        head_v_dim,
+        k_bucket_size);
+  } else {
+    using scalar_t = float;
+    gdn::xe2::dispatch_state_dtype_decode_xe2<scalar_t>(
+        queue,
+        core_attn_out,
+        q,
+        k,
+        v,
+        b,
+        a,
+        A_log,
+        dt_bias,
+        ssm_state,
+        ssm_state_stride_0,
+        token_indx,
+        cache_indices_ptr,
+        has_initial_state_ptr,
+        batch_size,
+        num_k_heads,
+        head_k_dim,
+        num_v_heads,
+        head_v_dim,
+        k_bucket_size);
+  }
+}

--- a/csrc/xpu/gdn_attn/xe_2/gated_delta_rule_decode_xe2.cpp
+++ b/csrc/xpu/gdn_attn/xe_2/gated_delta_rule_decode_xe2.cpp
@@ -16,7 +16,6 @@ void gated_delta_rule_decode_xe2(
     const torch::Tensor& dt_bias,
     torch::Tensor& ssm_state,
     const torch::Tensor& cache_indices,
-    const std::optional<torch::Tensor>& has_initial_state,
     const int batch_size,
     const int num_k_heads,
     const int head_k_dim,
@@ -41,11 +40,7 @@ void gated_delta_rule_decode_xe2(
   TORCH_CHECK(head_k_dim % gdn::xe2::decode_sub_group_size == 0);
 
   const int ssm_state_stride_0 = ssm_state.stride(0);
-  const bool* has_initial_state_ptr =
-      has_initial_state.has_value()
-          ? reinterpret_cast<bool*>(has_initial_state->data_ptr())
-          : nullptr;
-    const int* cache_indices_ptr =
+  const int* cache_indices_ptr =
       reinterpret_cast<const int*>(cache_indices.data_ptr());
   const int k_bucket_size = head_k_dim / gdn::xe2::decode_sub_group_size;
 
@@ -65,7 +60,6 @@ void gated_delta_rule_decode_xe2(
         ssm_state_stride_0,
         token_indx,
         cache_indices_ptr,
-        has_initial_state_ptr,
         batch_size,
         num_k_heads,
         head_k_dim,
@@ -88,7 +82,6 @@ void gated_delta_rule_decode_xe2(
         ssm_state_stride_0,
         token_indx,
         cache_indices_ptr,
-        has_initial_state_ptr,
         batch_size,
         num_k_heads,
         head_k_dim,
@@ -111,7 +104,6 @@ void gated_delta_rule_decode_xe2(
         ssm_state_stride_0,
         token_indx,
         cache_indices_ptr,
-        has_initial_state_ptr,
         batch_size,
         num_k_heads,
         head_k_dim,

--- a/csrc/xpu/gdn_attn/xe_2/gated_delta_rule_decode_xe2.h
+++ b/csrc/xpu/gdn_attn/xe_2/gated_delta_rule_decode_xe2.h
@@ -1,5 +1,3 @@
-#include <optional>
-
 #include <sycl/sycl.hpp>
 #include <torch/all.h>
 
@@ -15,7 +13,6 @@ void gated_delta_rule_decode_xe2(
     const torch::Tensor& dt_bias,
     torch::Tensor& ssm_state,
     const torch::Tensor& cache_indices,
-    const std::optional<torch::Tensor>& has_initial_state,
     const int batch_size,
     const int num_k_heads,
     const int head_k_dim,

--- a/csrc/xpu/gdn_attn/xe_2/gated_delta_rule_decode_xe2.h
+++ b/csrc/xpu/gdn_attn/xe_2/gated_delta_rule_decode_xe2.h
@@ -19,3 +19,24 @@ void gated_delta_rule_decode_xe2(
     const int num_v_heads,
     const int head_v_dim,
     const int* token_indx = nullptr);
+
+void gated_delta_rule_decode_xe2_spec(
+    sycl::queue& queue,
+    torch::Tensor& core_attn_out,
+    const torch::Tensor& q,
+    const torch::Tensor& k,
+    const torch::Tensor& v,
+    const torch::Tensor& b,
+    const torch::Tensor& a,
+    const torch::Tensor& A_log,
+    const torch::Tensor& dt_bias,
+    torch::Tensor& ssm_state,
+    const torch::Tensor& cache_indices,
+    const torch::Tensor& num_accepted_tokens,
+    const int num_spec_decodes,
+    const int num_spec_tokens,
+    const int num_k_heads,
+    const int head_k_dim,
+    const int num_v_heads,
+    const int head_v_dim,
+    const int* token_indx = nullptr);

--- a/csrc/xpu/gdn_attn/xe_2/gated_delta_rule_decode_xe2.h
+++ b/csrc/xpu/gdn_attn/xe_2/gated_delta_rule_decode_xe2.h
@@ -1,0 +1,24 @@
+#include <optional>
+
+#include <sycl/sycl.hpp>
+#include <torch/all.h>
+
+void gated_delta_rule_decode_xe2(
+    sycl::queue& queue,
+    torch::Tensor& core_attn_out,
+    const torch::Tensor& q,
+    const torch::Tensor& k,
+    const torch::Tensor& v,
+    const torch::Tensor& b,
+    const torch::Tensor& a,
+    const torch::Tensor& A_log,
+    const torch::Tensor& dt_bias,
+    torch::Tensor& ssm_state,
+    const torch::Tensor& cache_indices,
+    const std::optional<torch::Tensor>& has_initial_state,
+    const int batch_size,
+    const int num_k_heads,
+    const int head_k_dim,
+    const int num_v_heads,
+    const int head_v_dim,
+    const int* token_indx = nullptr);

--- a/csrc/xpu/gdn_attn/xe_2/gated_delta_rule_decode_xe2.hpp
+++ b/csrc/xpu/gdn_attn/xe_2/gated_delta_rule_decode_xe2.hpp
@@ -21,10 +21,9 @@ struct gated_delta_rule_decode_kernel_xe2 {
   static constexpr bool supports_packed_state_io =
       std::is_same_v<StateT, float> || std::is_same_v<StateT, sycl::half> ||
       std::is_same_v<StateT, sycl::ext::oneapi::bfloat16>;
-  static constexpr bool use_packed_state_io_128 =
-      supports_packed_state_io && packed_state_bytes == sizeof(sycl::uint4);
-  static constexpr bool use_packed_state_io_64 =
-      supports_packed_state_io && packed_state_bytes == sizeof(sycl::uint2);
+    static constexpr bool use_vector_state_io =
+      supports_packed_state_io &&
+      (packed_state_bytes == 8 || packed_state_bytes == 16);
 
   gated_delta_rule_decode_kernel_xe2(
       T* core_attn_out,
@@ -84,6 +83,47 @@ struct gated_delta_rule_decode_kernel_xe2 {
     }
   }
 
+  template <typename VecT, int vec_size>
+  static inline void load_vec(const VecT* ptr, VecT (&dst)[vec_size]) {
+    sycl::vec<VecT, vec_size> in =
+        *reinterpret_cast<const sycl::vec<VecT, vec_size>*>(ptr);
+#pragma unroll
+    for (int i = 0; i < vec_size; ++i) {
+      dst[i] = in[i];
+    }
+  }
+
+  template <typename VecT, int vec_size>
+  static inline void load_vec_to_float(const VecT* ptr, float (&dst)[vec_size]) {
+    VecT tmp[vec_size];
+    load_vec<VecT, vec_size>(ptr, tmp);
+#pragma unroll
+    for (int i = 0; i < vec_size; ++i) {
+      dst[i] = static_cast<float>(tmp[i]);
+    }
+  }
+
+  template <typename VecT, int vec_size>
+  static inline void store_vec(VecT* ptr, const VecT (&src)[vec_size]) {
+    sycl::vec<VecT, vec_size> out;
+#pragma unroll
+    for (int i = 0; i < vec_size; ++i) {
+      out[i] = src[i];
+    }
+    *reinterpret_cast<sycl::vec<VecT, vec_size>*>(ptr) = out;
+  }
+
+  template <typename VecT, int vec_size>
+  static inline void store_vec_from_float(
+      VecT* ptr, const float (&src)[vec_size]) {
+    VecT tmp[vec_size];
+#pragma unroll
+    for (int i = 0; i < vec_size; ++i) {
+      tmp[i] = static_cast<VecT>(src[i]);
+    }
+    store_vec<VecT, vec_size>(ptr, tmp);
+  }
+
   [[sycl::reqd_sub_group_size(decode_sub_group_size)]] void
   operator()(sycl::nd_item<3> item) const {
     const int decode_id = item.get_group(0);
@@ -119,26 +159,11 @@ struct gated_delta_rule_decode_kernel_xe2 {
           const int state_offset =
               state_head_offset + (head_v_dim_id + j) * head_k_dim +
               k_bucket_size * sg_local_id;
-          if constexpr (use_packed_state_io_128) {
-            alignas(16) StateT state_pack_local[k_bucket_size];
-            reinterpret_cast<sycl::uint4*>(state_pack_local)[0] =
-                reinterpret_cast<const sycl::uint4*>(
-                    ssm_state_ptr + state_offset)[0];
-#pragma unroll
-            for (int i = 0; i < k_bucket_size; ++i) {
-              state_local[j * k_bucket_size + i] =
-                  static_cast<float>(state_pack_local[i]);
-            }
-          } else if constexpr (use_packed_state_io_64) {
-            alignas(8) StateT state_pack_local[k_bucket_size];
-            reinterpret_cast<sycl::uint2*>(state_pack_local)[0] =
-                reinterpret_cast<const sycl::uint2*>(
-                    ssm_state_ptr + state_offset)[0];
-#pragma unroll
-            for (int i = 0; i < k_bucket_size; ++i) {
-              state_local[j * k_bucket_size + i] =
-                  static_cast<float>(state_pack_local[i]);
-            }
+          if constexpr (use_vector_state_io) {
+            load_vec_to_float<StateT, k_bucket_size>(
+                ssm_state_ptr + state_offset,
+                reinterpret_cast<float (&)[k_bucket_size]>(
+                    state_local[j * k_bucket_size]));
           } else {
 #pragma unroll
             for (int i = 0; i < k_bucket_size; ++i) {
@@ -189,12 +214,10 @@ struct gated_delta_rule_decode_kernel_xe2 {
         k_local[i] /= sycl::sqrt(k_sum);
       }
 
-#pragma unroll
-      for (int i = 0; i < v_dim_per_sg; ++i) {
-        v_local[i] =
-            v[decode_id * num_v_heads * head_v_dim +
-              num_v_heads_id * head_v_dim + head_v_dim_id + i];
-      }
+      load_vec_to_float<T, v_dim_per_sg>(
+          v + decode_id * num_v_heads * head_v_dim +
+              num_v_heads_id * head_v_dim + head_v_dim_id,
+          v_local);
 
       float kv_mem[v_dim_per_sg];
 #pragma unroll
@@ -240,13 +263,10 @@ struct gated_delta_rule_decode_kernel_xe2 {
       }
 
       if (sg_local_id == 0) {
-#pragma unroll
-        for (int i = 0; i < v_dim_per_sg; ++i) {
-          core_attn_out
-              [global_t * num_v_heads * head_v_dim +
-               num_v_heads_id * head_v_dim + head_v_dim_id + i] =
-                  static_cast<T>(res[i]);
-        }
+        store_vec_from_float<T, v_dim_per_sg>(
+            core_attn_out + global_t * num_v_heads * head_v_dim +
+                num_v_heads_id * head_v_dim + head_v_dim_id,
+            res);
       }
 
 #pragma unroll
@@ -254,24 +274,11 @@ struct gated_delta_rule_decode_kernel_xe2 {
         const int state_offset =
             state_head_offset + (head_v_dim_id + j) * head_k_dim +
             k_bucket_size * sg_local_id;
-        if constexpr (use_packed_state_io_128) {
-          alignas(16) StateT state_pack_local[k_bucket_size];
-#pragma unroll
-          for (int i = 0; i < k_bucket_size; ++i) {
-            state_pack_local[i] =
-                static_cast<StateT>(state_local[j * k_bucket_size + i]);
-          }
-          reinterpret_cast<sycl::uint4*>(ssm_state_ptr + state_offset)[0] =
-              reinterpret_cast<sycl::uint4*>(state_pack_local)[0];
-        } else if constexpr (use_packed_state_io_64) {
-          alignas(8) StateT state_pack_local[k_bucket_size];
-#pragma unroll
-          for (int i = 0; i < k_bucket_size; ++i) {
-            state_pack_local[i] =
-                static_cast<StateT>(state_local[j * k_bucket_size + i]);
-          }
-          reinterpret_cast<sycl::uint2*>(ssm_state_ptr + state_offset)[0] =
-              reinterpret_cast<sycl::uint2*>(state_pack_local)[0];
+        if constexpr (use_vector_state_io) {
+          store_vec_from_float<StateT, k_bucket_size>(
+              ssm_state_ptr + state_offset,
+              reinterpret_cast<float (&)[k_bucket_size]>(
+                  state_local[j * k_bucket_size]));
         } else {
 #pragma unroll
           for (int i = 0; i < k_bucket_size; ++i) {

--- a/csrc/xpu/gdn_attn/xe_2/gated_delta_rule_decode_xe2.hpp
+++ b/csrc/xpu/gdn_attn/xe_2/gated_delta_rule_decode_xe2.hpp
@@ -1,0 +1,491 @@
+#pragma once
+
+#include <sycl/sycl.hpp>
+#include <type_traits>
+#include <torch/all.h>
+
+namespace gdn {
+namespace xe2 {
+
+static constexpr int decode_sub_group_size = 32;
+
+template <typename T, typename StateT, int k_bucket_size>
+struct gated_delta_rule_decode_kernel_xe2 {
+ public:
+  static constexpr int group_size = 256;
+  static constexpr int sg_per_group = group_size / decode_sub_group_size;
+  static constexpr int v_dim_per_sg = 4;
+  static constexpr int v_dim_per_group = v_dim_per_sg * sg_per_group;
+  static constexpr float eps = 0.000001f;
+  static constexpr int packed_state_bytes = k_bucket_size * sizeof(StateT);
+  static constexpr bool supports_packed_state_io =
+      std::is_same_v<StateT, float> || std::is_same_v<StateT, sycl::half> ||
+      std::is_same_v<StateT, sycl::ext::oneapi::bfloat16>;
+  static constexpr bool use_packed_state_io_128 =
+      supports_packed_state_io && packed_state_bytes == sizeof(sycl::uint4);
+  static constexpr bool use_packed_state_io_64 =
+      supports_packed_state_io && packed_state_bytes == sizeof(sycl::uint2);
+
+  gated_delta_rule_decode_kernel_xe2(
+      T* core_attn_out,
+      const T* q,
+      const T* k,
+      const T* v,
+      const T* b,
+      const T* a,
+      const float* A_log,
+      const T* dt_bias,
+      StateT* ssm_state,
+      const int ssm_state_stride_0,
+      const int* token_indx,
+      const int* cache_indices,
+      const bool* has_initial_state,
+      const int batch_size,
+      const int num_k_heads,
+      const int head_k_dim,
+      const int num_v_heads,
+      const int head_v_dim)
+      : core_attn_out(core_attn_out),
+        q(q),
+        k(k),
+        v(v),
+        b(b),
+        a(a),
+        A_log(A_log),
+        dt_bias(dt_bias),
+        ssm_state(ssm_state),
+        ssm_state_stride_0(ssm_state_stride_0),
+        token_indx(token_indx),
+        cache_indices(cache_indices),
+        has_initial_state(has_initial_state),
+        batch_size(batch_size),
+        num_k_heads(num_k_heads),
+        head_k_dim(head_k_dim),
+        num_v_heads(num_v_heads),
+        head_v_dim(head_v_dim) {}
+
+  static inline sycl::nd_range<3> get_nd_range(
+      const int batch_size, const int num_v_heads, const int head_v_dim) {
+    sycl::range<3> local(1, 1, group_size);
+    sycl::range<3> global(batch_size, num_v_heads, 1);
+    return sycl::nd_range<3>(global * local, local);
+  }
+
+  static inline float act_sigmoid(float& x) {
+    return 1.0f / (1.0f + sycl::exp(-x));
+  }
+
+  static inline float
+  act_softplus(float& x, float beta = 1.0f, float threshold = 20.0f) {
+    if (beta * x < threshold) {
+      return sycl::log(1.0f + sycl::exp(beta * x)) / beta;
+    } else {
+      return x;
+    }
+  }
+
+  [[sycl::reqd_sub_group_size(decode_sub_group_size)]] void
+  operator()(sycl::nd_item<3> item) const {
+    const int decode_id = item.get_group(0);
+    const int num_v_heads_id = item.get_group(1);
+
+    auto sg = item.get_sub_group();
+    const int sg_id = sg.get_group_id();
+    const int sg_local_id = sg.get_local_id();
+    const int kv_ratio = num_v_heads / num_k_heads;
+    const float scale = 1.0f / sycl::sqrt(float(head_k_dim));
+    float A_log_local = A_log[num_v_heads_id];
+    float dt_bias_local = dt_bias[num_v_heads_id];
+    A_log_local = -sycl::exp(A_log_local);
+
+    const int state_head_offset = num_v_heads_id * head_k_dim * head_v_dim;
+    const int global_t =
+        (token_indx != nullptr) ? token_indx[decode_id] : decode_id;
+
+    StateT* ssm_state_ptr =
+        ssm_state +
+        static_cast<int64_t>(cache_indices[decode_id]) * ssm_state_stride_0;
+
+    for (int head_v_dim_id = sg_id * v_dim_per_sg; head_v_dim_id < head_v_dim;
+         head_v_dim_id += v_dim_per_group) {
+      alignas(16) float state_local[v_dim_per_sg * k_bucket_size];
+      float q_local[k_bucket_size];
+      float k_local[k_bucket_size];
+      float v_local[v_dim_per_sg];
+
+      if (has_initial_state == nullptr || has_initial_state[decode_id]) {
+#pragma unroll
+        for (int j = 0; j < v_dim_per_sg; ++j) {
+          const int state_offset =
+              state_head_offset + (head_v_dim_id + j) * head_k_dim +
+              k_bucket_size * sg_local_id;
+          if constexpr (use_packed_state_io_128) {
+            alignas(16) StateT state_pack_local[k_bucket_size];
+            reinterpret_cast<sycl::uint4*>(state_pack_local)[0] =
+                reinterpret_cast<const sycl::uint4*>(
+                    ssm_state_ptr + state_offset)[0];
+#pragma unroll
+            for (int i = 0; i < k_bucket_size; ++i) {
+              state_local[j * k_bucket_size + i] =
+                  static_cast<float>(state_pack_local[i]);
+            }
+          } else if constexpr (use_packed_state_io_64) {
+            alignas(8) StateT state_pack_local[k_bucket_size];
+            reinterpret_cast<sycl::uint2*>(state_pack_local)[0] =
+                reinterpret_cast<const sycl::uint2*>(
+                    ssm_state_ptr + state_offset)[0];
+#pragma unroll
+            for (int i = 0; i < k_bucket_size; ++i) {
+              state_local[j * k_bucket_size + i] =
+                  static_cast<float>(state_pack_local[i]);
+            }
+          } else {
+#pragma unroll
+            for (int i = 0; i < k_bucket_size; ++i) {
+              state_local[j * k_bucket_size + i] =
+                  static_cast<float>(ssm_state_ptr[state_offset + i]);
+            }
+          }
+        }
+      } else {
+#pragma unroll
+        for (int j = 0; j < v_dim_per_sg; ++j) {
+#pragma unroll
+          for (int i = 0; i < k_bucket_size; ++i) {
+            state_local[j * k_bucket_size + i] = 0.0f;
+          }
+        }
+      }
+
+      float b_local = b[decode_id * num_v_heads + num_v_heads_id];
+      float beta = act_sigmoid(b_local);
+      float a_local = a[decode_id * num_v_heads + num_v_heads_id] +
+                      dt_bias_local;
+      float g = sycl::exp(A_log_local * act_softplus(a_local));
+
+      float q_sum = 0.0f;
+      float k_sum = 0.0f;
+#pragma unroll
+      for (int i = 0; i < k_bucket_size; ++i) {
+        q_local[i] =
+            q[decode_id * num_k_heads * head_k_dim +
+              (num_v_heads_id / kv_ratio) * head_k_dim +
+              (k_bucket_size * sg_local_id + i)];
+        k_local[i] =
+            k[decode_id * num_k_heads * head_k_dim +
+              (num_v_heads_id / kv_ratio) * head_k_dim +
+              (k_bucket_size * sg_local_id + i)];
+        q_sum += q_local[i] * q_local[i];
+        k_sum += k_local[i] * k_local[i];
+      }
+      q_sum = sycl::reduce_over_group(sg, q_sum, sycl::plus<>());
+      k_sum = sycl::reduce_over_group(sg, k_sum, sycl::plus<>());
+      q_sum += eps;
+      k_sum += eps;
+#pragma unroll
+      for (int i = 0; i < k_bucket_size; ++i) {
+        q_local[i] /= sycl::sqrt(q_sum);
+        q_local[i] *= scale;
+        k_local[i] /= sycl::sqrt(k_sum);
+      }
+
+#pragma unroll
+      for (int i = 0; i < v_dim_per_sg; ++i) {
+        v_local[i] =
+            v[decode_id * num_v_heads * head_v_dim +
+              num_v_heads_id * head_v_dim + head_v_dim_id + i];
+      }
+
+      float kv_mem[v_dim_per_sg];
+#pragma unroll
+      for (int i = 0; i < v_dim_per_sg; ++i) {
+        kv_mem[i] = 0.0f;
+      }
+
+#pragma unroll
+      for (int j = 0; j < v_dim_per_sg; ++j) {
+#pragma unroll
+        for (int i = 0; i < k_bucket_size; ++i) {
+          state_local[j * k_bucket_size + i] *= g;
+          kv_mem[j] += state_local[j * k_bucket_size + i] * k_local[i];
+        }
+      }
+#pragma unroll
+      for (int i = 0; i < v_dim_per_sg; ++i) {
+        kv_mem[i] = sycl::reduce_over_group(sg, kv_mem[i], sycl::plus<>());
+      }
+
+      float delta[v_dim_per_sg];
+#pragma unroll
+      for (int i = 0; i < v_dim_per_sg; ++i) {
+        delta[i] = (v_local[i] - kv_mem[i]) * beta;
+      }
+
+      float res[v_dim_per_sg];
+#pragma unroll
+      for (int i = 0; i < v_dim_per_sg; ++i) {
+        res[i] = 0.0f;
+      }
+#pragma unroll
+      for (int j = 0; j < v_dim_per_sg; ++j) {
+#pragma unroll
+        for (int i = 0; i < k_bucket_size; ++i) {
+          state_local[j * k_bucket_size + i] += k_local[i] * delta[j];
+          res[j] += state_local[j * k_bucket_size + i] * q_local[i];
+        }
+      }
+#pragma unroll
+      for (int i = 0; i < v_dim_per_sg; ++i) {
+        res[i] = sycl::reduce_over_group(sg, res[i], sycl::plus<>());
+      }
+
+      if (sg_local_id == 0) {
+#pragma unroll
+        for (int i = 0; i < v_dim_per_sg; ++i) {
+          core_attn_out
+              [global_t * num_v_heads * head_v_dim +
+               num_v_heads_id * head_v_dim + head_v_dim_id + i] =
+                  static_cast<T>(res[i]);
+        }
+      }
+
+#pragma unroll
+      for (int j = 0; j < v_dim_per_sg; ++j) {
+        const int state_offset =
+            state_head_offset + (head_v_dim_id + j) * head_k_dim +
+            k_bucket_size * sg_local_id;
+        if constexpr (use_packed_state_io_128) {
+          alignas(16) StateT state_pack_local[k_bucket_size];
+#pragma unroll
+          for (int i = 0; i < k_bucket_size; ++i) {
+            state_pack_local[i] =
+                static_cast<StateT>(state_local[j * k_bucket_size + i]);
+          }
+          reinterpret_cast<sycl::uint4*>(ssm_state_ptr + state_offset)[0] =
+              reinterpret_cast<sycl::uint4*>(state_pack_local)[0];
+        } else if constexpr (use_packed_state_io_64) {
+          alignas(8) StateT state_pack_local[k_bucket_size];
+#pragma unroll
+          for (int i = 0; i < k_bucket_size; ++i) {
+            state_pack_local[i] =
+                static_cast<StateT>(state_local[j * k_bucket_size + i]);
+          }
+          reinterpret_cast<sycl::uint2*>(ssm_state_ptr + state_offset)[0] =
+              reinterpret_cast<sycl::uint2*>(state_pack_local)[0];
+        } else {
+#pragma unroll
+          for (int i = 0; i < k_bucket_size; ++i) {
+            ssm_state_ptr[state_offset + i] =
+                static_cast<StateT>(state_local[j * k_bucket_size + i]);
+          }
+        }
+      }
+    }
+  }
+
+ private:
+  T* core_attn_out;
+  const T* q;
+  const T* k;
+  const T* v;
+  const T* b;
+  const T* a;
+  const float* A_log;
+  const T* dt_bias;
+  StateT* ssm_state;
+  const int ssm_state_stride_0;
+  const int* token_indx;
+  const int* cache_indices;
+  const bool* has_initial_state;
+  const int batch_size;
+  const int num_k_heads;
+  const int head_k_dim;
+  const int num_v_heads;
+  const int head_v_dim;
+};
+
+template <typename T, typename StateT, int k_bucket_size>
+void kernel_launcher_decode_xe2(
+    sycl::queue& queue,
+    T* core_attn_out,
+    const T* q,
+    const T* k,
+    const T* v,
+    const T* b,
+    const T* a,
+    const float* A_log,
+    const T* dt_bias,
+    StateT* ssm_state,
+    const int ssm_state_stride_0,
+    const int* token_indx,
+    const int* cache_indices,
+    const bool* has_initial_state,
+    const int batch_size,
+    const int num_k_heads,
+    const int head_k_dim,
+    const int num_v_heads,
+    const int head_v_dim) {
+  using KERNEL = gated_delta_rule_decode_kernel_xe2<T, StateT, k_bucket_size>;
+  auto range = KERNEL::get_nd_range(batch_size, num_v_heads, head_v_dim);
+  assert(head_v_dim % KERNEL::v_dim_per_group == 0);
+  queue.submit([&](sycl::handler& cgh) {
+    KERNEL task(
+        core_attn_out,
+        q,
+        k,
+        v,
+        b,
+        a,
+        A_log,
+        dt_bias,
+        ssm_state,
+        ssm_state_stride_0,
+        token_indx,
+        cache_indices,
+        has_initial_state,
+        batch_size,
+        num_k_heads,
+        head_k_dim,
+        num_v_heads,
+        head_v_dim);
+    cgh.parallel_for(range, task);
+  });
+}
+
+template <typename T>
+void dispatch_state_dtype_decode_xe2(
+    sycl::queue& queue,
+    torch::Tensor& core_attn_out,
+    const torch::Tensor& q,
+    const torch::Tensor& k,
+    const torch::Tensor& v,
+    const torch::Tensor& b,
+    const torch::Tensor& a,
+    const torch::Tensor& A_log,
+    const torch::Tensor& dt_bias,
+    torch::Tensor& ssm_state,
+    const int ssm_state_stride_0,
+    const int* token_indx,
+    const int* cache_indices,
+    const bool* has_initial_state,
+    const int batch_size,
+    const int num_k_heads,
+    const int head_k_dim,
+    const int num_v_heads,
+    const int head_v_dim,
+    const int k_bucket_size) {
+#define XE2_DECODE_BUCKET_DISPATCH(state_scalar_t)                           \
+  switch (k_bucket_size) {                                                   \
+    case 1:                                                                  \
+      kernel_launcher_decode_xe2<T, state_scalar_t, 1>(                      \
+          queue,                                                              \
+          reinterpret_cast<T*>(core_attn_out.data_ptr()),                    \
+          reinterpret_cast<T*>(q.data_ptr()),                                \
+          reinterpret_cast<T*>(k.data_ptr()),                                \
+          reinterpret_cast<T*>(v.data_ptr()),                                \
+          reinterpret_cast<T*>(b.data_ptr()),                                \
+          reinterpret_cast<T*>(a.data_ptr()),                                \
+          reinterpret_cast<float*>(A_log.data_ptr()),                        \
+          reinterpret_cast<T*>(dt_bias.data_ptr()),                          \
+          reinterpret_cast<state_scalar_t*>(ssm_state.data_ptr()),           \
+          ssm_state_stride_0,                                                 \
+          token_indx,                                                         \
+          cache_indices,                                                      \
+          has_initial_state,                                                  \
+          batch_size,                                                         \
+          num_k_heads,                                                        \
+          head_k_dim,                                                         \
+          num_v_heads,                                                        \
+          head_v_dim);                                                        \
+      break;                                                                  \
+    case 2:                                                                  \
+      kernel_launcher_decode_xe2<T, state_scalar_t, 2>(                      \
+          queue,                                                              \
+          reinterpret_cast<T*>(core_attn_out.data_ptr()),                    \
+          reinterpret_cast<T*>(q.data_ptr()),                                \
+          reinterpret_cast<T*>(k.data_ptr()),                                \
+          reinterpret_cast<T*>(v.data_ptr()),                                \
+          reinterpret_cast<T*>(b.data_ptr()),                                \
+          reinterpret_cast<T*>(a.data_ptr()),                                \
+          reinterpret_cast<float*>(A_log.data_ptr()),                        \
+          reinterpret_cast<T*>(dt_bias.data_ptr()),                          \
+          reinterpret_cast<state_scalar_t*>(ssm_state.data_ptr()),           \
+          ssm_state_stride_0,                                                 \
+          token_indx,                                                         \
+          cache_indices,                                                      \
+          has_initial_state,                                                  \
+          batch_size,                                                         \
+          num_k_heads,                                                        \
+          head_k_dim,                                                         \
+          num_v_heads,                                                        \
+          head_v_dim);                                                        \
+      break;                                                                  \
+    case 4:                                                                  \
+      kernel_launcher_decode_xe2<T, state_scalar_t, 4>(                      \
+          queue,                                                              \
+          reinterpret_cast<T*>(core_attn_out.data_ptr()),                    \
+          reinterpret_cast<T*>(q.data_ptr()),                                \
+          reinterpret_cast<T*>(k.data_ptr()),                                \
+          reinterpret_cast<T*>(v.data_ptr()),                                \
+          reinterpret_cast<T*>(b.data_ptr()),                                \
+          reinterpret_cast<T*>(a.data_ptr()),                                \
+          reinterpret_cast<float*>(A_log.data_ptr()),                        \
+          reinterpret_cast<T*>(dt_bias.data_ptr()),                          \
+          reinterpret_cast<state_scalar_t*>(ssm_state.data_ptr()),           \
+          ssm_state_stride_0,                                                 \
+          token_indx,                                                         \
+          cache_indices,                                                      \
+          has_initial_state,                                                  \
+          batch_size,                                                         \
+          num_k_heads,                                                        \
+          head_k_dim,                                                         \
+          num_v_heads,                                                        \
+          head_v_dim);                                                        \
+      break;                                                                  \
+    case 8:                                                                  \
+      kernel_launcher_decode_xe2<T, state_scalar_t, 8>(                      \
+          queue,                                                              \
+          reinterpret_cast<T*>(core_attn_out.data_ptr()),                    \
+          reinterpret_cast<T*>(q.data_ptr()),                                \
+          reinterpret_cast<T*>(k.data_ptr()),                                \
+          reinterpret_cast<T*>(v.data_ptr()),                                \
+          reinterpret_cast<T*>(b.data_ptr()),                                \
+          reinterpret_cast<T*>(a.data_ptr()),                                \
+          reinterpret_cast<float*>(A_log.data_ptr()),                        \
+          reinterpret_cast<T*>(dt_bias.data_ptr()),                          \
+          reinterpret_cast<state_scalar_t*>(ssm_state.data_ptr()),           \
+          ssm_state_stride_0,                                                 \
+          token_indx,                                                         \
+          cache_indices,                                                      \
+          has_initial_state,                                                  \
+          batch_size,                                                         \
+          num_k_heads,                                                        \
+          head_k_dim,                                                         \
+          num_v_heads,                                                        \
+          head_v_dim);                                                        \
+      break;                                                                  \
+    default:                                                                  \
+      TORCH_CHECK(false, "unsupported k_bucket_size: ", k_bucket_size);      \
+  }
+
+  if (ssm_state.scalar_type() == at::kFloat) {
+    using state_scalar_t = float;
+    XE2_DECODE_BUCKET_DISPATCH(state_scalar_t)
+  } else if (ssm_state.scalar_type() == at::kBFloat16) {
+    using state_scalar_t = sycl::ext::oneapi::bfloat16;
+    XE2_DECODE_BUCKET_DISPATCH(state_scalar_t)
+  } else if (ssm_state.scalar_type() == at::kHalf) {
+    using state_scalar_t = sycl::half;
+    XE2_DECODE_BUCKET_DISPATCH(state_scalar_t)
+  } else {
+    TORCH_CHECK(
+        false,
+        "ssm_state dtype must be float32/float16/bfloat16, but got ",
+        ssm_state.scalar_type());
+  }
+
+#undef XE2_DECODE_BUCKET_DISPATCH
+}
+
+}  // namespace xe2
+}  // namespace gdn

--- a/csrc/xpu/gdn_attn/xe_2/gated_delta_rule_decode_xe2.hpp
+++ b/csrc/xpu/gdn_attn/xe_2/gated_delta_rule_decode_xe2.hpp
@@ -276,6 +276,292 @@ struct gated_delta_rule_decode_kernel_xe2 {
 };
 
 template <typename T, typename StateT, int k_bucket_size>
+struct gated_delta_rule_decode_spec_kernel_xe2 {
+ public:
+  static constexpr int group_size = 256;
+  static constexpr int sg_per_group = group_size / decode_sub_group_size;
+  static constexpr int v_dim_per_sg = 4;
+  static constexpr int v_dim_per_group = v_dim_per_sg * sg_per_group;
+  static constexpr float eps = 0.000001f;
+
+  gated_delta_rule_decode_spec_kernel_xe2(
+      T* core_attn_out,
+      const T* q,
+      const T* k,
+      const T* v,
+      const T* b,
+      const T* a,
+      const float* A_log,
+      const T* dt_bias,
+      StateT* ssm_state,
+      const int ssm_state_stride_0,
+      const int* token_indx,
+      const int* cache_indices,
+      const int cache_indices_stride_0,
+      const int* num_accepted_tokens,
+      const int num_spec_decodes,
+      const int num_spec_tokens,
+      const int num_k_heads,
+      const int head_k_dim,
+      const int num_v_heads,
+      const int head_v_dim)
+      : core_attn_out(core_attn_out),
+        q(q),
+        k(k),
+        v(v),
+        b(b),
+        a(a),
+        A_log(A_log),
+        dt_bias(dt_bias),
+        ssm_state(ssm_state),
+        ssm_state_stride_0(ssm_state_stride_0),
+        token_indx(token_indx),
+        cache_indices(cache_indices),
+        cache_indices_stride_0(cache_indices_stride_0),
+        num_accepted_tokens(num_accepted_tokens),
+        num_spec_decodes(num_spec_decodes),
+        num_spec_tokens(num_spec_tokens),
+        num_k_heads(num_k_heads),
+        head_k_dim(head_k_dim),
+        num_v_heads(num_v_heads),
+        head_v_dim(head_v_dim) {}
+
+  static inline sycl::nd_range<3> get_nd_range(
+      const int num_spec_decodes, const int num_v_heads,
+      const int head_v_dim) {
+    sycl::range<3> local(1, 1, group_size);
+    sycl::range<3> global(num_spec_decodes, num_v_heads, 1);
+    return sycl::nd_range<3>(global * local, local);
+  }
+
+  static inline float act_sigmoid(float& x) {
+    return 1.0f / (1.0f + sycl::exp(-x));
+  }
+
+  static inline float
+  act_softplus(float& x, float beta = 1.0f, float threshold = 20.0f) {
+    if (beta * x < threshold) {
+      return sycl::log(1.0f + sycl::exp(beta * x)) / beta;
+    } else {
+      return x;
+    }
+  }
+
+  template <typename VecT, int vec_size>
+  static inline void load_vec(const VecT* ptr, VecT (&dst)[vec_size]) {
+    sycl::vec<VecT, vec_size> in =
+        *reinterpret_cast<const sycl::vec<VecT, vec_size>*>(ptr);
+#pragma unroll
+    for (int i = 0; i < vec_size; ++i) {
+      dst[i] = in[i];
+    }
+  }
+
+  template <typename VecT, int vec_size>
+  static inline void load_vec_to_float(const VecT* ptr, float (&dst)[vec_size]) {
+    VecT tmp[vec_size];
+    load_vec<VecT, vec_size>(ptr, tmp);
+#pragma unroll
+    for (int i = 0; i < vec_size; ++i) {
+      dst[i] = static_cast<float>(tmp[i]);
+    }
+  }
+
+  template <typename VecT, int vec_size>
+  static inline void store_vec(VecT* ptr, const VecT (&src)[vec_size]) {
+    sycl::vec<VecT, vec_size> out;
+#pragma unroll
+    for (int i = 0; i < vec_size; ++i) {
+      out[i] = src[i];
+    }
+    *reinterpret_cast<sycl::vec<VecT, vec_size>*>(ptr) = out;
+  }
+
+  template <typename VecT, int vec_size>
+  static inline void store_vec_from_float(
+      VecT* ptr, const float (&src)[vec_size]) {
+    VecT tmp[vec_size];
+#pragma unroll
+    for (int i = 0; i < vec_size; ++i) {
+      tmp[i] = static_cast<VecT>(src[i]);
+    }
+    store_vec<VecT, vec_size>(ptr, tmp);
+  }
+
+  [[sycl::reqd_sub_group_size(decode_sub_group_size)]] void
+  operator()(sycl::nd_item<3> item) const {
+    const int decode_id = item.get_group(0);
+    const int num_v_heads_id = item.get_group(1);
+
+    auto sg = item.get_sub_group();
+    const int sg_id = sg.get_group_id();
+    const int sg_local_id = sg.get_local_id();
+    const int kv_ratio = num_v_heads / num_k_heads;
+    const float scale = 1.0f / sycl::sqrt(float(head_k_dim));
+    float A_log_local = A_log[num_v_heads_id];
+    float dt_bias_local = dt_bias[num_v_heads_id];
+    A_log_local = -sycl::exp(A_log_local);
+
+    const int state_head_offset = num_v_heads_id * head_k_dim * head_v_dim;
+
+    int init_col = num_accepted_tokens[decode_id] - 1;
+    if (init_col < 0) {
+      init_col = 0;
+    }
+    const int init_state_idx =
+        cache_indices[decode_id * cache_indices_stride_0 + init_col];
+    const StateT* init_state_ptr =
+        ssm_state + static_cast<int64_t>(init_state_idx) * ssm_state_stride_0;
+
+    for (int head_v_dim_id = sg_id * v_dim_per_sg; head_v_dim_id < head_v_dim;
+         head_v_dim_id += v_dim_per_group) {
+      alignas(16) float state_local[v_dim_per_sg * k_bucket_size];
+      float q_local[k_bucket_size];
+      float k_local[k_bucket_size];
+      float v_local[v_dim_per_sg];
+
+#pragma unroll
+      for (int j = 0; j < v_dim_per_sg; ++j) {
+        const int state_offset =
+            state_head_offset + (head_v_dim_id + j) * head_k_dim +
+            k_bucket_size * sg_local_id;
+        load_vec_to_float<StateT, k_bucket_size>(
+            init_state_ptr + state_offset,
+            reinterpret_cast<float (&)[k_bucket_size]>(
+                state_local[j * k_bucket_size]));
+      }
+
+      for (int t_local = 0; t_local < num_spec_tokens; ++t_local) {
+        const int t = decode_id * num_spec_tokens + t_local;
+
+        float b_local = b[t * num_v_heads + num_v_heads_id];
+        float beta = act_sigmoid(b_local);
+        float a_local = a[t * num_v_heads + num_v_heads_id] + dt_bias_local;
+        float g = sycl::exp(A_log_local * act_softplus(a_local));
+
+        float q_sum = 0.0f;
+        float k_sum = 0.0f;
+#pragma unroll
+        for (int i = 0; i < k_bucket_size; ++i) {
+          q_local[i] =
+              q[t * num_k_heads * head_k_dim +
+                (num_v_heads_id / kv_ratio) * head_k_dim +
+                (k_bucket_size * sg_local_id + i)];
+          k_local[i] =
+              k[t * num_k_heads * head_k_dim +
+                (num_v_heads_id / kv_ratio) * head_k_dim +
+                (k_bucket_size * sg_local_id + i)];
+          q_sum += q_local[i] * q_local[i];
+          k_sum += k_local[i] * k_local[i];
+        }
+        q_sum = sycl::reduce_over_group(sg, q_sum, sycl::plus<>());
+        k_sum = sycl::reduce_over_group(sg, k_sum, sycl::plus<>());
+        q_sum += eps;
+        k_sum += eps;
+#pragma unroll
+        for (int i = 0; i < k_bucket_size; ++i) {
+          q_local[i] /= sycl::sqrt(q_sum);
+          q_local[i] *= scale;
+          k_local[i] /= sycl::sqrt(k_sum);
+        }
+
+        load_vec_to_float<T, v_dim_per_sg>(
+            v + t * num_v_heads * head_v_dim +
+                num_v_heads_id * head_v_dim + head_v_dim_id,
+            v_local);
+
+        float kv_mem[v_dim_per_sg];
+#pragma unroll
+        for (int i = 0; i < v_dim_per_sg; ++i) {
+          kv_mem[i] = 0.0f;
+        }
+#pragma unroll
+        for (int j = 0; j < v_dim_per_sg; ++j) {
+#pragma unroll
+          for (int i = 0; i < k_bucket_size; ++i) {
+            state_local[j * k_bucket_size + i] *= g;
+            kv_mem[j] += state_local[j * k_bucket_size + i] * k_local[i];
+          }
+        }
+#pragma unroll
+        for (int i = 0; i < v_dim_per_sg; ++i) {
+          kv_mem[i] = sycl::reduce_over_group(sg, kv_mem[i], sycl::plus<>());
+        }
+
+        float delta[v_dim_per_sg];
+#pragma unroll
+        for (int i = 0; i < v_dim_per_sg; ++i) {
+          delta[i] = (v_local[i] - kv_mem[i]) * beta;
+        }
+
+        float res[v_dim_per_sg];
+#pragma unroll
+        for (int i = 0; i < v_dim_per_sg; ++i) {
+          res[i] = 0.0f;
+        }
+#pragma unroll
+        for (int j = 0; j < v_dim_per_sg; ++j) {
+#pragma unroll
+          for (int i = 0; i < k_bucket_size; ++i) {
+            state_local[j * k_bucket_size + i] += k_local[i] * delta[j];
+            res[j] += state_local[j * k_bucket_size + i] * q_local[i];
+          }
+        }
+#pragma unroll
+        for (int i = 0; i < v_dim_per_sg; ++i) {
+          res[i] = sycl::reduce_over_group(sg, res[i], sycl::plus<>());
+        }
+
+        if (sg_local_id == 0) {
+          const int global_t = (token_indx != nullptr) ? token_indx[t] : t;
+          store_vec_from_float<T, v_dim_per_sg>(
+              core_attn_out + global_t * num_v_heads * head_v_dim +
+                  num_v_heads_id * head_v_dim + head_v_dim_id,
+              res);
+        }
+
+        const int writeback_idx =
+            cache_indices[decode_id * cache_indices_stride_0 + t_local];
+        StateT* writeback_ptr =
+            ssm_state + static_cast<int64_t>(writeback_idx) * ssm_state_stride_0;
+#pragma unroll
+        for (int j = 0; j < v_dim_per_sg; ++j) {
+          const int state_offset =
+              state_head_offset + (head_v_dim_id + j) * head_k_dim +
+              k_bucket_size * sg_local_id;
+          store_vec_from_float<StateT, k_bucket_size>(
+              writeback_ptr + state_offset,
+              reinterpret_cast<float (&)[k_bucket_size]>(
+                  state_local[j * k_bucket_size]));
+        }
+      }
+    }
+  }
+
+ private:
+  T* core_attn_out;
+  const T* q;
+  const T* k;
+  const T* v;
+  const T* b;
+  const T* a;
+  const float* A_log;
+  const T* dt_bias;
+  StateT* ssm_state;
+  const int ssm_state_stride_0;
+  const int* token_indx;
+  const int* cache_indices;
+  const int cache_indices_stride_0;
+  const int* num_accepted_tokens;
+  const int num_spec_decodes;
+  const int num_spec_tokens;
+  const int num_k_heads;
+  const int head_k_dim;
+  const int num_v_heads;
+  const int head_v_dim;
+};
+
+template <typename T, typename StateT, int k_bucket_size>
 void kernel_launcher_decode_xe2(
     sycl::queue& queue,
     T* core_attn_out,
@@ -454,6 +740,209 @@ void dispatch_state_dtype_decode_xe2(
   }
 
 #undef XE2_DECODE_BUCKET_DISPATCH
+}
+
+template <typename T, typename StateT, int k_bucket_size>
+void kernel_launcher_decode_xe2_spec(
+    sycl::queue& queue,
+    T* core_attn_out,
+    const T* q,
+    const T* k,
+    const T* v,
+    const T* b,
+    const T* a,
+    const float* A_log,
+    const T* dt_bias,
+    StateT* ssm_state,
+    const int ssm_state_stride_0,
+    const int* token_indx,
+    const int* cache_indices,
+    const int cache_indices_stride_0,
+    const int* num_accepted_tokens,
+    const int num_spec_decodes,
+    const int num_spec_tokens,
+    const int num_k_heads,
+    const int head_k_dim,
+    const int num_v_heads,
+    const int head_v_dim) {
+  using KERNEL =
+      gated_delta_rule_decode_spec_kernel_xe2<T, StateT, k_bucket_size>;
+  auto range = KERNEL::get_nd_range(num_spec_decodes, num_v_heads, head_v_dim);
+  TORCH_CHECK(
+      head_v_dim % KERNEL::v_dim_per_group == 0,
+      "head_v_dim must be divisible by ",
+      KERNEL::v_dim_per_group,
+      " for XE2 spec decode, but got ",
+      head_v_dim);
+  queue.submit([&](sycl::handler& cgh) {
+    KERNEL task(
+        core_attn_out,
+        q,
+        k,
+        v,
+        b,
+        a,
+        A_log,
+        dt_bias,
+        ssm_state,
+        ssm_state_stride_0,
+        token_indx,
+        cache_indices,
+        cache_indices_stride_0,
+        num_accepted_tokens,
+        num_spec_decodes,
+        num_spec_tokens,
+        num_k_heads,
+        head_k_dim,
+        num_v_heads,
+        head_v_dim);
+    cgh.parallel_for(range, task);
+  });
+}
+
+template <typename T>
+void dispatch_state_dtype_decode_xe2_spec(
+    sycl::queue& queue,
+    torch::Tensor& core_attn_out,
+    const torch::Tensor& q,
+    const torch::Tensor& k,
+    const torch::Tensor& v,
+    const torch::Tensor& b,
+    const torch::Tensor& a,
+    const torch::Tensor& A_log,
+    const torch::Tensor& dt_bias,
+    torch::Tensor& ssm_state,
+    const int ssm_state_stride_0,
+    const int* token_indx,
+    const int* cache_indices,
+    const int cache_indices_stride_0,
+    const int* num_accepted_tokens,
+    const int num_spec_decodes,
+    const int num_spec_tokens,
+    const int num_k_heads,
+    const int head_k_dim,
+    const int num_v_heads,
+    const int head_v_dim,
+    const int k_bucket_size) {
+#define XE2_DECODE_SPEC_BUCKET_DISPATCH(state_scalar_t)                    \
+  switch (k_bucket_size) {                                                 \
+    case 1:                                                                \
+      kernel_launcher_decode_xe2_spec<T, state_scalar_t, 1>(               \
+          queue,                                                            \
+          reinterpret_cast<T*>(core_attn_out.data_ptr()),                  \
+          reinterpret_cast<T*>(q.data_ptr()),                              \
+          reinterpret_cast<T*>(k.data_ptr()),                              \
+          reinterpret_cast<T*>(v.data_ptr()),                              \
+          reinterpret_cast<T*>(b.data_ptr()),                              \
+          reinterpret_cast<T*>(a.data_ptr()),                              \
+          reinterpret_cast<float*>(A_log.data_ptr()),                      \
+          reinterpret_cast<T*>(dt_bias.data_ptr()),                        \
+          reinterpret_cast<state_scalar_t*>(ssm_state.data_ptr()),         \
+          ssm_state_stride_0,                                               \
+          token_indx,                                                       \
+          cache_indices,                                                    \
+          cache_indices_stride_0,                                           \
+          num_accepted_tokens,                                              \
+          num_spec_decodes,                                                 \
+          num_spec_tokens,                                                  \
+          num_k_heads,                                                      \
+          head_k_dim,                                                       \
+          num_v_heads,                                                      \
+          head_v_dim);                                                      \
+      break;                                                                \
+    case 2:                                                                \
+      kernel_launcher_decode_xe2_spec<T, state_scalar_t, 2>(               \
+          queue,                                                            \
+          reinterpret_cast<T*>(core_attn_out.data_ptr()),                  \
+          reinterpret_cast<T*>(q.data_ptr()),                              \
+          reinterpret_cast<T*>(k.data_ptr()),                              \
+          reinterpret_cast<T*>(v.data_ptr()),                              \
+          reinterpret_cast<T*>(b.data_ptr()),                              \
+          reinterpret_cast<T*>(a.data_ptr()),                              \
+          reinterpret_cast<float*>(A_log.data_ptr()),                      \
+          reinterpret_cast<T*>(dt_bias.data_ptr()),                        \
+          reinterpret_cast<state_scalar_t*>(ssm_state.data_ptr()),         \
+          ssm_state_stride_0,                                               \
+          token_indx,                                                       \
+          cache_indices,                                                    \
+          cache_indices_stride_0,                                           \
+          num_accepted_tokens,                                              \
+          num_spec_decodes,                                                 \
+          num_spec_tokens,                                                  \
+          num_k_heads,                                                      \
+          head_k_dim,                                                       \
+          num_v_heads,                                                      \
+          head_v_dim);                                                      \
+      break;                                                                \
+    case 4:                                                                \
+      kernel_launcher_decode_xe2_spec<T, state_scalar_t, 4>(               \
+          queue,                                                            \
+          reinterpret_cast<T*>(core_attn_out.data_ptr()),                  \
+          reinterpret_cast<T*>(q.data_ptr()),                              \
+          reinterpret_cast<T*>(k.data_ptr()),                              \
+          reinterpret_cast<T*>(v.data_ptr()),                              \
+          reinterpret_cast<T*>(b.data_ptr()),                              \
+          reinterpret_cast<T*>(a.data_ptr()),                              \
+          reinterpret_cast<float*>(A_log.data_ptr()),                      \
+          reinterpret_cast<T*>(dt_bias.data_ptr()),                        \
+          reinterpret_cast<state_scalar_t*>(ssm_state.data_ptr()),         \
+          ssm_state_stride_0,                                               \
+          token_indx,                                                       \
+          cache_indices,                                                    \
+          cache_indices_stride_0,                                           \
+          num_accepted_tokens,                                              \
+          num_spec_decodes,                                                 \
+          num_spec_tokens,                                                  \
+          num_k_heads,                                                      \
+          head_k_dim,                                                       \
+          num_v_heads,                                                      \
+          head_v_dim);                                                      \
+      break;                                                                \
+    case 8:                                                                \
+      kernel_launcher_decode_xe2_spec<T, state_scalar_t, 8>(               \
+          queue,                                                            \
+          reinterpret_cast<T*>(core_attn_out.data_ptr()),                  \
+          reinterpret_cast<T*>(q.data_ptr()),                              \
+          reinterpret_cast<T*>(k.data_ptr()),                              \
+          reinterpret_cast<T*>(v.data_ptr()),                              \
+          reinterpret_cast<T*>(b.data_ptr()),                              \
+          reinterpret_cast<T*>(a.data_ptr()),                              \
+          reinterpret_cast<float*>(A_log.data_ptr()),                      \
+          reinterpret_cast<T*>(dt_bias.data_ptr()),                        \
+          reinterpret_cast<state_scalar_t*>(ssm_state.data_ptr()),         \
+          ssm_state_stride_0,                                               \
+          token_indx,                                                       \
+          cache_indices,                                                    \
+          cache_indices_stride_0,                                           \
+          num_accepted_tokens,                                              \
+          num_spec_decodes,                                                 \
+          num_spec_tokens,                                                  \
+          num_k_heads,                                                      \
+          head_k_dim,                                                       \
+          num_v_heads,                                                      \
+          head_v_dim);                                                      \
+      break;                                                                \
+    default:                                                                \
+      TORCH_CHECK(false, "unsupported k_bucket_size: ", k_bucket_size);    \
+  }
+
+  if (ssm_state.scalar_type() == at::kFloat) {
+    using state_scalar_t = float;
+    XE2_DECODE_SPEC_BUCKET_DISPATCH(state_scalar_t)
+  } else if (ssm_state.scalar_type() == at::kBFloat16) {
+    using state_scalar_t = sycl::ext::oneapi::bfloat16;
+    XE2_DECODE_SPEC_BUCKET_DISPATCH(state_scalar_t)
+  } else if (ssm_state.scalar_type() == at::kHalf) {
+    using state_scalar_t = sycl::half;
+    XE2_DECODE_SPEC_BUCKET_DISPATCH(state_scalar_t)
+  } else {
+    TORCH_CHECK(
+        false,
+        "ssm_state dtype must be float32/float16/bfloat16, but got ",
+        ssm_state.scalar_type());
+  }
+
+#undef XE2_DECODE_SPEC_BUCKET_DISPATCH
 }
 
 }  // namespace xe2

--- a/csrc/xpu/gdn_attn/xe_2/gated_delta_rule_decode_xe2.hpp
+++ b/csrc/xpu/gdn_attn/xe_2/gated_delta_rule_decode_xe2.hpp
@@ -17,13 +17,6 @@ struct gated_delta_rule_decode_kernel_xe2 {
   static constexpr int v_dim_per_sg = 4;
   static constexpr int v_dim_per_group = v_dim_per_sg * sg_per_group;
   static constexpr float eps = 0.000001f;
-  static constexpr int packed_state_bytes = k_bucket_size * sizeof(StateT);
-  static constexpr bool supports_packed_state_io =
-      std::is_same_v<StateT, float> || std::is_same_v<StateT, sycl::half> ||
-      std::is_same_v<StateT, sycl::ext::oneapi::bfloat16>;
-    static constexpr bool use_vector_state_io =
-      supports_packed_state_io &&
-      (packed_state_bytes == 8 || packed_state_bytes == 16);
 
   gated_delta_rule_decode_kernel_xe2(
       T* core_attn_out,
@@ -38,7 +31,6 @@ struct gated_delta_rule_decode_kernel_xe2 {
       const int ssm_state_stride_0,
       const int* token_indx,
       const int* cache_indices,
-      const bool* has_initial_state,
       const int batch_size,
       const int num_k_heads,
       const int head_k_dim,
@@ -56,7 +48,6 @@ struct gated_delta_rule_decode_kernel_xe2 {
         ssm_state_stride_0(ssm_state_stride_0),
         token_indx(token_indx),
         cache_indices(cache_indices),
-        has_initial_state(has_initial_state),
         batch_size(batch_size),
         num_k_heads(num_k_heads),
         head_k_dim(head_k_dim),
@@ -153,33 +144,15 @@ struct gated_delta_rule_decode_kernel_xe2 {
       float k_local[k_bucket_size];
       float v_local[v_dim_per_sg];
 
-      if (has_initial_state == nullptr || has_initial_state[decode_id]) {
 #pragma unroll
-        for (int j = 0; j < v_dim_per_sg; ++j) {
-          const int state_offset =
-              state_head_offset + (head_v_dim_id + j) * head_k_dim +
-              k_bucket_size * sg_local_id;
-          if constexpr (use_vector_state_io) {
-            load_vec_to_float<StateT, k_bucket_size>(
-                ssm_state_ptr + state_offset,
-                reinterpret_cast<float (&)[k_bucket_size]>(
-                    state_local[j * k_bucket_size]));
-          } else {
-#pragma unroll
-            for (int i = 0; i < k_bucket_size; ++i) {
-              state_local[j * k_bucket_size + i] =
-                  static_cast<float>(ssm_state_ptr[state_offset + i]);
-            }
-          }
-        }
-      } else {
-#pragma unroll
-        for (int j = 0; j < v_dim_per_sg; ++j) {
-#pragma unroll
-          for (int i = 0; i < k_bucket_size; ++i) {
-            state_local[j * k_bucket_size + i] = 0.0f;
-          }
-        }
+      for (int j = 0; j < v_dim_per_sg; ++j) {
+        const int state_offset =
+            state_head_offset + (head_v_dim_id + j) * head_k_dim +
+            k_bucket_size * sg_local_id;
+        load_vec_to_float<StateT, k_bucket_size>(
+            ssm_state_ptr + state_offset,
+            reinterpret_cast<float (&)[k_bucket_size]>(
+                state_local[j * k_bucket_size]));
       }
 
       float b_local = b[decode_id * num_v_heads + num_v_heads_id];
@@ -274,18 +247,10 @@ struct gated_delta_rule_decode_kernel_xe2 {
         const int state_offset =
             state_head_offset + (head_v_dim_id + j) * head_k_dim +
             k_bucket_size * sg_local_id;
-        if constexpr (use_vector_state_io) {
-          store_vec_from_float<StateT, k_bucket_size>(
-              ssm_state_ptr + state_offset,
-              reinterpret_cast<float (&)[k_bucket_size]>(
-                  state_local[j * k_bucket_size]));
-        } else {
-#pragma unroll
-          for (int i = 0; i < k_bucket_size; ++i) {
-            ssm_state_ptr[state_offset + i] =
-                static_cast<StateT>(state_local[j * k_bucket_size + i]);
-          }
-        }
+        store_vec_from_float<StateT, k_bucket_size>(
+            ssm_state_ptr + state_offset,
+            reinterpret_cast<float (&)[k_bucket_size]>(
+                state_local[j * k_bucket_size]));
       }
     }
   }
@@ -303,7 +268,6 @@ struct gated_delta_rule_decode_kernel_xe2 {
   const int ssm_state_stride_0;
   const int* token_indx;
   const int* cache_indices;
-  const bool* has_initial_state;
   const int batch_size;
   const int num_k_heads;
   const int head_k_dim;
@@ -326,7 +290,6 @@ void kernel_launcher_decode_xe2(
     const int ssm_state_stride_0,
     const int* token_indx,
     const int* cache_indices,
-    const bool* has_initial_state,
     const int batch_size,
     const int num_k_heads,
     const int head_k_dim,
@@ -334,7 +297,12 @@ void kernel_launcher_decode_xe2(
     const int head_v_dim) {
   using KERNEL = gated_delta_rule_decode_kernel_xe2<T, StateT, k_bucket_size>;
   auto range = KERNEL::get_nd_range(batch_size, num_v_heads, head_v_dim);
-  assert(head_v_dim % KERNEL::v_dim_per_group == 0);
+  TORCH_CHECK(
+      head_v_dim % KERNEL::v_dim_per_group == 0,
+      "head_v_dim must be divisible by ",
+      KERNEL::v_dim_per_group,
+      " for XE2 decode, but got ",
+      head_v_dim);
   queue.submit([&](sycl::handler& cgh) {
     KERNEL task(
         core_attn_out,
@@ -349,7 +317,6 @@ void kernel_launcher_decode_xe2(
         ssm_state_stride_0,
         token_indx,
         cache_indices,
-        has_initial_state,
         batch_size,
         num_k_heads,
         head_k_dim,
@@ -374,7 +341,6 @@ void dispatch_state_dtype_decode_xe2(
     const int ssm_state_stride_0,
     const int* token_indx,
     const int* cache_indices,
-    const bool* has_initial_state,
     const int batch_size,
     const int num_k_heads,
     const int head_k_dim,
@@ -398,7 +364,6 @@ void dispatch_state_dtype_decode_xe2(
           ssm_state_stride_0,                                                 \
           token_indx,                                                         \
           cache_indices,                                                      \
-          has_initial_state,                                                  \
           batch_size,                                                         \
           num_k_heads,                                                        \
           head_k_dim,                                                         \
@@ -420,7 +385,6 @@ void dispatch_state_dtype_decode_xe2(
           ssm_state_stride_0,                                                 \
           token_indx,                                                         \
           cache_indices,                                                      \
-          has_initial_state,                                                  \
           batch_size,                                                         \
           num_k_heads,                                                        \
           head_k_dim,                                                         \
@@ -442,7 +406,6 @@ void dispatch_state_dtype_decode_xe2(
           ssm_state_stride_0,                                                 \
           token_indx,                                                         \
           cache_indices,                                                      \
-          has_initial_state,                                                  \
           batch_size,                                                         \
           num_k_heads,                                                        \
           head_k_dim,                                                         \
@@ -464,7 +427,6 @@ void dispatch_state_dtype_decode_xe2(
           ssm_state_stride_0,                                                 \
           token_indx,                                                         \
           cache_indices,                                                      \
-          has_initial_state,                                                  \
           batch_size,                                                         \
           num_k_heads,                                                        \
           head_k_dim,                                                         \


### PR DESCRIPTION
Only optimize the decode path in Gated Delta Rule, no prefill changes. Big decode/spec wins (−13% to −23% median) in latency.
