### PR TITLE
attn: enable kv_tile=128 with ReduceK=4-safe layout

### DIFF
--- a/benchmark/src/flash_attn_interface_.py
+++ b/benchmark/src/flash_attn_interface_.py
@@ -27,11 +27,13 @@ def _as_int32_device_tensor(x, device: torch.device) -> torch.Tensor:
 
 
 def _kv_tile_from_block_size(block_size: int) -> int:
-    # Mirror of flash_api.cpp get_num_splits() / TileShapeQK<1>.
+    # Mirror of paged_decode_utils.hpp::dispatch_by_page_size.
     if block_size == 16:
         return 16
     if block_size == 32:
         return 32
+    if block_size > 0 and block_size % 128 == 0:
+        return 128
     return 64
 
 

--- a/csrc/flash_attn/flash_api.cpp
+++ b/csrc/flash_attn/flash_api.cpp
@@ -24,10 +24,10 @@ inline int get_num_splits(
   // The decode kernel iterates kv_tile-sized work units within each page,
   // not page-sized units. The dispatch (see paged_decode_utils.hpp::
   // dispatch_by_page_size) routes
-  //   block_size == 16              -> kv_tile=_16 (SubgroupLayoutQK<_1,_1,_1>,
-  //   SGPerWG=1) block_size == 32              -> kv_tile=_32
-  //   (SubgroupLayoutQK<_1,_2,_1>, SGPerWG=2) block_size > 0 && %% 64 == 0  ->
-  //   kv_tile=_64  (SubgroupLayoutQK<_1,_4,_1>, SGPerWG=4)
+  //   block_size == 16              -> kv_tile=_16 (SGPerWG=1)
+  //   block_size == 32              -> kv_tile=_32 (SGPerWG=2)
+  //   block_size % 128 == 0         -> kv_tile=_128 (SGPerWG=4, ReduceK=4)
+  //   other block_size % 64 == 0    -> kv_tile=_64 (SGPerWG=4)
   int kv_tile;
   int sg_per_wg;
   int policy_split_cap;
@@ -39,6 +39,10 @@ inline int get_num_splits(
     kv_tile = 32;
     sg_per_wg = 2;
     policy_split_cap = 32;
+  } else if (block_size > 0 && (block_size % 128) == 0) {
+    kv_tile = 128;
+    sg_per_wg = 4;
+    policy_split_cap = 64;
   } else {
     kv_tile = 64;
     sg_per_wg = 4;

--- a/csrc/xpu/attn/xe_2/fmha_utils.hpp
+++ b/csrc/xpu/attn/xe_2/fmha_utils.hpp
@@ -179,17 +179,16 @@ struct decode_policy_qpacked_head<q_packed, head_dim, _64> {
 };
 
 // kv_tile == _128
-// NOTE: Currently UNUSED. The dispatcher in paged_decode_utils.hpp routes
-// page_size that is a multiple of 128 through the kv_tile=_64 policy because
-// this _128 policy uses SubgroupLayoutQK<_1,_8,_1> (ReduceK=8), which
-// triggers a wrong-result bug in the cross-SG SLM reduction
-// (chunk_prefill_epilogue.hpp::reduce_A) when SGTileShapeO collapses to
-// (1, 32). See dispatch_by_page_size for details. Kept here so it can be
-// re-enabled once the upstream ReduceK=8 reduction path is fixed.
+// Prefer SubgroupLayoutQK<_1,_4,_1> (ReduceK=4) over <_1,_8,_1>.
+// ReduceK=8 collapses SGTileShapeO to (1,32) and hits a wrong-result bug in
+// chunk_prefill_epilogue.hpp::reduce_A (gpt-oss-20b accuracy cliff).
+// ReduceK=4 keeps the well-tested (2,32) epilogue path while still covering
+// a 128-wide K tile (4 SGs × 32), cutting page_size/128 mainloop trips vs
+// iterating two _64 sub-tiles.
 template <typename q_packed, typename head_dim>
 struct decode_policy_qpacked_head<q_packed, head_dim, _128> {
   using ShapeQK = Shape<q_packed, _128, _64>;
   using ShapePV = Shape<q_packed, _32, _128>;
   using ShapeOut = Shape<q_packed, head_dim>;
-  using SubgroupLayoutQK = Layout<Shape<_1, _8, _1>>;
+  using SubgroupLayoutQK = Layout<Shape<_1, _4, _1>>;
 };

--- a/csrc/xpu/attn/xe_2/paged_decode_utils.hpp
+++ b/csrc/xpu/attn/xe_2/paged_decode_utils.hpp
@@ -175,22 +175,15 @@ inline void dispatch_by_page_size(
   // the page-table indirection, so any page_size that is a positive multiple
   // of the policy's kv_tile is supported.
   //
-  // NOTE: We intentionally route page_size that is a multiple of 128 through
-  // the kv_tile=_64 policy (instead of _128) because the _128 decode policy
-  // uses SubgroupLayoutQK<_1,_8,_1> (8-SG K split, ReduceK=8) which exercises
-  // a buggy cross-SG SLM reduction path in
-  // chunk_prefill_epilogue.hpp::reduce_A. The bug only manifests in real
-  // autoregressive serving (gpt-oss-20b gsm8k strict-match drops ~12pp) and
-  // stems from the degenerate SGTileShapeO=(1,32) produced when ReduceK=8. The
-  // _64 policy uses ReduceK=4 with the well-tested SGTileShapeO=(2,32) layout.
-  // The mainloop iterates page_size/64 sub-tiles per page (2 for page=128, 4
-  // for page=256, ...), so correctness is preserved at a small parallelism
-  // cost. Restore the _128 routing once the underlying ReduceK=8 bug is fixed
-  // upstream.
+  // page_size multiples of 128 use kv_tile=_128 with ReduceK=4 layout
+  // (see decode_policy_qpacked_head<..., _128>). Other multiples of 64 use
+  // kv_tile=_64. Both keep the tested ReduceK=4 epilogue path.
   if (page_size == 16) {
     dispatch_by_head_size<QGroup, _16>(head_case, queue, cuQKType, args);
   } else if (page_size == 32) {
     dispatch_by_head_size<QGroup, _32>(head_case, queue, cuQKType, args);
+  } else if (page_size > 0 && (page_size % 128) == 0) {
+    dispatch_by_head_size<QGroup, _128>(head_case, queue, cuQKType, args);
   } else if (page_size > 0 && (page_size % 64) == 0) {
     dispatch_by_head_size<QGroup, _64>(head_case, queue, cuQKType, args);
   } else {

--- a/tests/flash_attn/test_flash_attn_varlen_func.py
+++ b/tests/flash_attn/test_flash_attn_varlen_func.py
@@ -522,12 +522,10 @@ def test_decode_with_paged_kv(
     # if q_dtype is not None and (dtype != torch.bfloat16 or fa_version == 2):
     #     pytest.skip("Flash attention with quantized inputs is only "
     #                 "supported on version 3 with bfloat16 base type")
-    # NOTE: head_size=512 + block_size>=128 was previously skipped because the
-    # kv_tile=_128 decode policy + head_size=512 ShapePV exceeded SLM. The
-    # _128 policy is no longer dispatched; all multiples of 64 use the
-    # kv_tile=_64 policy (see paged_decode_utils.hpp::dispatch_by_page_size),
-    # so SLM usage is independent of block_size for block_size>=64. The
-    # head_size=512 case has been verified to pass for all BLOCK_SIZES.
+    # NOTE: page_size multiples of 128 dispatch through kv_tile=_128 with
+    # ReduceK=4 (SubgroupLayoutQK<_1,_4,_1>) to avoid the ReduceK=8 epilogue
+    # bug. Other multiples of 64 still use kv_tile=_64. head_size=512 has
+    # been verified for the ReduceK=4 path; watch SLM if SGPerWG grows.
     if num_heads == (16, 1) and head_size == 256:
         pytest.skip("skip test cases that may run out of SLM.")
     if block_size == 128 and num_blocks == 32768 and head_size >= 192:

--- a/vllm_xpu_kernels/flash_attn_interface.py
+++ b/vllm_xpu_kernels/flash_attn_interface.py
@@ -160,11 +160,13 @@ def _normalize_descale_tensor(
 
 
 def _kv_tile_from_block_size(block_size: int) -> int:
-    # Mirror of flash_api.cpp get_num_splits() / TileShapeQK<1>.
+    # Mirror of paged_decode_utils.hpp::dispatch_by_page_size.
     if block_size == 16:
         return 16
     if block_size == 32:
         return 32
+    if block_size > 0 and block_size % 128 == 0:
+        return 128
     return 64
 
 


### PR DESCRIPTION
## Purpose

Route page_size multiples of 128 through `kv_tile=_128` with a ReduceK=4-safe decode layout (instead of walking page-128 via the `_64` tile path).

- C++: page % 128 == 0 → `_128`; other multiples of 64 stay `_64`.
- Python `_kv_tile_from_block_size` mirrors routing for host split planning.
- **Opt-in:** page_size=128 AOT **and** serve `--block-size 128`. Default page-64 unchanged in practice.

## Test Plan

- [x] Focused page128 accuracy on Arc Pro B70
- [x] Micro A/B vs matching `main` `base_p128` build
- [x] Optional decode-bound E2E with `--block-size 128`

## Test Result

**Hardware:** Intel Arc Pro B70 · **Commit:** `7f0355e`

### Accuracy
Focused page128: **4/4**.

### Micro vs `base_p128` (block_size=128)
| Case | Base ms | Cand ms | Δ |
|------|---------|---------|---|
| `mix_decode_heavy` | 0.3236 | 0.2720 | **+15.95%** |
| `mix_long_kv` | 0.3439 | 0.3099 | +9.89% |
| `decode_uniform` | 0.1168 | 0.1155 | +1.11% |

**Micro KEEP:** yes (`mix_decode_heavy` ≥10%).

### Serve E2E (supporting, decode-bound prefix_rep, `--block-size 128`)
PR5 attn+FA2 p128 vs base_p128 (Qwen2.5-7B, out=512, conc=8, failed=0):
| | Base | Cand | Δ |
|--|------|------|---|
| tok/s | 272.60 | 266.26 | **−2.33%** |
| TPOT ms | 28.75 | 29.49 | −2.57% |

**Claim:** micro KEEP for page128 mix-decode; **not** claiming E2E tok/s uplift on this recipe. Default page64 unchanged.

## (Optional) Documentation Update

None for default presets.
