### PR TITLE
ci: add nightly BMG benchmark workflow

### DIFF
--- a/.github/workflows/nightly-benchmark.yaml
+++ b/.github/workflows/nightly-benchmark.yaml
@@ -20,6 +20,8 @@ on:
   pull_request:
     branches: [main]
     types: [labeled]
+  issue_comment:
+    types: [created]
 
 permissions:
   contents: read
@@ -28,7 +30,7 @@ permissions:
   pull-requests: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
@@ -46,12 +48,19 @@ jobs:
       (github.event_name == 'workflow_run' &&
        github.event.workflow_run.conclusion == 'success') ||
       github.event_name == 'workflow_dispatch' ||
-      github.event_name == 'pull_request'
+      github.event_name == 'push' ||
+      github.event_name == 'pull_request' ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request != null &&
+       contains(github.event.comment.body, 'trigger benchmark'))
     outputs:
       head_sha: ${{ steps.resolve.outputs.head_sha }}
       run_id: ${{ steps.resolve.outputs.run_id }}
       should_run: ${{ steps.resolve.outputs.should_run }}
       short_sha: ${{ steps.resolve.outputs.short_sha }}
+      trigger: ${{ steps.resolve.outputs.trigger }}
+      pr_number: ${{ steps.resolve.outputs.pr_number }}
+      head_branch: ${{ steps.resolve.outputs.head_branch }}
     steps:
       - name: Resolve unit-test wheel artifact run
         id: resolve
@@ -92,10 +101,13 @@ jobs:
 
             let runId = '';
             let headSha = context.sha;
+            let trigger = 'nightly';
+            let prNumber = '';
+            let headBranch = '';
 
             if (context.eventName === 'workflow_run') {
               if (context.payload.workflow_run.event === 'pull_request') {
-                const prNumber = await associatedPullRequestNumber(context.payload.workflow_run);
+                prNumber = await associatedPullRequestNumber(context.payload.workflow_run);
                 if (!prNumber) {
                   skip('Unit-test workflow run is not associated with a pull request.');
                   return;
@@ -104,6 +116,8 @@ jobs:
                   skip(`Pull request #${prNumber} does not have ${needBenchmarkLabel}.`);
                   return;
                 }
+                trigger = 'pr';
+                headBranch = context.payload.workflow_run.head_branch || '';
               } else if (context.payload.workflow_run.event !== 'schedule') {
                 skip(
                   `Ignoring unit-test workflow_run event ${context.payload.workflow_run.event}.`,
@@ -118,8 +132,26 @@ jobs:
                 return;
               }
               headSha = context.payload.pull_request.head.sha;
+              trigger = 'pr';
+              prNumber = context.payload.pull_request.number;
+              headBranch = context.payload.pull_request.head.ref || '';
             } else if (context.eventName === 'workflow_dispatch') {
               runId = context.payload.inputs?.test_workflow_run_id || '';
+            } else if (context.eventName === 'issue_comment') {
+              const comment = (context.payload.comment?.body || '').trim().toLowerCase();
+              if (!context.payload.issue?.pull_request || comment !== 'trigger benchmark') {
+                skip(`Ignoring comment: ${context.payload.comment?.body || '<empty>'}`);
+                return;
+              }
+              prNumber = context.payload.issue.number;
+              const {data: pr} = await github.rest.pulls.get({
+                owner,
+                repo,
+                pull_number: prNumber,
+              });
+              headSha = pr.head.sha;
+              headBranch = pr.head.ref || '';
+              trigger = 'pr';
             }
 
             if (runId) {
@@ -157,7 +189,7 @@ jobs:
               );
               const run = runs.find((item) => item.conclusion === 'success');
               if (!run) {
-                if (context.eventName === 'pull_request') {
+                if (context.eventName === 'pull_request' || context.eventName === 'issue_comment') {
                   skip(
                     `No successful ${process.env.UNIT_TEST_WORKFLOW} run is ready for ${headSha}; waiting for workflow_run completion.`,
                   );
@@ -175,6 +207,9 @@ jobs:
             core.setOutput('should_run', 'true');
             core.setOutput('short_sha', headSha.slice(0, 7));
             core.setOutput('run_id', runId);
+            core.setOutput('trigger', trigger);
+            core.setOutput('pr_number', String(prNumber || ''));
+            core.setOutput('head_branch', headBranch);
 
   build-docker-image-bmg:
     runs-on: self-hosted-bmg
@@ -272,6 +307,34 @@ jobs:
             --threshold "${{ env.REGRESSION_THRESHOLD }}" \
             --output-dir "${{ env.BENCHMARK_RESULTS_DIR }}" \
             --fail-on-regression
+
+      - name: Upload benchmark results to database
+        if: always()
+        continue-on-error: true
+        env:
+          DB_HOST: ${{ vars.DB_HOST || 'localhost' }}
+          DB_PORT: ${{ vars.DB_PORT || '5432' }}
+          DB_NAME: ${{ vars.DB_NAME || 'vllm_benchmarks' }}
+          DB_USER: ${{ vars.DB_USER || 'vllmadmin' }}
+          DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
+          TRIGGER: ${{ needs.resolve-wheel-artifact.outputs.trigger }}
+          SHORT_SHA: ${{ needs.resolve-wheel-artifact.outputs.short_sha }}
+          PR_NUMBER: ${{ needs.resolve-wheel-artifact.outputs.pr_number }}
+          HEAD_BRANCH: ${{ needs.resolve-wheel-artifact.outputs.head_branch }}
+        run: |
+          if [ "${TRIGGER}" = "pr" ]; then
+            DOCKER_TAG="pr-${PR_NUMBER}-${SHORT_SHA}"
+            RESULT_ID="pr-${PR_NUMBER}-${HEAD_BRANCH}-${SHORT_SHA}"
+          else
+            DOCKER_TAG="nightly-${SHORT_SHA}"
+            RESULT_ID="nightly-${SHORT_SHA}"
+          fi
+          uv pip install "psycopg[binary]"
+          python tools/upload_benchmark_db.py \
+            --results-dir "${{ env.BENCHMARK_RESULTS_DIR }}/raw" \
+            --docker-tag "${DOCKER_TAG}" \
+            --node-label bmg \
+            --result-id "${RESULT_ID}"
 
       - name: Add benchmark summary
         if: always()

--- a/.github/workflows/nightly-benchmark.yaml
+++ b/.github/workflows/nightly-benchmark.yaml
@@ -4,7 +4,6 @@ on:
   workflow_run:
     workflows: ["run unit tests on Intel GPU."]
     types: [completed]
-    branches: [main]
   workflow_dispatch:
     inputs:
       benchmark_suite:
@@ -20,11 +19,13 @@ on:
         required: false
   pull_request:
     branches: [main]
-    types: [opened, reopened, synchronize, labeled]
+    types: [labeled]
 
 permissions:
   contents: read
   actions: write
+  issues: read
+  pull-requests: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -35,6 +36,7 @@ env:
   BENCHMARK_RESULTS_DIR: benchmark-results
   BENCHMARK_SUITE: ${{ github.event.inputs.benchmark_suite || 'nightly' }}
   REGRESSION_THRESHOLD: ${{ github.event.inputs.regression_threshold || '0.10' }}
+  NEED_BENCHMARK_LABEL: need_benchmark
   UNIT_TEST_WORKFLOW: run unit tests on Intel GPU.
 
 jobs:
@@ -42,14 +44,13 @@ jobs:
     runs-on: self-hosted-bmg
     if: |
       (github.event_name == 'workflow_run' &&
-       github.event.workflow_run.conclusion == 'success' &&
-       github.event.workflow_run.event == 'schedule') ||
+       github.event.workflow_run.conclusion == 'success') ||
       github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'pull_request' &&
-       contains(github.event.pull_request.labels.*.name, 'need_benchmark'))
+      github.event_name == 'pull_request'
     outputs:
       head_sha: ${{ steps.resolve.outputs.head_sha }}
       run_id: ${{ steps.resolve.outputs.run_id }}
+      should_run: ${{ steps.resolve.outputs.should_run }}
       short_sha: ${{ steps.resolve.outputs.short_sha }}
     steps:
       - name: Resolve unit-test wheel artifact run
@@ -59,17 +60,75 @@ jobs:
           script: |
             const owner = context.repo.owner;
             const repo = context.repo.repo;
+            const needBenchmarkLabel = process.env.NEED_BENCHMARK_LABEL;
+
+            async function hasNeedBenchmarkLabel(prNumber) {
+              const {data: issue} = await github.rest.issues.get({
+                owner,
+                repo,
+                issue_number: prNumber,
+              });
+              return issue.labels.some((label) => label.name === needBenchmarkLabel);
+            }
+
+            async function associatedPullRequestNumber(workflowRun) {
+              const pullRequests = workflowRun.pull_requests || [];
+              if (pullRequests.length) {
+                return pullRequests[0].number;
+              }
+              const {data: pullRequestsForCommit} = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+                owner,
+                repo,
+                commit_sha: workflowRun.head_sha,
+              });
+              return pullRequestsForCommit.find((pr) => pr.state === 'open')?.number ||
+                pullRequestsForCommit[0]?.number;
+            }
+
+            function skip(message) {
+              core.notice(message);
+              core.setOutput('should_run', 'false');
+            }
 
             let runId = '';
             let headSha = context.sha;
 
             if (context.eventName === 'workflow_run') {
+              if (context.payload.workflow_run.event === 'pull_request') {
+                const prNumber = await associatedPullRequestNumber(context.payload.workflow_run);
+                if (!prNumber) {
+                  skip('Unit-test workflow run is not associated with a pull request.');
+                  return;
+                }
+                if (!(await hasNeedBenchmarkLabel(prNumber))) {
+                  skip(`Pull request #${prNumber} does not have ${needBenchmarkLabel}.`);
+                  return;
+                }
+              } else if (context.payload.workflow_run.event !== 'schedule') {
+                skip(
+                  `Ignoring unit-test workflow_run event ${context.payload.workflow_run.event}.`,
+                );
+                return;
+              }
               runId = String(context.payload.workflow_run.id);
               headSha = context.payload.workflow_run.head_sha;
             } else if (context.eventName === 'pull_request') {
+              if (context.payload.label?.name !== needBenchmarkLabel) {
+                skip(`Ignoring label ${context.payload.label?.name || '<unknown>'}.`);
+                return;
+              }
               headSha = context.payload.pull_request.head.sha;
             } else if (context.eventName === 'workflow_dispatch') {
               runId = context.payload.inputs?.test_workflow_run_id || '';
+            }
+
+            if (runId) {
+              const {data: run} = await github.rest.actions.getWorkflowRun({
+                owner,
+                repo,
+                run_id: Number(runId),
+              });
+              headSha = run.head_sha;
             }
 
             if (!runId) {
@@ -98,6 +157,12 @@ jobs:
               );
               const run = runs.find((item) => item.conclusion === 'success');
               if (!run) {
+                if (context.eventName === 'pull_request') {
+                  skip(
+                    `No successful ${process.env.UNIT_TEST_WORKFLOW} run is ready for ${headSha}; waiting for workflow_run completion.`,
+                  );
+                  return;
+                }
                 core.setFailed(
                   `No successful ${process.env.UNIT_TEST_WORKFLOW} run found for ${headSha}`,
                 );
@@ -107,12 +172,14 @@ jobs:
             }
 
             core.setOutput('head_sha', headSha);
