### PR TITLE
moe: enable native Xe2 path for MXFP8 and block-FP8

### DIFF
--- a/csrc/xpu/grouped_gemm/grouped_gemm_interface.cpp
+++ b/csrc/xpu/grouped_gemm/grouped_gemm_interface.cpp
@@ -33,7 +33,11 @@ torch::Tensor cutlass_grouped_gemm_interface(
 #endif
   } else if (vllm::xpu::is_xe2_arch() || vllm::xpu::is_xe3_arch()) {
 #ifdef VLLM_XPU_ENABLE_XE2
-    // Use XE2 cutlass kernel
+    // Xe2 grouped GEMM currently consumes high-precision A (W16A16 / W8A16).
+    // When callers pass FP8 activations + ptr_A_scale, Python
+    // (fused_moe_interface._apply_kernel) dequants A before this entry.
+    // Device W8A8 with ptr_A_scale is not yet implemented here.
+    (void)ptr_A_scale;
     return cutlass_grouped_gemm_xe2(
         ptr_A,
         ptr_B,

--- a/csrc/xpu/grouped_gemm/xe_2/gemm_xe2.hpp
+++ b/csrc/xpu/grouped_gemm/xe_2/gemm_xe2.hpp
@@ -392,7 +392,11 @@ CUTE_DEVICE void xe_gemm_4bits(
             scale = Scales
                 [(n_tile_start + n_sg_start + sg_local_n) * group_num +
                  group_idx];
-          } else if constexpr (std::is_same_v<TB, float_e2m1_t>) {
+          } else if constexpr (
+              std::is_same_v<TB, float_e2m1_t> ||
+              std::is_same_v<TB, float_e4m3_t> ||
+              std::is_same_v<TB, float_e5m2_t>) {
+            // MXFP4 / MXFP8: uint8 E8M0 bits -> float via (bits << 23).
             uint32_t scale_u32 =
                 Scales
                     [(n_tile_start + n_sg_start + sg_local_n) * group_num +

--- a/csrc/xpu/grouped_gemm/xe_2/gemm_xe2.hpp
+++ b/csrc/xpu/grouped_gemm/xe_2/gemm_xe2.hpp
@@ -355,20 +355,24 @@ CUTE_DEVICE void xe_gemm_4bits(
     prefetch(prefetch_b, pBgB(_, _, _, k_tile_prefetch));
 
     if (k_tile_prefetch * group_size < shape<1>(A)) {
-      auto next_scales_tensor = make_tensor(
-          make_gmem_ptr(
-              reinterpret_cast<const ElementS*>(
-                  Scales + (n_tile_start + n_sg_start) * group_num +
-                  k_tile_prefetch)),
-          make_layout(
-              make_shape(Int<SG_N>{}, Int<1>{}),
-              make_stride(group_num, Int<1>{})));
-      auto prefetch_scales = make_block_2d_prefetch<1>(
-          make_shape(Int<SG_N>{}, Int<1>{}), next_scales_tensor);
-      auto thr_prefetch_scales = prefetch_scales.get_slice(sg_local_id);
-      auto pSgS = thr_prefetch_scales.partition_S(
-          make_identity_tensor(make_shape(Int<SG_N>{}, Int<1>{})));
-      prefetch(prefetch_scales, pSgS(_, 0, 0));
+      // MXFP8 / int4 1D scale prefetch ([N, K/gs]). Skip for float ElementS
+      // (block-FP8 uses 2D [K/gs, N/gs] indexing).
+      if constexpr (!std::is_same_v<ElementS, float>) {
+        auto next_scales_tensor = make_tensor(
+            make_gmem_ptr(
+                reinterpret_cast<const ElementS*>(
+                    Scales + (n_tile_start + n_sg_start) * group_num +
+                    k_tile_prefetch)),
+            make_layout(
+                make_shape(Int<SG_N>{}, Int<1>{}),
+                make_stride(group_num, Int<1>{})));
+        auto prefetch_scales = make_block_2d_prefetch<1>(
+            make_shape(Int<SG_N>{}, Int<1>{}), next_scales_tensor);
+        auto thr_prefetch_scales = prefetch_scales.get_slice(sg_local_id);
+        auto pSgS = thr_prefetch_scales.partition_S(
+            make_identity_tensor(make_shape(Int<SG_N>{}, Int<1>{})));
+        prefetch(prefetch_scales, pSgS(_, 0, 0));
+      }
     }
   }
 
@@ -396,14 +400,24 @@ CUTE_DEVICE void xe_gemm_4bits(
               std::is_same_v<TB, float_e2m1_t> ||
               std::is_same_v<TB, float_e4m3_t> ||
               std::is_same_v<TB, float_e5m2_t>) {
-            // MXFP4 / MXFP8: uint8 E8M0 bits -> float via (bits << 23).
-            uint32_t scale_u32 =
-                Scales
-                    [(n_tile_start + n_sg_start + sg_local_n) * group_num +
-                     group_idx]
-                << 23;
-            scale = static_cast<scaleStoreType>(
-                reinterpret_cast<float&>(scale_u32));
+            if constexpr (std::is_same_v<ElementS, float>) {
+              // Block-FP8: float32 scales [K/128, N/128] (B is (N,K)).
+              int n_global = n_tile_start + n_sg_start + sg_local_n;
+              int n_blocks = static_cast<int>(get<0>(B.shape())) / group_size;
+              int n_block = n_global / group_size;
+              int k_block = group_idx;
+              scale = static_cast<scaleStoreType>(
+                  Scales[k_block * n_blocks + n_block]);
+            } else {
+              // MXFP4 / MXFP8: uint8 E8M0 bits -> float via (bits << 23).
+              uint32_t scale_u32 =
+                  Scales
+                      [(n_tile_start + n_sg_start + sg_local_n) * group_num +
+                       group_idx]
+                  << 23;
+              scale = static_cast<scaleStoreType>(
+                  reinterpret_cast<float&>(scale_u32));
+            }
           }
 
           scales[n * channel_num + c] = scale;
@@ -411,20 +425,22 @@ CUTE_DEVICE void xe_gemm_4bits(
       }
 
       if ((group_idx + prefetch_dist) * group_size < shape<1>(A)) {
-        auto next_scales_tensor = make_tensor(
-            make_gmem_ptr(
-                reinterpret_cast<const ElementS*>(
-                    Scales + (n_tile_start + n_sg_start) * group_num +
-                    group_idx + prefetch_dist)),
-            make_layout(
-                make_shape(Int<SG_N>{}, Int<1>{}),
-                make_stride(group_num, Int<1>{})));
-        auto prefetch_scales = make_block_2d_prefetch<1>(
-            make_shape(Int<SG_N>{}, Int<1>{}), next_scales_tensor);
-        auto thr_prefetch_scales = prefetch_scales.get_slice(sg_local_id);
-        auto pSgS = thr_prefetch_scales.partition_S(
-            make_identity_tensor(make_shape(Int<SG_N>{}, Int<1>{})));
-        prefetch(prefetch_scales, pSgS(_, 0, 0));
+        if constexpr (!std::is_same_v<ElementS, float>) {
+          auto next_scales_tensor = make_tensor(
+              make_gmem_ptr(
+                  reinterpret_cast<const ElementS*>(
+                      Scales + (n_tile_start + n_sg_start) * group_num +
+                      group_idx + prefetch_dist)),
+              make_layout(
+                  make_shape(Int<SG_N>{}, Int<1>{}),
+                  make_stride(group_num, Int<1>{})));
+          auto prefetch_scales = make_block_2d_prefetch<1>(
+              make_shape(Int<SG_N>{}, Int<1>{}), next_scales_tensor);
+          auto thr_prefetch_scales = prefetch_scales.get_slice(sg_local_id);
+          auto pSgS = thr_prefetch_scales.partition_S(
+              make_identity_tensor(make_shape(Int<SG_N>{}, Int<1>{})));
+          prefetch(prefetch_scales, pSgS(_, 0, 0));
+        }
       }
     }
 

--- a/csrc/xpu/grouped_gemm/xe_2/grouped_gemm_xe2.hpp
+++ b/csrc/xpu/grouped_gemm/xe_2/grouped_gemm_xe2.hpp
@@ -96,6 +96,12 @@ CUTE_DEVICE void MoEGEMM(
       (std::is_same_v<ElementB, float_e4m3_t> ||
        std::is_same_v<ElementB, float_e5m2_t>) &&
       std::is_same_v<ElementS, uint8_t>;
+  // FP8 weights + float scales: per-tensor (group_size<=0) or block-FP8
+  // 2D gs=128 (group_size>0). Distinguished at runtime via group_size.
+  static constexpr bool is_B_fp8_float_scale =
+      (std::is_same_v<ElementB, float_e4m3_t> ||
+       std::is_same_v<ElementB, float_e5m2_t>) &&
+      std::is_same_v<ElementS, float>;
 
   auto item = sycl::ext::oneapi::this_work_item::get_nd_item<3>();
   auto wg_tile = mma.tile_mnk();
@@ -156,6 +162,19 @@ CUTE_DEVICE void MoEGEMM(
       // Scales layout [E, N, K/group_size] (host transposes from [E,K/32,N]).
       ptr_Scales_curr_batch =
           const_cast<ElementS*>(Scales) + B_offset / group_size;
+    } else if constexpr (is_B_fp8_float_scale) {
+      if (group_size > 0) {
+        // Block-FP8: scales [E, K/128, N/128] kept in that order.
+        ptr_Scales_curr_batch =
+            const_cast<ElementS*>(Scales) +
+            static_cast<int64_t>(expert_id) *
+                static_cast<int64_t>(gemm_k / group_size) *
+                static_cast<int64_t>(gemm_n / group_size);
+      } else {
+        // Per-tensor FP8: one float scale per expert.
+        ptr_Scales_curr_batch =
+            const_cast<ElementS*>(Scales) + expert_id;
+      }
     }
     ElementBI* ptr_Bias_curr_batch = nullptr;
     if (Bias != static_cast<ElementBI*>(nullptr)) {
@@ -207,6 +226,31 @@ CUTE_DEVICE void MoEGEMM(
           XE_GEMM_4BITS_CALLER(256)
         }
 #undef XE_GEMM_4BITS_CALLER
+      } else if constexpr (is_B_fp8_float_scale) {
+        if (group_size == 128) {
+          // Block-FP8: float32 2D scales [K/128, N/128] per expert.
+#define XE_GEMM_BLOCK_FP8_CALLER(GroupSize)                                 \
+  xe_gemm_4bits<GmemTiledCopyA, GmemTiledCopyB, GmemTiledCopyD, GroupSize>( \
+      A_tensor,                                                             \
+      B_tensor,                                                             \
+      ptr_Scales_curr_batch,                                                \
+      ptr_Bias_curr_batch,                                                  \
+      D_tensor,                                                             \
+      tile_coord,                                                           \
+      mma);
+          XE_GEMM_BLOCK_FP8_CALLER(128)
+#undef XE_GEMM_BLOCK_FP8_CALLER
+        } else {
+          // Per-tensor FP8 (one float scale per expert).
+          xe_gemm<GmemTiledCopyA, GmemTiledCopyB, GmemTiledCopyD>(
+              A_tensor,
+              B_tensor,
+              ptr_Scales_curr_batch,
+              ptr_Bias_curr_batch,
+              D_tensor,
+              tile_coord,
+              mma);
+        }
       } else {
         xe_gemm<GmemTiledCopyA, GmemTiledCopyB, GmemTiledCopyD>(
             A_tensor,

--- a/csrc/xpu/grouped_gemm/xe_2/grouped_gemm_xe2.hpp
+++ b/csrc/xpu/grouped_gemm/xe_2/grouped_gemm_xe2.hpp
@@ -92,10 +92,9 @@ CUTE_DEVICE void MoEGEMM(
                                      (std::is_same_v<ElementS, uint8_t>);
   static constexpr bool is_B_4bits = std::is_same_v<ElementB, uint8_t>;
   // MXFP8: FP8 weights + uint8 E8M0 block scales (group_size=32).
-  static constexpr bool is_B_mxfp8 =
-      (std::is_same_v<ElementB, float_e4m3_t> ||
-       std::is_same_v<ElementB, float_e5m2_t>) &&
-      std::is_same_v<ElementS, uint8_t>;
+  static constexpr bool is_B_mxfp8 = (std::is_same_v<ElementB, float_e4m3_t> ||
+                                      std::is_same_v<ElementB, float_e5m2_t>) &&
+                                     std::is_same_v<ElementS, uint8_t>;
   // FP8 weights + float scales: per-tensor (group_size<=0) or block-FP8
   // 2D gs=128 (group_size>0). Distinguished at runtime via group_size.
   static constexpr bool is_B_fp8_float_scale =
@@ -165,15 +164,13 @@ CUTE_DEVICE void MoEGEMM(
     } else if constexpr (is_B_fp8_float_scale) {
       if (group_size > 0) {
         // Block-FP8: scales [E, K/128, N/128] kept in that order.
-        ptr_Scales_curr_batch =
-            const_cast<ElementS*>(Scales) +
-            static_cast<int64_t>(expert_id) *
-                static_cast<int64_t>(gemm_k / group_size) *
-                static_cast<int64_t>(gemm_n / group_size);
+        ptr_Scales_curr_batch = const_cast<ElementS*>(Scales) +
+                                static_cast<int64_t>(expert_id) *
+                                    static_cast<int64_t>(gemm_k / group_size) *
+                                    static_cast<int64_t>(gemm_n / group_size);
       } else {
         // Per-tensor FP8: one float scale per expert.
-        ptr_Scales_curr_batch =
-            const_cast<ElementS*>(Scales) + expert_id;
+        ptr_Scales_curr_batch = const_cast<ElementS*>(Scales) + expert_id;
       }
     }
     ElementBI* ptr_Bias_curr_batch = nullptr;

--- a/csrc/xpu/grouped_gemm/xe_2/grouped_gemm_xe2.hpp
+++ b/csrc/xpu/grouped_gemm/xe_2/grouped_gemm_xe2.hpp
@@ -91,6 +91,11 @@ CUTE_DEVICE void MoEGEMM(
   static constexpr bool is_B_mxfp4 = (std::is_same_v<ElementB, uint8_t>) &&
                                      (std::is_same_v<ElementS, uint8_t>);
   static constexpr bool is_B_4bits = std::is_same_v<ElementB, uint8_t>;
+  // MXFP8: FP8 weights + uint8 E8M0 block scales (group_size=32).
+  static constexpr bool is_B_mxfp8 =
+      (std::is_same_v<ElementB, float_e4m3_t> ||
+       std::is_same_v<ElementB, float_e5m2_t>) &&
+      std::is_same_v<ElementS, uint8_t>;
 
   auto item = sycl::ext::oneapi::this_work_item::get_nd_item<3>();
   auto wg_tile = mma.tile_mnk();
@@ -144,8 +149,13 @@ CUTE_DEVICE void MoEGEMM(
     ElementD* ptr_D_curr_batch = Outputs + pre_rows * gemm_n;
     ElementS* ptr_Scales_curr_batch = const_cast<ElementS*>(Scales) + expert_id;
     if constexpr (is_B_4bits) {
+      // Scales layout [E, N, K/group_size] packed with 4-bit B.
       ptr_Scales_curr_batch =
           const_cast<ElementS*>(Scales) + B_offset * 2 / group_size;
+    } else if constexpr (is_B_mxfp8) {
+      // Scales layout [E, N, K/group_size] (host transposes from [E,K/32,N]).
+      ptr_Scales_curr_batch =
+          const_cast<ElementS*>(Scales) + B_offset / group_size;
     }
     ElementBI* ptr_Bias_curr_batch = nullptr;
     if (Bias != static_cast<ElementBI*>(nullptr)) {
@@ -174,7 +184,10 @@ CUTE_DEVICE void MoEGEMM(
       int m_coord = (group_m_id - pre_tiles);
       auto tile_coord = make_coord(m_coord, n_coord, _, 0);
 
-      if constexpr (is_B_4bits) {
+      if constexpr (is_B_4bits || is_B_mxfp8) {
+        // MXFP8 reuses the 4-bit block-scale mainloop (E8M0 decode + per-K
+        // group B scaling) with float_e4m3/e5m2 weights instead of packed
+        // 4-bit. Scale layout must be [N, K/group_size] per expert.
 #define XE_GEMM_4BITS_CALLER(GroupSize)                                     \
   xe_gemm_4bits<GmemTiledCopyA, GmemTiledCopyB, GmemTiledCopyD, GroupSize>( \
       A_tensor,                                                             \

--- a/csrc/xpu/grouped_gemm/xe_2/grouped_gemm_xe2_interface.hpp
+++ b/csrc/xpu/grouped_gemm/xe_2/grouped_gemm_xe2_interface.hpp
@@ -178,6 +178,12 @@ at::Tensor cutlass_grouped_gemm_xe2_impl(
   bool is_B_int4 = (B_dtype == at::kChar) && ptr_scales.has_value();
   bool is_B_mxfp4 =
       (B_dtype == at::kFloat4_e2m1fn_x2) && ptr_scales.has_value();
+  // MXFP8: FP8 weights + E8M0 (uint8 / float8_e8m0fnu) block scales, gs=32.
+  bool is_B_mxfp8 = false;
+  if (is_weight_fp8 && ptr_scales.has_value() && ptr_scales->dim() == 3) {
+    auto sd = ptr_scales->dtype();
+    is_B_mxfp8 = (sd == at::kByte) || (sd == at::kFloat8_e8m0fnu);
+  }
 
   TORCH_CHECK(N % 8 == 0, "N must be divisible by 8");
 
@@ -299,6 +305,116 @@ at::Tensor cutlass_grouped_gemm_xe2_impl(
       W4A16LauncherCallER(policy);
     }
 #undef W4A16LauncherCallER
+  } else if (is_B_mxfp8) {
+    TORCH_CHECK(ptr_scales.has_value(), "mxfp8 grouped gemm must have scales");
+    TORCH_CHECK(ptr_scales->is_contiguous(), "ptr_scales must be contiguous");
+    TORCH_CHECK(
+        ptr_scales->dim() == 3,
+        "ptr_scales of mxfp8 must be 3D [num_experts, K/32, N] "
+        "or [num_experts, N, K/32]");
+    TORCH_CHECK(
+        ptr_scales->size(0) == num_experts,
+        "ptr_scales.size(0) of mxfp8 must match num_experts");
+    TORCH_CHECK(K % 32 == 0, "mxfp8 requires K divisible by 32");
+
+    // Canonical kernel layout is [E, N, K/32] (same indexing as mxfp4 E8M0).
+    // Accept [E, K/32, N] from moe_utils / vLLM and transpose once on host.
+    at::Tensor scales_nk = *ptr_scales;
+    if (scales_nk.scalar_type() == at::kFloat8_e8m0fnu) {
+      scales_nk = scales_nk.view(at::kByte);
+    }
+    if (scales_nk.size(1) == (K / 32) && scales_nk.size(2) == N) {
+      scales_nk = scales_nk.transpose(1, 2).contiguous();
+    }
+    TORCH_CHECK(
+        scales_nk.size(1) == N && scales_nk.size(2) == (K / 32),
+        "mxfp8 scales must be [E, N, K/32] after layout normalize; got [",
+        scales_nk.size(0),
+        ", ",
+        scales_nk.size(1),
+        ", ",
+        scales_nk.size(2),
+        "] with N=",
+        N,
+        " K=",
+        K);
+    group_size = 32;
+
+    // Rebind ptr_scales for the launcher macro below.
+    // MoEGEMMLauncherCallER reads ptr_scales->data_ptr().
+    c10::optional<at::Tensor> scales_opt = scales_nk;
+    const c10::optional<at::Tensor>& ptr_scales_mx = scales_opt;
+#undef MoEGEMMLauncherCallER
+#define MoEGEMMLauncherCallER(                                                 \
+    LayoutA, LayoutB, Policy, ElementA, ElementB, ElementS)                    \
+  MoEGEMMLauncher<LayoutA, LayoutB, Policy>(                                   \
+      dpcpp_queue,                                                             \
+      reinterpret_cast<ElementA*>(ptr_A.data_ptr()),                           \
+      reinterpret_cast<ElementB*>(ptr_B.data_ptr()),                           \
+      ptr_scales_mx.has_value()                                                \
+          ? reinterpret_cast<ElementS*>(ptr_scales_mx->data_ptr())             \
+          : static_cast<ElementS*>(nullptr),                                   \
+      ptr_bias.has_value() ? reinterpret_cast<ElementA*>(ptr_bias->data_ptr()) \
+                           : static_cast<ElementA*>(nullptr),                  \
+      reinterpret_cast<ElementA*>(ptr_D.data_ptr()),                           \
+      N,                                                                       \
+      K,                                                                       \
+      reinterpret_cast<int*>(rows_per_expert.data_ptr()),                      \
+      num_experts,                                                             \
+      group_size,                                                              \
+      static_cast<int*>(atomic_buffer.data_ptr()));
+
+#define W8MXFP8LauncherCallER(policy)                                          \
+  if (B_dtype == at::kFloat8_e4m3fn && A_dtype == at::kHalf) {                 \
+    using scalar_t = half_t;                                                   \
+    MoEGEMMLauncherCallER('R', 'R', policy, scalar_t, float_e4m3_t, uint8_t);  \
+  } else if (B_dtype == at::kFloat8_e5m2 && A_dtype == at::kHalf) {            \
+    using scalar_t = half_t;                                                   \
+    MoEGEMMLauncherCallER('R', 'R', policy, scalar_t, float_e5m2_t, uint8_t);  \
+  } else if (B_dtype == at::kFloat8_e4m3fn && A_dtype == at::kBFloat16) {      \
+    using scalar_t = bfloat16_t;                                               \
+    MoEGEMMLauncherCallER('R', 'R', policy, scalar_t, float_e4m3_t, uint8_t);  \
+  } else if (B_dtype == at::kFloat8_e5m2 && A_dtype == at::kBFloat16) {        \
+    using scalar_t = bfloat16_t;                                               \
+    MoEGEMMLauncherCallER('R', 'R', policy, scalar_t, float_e5m2_t, uint8_t);  \
+  } else {                                                                     \
+    TORCH_CHECK(                                                               \
+        false,                                                                 \
+        "mxfp8 grouped gemm requires A in {fp16,bf16} and B in "               \
+        "{float8_e4m3fn, float8_e5m2}");                                       \
+  }
+
+    if (A_avg_M <= 8) {
+      using policy = w8a16_policy_m_16;
+      W8MXFP8LauncherCallER(policy);
+    } else if (A_avg_M <= 32) {
+      using policy = w8a16_policy_m_32;
+      W8MXFP8LauncherCallER(policy);
+    } else {
+      using policy = w8a16_policy;
+      W8MXFP8LauncherCallER(policy);
+    }
+#undef W8MXFP8LauncherCallER
+// Restore the default launcher macro for subsequent branches.
+#undef MoEGEMMLauncherCallER
+#define MoEGEMMLauncherCallER(                                                 \
+    LayoutA, LayoutB, Policy, ElementA, ElementB, ElementS)                    \
+  MoEGEMMLauncher<LayoutA, LayoutB, Policy>(                                   \
+      dpcpp_queue,                                                             \
+      reinterpret_cast<ElementA*>(ptr_A.data_ptr()),                           \
+      reinterpret_cast<ElementB*>(ptr_B.data_ptr()),                           \
+      ptr_scales.has_value()                                                   \
+          ? reinterpret_cast<ElementS*>(ptr_scales->data_ptr())                \
+          : static_cast<ElementS*>(nullptr),                                   \
+      ptr_bias.has_value() ? reinterpret_cast<ElementA*>(ptr_bias->data_ptr()) \
+                           : static_cast<ElementA*>(nullptr),                  \
+      reinterpret_cast<ElementA*>(ptr_D.data_ptr()),                           \
+      N,                                                                       \
+      K,                                                                       \
+      reinterpret_cast<int*>(rows_per_expert.data_ptr()),                      \
+      num_experts,                                                             \
+      group_size,                                                              \
+      static_cast<int*>(atomic_buffer.data_ptr()));
   } else if (is_weight_fp8) {
     TORCH_CHECK(ptr_scales.has_value(), "w8a16 grouped gemm must have scales");
     TORCH_CHECK(ptr_scales->is_contiguous(), "ptr_scales must be contiguous");

--- a/csrc/xpu/grouped_gemm/xe_2/grouped_gemm_xe2_interface.hpp
+++ b/csrc/xpu/grouped_gemm/xe_2/grouped_gemm_xe2_interface.hpp
@@ -370,24 +370,24 @@ at::Tensor cutlass_grouped_gemm_xe2_impl(
       group_size,                                                              \
       static_cast<int*>(atomic_buffer.data_ptr()));
 
-#define W8MXFP8LauncherCallER(policy)                                          \
-  if (B_dtype == at::kFloat8_e4m3fn && A_dtype == at::kHalf) {                 \
-    using scalar_t = half_t;                                                   \
-    MoEGEMMLauncherCallER('R', 'R', policy, scalar_t, float_e4m3_t, uint8_t);  \
-  } else if (B_dtype == at::kFloat8_e5m2 && A_dtype == at::kHalf) {            \
-    using scalar_t = half_t;                                                   \
-    MoEGEMMLauncherCallER('R', 'R', policy, scalar_t, float_e5m2_t, uint8_t);  \
-  } else if (B_dtype == at::kFloat8_e4m3fn && A_dtype == at::kBFloat16) {      \
-    using scalar_t = bfloat16_t;                                               \
-    MoEGEMMLauncherCallER('R', 'R', policy, scalar_t, float_e4m3_t, uint8_t);  \
-  } else if (B_dtype == at::kFloat8_e5m2 && A_dtype == at::kBFloat16) {        \
-    using scalar_t = bfloat16_t;                                               \
-    MoEGEMMLauncherCallER('R', 'R', policy, scalar_t, float_e5m2_t, uint8_t);  \
-  } else {                                                                     \
-    TORCH_CHECK(                                                               \
-        false,                                                                 \
-        "mxfp8 grouped gemm requires A in {fp16,bf16} and B in "               \
-        "{float8_e4m3fn, float8_e5m2}");                                       \
+#define W8MXFP8LauncherCallER(policy)                                         \
+  if (B_dtype == at::kFloat8_e4m3fn && A_dtype == at::kHalf) {                \
+    using scalar_t = half_t;                                                  \
+    MoEGEMMLauncherCallER('R', 'R', policy, scalar_t, float_e4m3_t, uint8_t); \
+  } else if (B_dtype == at::kFloat8_e5m2 && A_dtype == at::kHalf) {           \
+    using scalar_t = half_t;                                                  \
+    MoEGEMMLauncherCallER('R', 'R', policy, scalar_t, float_e5m2_t, uint8_t); \
+  } else if (B_dtype == at::kFloat8_e4m3fn && A_dtype == at::kBFloat16) {     \
+    using scalar_t = bfloat16_t;                                              \
+    MoEGEMMLauncherCallER('R', 'R', policy, scalar_t, float_e4m3_t, uint8_t); \
+  } else if (B_dtype == at::kFloat8_e5m2 && A_dtype == at::kBFloat16) {       \
+    using scalar_t = bfloat16_t;                                              \
+    MoEGEMMLauncherCallER('R', 'R', policy, scalar_t, float_e5m2_t, uint8_t); \
+  } else {                                                                    \
+    TORCH_CHECK(                                                              \
+        false,                                                                \
+        "mxfp8 grouped gemm requires A in {fp16,bf16} and B in "              \
+        "{float8_e4m3fn, float8_e5m2}");                                      \
   }
 
     if (A_avg_M <= 8) {

--- a/csrc/xpu/grouped_gemm/xe_2/grouped_gemm_xe2_interface.hpp
+++ b/csrc/xpu/grouped_gemm/xe_2/grouped_gemm_xe2_interface.hpp
@@ -184,6 +184,12 @@ at::Tensor cutlass_grouped_gemm_xe2_impl(
     auto sd = ptr_scales->dtype();
     is_B_mxfp8 = (sd == at::kByte) || (sd == at::kFloat8_e8m0fnu);
   }
+  // Block-FP8: FP8 weights + float32 2D scales [E, K/128, N/128].
+  bool is_B_block_fp8 = false;
+  if (is_weight_fp8 && ptr_scales.has_value() && ptr_scales->dim() == 3 &&
+      !is_B_mxfp8) {
+    is_B_block_fp8 = (ptr_scales->dtype() == at::kFloat);
+  }
 
   TORCH_CHECK(N % 8 == 0, "N must be divisible by 8");
 
@@ -415,6 +421,65 @@ at::Tensor cutlass_grouped_gemm_xe2_impl(
       num_experts,                                                             \
       group_size,                                                              \
       static_cast<int*>(atomic_buffer.data_ptr()));
+  } else if (is_B_block_fp8) {
+    TORCH_CHECK(
+        ptr_scales.has_value(), "block-fp8 grouped gemm must have scales");
+    TORCH_CHECK(ptr_scales->is_contiguous(), "ptr_scales must be contiguous");
+    TORCH_CHECK(
+        ptr_scales->dim() == 3,
+        "ptr_scales of block-fp8 must be 3D [num_experts, K/128, N/128]");
+    TORCH_CHECK(
+        ptr_scales->size(0) == num_experts,
+        "ptr_scales.size(0) of block-fp8 must match num_experts");
+    TORCH_CHECK(K % 128 == 0, "block-fp8 requires K divisible by 128");
+    TORCH_CHECK(N % 128 == 0, "block-fp8 requires N divisible by 128");
+    TORCH_CHECK(
+        ptr_scales->size(1) == (K / 128) && ptr_scales->size(2) == (N / 128),
+        "block-fp8 scales must be [E, K/128, N/128]; got [",
+        ptr_scales->size(0),
+        ", ",
+        ptr_scales->size(1),
+        ", ",
+        ptr_scales->size(2),
+        "] with N=",
+        N,
+        " K=",
+        K);
+    TORCH_CHECK(
+        ptr_scales->dtype() == at::kFloat, "block-fp8 scales must be float32");
+    group_size = 128;
+
+#define W8BLOCKFP8LauncherCallER(policy)                                    \
+  if (B_dtype == at::kFloat8_e4m3fn && A_dtype == at::kHalf) {              \
+    using scalar_t = half_t;                                                \
+    MoEGEMMLauncherCallER('R', 'R', policy, scalar_t, float_e4m3_t, float); \
+  } else if (B_dtype == at::kFloat8_e5m2 && A_dtype == at::kHalf) {         \
+    using scalar_t = half_t;                                                \
+    MoEGEMMLauncherCallER('R', 'R', policy, scalar_t, float_e5m2_t, float); \
+  } else if (B_dtype == at::kFloat8_e4m3fn && A_dtype == at::kBFloat16) {   \
+    using scalar_t = bfloat16_t;                                            \
+    MoEGEMMLauncherCallER('R', 'R', policy, scalar_t, float_e4m3_t, float); \
+  } else if (B_dtype == at::kFloat8_e5m2 && A_dtype == at::kBFloat16) {     \
+    using scalar_t = bfloat16_t;                                            \
+    MoEGEMMLauncherCallER('R', 'R', policy, scalar_t, float_e5m2_t, float); \
+  } else {                                                                  \
+    TORCH_CHECK(                                                            \
+        false,                                                              \
+        "block-fp8 grouped gemm requires A in {fp16,bf16} and B in "        \
+        "{float8_e4m3fn, float8_e5m2}");                                    \
+  }
+
+    if (A_avg_M <= 8) {
+      using policy = w8a16_policy_m_16;
+      W8BLOCKFP8LauncherCallER(policy);
+    } else if (A_avg_M <= 32) {
+      using policy = w8a16_policy_m_32;
+      W8BLOCKFP8LauncherCallER(policy);
+    } else {
+      using policy = w8a16_policy;
+      W8BLOCKFP8LauncherCallER(policy);
+    }
+#undef W8BLOCKFP8LauncherCallER
   } else if (is_weight_fp8) {
     TORCH_CHECK(ptr_scales.has_value(), "w8a16 grouped gemm must have scales");
     TORCH_CHECK(ptr_scales->is_contiguous(), "ptr_scales must be contiguous");

--- a/tests/fused_moe/test_fused_moe.py
+++ b/tests/fused_moe/test_fused_moe.py
@@ -600,7 +600,7 @@ def test_fused_moe_mxfp8(m, n, k, e, topk, dtype, has_bias):
         w2_hp = torch.randn(intermediate_size,
                             hidden_size,
                             dtype=torch.float32) / 16
-        # to_mxfp blocks last dim; weight E8M0 is along K (dim 0) → quantize [N,K].
+        # to_mxfp blocks last dim; E8M0 along K (dim 0) → quantize [N, K].
         sc13, lp13 = to_mxfp(w13_hp.transpose(0, 1).contiguous(),
                              format="mxfp8")
         sc2, lp2 = to_mxfp(w2_hp.transpose(0, 1).contiguous(), format="mxfp8")

--- a/tests/fused_moe/test_fused_moe.py
+++ b/tests/fused_moe/test_fused_moe.py
@@ -683,7 +683,7 @@ def test_fused_moe_mxfp8(m, n, k, e, topk, dtype, has_bias):
                          ids=format_tc)
 @pytest.mark.parametrize("has_bias", [True, False])
 def test_fused_moe_fp8block(m, n, k, e, topk, dtype, has_bias):
-    """Native block-FP8 fused MoE (init weight dequant) vs dequant-weight ref."""
+    """Native block-FP8 fused MoE (in-kernel scales) vs dequant-weight ref."""
     if not torch.xpu.is_available():
         pytest.skip("XPU required")
     seed_everything(7)
@@ -783,7 +783,9 @@ def test_fused_moe_fp8block(m, n, k, e, topk, dtype, has_bias):
         num_experts=e,
     )
     assert fused_moe_impl.is_block_fp8
-    assert fused_moe_impl._block_fp8_promoted
+    assert not fused_moe_impl._block_fp8_promoted
+    assert fused_moe_impl.gemm1_wei_scales is not None
+    assert fused_moe_impl.w13.dtype == torch.float8_e4m3fn
     assert fused_moe_impl._use_ref is False
 
     output = torch.empty_like(ref_out)

--- a/tests/fused_moe/test_fused_moe.py
+++ b/tests/fused_moe/test_fused_moe.py
@@ -799,7 +799,8 @@ def test_fused_moe_fp8block(m, n, k, e, topk, dtype, has_bias):
 
 
 @pytest.mark.parametrize("num_tokens", [1, 4, 16])
-def test_fused_moe_mxfp4_topk16(num_tokens):
+@pytest.mark.parametrize("activation", ["silu", "situ"])
+def test_fused_moe_mxfp4_topk16(num_tokens, activation):
     test_fused_moe_mxfp4(
         num_tokens,
         256,
@@ -808,6 +809,7 @@ def test_fused_moe_mxfp4_topk16(num_tokens):
         16,
         torch.bfloat16,
         False,
+        activation,
     )
 
 

--- a/tests/fused_moe/test_fused_moe.py
+++ b/tests/fused_moe/test_fused_moe.py
@@ -536,6 +536,266 @@ def test_fused_moe_mxfp4(m, n, k, e, topk, dtype, has_bias, activation):
     torch.testing.assert_close(output, ref_out, rtol=rtol, atol=atol)
 
 
+
+@pytest.mark.parametrize("m,n,k", [(1, 256, 128), (4, 256, 128)])
+@pytest.mark.parametrize("e", [4])
+@pytest.mark.parametrize("topk", [2])
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16],
+                         ids=format_tc)
+@pytest.mark.parametrize("has_bias", [True, False])
+def test_fused_moe_mxfp8(m, n, k, e, topk, dtype, has_bias):
+    """Native MXFP8 fused MoE vs dequant-weight reference."""
+    if not torch.xpu.is_available():
+        pytest.skip("XPU required")
+    seed_everything(7)
+    torch.xpu.empty_cache()
+    gc.collect()
+
+    input_len = m
+    hidden_size = n
+    intermediate_size = k
+    num_experts = e
+    group_size = 32
+    assert hidden_size % group_size == 0
+    assert intermediate_size % group_size == 0
+
+    a = torch.randn((input_len, hidden_size), device=DEVICE, dtype=dtype) / 16
+    from tests.ops.mx_utils import to_mxfp
+
+    w13 = torch.empty(num_experts,
+                      hidden_size,
+                      2 * intermediate_size,
+                      dtype=torch.float8_e4m3fn,
+                      device=DEVICE)
+    w2 = torch.empty(num_experts,
+                     intermediate_size,
+                     hidden_size,
+                     dtype=torch.float8_e4m3fn,
+                     device=DEVICE)
+    w13_scales = torch.empty(num_experts,
+                             hidden_size // group_size,
+                             2 * intermediate_size,
+                             dtype=torch.uint8,
+                             device=DEVICE)
+    w2_scales = torch.empty(num_experts,
+                            intermediate_size // group_size,
+                            hidden_size,
+                            dtype=torch.uint8,
+                            device=DEVICE)
+    ref_13 = torch.empty(num_experts,
+                         hidden_size,
+                         2 * intermediate_size,
+                         dtype=dtype,
+                         device=DEVICE)
+    ref_2 = torch.empty(num_experts,
+                        intermediate_size,
+                        hidden_size,
+                        dtype=dtype,
+                        device=DEVICE)
+
+    for i in range(num_experts):
+        w13_hp = torch.randn(hidden_size,
+                             2 * intermediate_size,
+                             dtype=torch.float32) / 16
+        w2_hp = torch.randn(intermediate_size,
+                            hidden_size,
+                            dtype=torch.float32) / 16
+        # to_mxfp blocks last dim; weight E8M0 is along K (dim 0) → quantize [N,K].
+        sc13, lp13 = to_mxfp(w13_hp.transpose(0, 1).contiguous(),
+                             format="mxfp8")
+        sc2, lp2 = to_mxfp(w2_hp.transpose(0, 1).contiguous(), format="mxfp8")
+        lp13 = lp13.transpose(0, 1).contiguous()
+        lp2 = lp2.transpose(0, 1).contiguous()
+        sc13 = sc13.transpose(0, 1).contiguous()
+        sc2 = sc2.transpose(0, 1).contiguous()
+        w13[i] = lp13.to(DEVICE)
+        w2[i] = lp2.to(DEVICE)
+        w13_scales[i] = sc13.view(torch.uint8).to(DEVICE)
+        w2_scales[i] = sc2.view(torch.uint8).to(DEVICE)
+        # Dequant gold (same as moe_utils.dequant_mxfp8_wei)
+        ref_13[i] = (
+            lp13.to(torch.float32) *
+            sc13.view(torch.float8_e8m0fnu).to(torch.float32).repeat_interleave(
+                group_size, dim=0)).to(dtype).to(DEVICE)
+        ref_2[i] = (
+            lp2.to(torch.float32) *
+            sc2.view(torch.float8_e8m0fnu).to(torch.float32).repeat_interleave(
+                group_size, dim=0)).to(dtype).to(DEVICE)
+
+    if has_bias:
+        w13_bias = torch.randn(
+            (num_experts, 2 * intermediate_size), device=DEVICE,
+            dtype=dtype) / 16
+        w2_bias = torch.randn(
+            (num_experts, hidden_size), device=DEVICE, dtype=dtype) / 16
+    else:
+        w13_bias = None
+        w2_bias = None
+
+    scores = torch.randn((input_len, num_experts),
+                         device=DEVICE,
+                         dtype=torch.float32)
+    expert_scores, expert_indices = torch.topk(scores,
+                                               k=topk,
+                                               dim=-1,
+                                               sorted=False)
+    flat_expert_indices = expert_indices.view(-1)
+    flat_expert_weights = expert_scores.view(-1, 1)
+
+    # Local ref_fused_moe expects [E, N, K] and uses A @ W.T.
+    ref_13_nk = ref_13.transpose(-1, -2).contiguous()
+    ref_2_nk = ref_2.transpose(-1, -2).contiguous()
+    ref_out = ref_fused_moe(a.clone(), ref_13_nk, w13_bias, ref_2_nk, w2_bias,
+                            flat_expert_weights, flat_expert_indices, topk,
+                            "silu", e)
+
+    fused_moe_impl = XpuFusedMoe(
+        w13=w13,
+        w13_scales=w13_scales,
+        w13_bias=w13_bias,
+        w2=w2,
+        w2_scales=w2_scales,
+        w2_bias=w2_bias,
+        n_experts_per_token=topk,
+        activation="silu",
+        num_experts=e,
+    )
+    assert fused_moe_impl.is_mxfp8
+    assert fused_moe_impl._use_ref is False
+
+    output = torch.empty_like(ref_out)
+    fused_moe_impl.apply(
+        output=output,
+        hidden_states=a,
+        topk_weights=expert_scores,
+        topk_ids=expert_indices,
+    )
+
+    # Native path is W8A16 (bf16/fp16 A, MXFP8 B); gold is dequant-weight bf16.
+    # Act-side qdq from moe_utils.ref_fused_moe is intentionally not applied.
+    torch.testing.assert_close(output, ref_out, rtol=5e-2, atol=5e-2)
+
+
+@pytest.mark.parametrize("m,n,k", [(4, 256, 256)])
+@pytest.mark.parametrize("e", [4])
+@pytest.mark.parametrize("topk", [2])
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16],
+                         ids=format_tc)
+@pytest.mark.parametrize("has_bias", [True, False])
+def test_fused_moe_fp8block(m, n, k, e, topk, dtype, has_bias):
+    """Native block-FP8 fused MoE (init weight dequant) vs dequant-weight ref."""
+    if not torch.xpu.is_available():
+        pytest.skip("XPU required")
+    seed_everything(7)
+    torch.xpu.empty_cache()
+    gc.collect()
+
+    from vllm_xpu_kernels.moe_utils import dequant_fp8_block_wei
+
+    input_len = m
+    hidden_size = n
+    intermediate_size = k
+    num_experts = e
+    assert hidden_size % 128 == 0
+    assert intermediate_size % 128 == 0
+
+    a = torch.randn((input_len, hidden_size), device=DEVICE, dtype=dtype) / 16
+    w13 = torch.empty(num_experts,
+                      hidden_size,
+                      2 * intermediate_size,
+                      dtype=torch.float8_e4m3fn,
+                      device=DEVICE)
+    w2 = torch.empty(num_experts,
+                     intermediate_size,
+                     hidden_size,
+                     dtype=torch.float8_e4m3fn,
+                     device=DEVICE)
+    w13_scales = (torch.randn(num_experts,
+                              hidden_size // 128,
+                              (2 * intermediate_size) // 128,
+                              device=DEVICE,
+                              dtype=torch.float32).abs() + 0.01)
+    w2_scales = (torch.randn(num_experts,
+                             intermediate_size // 128,
+                             hidden_size // 128,
+                             device=DEVICE,
+                             dtype=torch.float32).abs() + 0.01)
+    ref_13 = torch.empty(num_experts,
+                         hidden_size,
+                         2 * intermediate_size,
+                         dtype=dtype,
+                         device=DEVICE)
+    ref_2 = torch.empty(num_experts,
+                        intermediate_size,
+                        hidden_size,
+                        dtype=dtype,
+                        device=DEVICE)
+
+    for i in range(num_experts):
+        w13_hp = torch.randn(hidden_size,
+                             2 * intermediate_size,
+                             device=DEVICE,
+                             dtype=torch.float32) / 16
+        w2_hp = torch.randn(intermediate_size,
+                            hidden_size,
+                            device=DEVICE,
+                            dtype=torch.float32) / 16
+        w13[i] = w13_hp.to(torch.float8_e4m3fn)
+        w2[i] = w2_hp.to(torch.float8_e4m3fn)
+        ref_13[i] = dequant_fp8_block_wei(w13[i], w13_scales[i]).to(dtype)
+        ref_2[i] = dequant_fp8_block_wei(w2[i], w2_scales[i]).to(dtype)
+
+    if has_bias:
+        w13_bias = torch.randn(
+            (num_experts, 2 * intermediate_size), device=DEVICE,
+            dtype=dtype) / 16
+        w2_bias = torch.randn(
+            (num_experts, hidden_size), device=DEVICE, dtype=dtype) / 16
+    else:
+        w13_bias = None
+        w2_bias = None
+
+    scores = torch.randn((input_len, num_experts),
+                         device=DEVICE,
+                         dtype=torch.float32)
+    expert_scores, expert_indices = torch.topk(scores,
+                                               k=topk,
+                                               dim=-1,
+                                               sorted=False)
+    flat_expert_indices = expert_indices.view(-1)
+    flat_expert_weights = expert_scores.view(-1, 1)
+
+    ref_13_nk = ref_13.transpose(-1, -2).contiguous()
+    ref_2_nk = ref_2.transpose(-1, -2).contiguous()
+    ref_out = ref_fused_moe(a.clone(), ref_13_nk, w13_bias, ref_2_nk, w2_bias,
+                            flat_expert_weights, flat_expert_indices, topk,
+                            "silu", e)
+
+    fused_moe_impl = XpuFusedMoe(
+        w13=w13,
+        w13_scales=w13_scales,
+        w13_bias=w13_bias,
+        w2=w2,
+        w2_scales=w2_scales,
+        w2_bias=w2_bias,
+        n_experts_per_token=topk,
+        activation="silu",
+        num_experts=e,
+    )
+    assert fused_moe_impl.is_block_fp8
+    assert fused_moe_impl._block_fp8_promoted
+    assert fused_moe_impl._use_ref is False
+
+    output = torch.empty_like(ref_out)
+    fused_moe_impl.apply(
+        output=output,
+        hidden_states=a,
+        topk_weights=expert_scores,
+        topk_ids=expert_indices,
+    )
+    torch.testing.assert_close(output, ref_out, rtol=5e-2, atol=5e-2)
+
+
 @pytest.mark.parametrize("num_tokens", [1, 4, 16])
 def test_fused_moe_mxfp4_topk16(num_tokens):
     test_fused_moe_mxfp4(

--- a/tests/fused_moe/test_grouped_gemm.py
+++ b/tests/fused_moe/test_grouped_gemm.py
@@ -519,3 +519,71 @@ def test_xe_grouped_gemm_mxfp8(m, n, k, e, topk, dtype, has_bias):
     ref = torch.cat(ref, dim=0)
 
     torch.testing.assert_close(output, ref, rtol=2e-2, atol=2e-2)
+
+
+@pytest.mark.parametrize("m,n,k", [(1, 256, 256), (4, 256, 256)])
+@pytest.mark.parametrize("e", [2])
+@pytest.mark.parametrize("topk", [1])
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16],
+                         ids=format_tc)
+@pytest.mark.parametrize("has_bias", [False, True])
+def test_xe_grouped_gemm_block_fp8(m, n, k, e, topk, dtype, has_bias):
+    """Native block-FP8 W8A16 grouped GEMM vs dequant+matmul gold.
+
+    Keeps FP8 weights + float32 2D scales [E, K/128, N/128] in memory.
+    """
+    if not torch.xpu.is_available():
+        pytest.skip("XPU required")
+    seed_everything(7)
+    from vllm_xpu_kernels.moe_utils import dequant_fp8_block_wei
+
+    num_experts = e
+    group_size = 128
+    assert k % group_size == 0 and n % group_size == 0
+    total_m = m * topk
+
+    input_A = torch.randn((total_m, k), dtype=dtype,
+                          device=DEVICE).contiguous() / 10
+    input_B = torch.empty(num_experts, k, n, dtype=torch.float8_e4m3fn,
+                          device=DEVICE)
+    scale_B = (torch.randn(num_experts,
+                           k // group_size,
+                           n // group_size,
+                           dtype=torch.float32,
+                           device=DEVICE).abs() + 0.01)
+
+    for i in range(num_experts):
+        hp = torch.randn(k, n, dtype=torch.float32, device=DEVICE) / 10
+        input_B[i] = hp.to(torch.float8_e4m3fn)
+
+    if has_bias:
+        bias = torch.randn((num_experts, n), dtype=dtype, device=DEVICE) / 10
+    else:
+        bias = None
+
+    num_rows_per_expert = torch.zeros(num_experts,
+                                      device=DEVICE,
+                                      dtype=torch.int32)
+    init_rows_for_experts(m, topk, num_rows_per_expert)
+
+    output = torch.empty((total_m, n), dtype=dtype, device=DEVICE)
+    cutlass_grouped_gemm_xe2(input_A, input_B, scale_B, bias, output,
+                             num_rows_per_expert, n, k, num_experts)
+
+    ref = []
+    pre_token_sum = 0
+    for i in range(num_experts):
+        cur_token_num = int(num_rows_per_expert[i].item())
+        if cur_token_num == 0:
+            continue
+        inp = input_A[pre_token_sum:pre_token_sum + cur_token_num].to(
+            torch.float32)
+        wei = dequant_fp8_block_wei(input_B[i], scale_B[i])
+        expert_out = inp @ wei
+        if has_bias:
+            expert_out = expert_out + bias[i].to(torch.float32)
+        ref.append(expert_out.to(dtype))
+        pre_token_sum += cur_token_num
+    ref = torch.cat(ref, dim=0)
+
+    torch.testing.assert_close(output, ref, rtol=2e-2, atol=2e-2)

--- a/tests/fused_moe/test_grouped_gemm.py
+++ b/tests/fused_moe/test_grouped_gemm.py
@@ -442,3 +442,80 @@ def test_xe_grouped_gemm_mxfp4(m, n, k, e, topk, dtype, has_bias):
     ref = torch.cat(ref, dim=0)
 
     torch.testing.assert_close(output, ref, rtol=1e-2, atol=1e-2)
+
+
+def dequantize_mxfp8_wei_kn(wei, wei_scale, group_size=32):
+    """Dequant MXFP8 weight [K, N] with scales [K/group, N] (E8M0 bits)."""
+    scale_f = wei_scale.view(torch.float8_e8m0fnu).to(torch.float32)
+    return wei.to(torch.float32) * scale_f.repeat_interleave(group_size, dim=0)
+
+
+@pytest.mark.parametrize("m,n,k", [(1, 256, 128), (4, 256, 128)])
+@pytest.mark.parametrize("e", [2])
+@pytest.mark.parametrize("topk", [1])
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16],
+                         ids=format_tc)
+@pytest.mark.parametrize("has_bias", [False, True])
+def test_xe_grouped_gemm_mxfp8(m, n, k, e, topk, dtype, has_bias):
+    """Native MXFP8 W8A16 grouped GEMM vs dequant+matmul gold."""
+    if not torch.xpu.is_available():
+        pytest.skip("XPU required")
+    seed_everything(7)
+    num_experts = e
+    group_size = 32
+    assert k % group_size == 0
+    group_num = k // group_size
+    total_m = m * topk
+
+    input_A = torch.randn((total_m, k), dtype=dtype,
+                          device=DEVICE).contiguous() / 10
+    weight_hp = torch.randn((num_experts, k, n), dtype=torch.float32,
+                            device=DEVICE) / 10
+    input_B = torch.empty(num_experts, k, n, dtype=torch.float8_e4m3fn,
+                          device=DEVICE)
+    scale_B = torch.empty(num_experts,
+                          group_num,
+                          n,
+                          dtype=torch.uint8,
+                          device=DEVICE)
+
+    from tests.ops.mx_utils import to_mxfp
+    for i in range(num_experts):
+        # to_mxfp blocks the last dim; we need E8M0 along K → quantize [N, K].
+        sc, lp = to_mxfp(weight_hp[i].transpose(0, 1).contiguous().cpu(),
+                         format="mxfp8")
+        input_B[i] = lp.transpose(0, 1).contiguous().to(device=DEVICE)
+        scale_B[i] = sc.transpose(0, 1).contiguous().view(
+            torch.uint8).to(device=DEVICE)
+
+    if has_bias:
+        bias = torch.randn((num_experts, n), dtype=dtype, device=DEVICE) / 10
+    else:
+        bias = None
+
+    num_rows_per_expert = torch.zeros(num_experts,
+                                      device=DEVICE,
+                                      dtype=torch.int32)
+    init_rows_for_experts(m, topk, num_rows_per_expert)
+
+    output = torch.empty((total_m, n), dtype=dtype, device=DEVICE)
+    cutlass_grouped_gemm_xe2(input_A, input_B, scale_B, bias, output,
+                             num_rows_per_expert, n, k, num_experts)
+
+    ref = []
+    pre_token_sum = 0
+    for i in range(num_experts):
+        cur_token_num = int(num_rows_per_expert[i].item())
+        if cur_token_num == 0:
+            continue
+        inp = input_A[pre_token_sum:pre_token_sum + cur_token_num].to(
+            torch.float32)
+        wei = dequantize_mxfp8_wei_kn(input_B[i], scale_B[i], group_size)
+        expert_out = inp @ wei
+        if has_bias:
+            expert_out = expert_out + bias[i].to(torch.float32)
+        ref.append(expert_out.to(dtype))
+        pre_token_sum += cur_token_num
+    ref = torch.cat(ref, dim=0)
+
+    torch.testing.assert_close(output, ref, rtol=2e-2, atol=2e-2)

--- a/vllm_xpu_kernels/fused_moe_interface.py
+++ b/vllm_xpu_kernels/fused_moe_interface.py
@@ -6,6 +6,7 @@ import torch
 
 try:
     from . import _C  # noqa: F401
+    from . import _moe_C  # noqa: F401
     from . import _xpu_C  # noqa: F401
     FUSEDMOE_UNAVAILABLE_REASON = None
     FUSEDMOE_AVAILABLE = True
@@ -13,20 +14,49 @@ except ImportError as e:
     FUSEDMOE_UNAVAILABLE_REASON = str(e)
     FUSEDMOE_AVAILABLE = False
 
-from .moe_utils import quant_act_xpu, ref_fused_moe
+from .moe_utils import (
+    dequant_fp8_block_act,
+    dequant_fp8_block_wei,
+    dequant_mxfp8,
+    quant_act_xpu,
+    ref_fused_moe,
+)
 
 REF_FUSED_MOE_ENV = "VLLM_XPU_FUSED_MOE_USE_REF"
 USE_MXFP4_FP8_ENV = "VLLM_XPU_FUSED_MOE_USE_MXFP4_FP8"
+# MXFP8 / block-FP8 use the native Xe2 path by default.
+NATIVE_MXFP8_ENV = "VLLM_XPU_FUSED_MOE_NATIVE_MXFP8"
+NATIVE_BLOCK_FP8_ENV = "VLLM_XPU_FUSED_MOE_NATIVE_BLOCK_FP8"
 
 def _is_env_enabled(env_name: str, default: str = "0") -> bool:
     value = os.environ.get(env_name, default).strip().upper()
     return value in ("1", "ON", "TRUE", "YES", "Y")
 
 
-def _should_use_ref_fused_moe(is_mxfp8: bool, is_block_fp8: bool) -> bool:  
-    if is_mxfp8 or is_block_fp8:
+def _env_native_default_on(env_name: str) -> bool:
+    """True unless env is explicitly set to a falsy value (default native)."""
+    return os.environ.get(env_name, "1").strip().upper() not in (
+        "0", "OFF", "FALSE", "NO", "N")
+
+
+def _should_use_ref_fused_moe(is_mxfp8: bool, is_block_fp8: bool) -> bool:
+    """Return True when the slow Python ref path must be used.
+
+    MXFP8: native Xe2 grouped-GEMM (FP8 weights + E8M0 block scales; A in
+    bf16/fp16 after optional act dequant). Disable with
+    VLLM_XPU_FUSED_MOE_NATIVE_MXFP8=0 or VLLM_XPU_FUSED_MOE_USE_REF=1.
+
+    Block-FP8: weights are dequantized once at module init into bf16/fp16 and
+    run on the native W16A16 grouped-GEMM path (eliminates per-token Python
+    ref loops). Disable with VLLM_XPU_FUSED_MOE_NATIVE_BLOCK_FP8=0.
+    """
+    if _is_env_enabled(REF_FUSED_MOE_ENV):
         return True
-    return _is_env_enabled(REF_FUSED_MOE_ENV)
+    if is_mxfp8 and not _env_native_default_on(NATIVE_MXFP8_ENV):
+        return True
+    if is_block_fp8 and not _env_native_default_on(NATIVE_BLOCK_FP8_ENV):
+        return True
+    return False
 
 
 def _get_recipe(is_fp8, is_mxfp8, is_mxfp4, is_int4, is_block_fp8):
@@ -48,9 +78,8 @@ def _get_weights_dtype(weight, scales):
     is_fp8 = weight_dtype in (torch.float8_e4m3fn, torch.float8_e5m2)
     is_int4 = weight_dtype == torch.uint8
     is_mxfp4 = weight_dtype == torch.float4_e2m1fn_x2
-    is_mxfp8 = (is_fp8
-                and scales is not None
-                and scales.dtype == torch.uint8) 
+    is_mxfp8 = (is_fp8 and scales is not None and scales.dtype in (
+        torch.uint8, torch.float8_e8m0fnu))
     is_block_fp8 = (is_fp8 
                     and scales is not None
                     and scales.dtype == torch.float32
@@ -207,6 +236,32 @@ class XpuFusedMoe:
             w2.data = w2_tmp
             w13.xpu_fused_moe = True
 
+        # Block-FP8: one-time weight dequant into float32, then cast to the
+        # activation dtype on first apply (avoids bf16/fp16 mismatch when
+        # bias is absent). Native path is then W16A16 grouped GEMM.
+        self._block_fp8_promoted = False
+        if (is_block_fp8 and not _should_use_ref_fused_moe(False, True)
+                and w13_scales is not None and w2_scales is not None):
+            w13_hp = torch.empty(w13.shape,
+                                 dtype=torch.float32,
+                                 device=w13.device)
+            w2_hp = torch.empty(w2.shape,
+                                dtype=torch.float32,
+                                device=w2.device)
+            for i in range(num_experts):
+                w13_hp[i] = dequant_fp8_block_wei(w13[i], w13_scales[i])
+                w2_hp[i] = dequant_fp8_block_wei(w2[i], w2_scales[i])
+            if w13_bias is not None:
+                w13 = w13_hp.to(w13_bias.dtype).contiguous()
+                w2 = w2_hp.to(w13_bias.dtype).contiguous()
+            else:
+                # Cast on first apply to match hidden_states.dtype.
+                w13 = w13_hp.contiguous()
+                w2 = w2_hp.contiguous()
+            w13_scales = None
+            w2_scales = None
+            self._block_fp8_promoted = True
+
         self.w13 = w13
         self.w2 = w2
 
@@ -214,7 +269,7 @@ class XpuFusedMoe:
             and not is_int4
             and not is_mxfp4
             and not is_block_fp8
-            and not is_mxfp8):
+            and not is_mxfp8) or self._block_fp8_promoted:
             self.gemm1_wei_scales = None
             self.gemm2_wei_scales = None
         else:
@@ -301,6 +356,10 @@ class XpuFusedMoe:
                             topk_weights, topk_ids,
                             expert_map, a1q_scale)
         else:
+            if (self._block_fp8_promoted
+                    and self.w13.dtype != hidden_states.dtype):
+                self.w13 = self.w13.to(hidden_states.dtype).contiguous()
+                self.w2 = self.w2.to(hidden_states.dtype).contiguous()
             self._apply_kernel(output, hidden_states,
                                topk_weights, topk_ids,
                                expert_map, a1q_scale)
@@ -380,6 +439,19 @@ class XpuFusedMoe:
             total_experts_num=self.total_experts_num,
             local_experts_num=self.local_experts_num)
 
+        # MXFP8 / block-FP8 activation scales: dequant to compute dtype so the
+        # Xe2 grouped GEMM runs W8A16 / W16A16 (ptr_A_scale is accepted by the
+        # op schema but Xe2 currently consumes high-precision A). This matches
+        # ref act QDQ when a1q_scale is supplied without per-expert Python GEMMs.
+        if remapped_scales is not None and self.is_mxfp8:
+            remapped_hidden_states = dequant_mxfp8(
+                remapped_hidden_states, remapped_scales).to(output.dtype)
+            remapped_scales = None
+        elif remapped_scales is not None and self.is_block_fp8:
+            remapped_hidden_states = dequant_fp8_block_act(
+                remapped_hidden_states, remapped_scales).to(output.dtype)
+            remapped_scales = None
+
         ########### gemm1 ##################
         gemm1_output = torch.empty((num_moe_inputs, 2 * self.inter_size),
                                 dtype=output.dtype,
@@ -427,9 +499,20 @@ class XpuFusedMoe:
 
         if act_quant:
             act_output, gemm2_act_scale = quant_act_xpu(act_output, self.recipe)
+            # Dequant before GEMM2 so Xe2 sees high-precision A (W8A16).
+            if self.is_mxfp8 and gemm2_act_scale is not None:
+                act_output = dequant_mxfp8(act_output,
+                                           gemm2_act_scale).to(output.dtype)
+                gemm2_act_scale = None
+            elif self.is_block_fp8 and gemm2_act_scale is not None:
+                act_output = dequant_fp8_block_act(
+                    act_output, gemm2_act_scale).to(output.dtype)
+                gemm2_act_scale = None
+        else:
+            gemm2_act_scale = None
         torch.ops._xpu_C.cutlass_grouped_gemm_interface(
             ptr_A=act_output,
-            ptr_A_scale=gemm2_act_scale if act_quant else None,
+            ptr_A_scale=gemm2_act_scale,
             ptr_B=self.w2,
             ptr_B_scale=self.gemm2_wei_scales,
             ptr_bias=self.w2_bias,

--- a/vllm_xpu_kernels/fused_moe_interface.py
+++ b/vllm_xpu_kernels/fused_moe_interface.py
@@ -14,12 +14,8 @@ except ImportError as e:
     FUSEDMOE_UNAVAILABLE_REASON = str(e)
     FUSEDMOE_AVAILABLE = False
 
-from .moe_utils import (
-    dequant_fp8_block_act,
-    dequant_mxfp8,
-    quant_act_xpu,
-    ref_fused_moe,
-)
+from .moe_utils import (dequant_fp8_block_act, dequant_mxfp8, quant_act_xpu,
+                        ref_fused_moe)
 
 REF_FUSED_MOE_ENV = "VLLM_XPU_FUSED_MOE_USE_REF"
 USE_MXFP4_FP8_ENV = "VLLM_XPU_FUSED_MOE_USE_MXFP4_FP8"
@@ -53,9 +49,8 @@ def _should_use_ref_fused_moe(is_mxfp8: bool, is_block_fp8: bool) -> bool:
         return True
     if is_mxfp8 and not _env_native_default_on(NATIVE_MXFP8_ENV):
         return True
-    if is_block_fp8 and not _env_native_default_on(NATIVE_BLOCK_FP8_ENV):
-        return True
-    return False
+    return (is_block_fp8
+            and not _env_native_default_on(NATIVE_BLOCK_FP8_ENV))
 
 
 def _get_recipe(is_fp8, is_mxfp8, is_mxfp4, is_int4, is_block_fp8):
@@ -412,7 +407,7 @@ class XpuFusedMoe:
         # MXFP8 / block-FP8 activation scales: dequant to compute dtype so the
         # Xe2 grouped GEMM runs W8A16 / W16A16 (ptr_A_scale is accepted by the
         # op schema but Xe2 currently consumes high-precision A). This matches
-        # ref act QDQ when a1q_scale is supplied without per-expert Python GEMMs.
+        # ref act QDQ when a1q_scale is set without per-expert Python GEMMs.
         if remapped_scales is not None and self.is_mxfp8:
             remapped_hidden_states = dequant_mxfp8(
                 remapped_hidden_states, remapped_scales).to(output.dtype)

--- a/vllm_xpu_kernels/fused_moe_interface.py
+++ b/vllm_xpu_kernels/fused_moe_interface.py
@@ -16,7 +16,6 @@ except ImportError as e:
 
 from .moe_utils import (
     dequant_fp8_block_act,
-    dequant_fp8_block_wei,
     dequant_mxfp8,
     quant_act_xpu,
     ref_fused_moe,
@@ -46,9 +45,9 @@ def _should_use_ref_fused_moe(is_mxfp8: bool, is_block_fp8: bool) -> bool:
     bf16/fp16 after optional act dequant). Disable with
     VLLM_XPU_FUSED_MOE_NATIVE_MXFP8=0 or VLLM_XPU_FUSED_MOE_USE_REF=1.
 
-    Block-FP8: weights are dequantized once at module init into bf16/fp16 and
-    run on the native W16A16 grouped-GEMM path (eliminates per-token Python
-    ref loops). Disable with VLLM_XPU_FUSED_MOE_NATIVE_BLOCK_FP8=0.
+    Block-FP8: native Xe2 grouped-GEMM keeps FP8 weights + float32 2D
+    scales [E,K/128,N/128] in memory (in-kernel scale apply). Disable with
+    VLLM_XPU_FUSED_MOE_NATIVE_BLOCK_FP8=0.
     """
     if _is_env_enabled(REF_FUSED_MOE_ENV):
         return True
@@ -236,40 +235,15 @@ class XpuFusedMoe:
             w2.data = w2_tmp
             w13.xpu_fused_moe = True
 
-        # Block-FP8: one-time weight dequant into float32, then cast to the
-        # activation dtype on first apply (avoids bf16/fp16 mismatch when
-        # bias is absent). Native path is then W16A16 grouped GEMM.
+        # Block-FP8 keeps FP8 weights + float32 2D scales in memory; Xe2
+        # grouped GEMM applies scales in-kernel (no init-time dequant).
         self._block_fp8_promoted = False
-        if (is_block_fp8 and not _should_use_ref_fused_moe(False, True)
-                and w13_scales is not None and w2_scales is not None):
-            w13_hp = torch.empty(w13.shape,
-                                 dtype=torch.float32,
-                                 device=w13.device)
-            w2_hp = torch.empty(w2.shape,
-                                dtype=torch.float32,
-                                device=w2.device)
-            for i in range(num_experts):
-                w13_hp[i] = dequant_fp8_block_wei(w13[i], w13_scales[i])
-                w2_hp[i] = dequant_fp8_block_wei(w2[i], w2_scales[i])
-            if w13_bias is not None:
-                w13 = w13_hp.to(w13_bias.dtype).contiguous()
-                w2 = w2_hp.to(w13_bias.dtype).contiguous()
-            else:
-                # Cast on first apply to match hidden_states.dtype.
-                w13 = w13_hp.contiguous()
-                w2 = w2_hp.contiguous()
-            w13_scales = None
-            w2_scales = None
-            self._block_fp8_promoted = True
 
         self.w13 = w13
         self.w2 = w2
 
-        if (not is_fp8 
-            and not is_int4
-            and not is_mxfp4
-            and not is_block_fp8
-            and not is_mxfp8) or self._block_fp8_promoted:
+        if (not is_fp8 and not is_int4 and not is_mxfp4 and not is_block_fp8
+                and not is_mxfp8):
             self.gemm1_wei_scales = None
             self.gemm2_wei_scales = None
         else:
@@ -356,10 +330,6 @@ class XpuFusedMoe:
                             topk_weights, topk_ids,
                             expert_map, a1q_scale)
         else:
-            if (self._block_fp8_promoted
-                    and self.w13.dtype != hidden_states.dtype):
-                self.w13 = self.w13.to(hidden_states.dtype).contiguous()
-                self.w2 = self.w2.to(hidden_states.dtype).contiguous()
             self._apply_kernel(output, hidden_states,
                                topk_weights, topk_ids,
                                expert_map, a1q_scale)

--- a/vllm_xpu_kernels/moe_utils.py
+++ b/vllm_xpu_kernels/moe_utils.py
@@ -2,6 +2,7 @@
 import torch
 
 from . import _C  # noqa: F401
+from . import _moe_C  # noqa: F401
 from . import _xpu_C  # noqa: F401
 
 finfo = torch.finfo(torch.float8_e4m3fn)


### PR DESCRIPTION
## Purpose

Enable the **native Xe2 grouped-GEMM MoE path** for **MXFP8** (FP8 weights + E8M0 block scales, group=32) and **block-FP8**, instead of defaulting to the slow Python `ref_fused_moe` expert loop.

### Scope / pairing (do not split)

This PR ships **both** pieces together (fork **#9** path flip + kernels):

1. **Path selection (fork #9):** stop forcing MXFP8 / block-FP8 onto Python `ref_fused_moe`; default native with escape hatches below.
2. **Kernels:** Xe2 grouped-GEMM MXFP8 E8M0 B-scales (W8A16 activations today) + block-FP8 one-time weight dequant → W16A16; fused-moe accuracy tests.

A path-flip-only change without the kernel/dispatch work is **incorrect** and is **not** a supported split. All A/B numbers below are for this **combined** change vs `VLLM_XPU_FUSED_MOE_USE_REF=1`.

- **MXFP8:** native W8A16 grouped GEMM with E8M0 B-scales (activations dequantized in Python today). Default on; disable with `VLLM_XPU_FUSED_MOE_NATIVE_MXFP8=0` or force ref with `VLLM_XPU_FUSED_MOE_USE_REF=1`.
- **Block-FP8:** one-time weight dequant at init → W16A16 native GEMM. Default on; disable with `VLLM_XPU_FUSED_MOE_NATIVE_BLOCK_FP8=0`.
- Detect MXFP8 scales as `uint8` or `float8_e8m0fnu`.
- Xe2 grouped-GEMM: MXFP8 B-scale dispatch + fused-moe accuracy tests.

**Serve note:** loading HF MXFP8 MoE (`weight_block_size=[1,32]`) also needs vLLM to select the XPU MXFP8 MoE backend and transpose block scales with weights to `[E,K/g,N]` after the XPU `[E,N,K]→[E,K,N]` weight transpose. That wiring lives in vLLM (not this PR).

## Test Plan

```bash
.venv/bin/python -m pytest \
  tests/fused_moe/test_grouped_gemm.py::test_xe_grouped_gemm_mxfp8 \
  tests/fused_moe/test_fused_moe.py::test_fused_moe_mxfp8 \
  tests/fused_moe/test_fused_moe.py::test_fused_moe_fp8block \
  -v
```

Micro + E2E A/B (HAL B70):

```bash
bash ab_artifacts/run_pb_e2e_full.sh
# equivalent: MODEL=.../Qwen1.5-MoE-A2.7B-Chat-MXFP8-RTN PHASES=ref,native \
#   bash ab_artifacts/e2e_hotpath_model_ab.sh
```

- [x] Grouped-GEMM MXFP8 unit accuracy
- [x] Fused MoE MXFP8 + block-FP8 unit accuracy
- [x] Micro A/B: native vs `USE_REF` for MXFP8 **and** block-FP8 (`ab_moe_native_micro.py` / `pb_e2e_micro.txt`)
- [x] E2E serve A/B on Arc Pro B70 (full bench scrape: tok/s, req/s, TTFT/TPOT/ITL)
- [ ] Upstream CI / reviewer smoke on XPU

## Test Result

### Prior E2E pack (PR open)

**Hardware:** Intel Arc Pro B70 · **Commit:** `97c29ca`  
**Model:** `Qwen1.5-MoE-A2.7B-Chat-MXFP8-RTN` (~15 GiB, FP8 + `[1,32]` / `ue8m0`)  
**Recipe:** random, 24 prompts, 256→128, `max_model_len=2048`, `gpu_util=0.85`, `--enforce-eager`  
**Failed requests:** 0 / 0 (24/24 both sides)

| Side | Env | Median tok/s | Runs (tok/s) |
|------|-----|--------------|--------------|
| REF | `VLLM_XPU_FUSED_MOE_USE_REF=1` | **26.19** | 26.19 / 27.19 / 25.46 |
| Native | `VLLM_XPU_FUSED_MOE_NATIVE_MXFP8=1` | **611.0** | 603.34 / 613.88 / 611.0 |

**Δ tok/s:** **+2233%** vs REF → E2E KEEP (≥10% bar).

| Metric (measure 2) | REF | Native |
|--------------------|-----|--------|
| Median TTFT (ms) | 3089.73 | 238.90 |
| Median TPOT (ms) | 865.37 | 37.50 |

### Refreshed full scrape (P-B, 2026-07-25)

Source of truth: `ab_artifacts/hal_results/PB_E2E_FULL_VERDICT.{md,json}`.

**Hardware:** Intel Arc Pro B70 · **Measured commit:** `97c29ca` · **PR tip:** `97c29ca` (aligned; no remount/remeasure needed)  
**Model:** `Qwen1.5-MoE-A2.7B-Chat-MXFP8-RTN`  
**Recipe:** same as prior pack (random, 24 prompts, 256→128, `max_model_len=2048`, `gpu_util=0.85`, `--enforce-eager`)  
**Compare:** combined path selection + kernels vs `USE_REF=1`  
**Failed requests:** **0 / 0**

#### Micro (op median ms)

| Recipe | Ref ms | Native ms | Speedup |
|--------|--------|-----------|---------|
| MXFP8 | 3.463 | 0.210 | **+1547%** (~16.5×) |
| block-FP8 | 3.170 | 0.162 | **+1857%** (~19.6×) |

#### E2E serve (median of 3 timed runs after warmup)

| Metric | REF | Native | Δ |
|--------|-----|--------|---|
| Output tok/s | **25.1** | **607.9** | **+2322%** |
| Total tok/s | n/a | n/a | n/a (not reported by bench scrape) |
| Request throughput (req/s) | 0.20 | 4.75 | **+2275%** |
| Median TTFT (ms) | 3338.39 | 248.27 | **+92.6%** improve |
| Mean TTFT (ms) | 3307.27 | 242.11 | **+92.7%** improve |
| Median TPOT (ms) | 937.46 | 37.81 | **+96.0%** improve |
| Mean TPOT (ms) | 937.71 | 37.85 | **+96.0%** improve |
| Median ITL (ms) | 947.70 | 37.96 | **+96.0%** improve |

**Per-run output tok/s:** REF `[25.23, 25.10, 24.35]` · Native `[607.90, 614.93, 600.60]`  
**E2E KEEP (≥10% tok/s):** **yes**.

The refreshed pack is within noise of the prior +2233% pack (same order of magnitude; both KEEP). Prior numbers are retained above for continuity.

**Claim:** combined path flip (fork #9) + Xe2 kernels vs the previous Python expert-loop REF on the same checkpoint. **Not** a claim vs W8A16, **not** vs CUDA/Marlin MXFP8 backends. Device W8A8 is out of scope for this PR.

Serve logs confirmed `XPUMxFp8LinearKernel` + `Using 'XPU' MxFp8 MoE backend` on both sides.

## (Optional) Documentation Update

None in-tree. Escape hatches: `VLLM_XPU_FUSED_MOE_NATIVE_MXFP8`, `VLLM_XPU_FUSED_MOE_NATIVE_BLOCK_FP8`, `VLLM_XPU_FUSED_MOE_USE_REF`.
