### PR TITLE
attn: fail closed by default on missing FA2 kernel shapes

### DIFF
--- a/KERNEL_CONFIGURATION.md
+++ b/KERNEL_CONFIGURATION.md
@@ -25,6 +25,17 @@ model requires a kernel combination that was not included in the build.
 
 ### If you see a kernel missing error:
 
+Missing shapes **fail closed by default**: `flash_attn_varlen_func` raises
+instead of silently falling back to a slow PyTorch reference path (which can
+destroy tok/s and break XPUGraph capture). For eager debugging only:
+
+```bash
+export VLLM_XPU_ATTN_ALLOW_FALLBACK=1
+```
+
+Under XPUGraph capture, fallback is always refused (even with
+`ALLOW_FALLBACK=1`). Rebuild with the config line from the error message.
+
 ```
 ❌ Chunk prefill kernel tuple not compiled for this configuration.
 ```
@@ -92,7 +103,7 @@ Config files are located in `csrc/xpu/attn/kernel_configs/`.
 | File | Kernels | Use Case |
 |------|---------|----------|
 | `paged_decode_full.conf` | 384 | All combinations — supports every model |
-| `paged_decode_default.conf` | ~17 | Llama, Qwen, DeepSeek MLA, Falcon (default build) |
+| `paged_decode_default.conf` | ~28 | Llama, Qwen, DeepSeek MLA, Falcon + pagesize=128 |
 
 ### Recommended Config per Model Family
 
@@ -321,6 +332,25 @@ cmake -DVLLM_CHUNK_PREFILL_CONFIG=/path/to/custom_prefill.conf \
 
 ## Troubleshooting
 