+            core.setOutput('should_run', 'true');
             core.setOutput('short_sha', headSha.slice(0, 7));
             core.setOutput('run_id', runId);
 
   build-docker-image-bmg:
     runs-on: self-hosted-bmg
     needs: resolve-wheel-artifact
+    if: needs.resolve-wheel-artifact.outputs.should_run == 'true'
     outputs:
       image_tag: ${{ steps.set-tag.outputs.image_tag }}
     steps:
@@ -143,6 +210,7 @@ jobs:
   run-benchmarks-bmg:
     runs-on: self-hosted-bmg
     needs: [resolve-wheel-artifact, build-docker-image-bmg]
+    if: needs.resolve-wheel-artifact.outputs.should_run == 'true'
     timeout-minutes: 240
     container:
       image: localhost:5000/xpu-kernel-ci-image:${{ needs.build-docker-image-bmg.outputs.image_tag }}
@@ -264,8 +332,8 @@ jobs:
 
   clean-repo-bmg:
     runs-on: self-hosted-bmg
-    needs: run-benchmarks-bmg
-    if: always()
+    needs: [resolve-wheel-artifact, run-benchmarks-bmg]
+    if: always() && needs.resolve-wheel-artifact.outputs.should_run == 'true'
     steps:
       - name: Clean workspace
         run: |

--- a/.github/workflows/nightly-benchmark.yaml
+++ b/.github/workflows/nightly-benchmark.yaml
@@ -216,6 +216,14 @@ jobs:
             echo "- Wheel artifact run: \`${{ needs.resolve-wheel-artifact.outputs.run_id }}\`"
             echo "- Baseline restored: \`${{ steps.restore-baseline.outputs['cache-hit'] || 'prefix-or-miss' }}\`"
             echo
+            if [ -s "${{ env.BENCHMARK_RESULTS_DIR }}/run_failures.json" ]; then
+              echo "### Benchmark Command Failures"
+              echo
+              echo '```json'
+              cat "${{ env.BENCHMARK_RESULTS_DIR }}/run_failures.json"
+              echo '```'
+              echo
+            fi
             if [ -f "${{ env.BENCHMARK_RESULTS_DIR }}/regression_report.md" ]; then
               cat "${{ env.BENCHMARK_RESULTS_DIR }}/regression_report.md"
             fi

