### PR TITLE
[ATTN] Align `softmax_lse` native layout with CUDA FlashAttention convention

### DIFF
--- a/csrc/flash_attn/flash_api.cpp
+++ b/csrc/flash_attn/flash_api.cpp
@@ -195,8 +195,12 @@ std::vector<at::Tensor> mha_varlen_fwd(
   if (return_softmax) {
     int total_seqlen_q = q.size(0);
     int num_heads_q = q.size(1);
+    // (nheads, total_seqlen_q) matches the CUDA/upstream FlashAttention
+    // softmax_lse convention, and the writer kernel writes directly in
+    // this layout (see chunk_prefill_kernel.hpp), so no transpose/copy is
+    // needed on the caller side (e.g. vLLM's xpu_ops wrapper).
     softmax_lse_opt = torch::empty(
-        {total_seqlen_q, num_heads_q},
+        {num_heads_q, total_seqlen_q},
         q.options().dtype(at::kFloat).device(q.device()));
   }
 

--- a/csrc/xpu/attn/xe_2/chunk_prefill.hpp
+++ b/csrc/xpu/attn/xe_2/chunk_prefill.hpp
@@ -54,7 +54,7 @@ struct chunk_prefill_args_t {
   bool is_sink = false;
   // softmax_lse output (nullptr when not requested)
   float* softmax_lse = nullptr;
-  int lse_stride = 0;  // stride along seq dim (= num_heads_q)
+  int lse_stride = 0;  // stride along head dim (= total_seqlen_q)
   // Q/O strides in CUTLASS order: (seq, head_size=1, heads, batch)
   int q_stride_seq = 0;
   int q_stride_heads = 0;

--- a/csrc/xpu/attn/xe_2/fmha_xe2.cpp
+++ b/csrc/xpu/attn/xe_2/fmha_xe2.cpp
@@ -161,7 +161,9 @@ void cutlass_chunk_prefill_impl(
   // Populate softmax_lse output pointer if requested
   if (softmax_lse.has_value()) {
     args.softmax_lse = softmax_lse.value().data_ptr<float>();
-    args.lse_stride = num_heads_q;
+    // softmax_lse is allocated as (num_heads_q, total_seqlen_q); stride
+    // along the query-row dimension is total_seqlen_q.
+    args.lse_stride = total_seqlen_q;
   }
   // Per-batch prefill/decode mask (nullptr -> process all batches)
   args.is_prefill =

--- a/csrc/xpu/attn/xe_2/kernel/chunk_prefill_kernel.hpp
+++ b/csrc/xpu/attn/xe_2/kernel/chunk_prefill_kernel.hpp
@@ -149,9 +149,9 @@ class XeFMHAFwdKernel {
     // softmax sink
     const ElementSink* ptr_S;
 
-    // softmax_lse output [total_seqlen_q, num_heads_q] (nullptr if disabled)
+    // softmax_lse output [num_heads_q, total_seqlen_q] (nullptr if disabled)
     float* softmax_lse;
-    int lse_stride;  // = num_heads_q
+    int lse_stride;  // = total_seqlen_q
 
     // per-batch mask: true = prefill, false = decode; nullptr = process all
     const bool* is_prefill;
@@ -484,7 +484,9 @@ class XeFMHAFwdKernel {
             float lse = static_cast<float>(tA_max(i)) * kLn2 +
                         sycl::log(static_cast<float>(sum_val));
             int global_q = qo_cumul + q_in_batch;
-            p.softmax_lse[global_q * p.lse_stride + head_q] = lse;
+            // softmax_lse is (num_heads_q, total_seqlen_q); write directly
+            // in that layout so no transpose/copy is needed by callers.
+            p.softmax_lse[head_q * p.lse_stride + global_q] = lse;
           }
         }
       }

--- a/tests/flash_attn/test_flash_attn_varlen_func.py
+++ b/tests/flash_attn/test_flash_attn_varlen_func.py
@@ -871,7 +871,7 @@ def ref_softmax_lse(
         lse[q, h] = log( sum_k exp(scale * (Q[q, h] . K[k, h])) )
     with optional causal masking. Kernel restricts LSE to
     Paged=False, Local=False, Sink=False, so this ref mirrors the same.
-    Returns a tensor of shape [sum(query_lens), num_query_heads] in float32.
+    Returns a tensor of shape [num_query_heads, sum(query_lens)] in float32.
     """
     num_query_heads = query.shape[1]
     lse_list: list[torch.Tensor] = []
@@ -891,13 +891,13 @@ def ref_softmax_lse(
                 diagonal=kv_len - query_len + 1,
             ).bool()
             attn.masked_fill_(mask, float("-inf"))
-        # logsumexp over kv dim, then transpose to [query_len, heads]
-        lse = torch.logsumexp(attn, dim=-1).transpose(0, 1).contiguous()
-        assert lse.shape == (query_len, num_query_heads)
+        # logsumexp over kv dim -> [heads, query_len]
+        lse = torch.logsumexp(attn, dim=-1)
+        assert lse.shape == (num_query_heads, query_len)
         lse_list.append(lse)
         start_q += query_len
         start_kv += kv_len
-    return torch.cat(lse_list, dim=0)
+    return torch.cat(lse_list, dim=1)
 
 
 # softmax_lse return is only supported when:
@@ -974,9 +974,9 @@ def test_varlen_with_softmax_lse(
                                               window_size=(-1, -1),
                                               return_softmax_lse=True)
 
-    # Output shape matches ref, and LSE shape is [total_seqlen_q, num_heads_q]
+    # Output shape matches ref, and LSE shape is [num_heads_q, total_seqlen_q]
     total_q = sum(query_lens)
-    assert softmax_lse.shape == (total_q, num_query_heads), softmax_lse.shape
+    assert softmax_lse.shape == (num_query_heads, total_q), softmax_lse.shape
     assert softmax_lse.dtype == torch.float32
 
     # Reference output (reuses the existing helper).

--- a/vllm_xpu_kernels/flash_attn_interface.py
+++ b/vllm_xpu_kernels/flash_attn_interface.py
@@ -375,8 +375,9 @@ def ref_paged_attn(query: torch.Tensor,
                                                 attn.size()[1], 1)
             attn = torch.cat([attn, sink_expanded], dim=-1)
         if return_softmax_lse:
-            # lse shape: [heads, query_len] -> transpose to [query_len, heads]
-            lse = torch.logsumexp(attn, dim=-1).transpose(0, 1).contiguous()
+            # lse shape: [heads, query_len], matching the CUDA/upstream
+            # FlashAttention (nheads, total_q) convention natively.
+            lse = torch.logsumexp(attn, dim=-1)
             lse_list.append(lse)
         attn = torch.softmax(attn, dim=-1).to(v.dtype)
         if sink is not None:
@@ -389,7 +390,7 @@ def ref_paged_attn(query: torch.Tensor,
 
     out_tensor = torch.cat(outputs, dim=0)
     if return_softmax_lse:
-        return out_tensor, torch.cat(lse_list, dim=0).float()
+        return out_tensor, torch.cat(lse_list, dim=1).float()
     return out_tensor
 
 


### PR DESCRIPTION
### Background

`flash_attn_varlen_func` currently allocates and writes the `softmax_lse` tensor in layout `(total_seqlen_q, num_heads_q)`. However, downstream consumers that follow the CUDA/upstream FlashAttention layout convention (e.g., vLLM's `merge_attn_states` / `mask_empty_context`) expect layout `(num_heads_q, total_seqlen_q)`.

This mismatch has caused real crashes in the following scenario:

- MLA (DeepSeek‑V2/V3) chunked‑prefill context processing invokes `mask_empty_context`;
- when a request contains an empty context chunk, the shape mismatch triggers a `RuntimeError` inside `output.masked_fill_`, ultimately leading to severe accuracy degradation.

### Fix

Correct the layout at the Flash Attention output source, so that the native output naturally conforms to downstream expectations, avoiding the need for subsequent transposition or manual fixes.

### Concrete changes

- `csrc/flash_attn/flash_api.cpp`: allocate `softmax_lse` as `(num_heads_q, total_seqlen_q)` instead of `(total_seqlen_q, num_heads_q)`.

- `csrc/xpu/attn/xe_2/fmha_xe2.cpp`, `csrc/xpu/attn/xe_2/chunk_prefill.hpp`: `lse_stride` now takes the stride along the query row dimension (`= total_seqlen_q`) rather than along the head dimension.

- `csrc/xpu/attn/xe_2/kernel/chunk_prefill_kernel.hpp`: the SYCL epilogue writes directly to `lse[head_q][global_q]` instead of `lse[global_q][head_q]`.

- `vllm_xpu_kernels/flash_attn_interface.py` (Python fallback): natively compute and concatenate `lse` in `(heads, query_len)` directly, rather than computing in that layout and then transposing.

- `tests/flash_attn/test_flash_attn_varlen_func.py`: update the shape assertions in the reference implementation `ref_softmax_lse` and in `test_varlen_with_softmax_lse` to the new `(num_heads_q, total_seqlen_q)` convention.