+### Error: "Fail-closed attention (default): refusing PyTorch attention fallback"
+
+**Cause:** The requested FA2 shape is not in your AOT config. Silent Python
+fallback is disabled by default.
+
+```bash
+# Fix: rebuild with the config line printed in the Original error, or use full:
+VLLM_PAGED_DECODE_CONFIG=paged_decode_full.conf \
+VLLM_CHUNK_PREFILL_CONFIG=chunk_prefill_full.conf \
+  pip install --no-build-isolation -e .
+
+# Debug-only (eager): allow the slow PyTorch path
+export VLLM_XPU_ATTN_ALLOW_FALLBACK=1
+```
+
+`paged_decode_default.conf` includes pagesize=16/32/64/**128** for common
+Llama/Qwen/DeepSeek/Falcon heads. Prefer extending that preset over enabling
+fallback for serve.
+
 ### Error: "Chunk prefill kernel not compiled for this configuration"
 
 **Cause:** The `head_size` for your model is not in the config.
@@ -386,7 +416,7 @@ cat build/temp_template/csrc/xpu/attn/xe_2/paged_decode_enabled_policies_gen.hpp
 
 | Config | Build Time | Chunk Prefill Kernels | Paged Decode Kernels | Flexibility |
 |--------|------------|----------------------|----------------------|-------------|
-| `default` | ~2 min | ~13 | ~17 | Llama, Qwen, DeepSeek MLA, Falcon |
+| `default` | ~2–5 min | ~13 | ~28 | Llama, Qwen, DeepSeek MLA, Falcon (+ page128) |
 | `full` | ~60 min | 216 | 384 | All models |
 
 ### Binary Size Impact

--- a/csrc/flash_attn/flash_api.cpp
+++ b/csrc/flash_attn/flash_api.cpp
@@ -364,6 +364,13 @@ std::vector<at::Tensor> mha_varlen_fwd(
     }
 
     // Output shape uses V's head_dim (may differ from Q/K for MLA)
+    //
+    // XPUGraph / piecewise capture invariant: q/k/v/out shapes and the
+    // effective num_kv_splits must be fixed for the captured graph. Prefer
+    // a caller-provided `out_` and an explicit `num_splits` so workspace
+    // tensors (tmp_out / max_logits / exp_sums) have stable sizes. The
+    // Python wrapper refuses capture when `out` is None
+    // (VLLM_XPU_ATTN_CAPTURE_STRICT semantics).
     if (!out_.has_value()) {
       out = torch::empty(
           {num_tokens, num_heads_q, v_head_dim},

--- a/csrc/xpu/attn/kernel_configs/paged_decode_default.conf
+++ b/csrc/xpu/attn/kernel_configs/paged_decode_default.conf
@@ -19,7 +19,8 @@
 # Falcon-7B's 71) use the qgroup=16 bucket and are split into ceil(ratio/16)
 # work-groups.
 #
-# This config contains: 21 explicit entries (vs 384 full combinations)
+# This config contains: 28 explicit entries (vs 384 full combinations)
+# Includes pagesize=128 for block_size=128 serve (Qwen/Llama on B70).
 # To enable sliding-window (Qwen2.5 / Llama-3.1 long context):
 #   uncomment the local=true lines below.
 # To cover Gemma-2 (head_size=256), add: 8,256,16,true,false,false etc.
@@ -29,6 +30,9 @@
 8,128,32,true,false,false
 8,128,64,true,false,false
 8,128,64,false,false,false
+# page_size=128 (block_size multiples of 128; kv_tile=_64 on main routing)
+8,128,128,true,false,false
+8,128,128,false,false,false
 
 # Sliding window (Qwen2.5, Llama-3.1 long context) — uncomment if needed:
 # 8,128,16,true,true,false
@@ -39,9 +43,11 @@
 8,192,16,true,false,false
 8,192,32,true,false,false
 8,192,64,true,false,false
+8,192,128,true,false,false
 
 8,64,16,false,false,false
 8,64,64,false,false,false
+8,64,128,false,false,false
 
 # --- Falcon-7B (MQA: 71 q heads / 1 kv head → qgroup=16, head_size=64) -------
 16,64,16,true,false,false
@@ -50,6 +56,8 @@
 16,64,32,false,false,false
 16,64,64,true,false,false
 16,64,64,false,false,false
+16,64,128,true,false,false
+16,64,128,false,false,false
 
 # openai/gpt-oss-20b
 8,64,64,false,true,true
@@ -59,6 +67,7 @@
 # zai-org/GLM-4-9B-chat, zai-org/glm-4-9b-hf
 # ByteDance-Seed/Seed-OSS-36B-Instruct
 16,128,64,false,false,false
+16,128,128,false,false,false
 
 # --- Sliding-window/local model coverage ------------------------------------
 # google/gemma-3-12b-it, google/gemma-4-26B-A4B-it

--- a/tests/flash_attn/test_xpu_graph_capture_safe.py
+++ b/tests/flash_attn/test_xpu_graph_capture_safe.py
@@ -1,0 +1,317 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Fail-closed-by-default + capture auto-on for FA2 / flash_attn_varlen_func."""
+from __future__ import annotations
+
+import logging
+
+import pytest
+import torch
+
+import vllm_xpu_kernels.flash_attn_interface as fai
+from vllm_xpu_kernels.flash_attn_interface import (
+    build_decode_split_plan,
+    flash_attn_varlen_func,
+)
+
+_ALLOW_ENV = "VLLM_XPU_ATTN_ALLOW_FALLBACK"
+
+
+def _truthy_env(monkeypatch, name: str, value: str) -> None:
+    monkeypatch.setenv(name, value)
+
+
+def _clear_allow_env(monkeypatch) -> None:
+    monkeypatch.delenv(_ALLOW_ENV, raising=False)
+
+
+@pytest.mark.parametrize("val,expect", [
+    ("1", True),
+    ("ON", True),
+    ("true", True),
+    ("Yes", True),
+    ("0", False),
+    ("", False),
+])
+def test_env_allow_fallback(monkeypatch, val, expect):
+    if val == "":
+        _clear_allow_env(monkeypatch)
+    else:
+        _truthy_env(monkeypatch, _ALLOW_ENV, val)
+    assert fai._env_allow_fallback() is expect
+
+
+def test_should_fail_closed_by_default(monkeypatch):
+    _clear_allow_env(monkeypatch)
+    monkeypatch.setattr(fai, "_is_xpu_capturing", lambda: False)
+    assert fai._should_fail_closed() is True
+
+
+def test_should_fail_closed_when_capturing_even_if_allow(monkeypatch):
+    _truthy_env(monkeypatch, _ALLOW_ENV, "1")
+    monkeypatch.setattr(fai, "_is_xpu_capturing", lambda: True)
+    assert fai._should_fail_closed() is True
+
+
+def test_should_not_fail_closed_when_allow_and_eager(monkeypatch):
+    _truthy_env(monkeypatch, _ALLOW_ENV, "1")
+    monkeypatch.setattr(fai, "_is_xpu_capturing", lambda: False)
+    assert fai._should_fail_closed() is False
+
+
+def test_build_decode_split_plan_accepts_cpu_and_list():
+    splits, work = build_decode_split_plan(
+        [128, 256],
+        kv_tile=64,
+        num_kv_splits=8,
+        num_xe_cores=20,
+        num_heads_kv=2,
+    )
+    assert splits.dtype == torch.int32
+    assert work.ndim == 2 and work.size(1) == 4
+    splits2, _ = build_decode_split_plan(
+        torch.tensor([128, 256], dtype=torch.int32, device="cpu"),
+        kv_tile=64,
+        num_kv_splits=8,
+        num_xe_cores=20,
+        num_heads_kv=2,
+    )
+    assert torch.equal(splits, splits2)
+
+
+def test_build_decode_split_plan_rejects_device_tensor():
+    if not torch.xpu.is_available():
+        # Still validate the check using a meta/cpu-fake path: construct
+        # a non-CPU tensor if CUDA/XPU unavailable by skipping.
+        pytest.skip("Need a non-CPU device to exercise the D2H guard")
+    kv = torch.tensor([128, 256], dtype=torch.int32, device="xpu")
+    with pytest.raises(RuntimeError, match="host-side kv_lens"):
+        build_decode_split_plan(
+            kv,
+            kv_tile=64,
+            num_kv_splits=8,
+            num_xe_cores=20,
+            num_heads_kv=2,
+        )
+
+
+def _minimal_varlen_args(device: torch.device, *, with_out: bool = False):
+    headdim = 64
+    nq, nkv = 8, 2
+    block = 64
+    batch = 1
+    kv_len = 128
+    q = torch.randn(batch, nq, headdim, dtype=torch.float16, device=device)
+    k = torch.randn(2, block, nkv, headdim, dtype=torch.float16, device=device)
+    v = torch.randn_like(k)
+    cu_q = torch.tensor([0, 1], dtype=torch.int32, device=device)
+    seqused = torch.tensor([kv_len], dtype=torch.int32, device=device)
+    block_table = torch.zeros(batch, 2, dtype=torch.int32, device=device)
+    block_table[0, 0] = 0
+    block_table[0, 1] = 1
+    args = dict(
+        q=q,
+        k=k,
+        v=v,
+        max_seqlen_q=1,
+        cu_seqlens_q=cu_q,
+        max_seqlen_k=kv_len,
+        seqused_k=seqused,
+        block_table=block_table,
+        softmax_scale=headdim**-0.5,
+        causal=True,
+    )
+    if with_out:
+        args["out"] = torch.empty_like(q)
+    return args
+
+
+def _require_fa2_xpu():
+    if not fai.FA2_AVAILABLE:
+        pytest.skip("FA2 extension not available")
+    if not torch.xpu.is_available():
+        pytest.skip("XPU required for FA2 dispatch path")
+
+
+def test_default_raises_on_not_compiled(monkeypatch):
+    _require_fa2_xpu()
+    _clear_allow_env(monkeypatch)
+    monkeypatch.setattr(fai, "_is_xpu_capturing", lambda: False)
+
+    def boom(*_a, **_k):
+        raise RuntimeError("Paged decode kernel not compiled for this config")
+
+    monkeypatch.setattr(torch.ops._vllm_fa2_C, "varlen_fwd", boom)
+    args = _minimal_varlen_args(torch.device("xpu"))
+    with pytest.raises(RuntimeError, match="Fail-closed|refusing"):
+        flash_attn_varlen_func(**args)
+
+
+def test_capturing_raises_even_with_allow_fallback(monkeypatch):
+    _require_fa2_xpu()
+    _truthy_env(monkeypatch, _ALLOW_ENV, "1")
+    monkeypatch.setattr(fai, "_is_xpu_capturing", lambda: True)
+
+    def boom(*_a, **_k):
+        raise RuntimeError("Paged decode kernel not compiled for this config")
+
+    monkeypatch.setattr(torch.ops._vllm_fa2_C, "varlen_fwd", boom)
+    # Capture requires a preallocated out before the op is invoked.
+    args = _minimal_varlen_args(torch.device("xpu"), with_out=True)
+    with pytest.raises(RuntimeError, match="Fail-closed|refusing|capture"):
+        flash_attn_varlen_func(**args)
+
+
+def test_capturing_requires_preallocated_out(monkeypatch):
+    _require_fa2_xpu()
+    monkeypatch.setattr(fai, "_is_xpu_capturing", lambda: True)
+    args = _minimal_varlen_args(torch.device("xpu"), with_out=False)
+    with pytest.raises(RuntimeError, match="preallocated `out`"):
+        flash_attn_varlen_func(**args)
+
+
+def test_device_host_kv_lens_split_plan_raises(monkeypatch):
+    _require_fa2_xpu()
+    monkeypatch.setattr(fai, "_is_xpu_capturing", lambda: True)
+
+    def boom(*_a, **_k):
+        raise RuntimeError("should not reach varlen_fwd")
+
+    monkeypatch.setattr(torch.ops._vllm_fa2_C, "varlen_fwd", boom)
+    device = torch.device("xpu")
+    args = _minimal_varlen_args(device, with_out=True)
+    args.pop("seqused_k")
+    args["host_kv_lens"] = torch.tensor([128], dtype=torch.int32, device=device)
+    args["num_splits_kv"] = 4
+    with pytest.raises(RuntimeError, match="host-side kv_lens"):
+        flash_attn_varlen_func(**args)
+
+
+def test_spec_decode_skipped_when_capturing(monkeypatch):
+    _require_fa2_xpu()
+    monkeypatch.setattr(fai, "_is_xpu_capturing", lambda: True)
+    called = {"spec": False, "fwd": False}
+
+    def fake_spec(*_a, **_k):
+        called["spec"] = True
+        return torch.empty(0)
+
+    def fake_fwd(*_a, **_k):
+        called["fwd"] = True
+        q = _a[0]
+        return (torch.empty_like(q), None)
+
+    monkeypatch.setattr(fai, "_spec_decode_varlen_fwd", fake_spec)
+    monkeypatch.setattr(torch.ops._vllm_fa2_C, "varlen_fwd", fake_fwd)
+
+    device = torch.device("xpu")
+    headdim = 64
+    batch, q_len, nq, nkv = 2, 4, 8, 2
+    block = 64
+    q = torch.randn(
+        batch * q_len, nq, headdim, dtype=torch.float16, device=device)
+    k = torch.randn(
+        8, block, nkv, headdim, dtype=torch.float16, device=device)
+    v = torch.randn_like(k)
+    cu_q = torch.tensor([0, 4, 8], dtype=torch.int32, device=device)
+    seqused = torch.tensor([128, 128], dtype=torch.int32, device=device)
+    block_table = torch.zeros(batch, 4, dtype=torch.int32, device=device)
+    out = torch.empty_like(q)
+    flash_attn_varlen_func(
+        q,
+        k,
+        v,
+        max_seqlen_q=q_len,
+        cu_seqlens_q=cu_q,
+        max_seqlen_k=128,
+        seqused_k=seqused,
+        block_table=block_table,
+        softmax_scale=headdim**-0.5,
+        causal=True,
+        out=out,
+    )
+    assert called["spec"] is False
+    assert called["fwd"] is True
+
+
+def test_fallback_allowed_when_opt_in_eager(monkeypatch, caplog):
+    _require_fa2_xpu()
+    _truthy_env(monkeypatch, _ALLOW_ENV, "1")
+    monkeypatch.setattr(fai, "_is_xpu_capturing", lambda: False)
+
+    def boom(*_a, **_k):
+        raise RuntimeError("Paged decode kernel not compiled for this config")
+
+    monkeypatch.setattr(torch.ops._vllm_fa2_C, "varlen_fwd", boom)
+    args = _minimal_varlen_args(torch.device("xpu"))
+    with caplog.at_level(logging.WARNING, logger=fai.__name__):
+        out = flash_attn_varlen_func(**args)
+    assert out is not None
+    assert any("falling back" in r.message for r in caplog.records)
+
+
+@pytest.mark.skipif(
+    not hasattr(torch.xpu, "XPUGraph") or not torch.xpu.is_available(),
+    reason="torch.xpu.XPUGraph not available")
+@pytest.mark.xfail(
+    reason="FA2 uses work_group_scratch_memory; SYCL Graph / XPUGraph "
+    "support is incomplete on current stacks (see HAL capture notes).",
+    strict=False,
+)
+def test_xpugraph_capture_replay_smoke():
+    """Capture→replay on a compiled paged-decode shape when FA2 is present."""
+    if not fai.FA2_AVAILABLE:
+        pytest.skip("FA2 extension not available")
+
+    device = torch.device("xpu")
+    headdim = 128
+    nq, nkv = 8, 1
+    block = 64
+    batch = 1
+    kv_len = 128
+    q = torch.randn(batch, nq, headdim, dtype=torch.float16, device=device)
+    k = torch.randn(
+        2, block, nkv, headdim, dtype=torch.float16, device=device)
+    v = torch.randn_like(k)
+    cu_q = torch.tensor([0, 1], dtype=torch.int32, device=device)
+    seqused = torch.tensor([kv_len], dtype=torch.int32, device=device)
+    block_table = torch.zeros(batch, 2, dtype=torch.int32, device=device)
+    block_table[0, 0] = 0
+    block_table[0, 1] = 1
+    out = torch.empty_like(q)
+    scale = headdim**-0.5
+
+    def run():
+        return flash_attn_varlen_func(
+            q,
+            k,
+            v,
+            max_seqlen_q=1,
+            cu_seqlens_q=cu_q,
+            max_seqlen_k=kv_len,
+            seqused_k=seqused,
+            block_table=block_table,
+            softmax_scale=scale,
+            causal=True,
+            out=out,
+        )
+
+    # Warmup eager path; skip if this shape is not compiled (fail-closed).
+    try:
+        for _ in range(3):
+            run()
+            torch.xpu.synchronize()
+    except RuntimeError as e:
+        if "not compiled" in str(e) or "Fail-closed" in str(e):
+            pytest.skip(f"shape not compiled in this build: {e}")
+        raise
+
+    g = torch.xpu.XPUGraph()
+    capture_ctx = getattr(torch.xpu, "graph", None)
+    if capture_ctx is None:
+        pytest.skip("torch.xpu.graph context manager not available")
+    with capture_ctx(g):
+        run()
+    for _ in range(5):
+        g.replay()
+        torch.xpu.synchronize()
+    assert torch.isfinite(out).all()

--- a/vllm_xpu_kernels/flash_attn_interface.py
+++ b/vllm_xpu_kernels/flash_attn_interface.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+import logging
 import os
 from typing import Optional
 
@@ -16,6 +17,43 @@ except ImportError as e:
 #isort: on
 
 DEFAULT_FA_VERSION = 2
+
+_logger = logging.getLogger(__name__)
+
+# Opt-in escape hatch for the slow PyTorch reference path when an XPU
+# kernel shape is not compiled. Production / serve defaults to fail-closed
+# (raise) so a missing AOT config cannot silently destroy tok/s.
+_ALLOW_FALLBACK_ENV = "VLLM_XPU_ATTN_ALLOW_FALLBACK"
+
+
+def _env_allow_fallback() -> bool:
+    """True when VLLM_XPU_ATTN_ALLOW_FALLBACK opts into PyTorch ref attn."""
+    return os.environ.get(_ALLOW_FALLBACK_ENV,
+                          "0").strip().upper() in ("1", "ON", "TRUE", "YES",
+                                                   "Y")
+
+
+def _is_xpu_capturing() -> bool:
+    """True when the current XPU stream is inside an XPUGraph capture."""
+    is_capturing = getattr(torch.xpu, "is_current_stream_capturing", None)
+    if is_capturing is None:
+        return False
+    try:
+        return bool(is_capturing())
+    except Exception:
+        return False
+
+
+def _should_fail_closed() -> bool:
+    """Refuse PyTorch fallback unless explicitly allowed and not capturing.
+
+    Under XPUGraph capture, always fail closed — host reference attention
+    breaks capture/replay even if ALLOW_FALLBACK is set.
+    """
+    if _is_xpu_capturing():
+        return True
+    return not _env_allow_fallback()
+
 
 # Speculative-decoding fast path.
 #
@@ -203,7 +241,9 @@ def build_decode_split_plan(
 
     Inputs
     ------
-    kv_lens         : per-seq KV length in tokens (list/tensor, on host).
+    kv_lens         : per-seq KV length in tokens (list or **CPU** tensor).
+                      Device tensors are rejected — D2H sync is unsafe under
+                      XPUGraph capture and is never performed here.
     kv_tile         : KV tile width in tokens (must equal the kernel's
                       get<1>(TileShapeQK{})).
     num_kv_splits   : global cap on per-seq split count (buffer dim).
@@ -227,7 +267,14 @@ def build_decode_split_plan(
       assignment, hard cap}; the kernel never needs to second-guess it.
     """
     if isinstance(kv_lens, torch.Tensor):
-        kv_lens_list = kv_lens.to(dtype=torch.int32, device="cpu").tolist()
+        if kv_lens.device.type != "cpu":
+            raise RuntimeError(
+                "build_decode_split_plan requires host-side kv_lens "
+                f"(CPU tensor or list); got tensor on {kv_lens.device}. "
+                "Pass host_kv_lens on CPU (or a Python list). Device→host "
+                "sync is not performed and is forbidden under XPUGraph "
+                "capture.")
+        kv_lens_list = kv_lens.to(dtype=torch.int32).tolist()
     else:
         kv_lens_list = [int(v) for v in kv_lens]
 
@@ -349,7 +396,7 @@ def ref_paged_attn(query: torch.Tensor,
             k = (k.to(torch.float32) * k_descale).to(dtype)
             v = (v.to(torch.float32) * v_descale).to(dtype)
         attn = torch.einsum("qhd,khd->hqk", q, k).float()
-        empty_mask = torch.ones(query_len, kv_len)
+        empty_mask = torch.ones(query_len, kv_len, device=attn.device)
         mask = torch.triu(empty_mask, diagonal=kv_len - query_len + 1).bool()
         if window_size_right > 0 or window_size_left > 0:
             if window_size_right < 0:
@@ -440,9 +487,10 @@ def flash_attn_varlen_func(
         cu_seqlens_k: Cumulative sequence lengths for keys/values when not
             using paged KV cache.
         seqused_k: Number of tokens used per sequence when using paged KV.
-        host_kv_lens: Optional host-side per-seq KV lengths. If provided,
-            this function converts them to an int32 device tensor and uses
-            it as seqused_k.
+        host_kv_lens: Optional **host-side** (CPU tensor or list) per-seq KV
+            lengths. If provided, this function uploads them as seqused_k and
+            may build a decode split plan. Device tensors are rejected by the
+            split planner (no D2H under XPUGraph capture).
         block_table: Optional block table for paged KV cache.
         num_splits: Backend-specific split parameter (non-KV specific),
             typically used to control work partitioning in some FA versions.
@@ -466,6 +514,13 @@ def flash_attn_varlen_func(
         "when enable block_table, seqused_k is needed"
     assert block_table is not None or cu_seqlens_k is not None, \
         "when block_table is disabled, cu_seqlens_k is needed"
+
+    capturing = _is_xpu_capturing()
+    if capturing and out is None:
+        raise RuntimeError(
+            "flash_attn_varlen_func: under XPUGraph capture, pass a "
+            "preallocated `out` tensor so the primary output is not "
+            "allocated inside the captured region.")
 
     if softmax_scale is None:
         softmax_scale = q.shape[-1]**(-0.5)
@@ -505,9 +560,12 @@ def flash_attn_varlen_func(
         # paged query batches (q_len = num_speculative_tokens + 1) from the
         # slow chunk-prefill kernel to the split-K decode kernel. See the
         # comment on _SPEC_DECODE_MAX_QLEN above for the rationale.
+        # Skip under XPUGraph capture: the path allocates fresh metadata
+        # (arange / zeros / repeat_interleave) every call.
         batch = cu_seqlens_q.numel() - 1
         is_uniform_qlen = (batch > 0 and q.shape[0] == batch * max_seqlen_q)
-        if (block_table is not None and causal and not return_softmax_lse
+        if (not capturing and block_table is not None and causal
+                and not return_softmax_lse
                 and softcap == 0.0 and alibi_slopes is None and q_v is None
                 and q_descale is None and scheduler_metadata is None
                 and seqused_k is not None
@@ -533,6 +591,8 @@ def flash_attn_varlen_func(
         # Compute per-seq splits and work_list on host, upload to device.
         # Only enable for decode (max_seqlen_q == 1) with paged KV cache,
         # multi-seq batches, and global num_splits_kv > 1.
+        # host_kv_lens must already be CPU/list (build_decode_split_plan
+        # refuses device tensors — required for XPUGraph capture safety).
         splits_per_seq_dev = None
         work_list_dev = None
         if (block_table is not None and host_kv_lens is not None
@@ -591,17 +651,24 @@ def flash_attn_varlen_func(
         except RuntimeError as e:
             if "not compiled" not in str(e):
                 raise
-            # Fallback to PyTorch reference implementation.
-            import logging
-            logger = logging.getLogger(__name__)
-            logger.warning(
+            # Missing AOT shape: fail closed by default. Opt into the slow
+            # PyTorch path with VLLM_XPU_ATTN_ALLOW_FALLBACK=1 (eager only;
+            # XPUGraph capture always refuses).
+            msg = (
                 "XPU kernel not compiled for this config, falling back "
                 "to PyTorch reference attention. Performance will be "
                 "significantly degraded.\n"
                 "To fix: rebuild with the config line shown above.\n"
                 "If this is unexpected, report at: "
                 "https://github.com/vllm-project/vllm-xpu-kernels/issues/364\n"
-                "Original error: %s", e)
+                "Original error: %s")
+            if _should_fail_closed():
+                raise RuntimeError(
+                    "Fail-closed attention (default): refusing PyTorch "
+                    "attention fallback. Set VLLM_XPU_ATTN_ALLOW_FALLBACK=1 "
+                    "to opt in for eager debug only (ignored under "
+                    "XPUGraph capture). " + (msg % e)) from e
+            _logger.warning(msg, e)
             out, softmax_lse = _fallback_varlen_attn(
                 q, k, v, cu_seqlens_q, cu_seqlens_k, seqused_k,
                 block_table, softmax_scale, causal,


### PR DESCRIPTION
## Purpose

**Breaking change (behavior):** missing FA2 / paged-decode AOT shapes used to **silently fall back** to a slow PyTorch reference path. That path can destroy tok/s and breaks XPUGraph capture/replay. This PR makes the wrapper **fail closed by default**.

Why: a missing config line should be a loud build/config error, not a silent multi‑× regression in serve.

### Behavior

- **Default:** raise with a clear rebuild / config hint (`Fail-closed attention…`)
- **Opt-in eager debug:** `VLLM_XPU_ATTN_ALLOW_FALLBACK=1` restores the PyTorch ref path
- **XPUGraph capture:** always refuse fallback (even with `ALLOW_FALLBACK=1`); require a preallocated `out`; reject device `kv_lens` in `build_decode_split_plan` (no D2H under capture); skip the speculative-decode metadata path that allocates every call
- **Config:** extend `paged_decode_default.conf` with **pagesize=128** for common Llama/Qwen/DeepSeek/Falcon heads (~17 → ~28 explicit entries; small default-build time bump)
- **Docs:** `KERNEL_CONFIGURATION.md` documents fail-closed + escape hatch + page128 coverage

### Migration for users who relied on silent fallback

1. Prefer fixing the build: rebuild with the config line printed in the error, or use `paged_decode_full.conf` / `chunk_prefill_full.conf`.
2. Eager debug only: `export VLLM_XPU_ATTN_ALLOW_FALLBACK=1` (ignored under XPUGraph capture).

Error text still points at https://github.com/vllm-project/vllm-xpu-kernels/issues/364 for unexpected missing shapes.

## Test Plan

```bash
.venv/bin/python -m pytest tests/flash_attn/test_xpu_graph_capture_safe.py -v
```

Micro + E2E A/B (HAL B70):

```bash
bash ab_artifacts/run_pc_e2e_full.sh
```

- [x] Env / fail-closed helpers and `build_decode_split_plan` host-only guard
- [x] Default raises on mocked "not compiled"; `ALLOW_FALLBACK=1` returns ref in eager
- [x] Capture requires preallocated `out`; fallback refused while capturing
- [ ] XPUGraph capture→replay smoke is marked **`xfail`** (FA2 scratch-memory / graph gap on current stacks) — not a merge blocker for fail-closed
- [x] HAL A/B: default raises; `ALLOW_FALLBACK=1` returns PyTorch ref
- [x] HAL micro + E2E happy-path wash (same kernels, open vs fail-closed iface)
- [ ] Upstream CI / reviewer smoke on XPU

## Test Result

### Behavior A/B (HAL B70)

| Side | Env | Result |
|------|-----|--------|
| A | default (no `ALLOW_FALLBACK`) | **PASS** — raises fail-closed on "not compiled" |
| B | `VLLM_XPU_ATTN_ALLOW_FALLBACK=1` | **PASS** — warn + PyTorch ref returns tensor |

### Full scrape (P-C, 2026-07-25)

**Hardware:** Intel Arc Pro B70 · **Model:** `Qwen/Qwen2.5-7B-Instruct`  
**Compare:** `#17` fail-closed iface vs `main` open iface · **same** attn/FA2 SOs  
**Claim:** happy-path wash (not a speedup). Miss-shape must raise. Failed requests: **0 / 0** both sides.

#### Micro happy-path (block64, kernels present)

| Case | Open ms | Fail-closed ms | Δ |
|------|---------|----------------|---|
| interleaved_short | 0.1523 | 0.1543 | -1.30% |
| mix_long_kv | 0.3689 | 0.3676 | +0.35% |
| mix_decode_heavy | 0.3094 | 0.3092 | **+0.06%** |

Happy-path OK (`|Δ|<5%` on `mix_decode_heavy`): **yes**.

#### E2E decode_bound @ block64 (median of 3 timed runs)

| Metric | Open (main) | Fail-closed | Δ |
|--------|-------------|-------------|---|
| Output tok/s | **273.23** | **273.4** | **+0.06%** |
| Request throughput (req/s) | 0.53 | 0.53 | +0.00% |
| Median TTFT (ms) | 279.52 | 280.2 | -0.24% |
| Mean TTFT (ms) | 252.61 | 254.2 | -0.63% |
| Median TPOT (ms) | 28.82 | 28.79 | +0.10% |
| Mean TPOT (ms) | 28.81 | 28.79 | +0.07% |
| Median ITL (ms) | 28.81 | 28.79 | +0.07% |

Per-run tok/s: open `[272.66, 273.23, 273.77]` · fail-closed `[273.24, 273.57, 273.4]`

#### E2E decode_bound @ block128 + `base_p128` kernels

| Metric | Open (main) | Fail-closed | Δ |
|--------|-------------|-------------|---|
| Output tok/s | **272.73** | **272.44** | **-0.11%** |
| Request throughput (req/s) | 0.53 | 0.53 | +0.00% |
| Median TTFT (ms) | 324.0 | 324.31 | -0.10% |
| Mean TTFT (ms) | 292.99 | 293.01 | -0.01% |
| Median TPOT (ms) | 28.78 | 28.82 | -0.14% |
| Mean TPOT (ms) | 28.78 | 28.81 | -0.10% |
| Median ITL (ms) | 28.78 | 28.79 | -0.04% |

Per-run tok/s: open `[272.73, 272.64, 272.76]` · fail-closed `[272.2, 272.62, 272.44]`

**Product KEEP:** **yes** (safety PR; happy-path wash within noise).

Pack: `ab_artifacts/hal_results/PC_E2E_FULL_VERDICT.md`.

## (Optional) Documentation Update

- Updated `KERNEL_CONFIGURATION.md` (fail-closed default, escape hatch, troubleshooting, pagesize=128 / ~28 default kernels).