### PR TITLE
refactor fused_moe benchmark

### DIFF
--- a/benchmark/benchmark_cutlass_fused_moe.py
+++ b/benchmark/benchmark_cutlass_fused_moe.py
@@ -4,6 +4,7 @@
 
 # isort: off
 import gc
+import statistics
 
 import torch
 import triton
@@ -12,7 +13,7 @@ import triton.testing
 from utils import bootstrap_benchmark_env, ensure_save_path_exists
 
 bootstrap_benchmark_env(__file__)
-from benchmark.src.fused_moe_interface_ import xpu_fused_moe_CalKernelTime
+from benchmark.src.fused_moe_interface_ import XpuFusedMoe_CalKernelTime
 from benchmark.src.get_model_config import (
     gen_cutlass_fused_moe_correctness_configs as gen_correctness_config)
 from benchmark.src.get_model_config import (gen_cutlass_fused_moe_perf_configs
@@ -163,7 +164,7 @@ def calculate_diff(config):
         print("❌ Implementations differ, ", config, " error: ", e)
 
 
-def get_benchmark(iterations):
+def get_benchmark():
 
     @triton.testing.perf_report(
         triton.testing.Benchmark(
@@ -203,17 +204,13 @@ def get_benchmark(iterations):
                   x_dtype,
                   w_dtype,
                   has_bias,
-                  provider,
-                  iterations=iterations):
+                  provider):
         print(f"Running config: {m, n, k, num_experts, topk, \
                                 x_dtype, w_dtype, \
                                 has_bias}, Provider: {provider}",
               flush=True)
         total_latency = 0.0
         ms = 0.0
-        assert iterations > 5, \
-            "Iterations should be greater than " \
-            "5 to have enough warmup iterations."
 
         _, _, w13_bias, _, w2_bias, _, \
             _, a, w13, w13_scales, w2, w2_scales, \
@@ -232,24 +229,66 @@ def get_benchmark(iterations):
                               activation="silu",
                               num_experts=num_experts)
             output = torch.empty_like(a)
-            start_event = torch.xpu.Event(enable_timing=True)
-            end_event = torch.xpu.Event(enable_timing=True)
-            for index in range(5):
+
+            def run_vllm_moe():
                 moe.apply(output=output,
                           hidden_states=a,
                           topk_weights=expert_scores,
                           topk_ids=expert_indices)
-            start_event.record()
-            for index in range(5, iterations):
-                moe.apply(output=output,
-                          hidden_states=a,
-                          topk_weights=expert_scores,
-                          topk_ids=expert_indices)
-            end_event.record()
-            torch.xpu.synchronize()
-            total_latency = start_event.elapsed_time(end_event)
+
+            # Use triton do_bench instead of a single start/end event span:
+            # it auto-warms up, flushes the L2 cache between reps and reports
+            # the median. A single event span also captures host-side launch
+            # overhead / queue bubbles between kernels, which is a large and
+            # noisy fraction of the time for small MoE configs.
+            ms, _, _ = triton.testing.do_bench(
+                run_vllm_moe,
+                quantiles=[0.5, 0.2, 0.8],
+            )
+            clear_xpu_cache()
+            return 1000 * ms
         else:
