### PR TITLE
attn: fail closed on unimplemented softcap and ALIBI

### DIFF
--- a/csrc/flash_attn/flash_api.cpp
+++ b/csrc/flash_attn/flash_api.cpp
@@ -128,6 +128,18 @@ std::vector<at::Tensor> mha_varlen_fwd(
       q_type == at::ScalarType::Half || q_type == at::ScalarType::BFloat16,
       "VLLM Kernel XPU only supports fp16 and bf16 type");
 
+  // Previously accepted then silently ignored — that silently wrong-results
+  // Gemma-style softcap / ALIBI models. Fail closed until device support lands.
+  TORCH_CHECK(
+      !alibi_slopes_.has_value(),
+      "alibi_slopes is not implemented on XPU flash attention yet");
+  TORCH_CHECK(
+      softcap == 0.0f,
+      "softcap=",
+      softcap,
+      " is not implemented on XPU flash attention yet "
+      "(pass softcap=0 or use a model without softcap)");
+
   TORCH_CHECK(
       v.scalar_type() == k_type, "key and value must have the same dtype");
   if (k_type != at::ScalarType::Float8_e5m2 &&

--- a/vllm_xpu_kernels/flash_attn_interface.py
+++ b/vllm_xpu_kernels/flash_attn_interface.py
@@ -530,6 +530,14 @@ def flash_attn_varlen_func(
                 softcap,
             )
 
+        if alibi_slopes is not None:
+            raise NotImplementedError(
+                "alibi_slopes is not implemented on XPU flash attention yet")
+        if softcap is not None and softcap != 0.0:
+            raise NotImplementedError(
+                f"softcap={softcap} is not implemented on XPU flash "
+                "attention yet (pass softcap=0)")
+
         # Compute per-seq splits and work_list on host, upload to device.
         # Only enable for decode (max_seqlen_q == 1) with paged KV cache,
         # multi-seq batches, and global num_splits_kv > 1.


### PR DESCRIPTION
## Purpose

Fail closed when XPU flash attention is called with `softcap != 0` or `alibi_slopes` set, instead of accepting those args and silently ignoring them (wrong results for Gemma-style softcap / ALIBI models).

Device softcap/ALIBI kernels remain follow-up work. Common Llama/Qwen paths (`softcap=0`, `alibi_slopes=None`) are unchanged.

Aligned with the existing fail-closed attention fallback policy.

## Test Plan

- [x] Code review: Python `NotImplementedError` + C++ `TORCH_CHECK` on the FA2 entry points
- [ ] On XPU: `softcap=0` / `alibi_slopes=None` still runs
- [ ] On XPU: `softcap>0` or non-None `alibi_slopes` raises a clear error

## Test Result

Correctness-only change (no throughput claim). Dense Llama/Qwen E2E paths do not exercise softcap/ALIBI.

## (Optional) Documentation Update

None.

---
Fork counterpart (merged): https://github.com/krisclarkdev/vllm-xpu-kernels/pull/11

Made with [Cursor](https://cursor.com)