--- a/.github/workflows/nightly-benchmark.yaml
+++ b/.github/workflows/nightly-benchmark.yaml
@@ -1,0 +1,213 @@
+name: nightly benchmark on Intel BMG
+
+on:
+  schedule:
+    # Beijing time 03:00, which is 19:00 UTC on the previous day.
+    - cron: '0 19 * * *'
+  workflow_dispatch:
+    inputs:
+      benchmark_suite:
+        description: 'Benchmark suite to run: smoke or nightly'
+        required: false
+        default: 'nightly'
+      regression_threshold:
+        description: 'Allowed relative regression before failing the job'
+        required: false
+        default: '0.10'
+  pull_request:
+    branches: [main]
+    types: [opened, reopened, synchronize, labeled]
+
+permissions:
+  contents: read
+  actions: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+env:
+  REGISTRY: localhost:5000
+  BENCHMARK_RESULTS_DIR: benchmark-results
+  BENCHMARK_SUITE: ${{ github.event.inputs.benchmark_suite || 'nightly' }}
+  REGRESSION_THRESHOLD: ${{ github.event.inputs.regression_threshold || '0.10' }}
+
+jobs:
+  build-docker-image-bmg:
+    runs-on: self-hosted-bmg
+    if: |
+      github.event_name != 'pull_request' ||
+      contains(github.event.pull_request.labels.*.name, 'need_benchmark')
+    outputs:
+      image_tag: ${{ steps.set-tag.outputs.image_tag }}
+    steps:
+      - name: Clean workspace
+        run: |
+          sudo chown -R "$(id -u):$(id -g)" . || true
+          git clean -ffdx || true
+          git reset --hard || true
+
+
+      - name: Checkout tested commit
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          set-safe-directory: true
+          clean: true
+
+      - name: Set image tag
+        id: set-tag
+        run: echo "image_tag=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+
+      - name: Build benchmark docker image
+        run: |
+          IMAGE_TAG=${GITHUB_SHA::7}
+          docker build -t "xpu-kernel-ci-image:${IMAGE_TAG}" -f Dockerfile.xpu .
+          docker tag "xpu-kernel-ci-image:${IMAGE_TAG}" "${{ env.REGISTRY }}/xpu-kernel-ci-image:${IMAGE_TAG}"
+          docker push "${{ env.REGISTRY }}/xpu-kernel-ci-image:${IMAGE_TAG}"
+
+  build-wheel-bmg:
+    runs-on: self-hosted-bmg
+    needs: build-docker-image-bmg
+    timeout-minutes: 90
+    container:
+      image: localhost:5000/xpu-kernel-ci-image:${{ needs.build-docker-image-bmg.outputs.image_tag }}
+      options: --device /dev/dri -v /dev/dri/by-path:/dev/dri/by-path --privileged -v ccache:/root/.ccache -e CCACHE_DIR=/root/.ccache
+    steps:
+      - name: Checkout tested commit
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          set-safe-directory: true
+
+      - name: Build wheel
+        run: |
+          git config --global --add safe.directory "${GITHUB_WORKSPACE}"
+          export CCACHE_DIR=/root/.ccache
+          export CCACHE_BASEDIR="${GITHUB_WORKSPACE}"
+          export CCACHE_NOHASHDIR=1
+          export CCACHE_COMPILERCHECK=content
+          ccache -s || true
+          git submodule sync && git submodule update --init --recursive
+          uv pip install -r requirements.txt
+          rm -rf dist/*
+          MAX_JOBS=128 uv build --no-build-isolation --wheel -v
+          ccache -s || true
+
+      - name: Upload wheel artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-wheel
+          path: dist/*.whl
+          retention-days: 30
+
+  run-benchmarks-bmg:
+    runs-on: self-hosted-bmg
+    needs: [build-docker-image-bmg, build-wheel-bmg]
+    timeout-minutes: 240
+    container:
+      image: localhost:5000/xpu-kernel-ci-image:${{ needs.build-docker-image-bmg.outputs.image_tag }}
+      options: --device /dev/dri -v /dev/dri/by-path:/dev/dri/by-path --privileged -v ccache:/root/.ccache -e CCACHE_DIR=/root/.ccache
+    steps:
+      - name: Checkout tested commit
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          set-safe-directory: true
+
+      - name: Download wheel artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: benchmark-wheel
+          path: dist/
+
+      - name: Install wheel
+        run: |
+          git config --global --add safe.directory "${GITHUB_WORKSPACE}"
+          uv pip install -r requirements.txt
+          WHEEL=$(find dist -name '*.whl' -print -quit)
+          VLLM_USE_PRECOMPILED=1 \
+          VLLM_PRECOMPILED_WHEEL_LOCATION="${WHEEL}" \
+          uv pip install --no-build-isolation -e . -v
+
+      - name: Restore main benchmark baseline
+        id: restore-baseline
+        uses: actions/cache/restore@v4
+        with:
+          path: benchmark-baseline
+          key: benchmark-baseline-${{ github.event.repository.default_branch }}-${{ github.sha }}
+          restore-keys: |
+            benchmark-baseline-${{ github.event.repository.default_branch }}-
+
+      - name: Run benchmark suite
+        env:
+          ZE_AFFINITY_MASK: '0'
+        run: |
+          python tools/benchmark_ci.py run \
+            --suite "${{ env.BENCHMARK_SUITE }}" \
+            --output-dir "${{ env.BENCHMARK_RESULTS_DIR }}"
+
+      - name: Normalize benchmark results
+        env:
+          ZE_AFFINITY_MASK: '0'
+        run: |
+          python tools/benchmark_ci.py normalize \
+            --input-dir "${{ env.BENCHMARK_RESULTS_DIR }}/raw" \
+            --output-dir "${{ env.BENCHMARK_RESULTS_DIR }}"
+
+      - name: Compare with main baseline
+        run: |
+          python tools/benchmark_ci.py compare \
+            --current "${{ env.BENCHMARK_RESULTS_DIR }}/results.jsonl" \
+            --baseline "benchmark-baseline/results.jsonl" \
+            --threshold "${{ env.REGRESSION_THRESHOLD }}" \
+            --output-dir "${{ env.BENCHMARK_RESULTS_DIR }}" \
+            --fail-on-regression
+
+      - name: Add benchmark summary
+        if: always()
+        run: |
+          {
+            echo "## Nightly BMG Benchmark"
+            echo
+            echo "- Suite: \`${{ env.BENCHMARK_SUITE }}\`"
+            echo "- Commit: \`${GITHUB_SHA::7}\`"
+            echo "- Baseline restored: \`${{ steps.restore-baseline.outputs['cache-hit'] || 'prefix-or-miss' }}\`"
+            echo
+            if [ -f "${{ env.BENCHMARK_RESULTS_DIR }}/regression_report.md" ]; then
+              cat "${{ env.BENCHMARK_RESULTS_DIR }}/regression_report.md"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload benchmark artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-results-${{ github.sha }}
+          path: |
+            benchmark-results/
+          retention-days: 90
+
+      - name: Prepare next baseline
+        if: success() && github.event_name == 'schedule' && github.ref == 'refs/heads/main'
+        run: |
+          rm -rf benchmark-baseline
+          mkdir -p benchmark-baseline
+          cp "${{ env.BENCHMARK_RESULTS_DIR }}/results.jsonl" benchmark-baseline/results.jsonl
+          cp "${{ env.BENCHMARK_RESULTS_DIR }}/results.csv" benchmark-baseline/results.csv
+          cp "${{ env.BENCHMARK_RESULTS_DIR }}/run_info.json" benchmark-baseline/run_info.json
+
+      - name: Save next main benchmark baseline
+        if: success() && github.event_name == 'schedule' && github.ref == 'refs/heads/main'
+        uses: actions/cache/save@v4
+        with:
+          path: benchmark-baseline
+          key: benchmark-baseline-${{ github.event.repository.default_branch }}-${{ github.run_id }}
+
+  clean-repo-bmg:
+    runs-on: self-hosted-bmg
+    needs: run-benchmarks-bmg
+    if: always()
+    steps:
+      - name: Clean workspace
+        run: |
+          sudo chown -R "$(id -u):$(id -g)" . || true
+          git clean -ffdx || true
+          git reset --hard || true

--- a/.github/workflows/nightly-benchmark.yaml
+++ b/.github/workflows/nightly-benchmark.yaml
@@ -1,9 +1,10 @@
 name: nightly benchmark on Intel BMG
 
 on:
-  schedule:
-    # Beijing time 03:00, which is 19:00 UTC on the previous day.
-    - cron: '0 19 * * *'
+  workflow_run:
+    workflows: ["run unit tests on Intel GPU."]
+    types: [completed]
+    branches: [main]
   workflow_dispatch:
     inputs:
       benchmark_suite:
@@ -14,6 +15,9 @@ on:
         description: 'Allowed relative regression before failing the job'
         required: false
         default: '0.10'
+      test_workflow_run_id:
+        description: 'Optional run id for the unit-test workflow that produced xpu-kernel-wheel'
+        required: false
   pull_request:
     branches: [main]
     types: [opened, reopened, synchronize, labeled]
@@ -31,13 +35,84 @@ env:
   BENCHMARK_RESULTS_DIR: benchmark-results
   BENCHMARK_SUITE: ${{ github.event.inputs.benchmark_suite || 'nightly' }}
   REGRESSION_THRESHOLD: ${{ github.event.inputs.regression_threshold || '0.10' }}
+  UNIT_TEST_WORKFLOW: run unit tests on Intel GPU.
 
 jobs:
-  build-docker-image-bmg:
+  resolve-wheel-artifact:
     runs-on: self-hosted-bmg
     if: |
-      github.event_name != 'pull_request' ||
-      contains(github.event.pull_request.labels.*.name, 'need_benchmark')
+      (github.event_name == 'workflow_run' &&
+       github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.event == 'schedule') ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' &&
+       contains(github.event.pull_request.labels.*.name, 'need_benchmark'))
+    outputs:
+      head_sha: ${{ steps.resolve.outputs.head_sha }}
+      run_id: ${{ steps.resolve.outputs.run_id }}
+      short_sha: ${{ steps.resolve.outputs.short_sha }}
+    steps:
+      - name: Resolve unit-test wheel artifact run
+        id: resolve
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+
+            let runId = '';
+            let headSha = context.sha;
+
+            if (context.eventName === 'workflow_run') {
+              runId = String(context.payload.workflow_run.id);
+              headSha = context.payload.workflow_run.head_sha;
+            } else if (context.eventName === 'pull_request') {
+              headSha = context.payload.pull_request.head.sha;
+            } else if (context.eventName === 'workflow_dispatch') {
+              runId = context.payload.inputs?.test_workflow_run_id || '';
+            }
+
+            if (!runId) {
+              const workflows = await github.paginate(
+                github.rest.actions.listRepoWorkflows,
+                {owner, repo, per_page: 100},
+              );
+              const workflow = workflows.find(
+                (item) => item.name === process.env.UNIT_TEST_WORKFLOW,
+              );
+              if (!workflow) {
+                core.setFailed(`Workflow not found: ${process.env.UNIT_TEST_WORKFLOW}`);
+                return;
+              }
+
+              const runs = await github.paginate(
+                github.rest.actions.listWorkflowRuns,
+                {
+                  owner,
+                  repo,
+                  workflow_id: workflow.id,
+                  head_sha: headSha,
+                  status: 'completed',
+                  per_page: 20,
+                },
+              );
+              const run = runs.find((item) => item.conclusion === 'success');
+              if (!run) {
+                core.setFailed(
+                  `No successful ${process.env.UNIT_TEST_WORKFLOW} run found for ${headSha}`,
+                );
+                return;
+              }
+              runId = String(run.id);
+            }
+
+            core.setOutput('head_sha', headSha);
+            core.setOutput('short_sha', headSha.slice(0, 7));
+            core.setOutput('run_id', runId);
+
+  build-docker-image-bmg:
+    runs-on: self-hosted-bmg
+    needs: resolve-wheel-artifact
     outputs:
       image_tag: ${{ steps.set-tag.outputs.image_tag }}
     steps:
@@ -47,61 +122,27 @@ jobs:
           git clean -ffdx || true
           git reset --hard || true
 
-
       - name: Checkout tested commit
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           set-safe-directory: true
           clean: true
+          ref: ${{ needs.resolve-wheel-artifact.outputs.head_sha }}
 
       - name: Set image tag
         id: set-tag
-        run: echo "image_tag=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+        run: echo "image_tag=${{ needs.resolve-wheel-artifact.outputs.short_sha }}" >> "$GITHUB_OUTPUT"
 
       - name: Build benchmark docker image
         run: |
-          IMAGE_TAG=${GITHUB_SHA::7}
+          IMAGE_TAG=${{ needs.resolve-wheel-artifact.outputs.short_sha }}
           docker build -t "xpu-kernel-ci-image:${IMAGE_TAG}" -f Dockerfile.xpu .
           docker tag "xpu-kernel-ci-image:${IMAGE_TAG}" "${{ env.REGISTRY }}/xpu-kernel-ci-image:${IMAGE_TAG}"
           docker push "${{ env.REGISTRY }}/xpu-kernel-ci-image:${IMAGE_TAG}"
 
-  build-wheel-bmg:
-    runs-on: self-hosted-bmg
-    needs: build-docker-image-bmg
-    timeout-minutes: 90
-    container:
-      image: localhost:5000/xpu-kernel-ci-image:${{ needs.build-docker-image-bmg.outputs.image_tag }}
-      options: --device /dev/dri -v /dev/dri/by-path:/dev/dri/by-path --privileged -v ccache:/root/.ccache -e CCACHE_DIR=/root/.ccache
-    steps:
-      - name: Checkout tested commit
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-        with:
-          set-safe-directory: true
-
-      - name: Build wheel
-        run: |
-          git config --global --add safe.directory "${GITHUB_WORKSPACE}"
-          export CCACHE_DIR=/root/.ccache
-          export CCACHE_BASEDIR="${GITHUB_WORKSPACE}"
-          export CCACHE_NOHASHDIR=1
-          export CCACHE_COMPILERCHECK=content
-          ccache -s || true
-          git submodule sync && git submodule update --init --recursive
-          uv pip install -r requirements.txt
-          rm -rf dist/*
-          MAX_JOBS=128 uv build --no-build-isolation --wheel -v
-          ccache -s || true
-
-      - name: Upload wheel artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: benchmark-wheel
-          path: dist/*.whl
-          retention-days: 30
-
   run-benchmarks-bmg:
     runs-on: self-hosted-bmg
-    needs: [build-docker-image-bmg, build-wheel-bmg]
+    needs: [resolve-wheel-artifact, build-docker-image-bmg]
     timeout-minutes: 240
     container:
       image: localhost:5000/xpu-kernel-ci-image:${{ needs.build-docker-image-bmg.outputs.image_tag }}
@@ -111,12 +152,15 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           set-safe-directory: true
+          ref: ${{ needs.resolve-wheel-artifact.outputs.head_sha }}
 
       - name: Download wheel artifact
         uses: actions/download-artifact@v4
         with:
-          name: benchmark-wheel
+          name: xpu-kernel-wheel
           path: dist/
+          run-id: ${{ needs.resolve-wheel-artifact.outputs.run_id }}
+          github-token: ${{ github.token }}
 
       - name: Install wheel
         run: |
@@ -132,7 +176,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: benchmark-baseline
-          key: benchmark-baseline-${{ github.event.repository.default_branch }}-${{ github.sha }}
+          key: benchmark-baseline-${{ github.event.repository.default_branch }}-${{ needs.resolve-wheel-artifact.outputs.head_sha }}
           restore-keys: |
             benchmark-baseline-${{ github.event.repository.default_branch }}-
 
@@ -168,7 +212,8 @@ jobs:
             echo "## Nightly BMG Benchmark"
             echo
             echo "- Suite: \`${{ env.BENCHMARK_SUITE }}\`"
-            echo "- Commit: \`${GITHUB_SHA::7}\`"
+            echo "- Commit: \`${{ needs.resolve-wheel-artifact.outputs.short_sha }}\`"
+            echo "- Wheel artifact run: \`${{ needs.resolve-wheel-artifact.outputs.run_id }}\`"
             echo "- Baseline restored: \`${{ steps.restore-baseline.outputs['cache-hit'] || 'prefix-or-miss' }}\`"
             echo
             if [ -f "${{ env.BENCHMARK_RESULTS_DIR }}/regression_report.md" ]; then
@@ -180,13 +225,17 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: benchmark-results-${{ github.sha }}
+          name: benchmark-results-${{ needs.resolve-wheel-artifact.outputs.head_sha }}
           path: |
             benchmark-results/
           retention-days: 90
 
       - name: Prepare next baseline
-        if: success() && github.event_name == 'schedule' && github.ref == 'refs/heads/main'
+        if: |
+          success() &&
+          github.event_name == 'workflow_run' &&
+          github.event.workflow_run.event == 'schedule' &&
+          github.event.workflow_run.head_branch == github.event.repository.default_branch
         run: |
           rm -rf benchmark-baseline
           mkdir -p benchmark-baseline
@@ -195,7 +244,11 @@ jobs:
           cp "${{ env.BENCHMARK_RESULTS_DIR }}/run_info.json" benchmark-baseline/run_info.json
 
       - name: Save next main benchmark baseline
-        if: success() && github.event_name == 'schedule' && github.ref == 'refs/heads/main'
+        if: |
+          success() &&
+          github.event_name == 'workflow_run' &&
+          github.event.workflow_run.event == 'schedule' &&
+          github.event.workflow_run.head_branch == github.event.repository.default_branch
         uses: actions/cache/save@v4
         with:
           path: benchmark-baseline

--- a/tools/benchmark_ci.py
+++ b/tools/benchmark_ci.py
@@ -22,6 +22,7 @@ from typing import Any
 class BenchmarkCommand:
     name: str
     argv: list[str]
+    required: bool = True
 
 
 def _python() -> str:
@@ -31,67 +32,6 @@ def _python() -> str:
 def _commands_for_suite(suite: str, raw_dir: Path) -> list[BenchmarkCommand]:
     python = _python()
     commands = [
-        BenchmarkCommand(
-            "grouped_topk",
-            [
-                python,
-                "benchmark/benchmark_grouped_topk.py",
-                "--save-path",
-                str(raw_dir / "grouped_topk"),
-            ],
-        ),
-        BenchmarkCommand(
-            "topk_softmax",
-            [
-                python,
-                "benchmark/benchmark_topk.py",
-                "--scoring-func",
-                "softmax",
-                "--save-path",
-                str(raw_dir / "topk"),
-            ],
-        ),
-    ]
-
-    if suite == "smoke":
-        return commands
-
-    if suite != "nightly":
-        raise ValueError(f"Unsupported benchmark suite: {suite}")
-
-    commands.extend([
-        BenchmarkCommand(
-            "topk_sigmoid",
-            [
-                python,
-                "benchmark/benchmark_topk.py",
-                "--scoring-func",
-                "sigmoid",
-                "--save-path",
-                str(raw_dir / "topk"),
-            ],
-        ),
-        BenchmarkCommand(
-            "topk_softplus_sqrt",
-            [
-                python,
-                "benchmark/benchmark_topk_softplus_sqrt.py",
-                "--save-path",
-                str(raw_dir / "topk_softplus_sqrt"),
-            ],
-        ),
-        BenchmarkCommand(
-            "gemm_onednn",
-            [
-                python,
-                "benchmark/benchmark_gemm_onednn.py",
-                "--benchmarks",
-                "bf16",
-                "fp8_w8a16",
-                "--save-path",
-                str(raw_dir / "gemm_onednn"),
-            ],
-        ),
         BenchmarkCommand(
             "cutlass_fused_moe",
             [
@@ -119,6 +59,72 @@ def _commands_for_suite(suite: str, raw_dir: Path) -> list[BenchmarkCommand]:
                 str(raw_dir / "flash_attn_varlen"),
             ],
         ),
+    ]
+
+    if suite == "smoke":
+        return commands
+
+    if suite != "nightly":
+        raise ValueError(f"Unsupported benchmark suite: {suite}")
+
+    commands.extend([
+        BenchmarkCommand(
+            "grouped_topk",
+            [
+                python,
+                "benchmark/benchmark_grouped_topk.py",
+                "--save-path",
+                str(raw_dir / "grouped_topk"),
+            ],
+            required=False,
+        ),
+        BenchmarkCommand(
+            "topk_softmax",
+            [
+                python,
+                "benchmark/benchmark_topk.py",
+                "--scoring-func",
+                "softmax",
+                "--save-path",
+                str(raw_dir / "topk"),
+            ],
+            required=False,
+        ),
+        BenchmarkCommand(
+            "topk_sigmoid",
+            [
+                python,
+                "benchmark/benchmark_topk.py",
+                "--scoring-func",
+                "sigmoid",
+                "--save-path",
+                str(raw_dir / "topk"),
+            ],
+            required=False,
+        ),
+        BenchmarkCommand(
+            "topk_softplus_sqrt",
+            [
+                python,
+                "benchmark/benchmark_topk_softplus_sqrt.py",
+                "--save-path",
+                str(raw_dir / "topk_softplus_sqrt"),
+            ],
+            required=False,
+        ),
+        BenchmarkCommand(
+            "gemm_onednn",
+            [
+                python,
+                "benchmark/benchmark_gemm_onednn.py",
+                "--benchmarks",
+                "bf16",
+                "fp8_w8a16",
+                "--save-path",
+                str(raw_dir / "gemm_onednn"),
+            ],
+            required=False,
+        ),
         BenchmarkCommand(
             "gdn_attn",
             [
@@ -127,6 +133,7 @@ def _commands_for_suite(suite: str, raw_dir: Path) -> list[BenchmarkCommand]:
                 "--save-path",
                 str(raw_dir / "gdn_attn"),
             ],
+            required=False,
         ),
         BenchmarkCommand(
             "causal_conv1d",
@@ -136,6 +143,7 @@ def _commands_for_suite(suite: str, raw_dir: Path) -> list[BenchmarkCommand]:
                 "--save-path",
                 str(raw_dir / "causal_conv1d"),
             ],
+            required=False,
         ),
         BenchmarkCommand(
             "gated_delta_rule",
@@ -145,6 +153,7 @@ def _commands_for_suite(suite: str, raw_dir: Path) -> list[BenchmarkCommand]:
                 "--save-path",
                 str(raw_dir / "gated_delta_rule"),
             ],
+            required=False,
         ),
         BenchmarkCommand(
             "lora",
@@ -179,9 +188,17 @@ def _commands_for_suite(suite: str, raw_dir: Path) -> list[BenchmarkCommand]:
                 "-o",
                 str(raw_dir / "lora"),
             ],
+            required=False,
         ),
     ])
     return commands
+
+
+def _prepare_command_outputs(command: BenchmarkCommand) -> None:
+    output_flags = {"--save-path", "--output-directory", "-o"}
+    for index, value in enumerate(command.argv[:-1]):
+        if value in output_flags:
+            Path(command.argv[index + 1]).mkdir(parents=True, exist_ok=True)
 
 
 def run_suite(args: argparse.Namespace) -> int:
@@ -196,7 +213,11 @@ def run_suite(args: argparse.Namespace) -> int:
         "suite": args.suite,
         "started_at": int(time.time()),
         "commands": [
-            {"name": command.name, "argv": command.argv}
+            {
+                "name": command.name,
+                "argv": command.argv,
+                "required": command.required,
+            }
             for command in commands
         ],
     }
@@ -206,10 +227,12 @@ def run_suite(args: argparse.Namespace) -> int:
     env = os.environ.copy()
     env.setdefault("ZE_AFFINITY_MASK", "0")
 
+    failures: list[dict[str, Any]] = []
     for command in commands:
         log_file = log_dir / f"{command.name}.log"
         print(f"::group::benchmark {command.name}", flush=True)
         print(" ".join(command.argv), flush=True)
+        _prepare_command_outputs(command)
         with log_file.open("w", encoding="utf-8") as log:
             process = subprocess.Popen(
                 command.argv,
@@ -225,11 +248,27 @@ def run_suite(args: argparse.Namespace) -> int:
             return_code = process.wait()
         print("::endgroup::", flush=True)
         if return_code != 0:
+            failures.append({
+                "name": command.name,
+                "required": command.required,
+                "return_code": return_code,
+                "log": str(log_file),
+            })
             print(
                 f"Benchmark {command.name} failed with {return_code}",
                 file=sys.stderr,
             )
-            return return_code
+            if command.required:
+                (output_dir / "run_failures.json").write_text(
+                    json.dumps(failures, indent=2) + "\n")
+                return return_code
+            print(
+                f"Continuing because {command.name} is low priority",
+                file=sys.stderr,
+            )
+
+    (output_dir / "run_failures.json").write_text(
+        json.dumps(failures, indent=2) + "\n")
 
     return 0
 

--- a/tools/benchmark_ci.py
+++ b/tools/benchmark_ci.py
@@ -1,0 +1,583 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Helpers for CI benchmark runs, normalization, and regression checks."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import os
+import pickle
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+@dataclass(frozen=True)
+class BenchmarkCommand:
+    name: str
+    argv: list[str]
+
+
+def _python() -> str:
+    return sys.executable
+
+
+def _commands_for_suite(suite: str, raw_dir: Path) -> list[BenchmarkCommand]:
+    python = _python()
+    commands = [
+        BenchmarkCommand(
+            "grouped_topk",
+            [
+                python,
+                "benchmark/benchmark_grouped_topk.py",
+                "--save-path",
+                str(raw_dir / "grouped_topk"),
+            ],
+        ),
+        BenchmarkCommand(
+            "topk_softmax",
+            [
+                python,
+                "benchmark/benchmark_topk.py",
+                "--scoring-func",
+                "softmax",
+                "--save-path",
+                str(raw_dir / "topk"),
+            ],
+        ),
+    ]
+
+    if suite == "smoke":
+        return commands
+
+    if suite != "nightly":
+        raise ValueError(f"Unsupported benchmark suite: {suite}")
+
+    commands.extend([
+        BenchmarkCommand(
+            "topk_sigmoid",
+            [
+                python,
+                "benchmark/benchmark_topk.py",
+                "--scoring-func",
+                "sigmoid",
+                "--save-path",
+                str(raw_dir / "topk"),
+            ],
+        ),
+        BenchmarkCommand(
+            "topk_softplus_sqrt",
+            [
+                python,
+                "benchmark/benchmark_topk_softplus_sqrt.py",
+                "--save-path",
+                str(raw_dir / "topk_softplus_sqrt"),
+            ],
+        ),
+        BenchmarkCommand(
+            "gemm_onednn",
+            [
+                python,
+                "benchmark/benchmark_gemm_onednn.py",
+                "--benchmarks",
+                "bf16",
+                "fp8_w8a16",
+                "--save-path",
+                str(raw_dir / "gemm_onednn"),
+            ],
+        ),
+        BenchmarkCommand(
+            "cutlass_fused_moe",
+            [
+                python,
+                "benchmark/benchmark_cutlass_fused_moe.py",
+                "--save-path",
+                str(raw_dir / "cutlass_fused_moe"),
+            ],
+        ),
+        BenchmarkCommand(
+            "flash_attn_decode",
+            [
+                python,
+                "benchmark/benchmark_cutlass_flash_attn_decode.py",
+                "--save-path",
+                str(raw_dir / "flash_attn_decode"),
+            ],
+        ),
+        BenchmarkCommand(
+            "flash_attn_varlen",
+            [
+                python,
+                "benchmark/benchmark_cutlass_flash_attn_varlen.py",
+                "--save-path",
+                str(raw_dir / "flash_attn_varlen"),
+            ],
+        ),
+        BenchmarkCommand(
+            "gdn_attn",
+            [
+                python,
+                "benchmark/benchmark_gdn_attn.py",
+                "--save-path",
+                str(raw_dir / "gdn_attn"),
+            ],
+        ),
+        BenchmarkCommand(
+            "causal_conv1d",
+            [
+                python,
+                "benchmark/benchmark_causal_conv1d.py",
+                "--save-path",
+                str(raw_dir / "causal_conv1d"),
+            ],
+        ),
+        BenchmarkCommand(
+            "gated_delta_rule",
+            [
+                python,
+                "benchmark/benchmark_gated_delta_rule.py",
+                "--save-path",
+                str(raw_dir / "gated_delta_rule"),
+            ],
+        ),
+        BenchmarkCommand(
+            "lora",
+            [
+                python,
+                "benchmark/benchmark_lora.py",
+                "list_bench",
+                "--dtype",
+                "torch.float16",
+                "--arg-pool-size",
+                "32",
+                "--batch-sizes",
+                "1",
+                "16",
+                "64",
+                "--hidden-sizes",
+                "2048",
+                "4096",
+                "--lora-ranks",
+                "16",
+                "--num-loras",
+                "1",
+                "4",
+                "--op-types",
+                "bgmv_shrink",
+                "bgmv_expand",
+                "bgmv_expand_slice",
+                "--seq-lengths",
+                "1",
+                "--sort-by-lora-id",
+                "1",
+                "-o",
+                str(raw_dir / "lora"),
+            ],
+        ),
+    ])
+    return commands
+
+
+def run_suite(args: argparse.Namespace) -> int:
+    output_dir = Path(args.output_dir)
+    raw_dir = output_dir / "raw"
+    log_dir = output_dir / "logs"
+    raw_dir.mkdir(parents=True, exist_ok=True)
+    log_dir.mkdir(parents=True, exist_ok=True)
+
+    commands = _commands_for_suite(args.suite, raw_dir)
+    manifest = {
+        "suite": args.suite,
+        "started_at": int(time.time()),
+        "commands": [
+            {"name": command.name, "argv": command.argv}
+            for command in commands
+        ],
+    }
+    (output_dir / "run_manifest.json").write_text(
+        json.dumps(manifest, indent=2) + "\n")
+
+    env = os.environ.copy()
+    env.setdefault("ZE_AFFINITY_MASK", "0")
+
+    for command in commands:
+        log_file = log_dir / f"{command.name}.log"
+        print(f"::group::benchmark {command.name}", flush=True)
+        print(" ".join(command.argv), flush=True)
+        with log_file.open("w", encoding="utf-8") as log:
+            process = subprocess.Popen(
+                command.argv,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+                env=env,
+            )
+            assert process.stdout is not None
+            for line in process.stdout:
+                print(line, end="")
+                log.write(line)
+            return_code = process.wait()
+        print("::endgroup::", flush=True)
+        if return_code != 0:
+            print(
+                f"Benchmark {command.name} failed with {return_code}",
+                file=sys.stderr,
+            )
+            return return_code
+
+    return 0
+
+
+def _try_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    text = str(value).strip()
+    if not text or text.lower() in {"nan", "none"}:
+        return None
+    text = text.replace("%", "")
+    try:
+        return float(text)
+    except ValueError:
+        return None
+
+
+def _looks_like_metric(name: str) -> bool:
+    lowered = name.lower()
+    patterns = (
+        "latency",
+        "time",
+        "_us",
+        "(us)",
+        "us",
+        "_ms",
+        "(ms)",
+        "tflops",
+        "bandwidth",
+        "gbs",
+        "gb/s",
+        "mbu",
+        "vllm",
+        "native",
+        "compile",
+        "flash",
+        "gdn",
+        "torch.mm",
+    )
+    return any(pattern in lowered for pattern in patterns)
+
+
+def _unit_for_metric(name: str) -> str:
+    lowered = name.lower()
+    if "tflops" in lowered:
+        return "tflops"
+    if "bandwidth" in lowered or "gb/s" in lowered or "gbs" in lowered:
+        return "gb/s"
+    if "mbu" in lowered or "%" in lowered:
+        return "percent"
+    if "ms" in lowered and "gems" not in lowered:
+        return "ms"
+    return "us"
+
+
+def _higher_is_better(metric: str, unit: str) -> bool:
+    lowered = metric.lower()
+    return unit in {"tflops", "gb/s", "percent"} or any(
+        token in lowered for token in ("tflops", "bandwidth", "mbu"))
+
+
+def _case_id(dimensions: dict[str, Any]) -> str:
+    payload = json.dumps(dimensions, sort_keys=True, default=str)
+    return hashlib.sha1(payload.encode("utf-8")).hexdigest()[:16]
+
+
+def _record_key(record: dict[str, Any]) -> tuple[str, str, str, str]:
+    return (
+        str(record["benchmark"]),
+        str(record["metric"]),
+        str(record["case_id"]),
+        str(record.get("unit", "")),
+    )
+
+
+def _metadata() -> dict[str, Any]:
+    keys = [
+        "GITHUB_REPOSITORY",
+        "GITHUB_RUN_ID",
+        "GITHUB_RUN_NUMBER",
+        "GITHUB_SHA",
+        "GITHUB_REF",
+        "GITHUB_REF_NAME",
+        "GITHUB_EVENT_NAME",
+        "GITHUB_ACTOR",
+        "RUNNER_NAME",
+        "RUNNER_ARCH",
+        "RUNNER_OS",
+        "ZE_AFFINITY_MASK",
+    ]
+    return {key.lower(): os.environ.get(key, "") for key in keys}
+
+
+def _records_from_csv(csv_file: Path, input_dir: Path) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    benchmark = str(csv_file.relative_to(input_dir).with_suffix(""))
+    with csv_file.open(newline="", encoding="utf-8") as handle:
+        reader = csv.DictReader(handle)
+        for row in reader:
+            metrics = {
+                key: _try_float(value)
+                for key, value in row.items()
+                if _looks_like_metric(key) and _try_float(value) is not None
+            }
+            if not metrics:
+                continue
+            dimensions = {
+                key: value
+                for key, value in row.items()
+                if key not in metrics and value not in (None, "")
+            }
+            for metric, value in metrics.items():
+                unit = _unit_for_metric(metric)
+                records.append({
+                    "benchmark": benchmark,
+                    "metric": metric,
+                    "value": value,
+                    "unit": unit,
+                    "higher_is_better": _higher_is_better(metric, unit),
+                    "dimensions": dimensions,
+                    "case_id": _case_id(dimensions),
+                    "source": str(csv_file.relative_to(input_dir)),
+                })
+    return records
+
+
+def _records_from_lora_pickle(
+    pickle_file: Path,
+    input_dir: Path,
+) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    try:
+        with pickle_file.open("rb") as handle:
+            measurements = pickle.load(handle)
+    except Exception as exc:  # noqa: BLE001
+        print(f"Skipping {pickle_file}: {exc}", file=sys.stderr)
+        return records
+
+    benchmark = str(pickle_file.relative_to(input_dir).with_suffix(""))
+    for measurement in measurements:
+        dimensions = {
+            "label": getattr(measurement, "label", ""),
+            "sub_label": getattr(measurement, "sub_label", ""),
+            "description": getattr(measurement, "description", ""),
+        }
+        value = float(measurement.median) * 1_000_000.0
+        records.append({
+            "benchmark": benchmark,
+            "metric": "median_latency_us",
+            "value": value,
+            "unit": "us",
+            "higher_is_better": False,
+            "dimensions": dimensions,
+            "case_id": _case_id(dimensions),
+            "source": str(pickle_file.relative_to(input_dir)),
+        })
+    return records
+
+
+def normalize(args: argparse.Namespace) -> int:
+    input_dir = Path(args.input_dir)
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    records: list[dict[str, Any]] = []
+    for csv_file in sorted(input_dir.rglob("*.csv")):
+        records.extend(_records_from_csv(csv_file, input_dir))
+    for pickle_file in sorted(input_dir.rglob("*.pkl")):
+        records.extend(_records_from_lora_pickle(pickle_file, input_dir))
+
+    metadata = _metadata()
+    for record in records:
+        record.update(metadata)
+
+    jsonl_file = output_dir / "results.jsonl"
+    with jsonl_file.open("w", encoding="utf-8") as handle:
+        for record in records:
+            handle.write(json.dumps(record, sort_keys=True) + "\n")
+
+    csv_file = output_dir / "results.csv"
+    fieldnames = [
+        "benchmark",
+        "metric",
+        "value",
+        "unit",
+        "higher_is_better",
+        "case_id",
+        "dimensions",
+        "source",
+        "github_sha",
+        "github_ref_name",
+        "github_run_id",
+        "github_event_name",
+        "runner_name",
+        "ze_affinity_mask",
+    ]
+    with csv_file.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        for record in records:
+            row = {key: record.get(key, "") for key in fieldnames}
+            row["dimensions"] = json.dumps(
+                record.get("dimensions", {}), sort_keys=True)
+            writer.writerow(row)
+
+    (output_dir / "run_info.json").write_text(
+        json.dumps(metadata, indent=2, sort_keys=True) + "\n")
+    print(f"Normalized {len(records)} benchmark metrics")
+    return 0 if records else 2
+
+
+def _load_jsonl(path: Path) -> list[dict[str, Any]]:
+    if not path.exists():
+        return []
+    records = []
+    with path.open(encoding="utf-8") as handle:
+        for line in handle:
+            line = line.strip()
+            if line:
+                records.append(json.loads(line))
+    return records
+
+
+def compare(args: argparse.Namespace) -> int:
+    current = _load_jsonl(Path(args.current))
+    baseline = _load_jsonl(Path(args.baseline))
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    baseline_by_key = {_record_key(record): record for record in baseline}
+    regressions = []
+    improvements = []
+    compared = 0
+
+    for record in current:
+        base = baseline_by_key.get(_record_key(record))
+        if base is None:
+            continue
+        base_value = float(base["value"])
+        current_value = float(record["value"])
+        if base_value <= 0:
+            continue
+        compared += 1
+        higher_is_better = bool(record.get("higher_is_better"))
+        if higher_is_better:
+            change = (base_value - current_value) / base_value
+            improvement = (current_value - base_value) / base_value
+        else:
+            change = (current_value - base_value) / base_value
+            improvement = (base_value - current_value) / base_value
+
+        item = {
+            "benchmark": record["benchmark"],
+            "metric": record["metric"],
+            "case_id": record["case_id"],
+            "unit": record.get("unit", ""),
+            "baseline": base_value,
+            "current": current_value,
+            "change": change,
+            "dimensions": record.get("dimensions", {}),
+        }
+        if change > args.threshold:
+            regressions.append(item)
+        elif improvement > args.threshold:
+            improvements.append(item)
+
+    report = _format_report(compared, regressions, improvements,
+                            args.threshold, bool(baseline))
+    (output_dir / "regression_report.md").write_text(report)
+    (output_dir / "regressions.json").write_text(
+        json.dumps(regressions, indent=2, sort_keys=True) + "\n")
+    print(report)
+
+    if regressions and args.fail_on_regression:
+        return 1
+    return 0
+
+
+def _format_report(
+    compared: int,
+    regressions: list[dict[str, Any]],
+    improvements: list[dict[str, Any]],
+    threshold: float,
+    has_baseline: bool,
+) -> str:
+    lines = ["## Benchmark Regression Report", ""]
+    if not has_baseline:
+        lines.extend([
+            "No baseline was found. This run will seed future comparisons.",
+            "",
+        ])
+        return "\n".join(lines)
+
+    lines.extend([
+        f"Compared metrics: **{compared}**",
+        f"Regression threshold: **{threshold:.1%}**",
+        f"Regressions: **{len(regressions)}**",
+        f"Improvements: **{len(improvements)}**",
+        "",
+    ])
+
+    if regressions:
+        lines.extend([
+            "### Regressions",
+            "",
+            "| Benchmark | Metric | Baseline | Current | Change | Case |",
+            "| --- | --- | ---: | ---: | ---: | --- |",
+        ])
+        for item in regressions[:50]:
+            lines.append(
+                "| {benchmark} | {metric} | {baseline:.4g} | "
+                "{current:.4g} | {change:.1%} | `{case_id}` |".format(
+                    **item))
+        lines.append("")
+    else:
+        lines.extend(["No benchmark regressions exceeded the threshold.", ""])
+
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    run_parser = subparsers.add_parser("run")
+    run_parser.add_argument("--suite", choices=["smoke", "nightly"],
+                            default="nightly")
+    run_parser.add_argument("--output-dir", required=True)
+    run_parser.set_defaults(func=run_suite)
+
+    normalize_parser = subparsers.add_parser("normalize")
+    normalize_parser.add_argument("--input-dir", required=True)
+    normalize_parser.add_argument("--output-dir", required=True)
+    normalize_parser.set_defaults(func=normalize)
+
+    compare_parser = subparsers.add_parser("compare")
+    compare_parser.add_argument("--current", required=True)
+    compare_parser.add_argument("--baseline", required=True)
+    compare_parser.add_argument("--output-dir", required=True)
+    compare_parser.add_argument("--threshold", type=float, default=0.10)
+    compare_parser.add_argument("--fail-on-regression", action="store_true")
+    compare_parser.set_defaults(func=compare)
+
+    args = parser.parse_args()
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/upload_benchmark_db.py
+++ b/tools/upload_benchmark_db.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Upload nightly microbenchmark CSV results into Postgres.
+
+Self-contained port of the CSV->params/metrics logic from
+vllm_test_framework/core/db_updater.py::insert_kernel_data. Reads the raw wide
+CSVs produced by the benchmark suite and inserts one row per shape into
+``vllm_nightly_microbenchmark``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import logging
+import math
+import os
+import re
+import sys
+from pathlib import Path
+from urllib.parse import quote_plus
+
+logger = logging.getLogger("upload_benchmark_db")
+
+
+def _strip_ylabel(col_name: str) -> str:
+    """Remove trailing ' (ylabel)' appended by Triton >= 3.7.0 CSV export."""
+    return re.sub(r"\s+\((?:[^()]*|\([^()]*\))*\)\s*$", "", col_name)
+
+
+def _is_metric_col(col_name: str) -> bool:
+    """Metric cols carry parenthesized units or a *flops keyword."""
+    lower = col_name.lower()
+    if re.search(r"\([^)]+\)", lower):
+        return True
+    return "tflops" in lower or "gflops" in lower
+
+
+def _clean_metric(value: str) -> float | None:
+    if value in (None, ""):
+        return None
+    try:
+        v = float(value)
+    except (TypeError, ValueError):
+        return None
+    if math.isnan(v) or math.isinf(v):
+        return None
+    return v
+
+
+def _kernel_name(csv_file: Path, results_dir: Path) -> str:
+    """Posix relpath under raw dir sans suffix (matches ``benchmark`` key)."""
+    return csv_file.relative_to(results_dir).with_suffix("").as_posix()
+
+
+def _rows_from_csv(csv_file: Path, results_dir: Path) -> list[dict]:
+    kernel_name = _kernel_name(csv_file, results_dir)
+    rows: list[dict] = []
+    with csv_file.open("r", newline="", encoding="utf-8") as handle:
+        reader = csv.DictReader(handle)
+        for row in reader:
+            params: dict = {}
+            metrics: dict = {}
+            for key, value in row.items():
+                if key is None:
+                    continue
+                clean_key = _strip_ylabel(key)
+                if _is_metric_col(key):
+                    metrics[clean_key] = _clean_metric(value)
+                else:
+                    params[clean_key] = value if value != "" else None
+            params_hash = hashlib.md5(
+                json.dumps(params, sort_keys=True).encode()
+            ).hexdigest()
+            rows.append({
+                "kernel_name": kernel_name,
+                "params": params,
+                "metrics": metrics,
+                "params_hash": params_hash,
+            })
+    return rows
+
+
+def collect_rows(results_dir: Path) -> list[dict]:
+    rows: list[dict] = []
+    for csv_file in sorted(results_dir.rglob("*.csv")):
+        rows.extend(_rows_from_csv(csv_file, results_dir))
+    return rows
+
+
+def _db_url(args: argparse.Namespace) -> str:
+    password = quote_plus(args.db_password)
+    return (
+        f"postgresql://{args.db_user}:{password}"
+        f"@{args.db_host}:{args.db_port}/{args.db_name}"
+    )
+
+
+def insert_rows(args: argparse.Namespace, rows: list[dict]) -> int:
+    import psycopg  # pip install "psycopg[binary]"
+
+    sql = (
+        f"INSERT INTO {args.table} "
+        "(kernel_name, docker_tag, params, metrics, node_label, "
+        "params_hash, result_id) "
+        "VALUES (%s, %s, %s, %s, %s, %s, %s)"
+    )
+    inserted = 0
+    failed = 0
+    with psycopg.connect(_db_url(args)) as conn, conn.cursor() as cur:
+        for row in rows:
+            try:
+                cur.execute(sql, (
+                    row["kernel_name"],
+                    args.docker_tag,
+                    json.dumps(row["params"]),
+                    json.dumps(row["metrics"]),
+                    args.node_label,
+                    row["params_hash"],
+                    args.result_id,
+                ))
+                inserted += 1
+            except Exception as exc:  # noqa: BLE001
+                failed += 1
+                logger.warning(
+                    "Row for kernel %s failed: %s", row["kernel_name"], exc
+                )
+        conn.commit()
+    if failed:
+        logger.warning("%d/%d rows failed to insert", failed, len(rows))
+    return inserted
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--results-dir", default="benchmark-results/raw")
+    parser.add_argument("--docker-tag", required=True)
+    parser.add_argument(
+        "--node-label", default=os.environ.get("DB_NODE_LABEL", "bmg")
+    )
+    parser.add_argument("--result-id", required=True)
+    parser.add_argument(
+        "--table",
+        default=os.environ.get("DB_TABLE", "vllm_nightly_microbenchmark"),
+    )
+    parser.add_argument(
+        "--db-host", default=os.environ.get("DB_HOST", "localhost")
+    )
+    parser.add_argument(
+        "--db-port", default=os.environ.get("DB_PORT", "5432")
+    )
+    parser.add_argument(
+        "--db-name", default=os.environ.get("DB_NAME", "vllm_benchmarks")
+    )
+    parser.add_argument(
+        "--db-user", default=os.environ.get("DB_USER", "vllmadmin")
+    )
+    parser.add_argument(
+        "--db-password", default=os.environ.get("DB_PASSWORD", "")
+    )
+    parser.add_argument("--dry-run", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+    args = parse_args(argv)
+
+    results_dir = Path(args.results_dir)
+    if not results_dir.is_dir():
+        logger.warning(
+            "Results dir %s not found; skipping DB upload.", results_dir
+        )
+        return 0
+
+    rows = collect_rows(results_dir)
+    if not rows:
+        logger.warning(
+            "No CSV rows found under %s; skipping DB upload.", results_dir
+        )
+        return 0
+
+    logger.info(
+        "Collected %d rows for docker_tag=%s result_id=%s",
+        len(rows), args.docker_tag, args.result_id,
+    )
+
+    if args.dry_run:
+        for row in rows[:5]:
+            logger.info("DRY-RUN %s", json.dumps(row, sort_keys=True))
+        logger.info("DRY-RUN total rows: %d", len(rows))
+        return 0
+
+    if not args.db_password:
+        logger.warning("DB_PASSWORD is empty; skipping DB upload.")
+        return 0
+
+    try:
+        inserted = insert_rows(args, rows)
+        logger.info("Inserted %d rows into %s", inserted, args.table)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("DB upload failed (non-fatal): %s", exc)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Add a BMG-only nightly benchmark CI workflow for vLLM XPU kernels.

This PR introduces:

- A scheduled benchmark workflow that runs on the latest `main` commit at Beijing time 03:00.
- Manual benchmark triggering through `workflow_dispatch`.
- PR benchmark triggering through the `need_benchmark` label.
- Docker image build from the tested commit's `Dockerfile.xpu`.
- Wheel build/install before benchmark execution.
- BMG-only execution on `self-hosted-bmg`.
- Dashboard-friendly normalized benchmark outputs in JSONL and CSV.
- Cross-build comparison against the latest cached `main` baseline.
- Automatic regression detection with a configurable threshold.

## Details

The new workflow builds and pushes a benchmark Docker image to the local registry, builds the wheel inside that image, installs it, then runs the selected benchmark suite.

Benchmark outputs include:

- Raw benchmark output and logs.
- `results.jsonl` for structured ingestion.
- `results.csv` for dashboard or spreadsheet workflows.
- `run_info.json` with CI/runtime metadata.
- `regression_report.md` and `regressions.json` for automatic regression review.

The default threshold is `10%`, and regressions above the threshold fail the benchmark job.

## Validation

- Ran Python syntax validation for `tools/benchmark_ci.py`.
- VS Code diagnostics reported no errors for the workflow or helper script.
- Pre-commit hooks passed during commit:
  - ruff
  - codespell
  - isort
  - GitHub Actions workflow lint
  - mypy
  - SPDX header check
  - signoff check

## Notes

A full Docker build and benchmark run should be validated on the self-hosted BMG CI runner.