-            n_measured = iterations - 5
+            moe = XpuFusedMoe_CalKernelTime(w13=w13,
+                            w13_scales=w13_scales,
+                            w13_bias=w13_bias,
+                            w2=w2,
+                            w2_scales=w2_scales,
+                            w2_bias=w2_bias,
+                            n_experts_per_token=topk,
+                            activation="silu",
+                            num_experts=num_experts)
+            output = torch.empty_like(a)
+            # L2 cache flush buffer, mirroring triton.testing.do_bench, so
+            # the per-sub-kernel timings are not biased by warm caches.
+            cache = torch.empty(int(256e6 // 4), dtype=torch.int, device=DEVICE)
+
+            # Size the measurement loop by a time budget like
+            # triton.testing.do_bench: first estimate the per-call time, then
+            # pick warmup / repeat counts so we warm up ~25ms and measure
+            # ~100ms worth of iterations (auto-scales with kernel size).
+            warmup_ms = 25
+            rep_ms = 100
+            for _ in range(5):
+                moe.apply(output=output,
+                    hidden_states=a,
+                    topk_weights=expert_scores,
+                    topk_ids=expert_indices)
+            torch.xpu.synchronize()
+            est_start = torch.xpu.Event(enable_timing=True)
+            est_end = torch.xpu.Event(enable_timing=True)
+            est_start.record()
+            for _ in range(5):
+                moe.apply(output=output,
+                    hidden_states=a,
+                    topk_weights=expert_scores,
+                    topk_ids=expert_indices)
+            est_end.record()
+            torch.xpu.synchronize()
+            estimate_ms = est_start.elapsed_time(est_end) / 5
+            n_warmup = max(1, int(warmup_ms / estimate_ms))
+            n_measured = max(1, int(rep_ms / estimate_ms))
+
+            # per-sub-kernel events, sized to the measured loop
             remap_se = [
                 torch.xpu.Event(enable_timing=True) for _ in range(n_measured)
             ]
@@ -274,52 +313,51 @@ def get_benchmark(iterations):
             gather_ee = [
                 torch.xpu.Event(enable_timing=True) for _ in range(n_measured)
             ]
-            gemm1_info = gemm2_info = None
-            for index in range(iterations):
-                i = index - 5 if index >= 5 else None
-                cur_gemm1_info, cur_gemm2_info = xpu_fused_moe_CalKernelTime(
+            # extra warm up before the measured loop
+            for _ in range(n_warmup):
+                moe.apply(output=output,
                     hidden_states=a,
-                    w13=w13,
-                    w13_scales=w13_scales,
-                    w13_bias=w13_bias,
-                    w2=w2,
-                    w2_scales=w2_scales,
-                    w2_bias=w2_bias,
                     topk_weights=expert_scores,
-                    topk_ids=expert_indices,
-                    n_experts_per_token=topk,
-                    activation="silu",
-                    num_experts=num_experts,
-                    is_fp8=(w_dtype is not None),
-                    start_event_remap=remap_se[i] if i is not None else None,
-                    end_event_remap=remap_ee[i] if i is not None else None,
-                    start_event_gemm1=gemm1_se[i] if i is not None else None,
-                    end_event_gemm1=gemm1_ee[i] if i is not None else None,
-                    start_event_gemm2=gemm2_se[i] if i is not None else None,
-                    end_event_gemm2=gemm2_ee[i] if i is not None else None,
-                    start_event_gather=gather_se[i] if i is not None else None,
-                    end_event_gather=gather_ee[i] if i is not None else None,
-                )
-                if index == 5:
+                    topk_ids=expert_indices)
+            gemm1_info = gemm2_info = None
+            for i in range(n_measured):
+                cache.zero_()  # flush L2 before each measured iteration
+                cur_gemm1_info, cur_gemm2_info = \
+                    moe.apply(output=output,
+                        hidden_states=a,
+                        topk_weights=expert_scores,
+                        topk_ids=expert_indices,
+                        start_event_remap=remap_se[i],
+                        end_event_remap=remap_ee[i],
+                        start_event_gemm1=gemm1_se[i],
+                        end_event_gemm1=gemm1_ee[i],
+                        start_event_gemm2=gemm2_se[i],
+                        end_event_gemm2=gemm2_ee[i],
+                        start_event_gather=gather_se[i],
+                        end_event_gather=gather_ee[i],)
+                if i == 0:
                     gemm1_info = cur_gemm1_info
                     gemm2_info = cur_gemm2_info
             torch.xpu.synchronize()
-            remap_latency = sum(
+            # Take the per-iteration median (like do_bench) instead of the
+            # mean, then scale by n_measured so the downstream
+            # `total_latency / n_measured` still yields the median.
+            remap_latency = statistics.median([
                 remap_se[i].elapsed_time(remap_ee[i])
                 for i in range(n_measured)
-            )
-            gemm1_latency = sum(
+            ]) * n_measured
+            gemm1_latency = statistics.median([
                 gemm1_se[i].elapsed_time(gemm1_ee[i])
                 for i in range(n_measured)
-            )
-            gemm2_latency = sum(
+            ]) * n_measured
+            gemm2_latency = statistics.median([
                 gemm2_se[i].elapsed_time(gemm2_ee[i])
                 for i in range(n_measured)
-            )
-            gather_latency = sum(
+            ]) * n_measured
+            gather_latency = statistics.median([
                 gather_se[i].elapsed_time(gather_ee[i])
                 for i in range(n_measured)
-            )
+            ]) * n_measured
             gemm1_m, gemm1_n, gemm1_k, gemm1_expert = gemm1_info
             gemm2_m, gemm2_n, gemm2_k, gemm2_expert = gemm2_info
             if provider == "vllm_kernel_remap":
@@ -351,7 +389,7 @@ def get_benchmark(iterations):
                 return memory_usage_GB / (ms / 1000)  # GB/s
 
         torch.xpu.synchronize()
-        ms = total_latency / (iterations - 5)
+        ms = total_latency / n_measured
         clear_xpu_cache()
         return 1000 * ms
 
@@ -363,7 +401,6 @@ if __name__ == "__main__":
     args = parse_args()
     seed = 1234
     seed_everything(seed)
-    iterations = 20
 
     configs = gen_correctness_config()
 
@@ -375,7 +412,7 @@ if __name__ == "__main__":
         clear_xpu_cache()
 
     configs = gen_perf_configs()
-    benchmark = get_benchmark(iterations=iterations)
+    benchmark = get_benchmark()
     save_path = ensure_save_path_exists(args.save_path)
     # Run performance benchmark
     benchmark.run(print_data=True, save_path=save_path)

--- a/benchmark/src/fused_moe_interface_.py
+++ b/benchmark/src/fused_moe_interface_.py
@@ -1,230 +1,181 @@
 # SPDX-License-Identifier: Apache-2.0
+from typing import Optional
+
 import torch
 
-from vllm_xpu_kernels.fused_moe_interface import (  # noqa: F401
-    FUSEDMOE_AVAILABLE, FUSEDMOE_UNAVAILABLE_REASON, ceilDiv,
-    compute_num_tokens_per_block, cutlass_grouped_gemm,
-    cutlass_grouped_gemm_xe2, implement_zp)
+from vllm_xpu_kernels.fused_moe_interface import XpuFusedMoe, quant_act_xpu
 
 
-# vllm_xpu_kernel,main,
-#   https://github.com/vllm-project/vllm-xpu-kernels/tree/377e7eb
-def xpu_fused_moe_CalKernelTime(hidden_states,
-                                w13,
-                                w13_scales,
-                                w13_bias,
-                                w2,
-                                w2_scales,
-                                w2_bias,
-                                topk_weights,
-                                topk_ids,
-                                n_experts_per_token,
-                                activation,
-                                num_experts,
-                                ep_rank=0,
-                                ep_size=1,
-                                expert_map=None,
-                                output=None,
-                                is_fp8=False,
-                                is_int4=False,
-                                is_mxfp4=False,
-                                start_event_remap=None,
-                                end_event_remap=None,
-                                start_event_gemm1=None,
-                                end_event_gemm1=None,
-                                start_event_gemm2=None,
-                                end_event_gemm2=None,
-                                start_event_gather=None,
-                                end_event_gather=None):
-    '''
-    hidden_states: [num_rows, hidden_size]
-    w13: [num_experts, 2*inter_size, hidden_size]
-    w13_scales:
-        None for bf16/fp16
-        or [num_experts] for fp8
-        or [num_experts, 2*inter_size, hidden_size // group_size] for 4bits
-    w13_bias: [num_experts, 2*inter_size] or None
-    w2: [num_experts, hidden_size, inter_size]
-    w2_scales:
-        None for bf16/fp16
-        or [num_experts] for fp8
-        or [num_experts, hidden_size, inter_size // group_size] for 4bits
-    w2_bias: [num_experts, hidden_size] or None
-    topk_weights: [num_rows, topk]
-    topk_ids: [num_rows, topk]
-    n_experts_per_token: int
-    activation: str
-    num_experts: int
-    is_int4: bool
-    is_mxfp4: bool
-    '''
-    if output is None:
-        output = torch.empty_like(hidden_states)
-    else:
-        assert output.shape == hidden_states.shape, \
-            "output shape must be the same as hidden_states shape"
+class XpuFusedMoe_CalKernelTime(XpuFusedMoe):
+    def __init__(
+        self,
+        w13,
+        w13_scales,
+        w13_bias,
+        w2,
+        w2_scales,
+        w2_bias,
+        n_experts_per_token,
+        activation,
+        num_experts,
+        ep_rank=0,
+        ep_size=1,
+        expert_map=None,
+        gemm1_clamp_limit: Optional[float]=None,
+    ):
+        super().__init__(
+            w13,
+            w13_scales,
+            w13_bias,
+            w2,
+            w2_scales,
+            w2_bias,
+            n_experts_per_token,
+            activation,
+            num_experts,
+            ep_rank,
+            ep_size,
+            expert_map,
+            gemm1_clamp_limit)
 
-    if hasattr(w13, 'xpu_fused_moe'):
-        gemm1_n = w13.shape[2]
-        gemm2_n = w2.shape[2]
-    else:
-        gemm1_n = w13.shape[1]
-        gemm2_n = w2.shape[1]
+    def apply(
+        self,
+        output,
+        hidden_states,
+        topk_weights,
+        topk_ids,
+        expert_map=None,
+        a1q_scale=None,
+        start_event_remap=None,
+        end_event_remap=None,
+        start_event_gemm1=None,
+        end_event_gemm1=None,
+        start_event_gemm2=None,
+        end_event_gemm2=None,
+        start_event_gather=None,
+        end_event_gather=None
+    ):
+        num_rows, hidden_size = hidden_states.shape
+        num_moe_inputs = self.n_experts_per_token * num_rows
+        act_quant = a1q_scale is not None
+        
+        if expert_map is None and self.ep_size > 1:
+            expert_map = self.expert_map
 
-    # 4bits support [E, N, K]
-    # other types [E, K, N]
-    if not is_int4 and not is_mxfp4:
-        inter_size = list(w13.shape)[-1] // 2
-    else:
-        inter_size = list(w13.shape)[-2] // 2
+        if act_quant:
+            remapped_scales = torch.empty(
+                (num_rows * self.n_experts_per_token, a1q_scale.shape[1]),
+                dtype=a1q_scale.dtype,
+                device=a1q_scale.device)
+        else:
+            remapped_scales = None
+        remapped_hidden_states = torch.empty(
+            (num_rows * self.n_experts_per_token, hidden_size),
+            dtype=hidden_states.dtype,
+            device=hidden_states.device)
+        rows_per_expert = torch.zeros((self.num_experts),
+                                                dtype=torch.int32,
+                                                device=hidden_states.device)
+        unpermuted_row_to_permuted_row = torch.empty(
+            (num_rows, self.n_experts_per_token),
+            dtype=torch.int32,
+            device=hidden_states.device)
 
-    assert w13.is_contiguous() and w2.is_contiguous()
+        torch.xpu.synchronize()
+        if start_event_remap is not None:
+            start_event_remap.record()
+        torch.ops._moe_C.remap_hidden_states(
+            hidden_states=hidden_states,
+            hidden_states_scales=a1q_scale,
+            remapped_hidden_states=remapped_hidden_states,
+            remapped_hidden_states_scales=remapped_scales,
+            expert_map=expert_map,
+            rows_per_expert=rows_per_expert,
+            unpermuted_row_to_permuted_row=unpermuted_row_to_permuted_row,
+            topk_ids=topk_ids,
+            total_experts_num=self.total_experts_num,
+            local_experts_num=self.local_experts_num)
+        torch.xpu.synchronize()
+        if end_event_remap is not None:
+            end_event_remap.record()
 
-    # FIXME: move this to vllm
-    if is_int4 and not hasattr(w13, 'xpu_fused_moe'):
-        w13_tmp = torch.empty_like(w13)
-        w2_tmp = torch.empty_like(w2)
-        for i in range(num_experts):
-            w13_tmp[i] = implement_zp(w13[i])
-            w2_tmp[i] = implement_zp(w2[i])
-        w13_tmp = w13_tmp.contiguous()
-        w2_tmp = w2_tmp.contiguous()
-        w13.data = w13_tmp
-        w2.data = w2_tmp
-        w13.xpu_fused_moe = True
+        ########### gemm1 ##################
+        gemm1_output = torch.empty((num_moe_inputs, 2 * self.inter_size),
+                                dtype=output.dtype,
+                                device=output.device)
+        torch.xpu.synchronize()
+        if start_event_gemm1 is not None:
+            start_event_gemm1.record()
+        torch.ops._xpu_C.cutlass_grouped_gemm_interface(
+            ptr_A=remapped_hidden_states,
+            ptr_A_scale=remapped_scales,
+            ptr_B=self.w13,
+            ptr_B_scale=self.gemm1_wei_scales,
+            ptr_bias=self.w13_bias,
+            ptr_D=gemm1_output,
+            rows_per_expert=rows_per_expert,
+            N=2 * self.inter_size,
+            K=hidden_size,
+            num_experts=self.num_experts)
+        if end_event_gemm1 is not None:
+            end_event_gemm1.record()
 
-    # TODO: will all integrated in Cpp func. Temporary expose before gemm fusion
-    num_rows, hidden_size = list(hidden_states.shape)
-    num_moe_inputs = n_experts_per_token * num_rows
+        # Apply swiglu_limit clamping before activation
+        if self.gemm1_clamp_limit is not None and self.gemm1_clamp_limit > 0:
+            gate = gemm1_output[:, :self.inter_size]
+            up = gemm1_output[:, self.inter_size:]
+            gate.clamp_(max=self.gemm1_clamp_limit)
+            up.clamp_(min=-self.gemm1_clamp_limit, max=self.gemm1_clamp_limit)
 
-    # Use actual GEMM N dimensions for correct FLOPS calculation
-    gemm1_n = 2 * inter_size  # gemm1: N = 2 * inter_size
-    gemm2_n = hidden_size      # gemm2: N = hidden_size
-    
-    if topk_ids.dtype == torch.int32:
-        topk_ids = topk_ids.to(torch.int64)
-    gemm1_output = torch.empty((num_moe_inputs, 2 * inter_size),
-                               dtype=hidden_states.dtype,
-                               device=hidden_states.device)
+        # act
+        act_output = torch.empty(
+            (num_moe_inputs, self.inter_size * self.inter_size_scale),
+            dtype=gemm1_output.dtype,
+            device=gemm1_output.device)
+        self.act_func(act_output, gemm1_output)
 
-    if not is_fp8 and not is_int4 and not is_mxfp4:
-        gemm1_scales = None
-        gemm2_scales = None
-    else:
-        gemm1_scales = w13_scales
-        gemm2_scales = w2_scales
+        ########### gemm2 ##################
+        gemm2_output = torch.empty((num_moe_inputs, hidden_size),
+                                dtype=output.dtype,
+                                device=output.device)
 
-    if expert_map is None and ep_size > 1:
-        expert_map = torch.empty((num_experts * ep_size),
-                                 dtype=torch.int32,
-                                 device=hidden_states.device)
-        torch.ops._moe_C.init_expert_map(expert_map, num_experts, ep_rank,
-                                         ep_size)
+        if act_quant:
+            act_output, gemm2_act_scale = quant_act_xpu(act_output, self.recipe)
+        torch.xpu.synchronize()
+        if start_event_gemm2 is not None:
+            start_event_gemm2.record()
+        torch.ops._xpu_C.cutlass_grouped_gemm_interface(
+            ptr_A=act_output,
+            ptr_A_scale=gemm2_act_scale if act_quant else None,
+            ptr_B=self.w2,
+            ptr_B_scale=self.gemm2_wei_scales,
+            ptr_bias=self.w2_bias,
+            ptr_D=gemm2_output,
+            rows_per_expert=rows_per_expert,
+            N=hidden_size,
+            K=self.inter_size * self.inter_size_scale,
+            num_experts=self.num_experts)
+        if end_event_gemm2 is not None:
+            end_event_gemm2.record()
 
-    if expert_map is not None:
-        total_experts_num = expert_map.shape[0]
-    else:
-        total_experts_num = num_experts * ep_size
-    local_experts_num = num_experts
+        torch.xpu.synchronize()
+        if start_event_gather is not None:
+            start_event_gather.record()
+        torch.ops._moe_C.moe_gather(output, gemm2_output, topk_weights,
+                                    unpermuted_row_to_permuted_row,
+                                    self.num_experts)
+        if end_event_gather is not None:
+            end_event_gather.record()
 
-    remapped_hidden_states = torch.empty(
-        (num_rows * n_experts_per_token, hidden_size),
-        dtype=hidden_states.dtype,
-        device=hidden_states.device)
-    rows_per_expert = torch.zeros((num_experts),
-                                  dtype=torch.int32,
-                                  device=hidden_states.device)
-    unpermuted_row_to_permuted_row = torch.empty(
-        (num_rows, n_experts_per_token),
-        dtype=torch.int32,
-        device=hidden_states.device)
+        gemm1_n = 2 * self.inter_size  # gemm1: N = 2 * inter_size
+        gemm2_n = hidden_size      # gemm2: N = hidden_size
 
-    ########### remap ##################
-    if start_event_remap is not None:
-        start_event_remap.record()
-    torch.ops._moe_C.remap_hidden_states(
-        hidden_states=hidden_states,
-        hidden_states_scales=None,
-        remapped_hidden_states=remapped_hidden_states,
-        remapped_hidden_states_scales=None,
-        expert_map=expert_map,
-        rows_per_expert=rows_per_expert,
-        unpermuted_row_to_permuted_row=unpermuted_row_to_permuted_row,
-        topk_ids=topk_ids,
-        total_experts_num=total_experts_num,
-        local_experts_num=local_experts_num)
-    if end_event_remap is not None:
-        end_event_remap.record()
+        active_experts1 = (rows_per_expert > 0).sum().item()
+        gemm1_m = remapped_hidden_states.shape[0]
+        gemm1_k = remapped_hidden_states.shape[1]
 
-    ########### gemm1 ##################
-    input_B = w13
-
-    if start_event_gemm1 is not None:
-        start_event_gemm1.record()
-    torch.ops._xpu_C.cutlass_grouped_gemm_interface(
-        ptr_A=remapped_hidden_states,
-        ptr_A_scale=None,
-        ptr_B=input_B,
-        ptr_B_scale=gemm1_scales,
-        ptr_bias=w13_bias,
-        ptr_D=gemm1_output,
-        rows_per_expert=rows_per_expert,
-        N=2 * inter_size,
-        K=hidden_size,
-        num_experts=num_experts)
-    if end_event_gemm1 is not None:
-        end_event_gemm1.record()
-    active_experts1 = (rows_per_expert > 0).sum().item()
-    gemm1_m = remapped_hidden_states.shape[0]
-    gemm1_k = remapped_hidden_states.shape[1]
-
-    # act
-    act_output = torch.empty((num_moe_inputs, inter_size),
-                             dtype=gemm1_output.dtype,
-                             device=gemm1_output.device)
-    if activation == "silu":
-        torch.ops._C.silu_and_mul(act_output, gemm1_output)
-    elif activation == "gelu":
-        torch.ops._C.gelu_and_mul(act_output, gemm1_output)
-    elif activation == "swigluoai" or ("SWIGLUOAI" in str(activation)):
-        torch.ops._C.swigluoai_and_mul(act_output, gemm1_output, 1.702, 7.0)
-    else:
-        raise ValueError(f"Unsupported FusedMoe activation: {activation}.")
-
-    ########### gemm2 ##################
-    input_A = act_output.contiguous()
-    input_B = w2
-    gemm2_output = torch.empty((num_moe_inputs, hidden_size),
-                               dtype=hidden_states.dtype,
-                               device=hidden_states.device)
-
-    if start_event_gemm2 is not None:
-        start_event_gemm2.record()
-    torch.ops._xpu_C.cutlass_grouped_gemm_interface(
-        ptr_A=input_A,
-        ptr_A_scale=None,
-        ptr_B=input_B,
-        ptr_B_scale=gemm2_scales,
-        ptr_bias=w2_bias,
-        ptr_D=gemm2_output,
-        rows_per_expert=rows_per_expert,
-        N=hidden_size,
-        K=inter_size,
-        num_experts=num_experts)
-
-    if end_event_gemm2 is not None:
-        end_event_gemm2.record()
-
-    if start_event_gather is not None:
-        start_event_gather.record()
-    torch.ops._moe_C.moe_gather(output, gemm2_output, topk_weights,
-                                unpermuted_row_to_permuted_row,
-                                num_experts)
-    if end_event_gather is not None:
-        end_event_gather.record()
-
-    active_experts2 = (rows_per_expert > 0).sum().item()
-    gemm2_m = input_A.shape[0]
-    gemm2_k = input_A.shape[1]
-    return ((gemm1_m, gemm1_n, gemm1_k, active_experts1),
-            (gemm2_m, gemm2_n, gemm2_k, active_experts2))
+        active_experts2 = (rows_per_expert > 0).sum().item()
+        gemm2_m = act_output.shape[0]
+        gemm2_k = act_output.shape[1]
+        return ((gemm1_m, gemm1_n, gemm1_k, active_experts1),
+                (gemm2_m, gemm2_n, gemm2_k, active_experts2))


### PR DESCRIPTION
1. Update xpu_fused_moe_CalKernelTime.
2. Use triton.testing.do_bench and statistics.median instead of event to get stable perf data.