### PR TITLE
cmake: mandate c++20 for xe kernels

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -231,8 +231,6 @@ message(STATUS "FetchContent base directory: ${FETCHCONTENT_BASE_DIR}")
 # when loaded by Python.
 set(CMAKE_INSTALL_RPATH "$ORIGIN")
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")
-
 if(VLLM_GPU_LANG STREQUAL "SYCL")
   #
   # For SYCL we want to use the same flags as CUDA, so we set them here. Note

--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -559,10 +559,6 @@ function(add_xe2_kernel_library LIBRARY_NAME)
     set(ARG_DESTINATION "vllm_xpu_kernels")
   endif()
 
-  # Set C++ standard
-  set(CMAKE_CXX_STANDARD 17)
-  set(CMAKE_CXX_STANDARD_REQUIRED ON)
-
   # Find all source files
   file(GLOB_RECURSE KERNEL_SOURCES "*.cpp" ${ATTN_KERNEL_SRCS_GEN})
 
@@ -579,6 +575,9 @@ function(add_xe2_kernel_library LIBRARY_NAME)
   if(ARG_INCLUDE_CMAKE_SOURCE_DIR)
     target_include_directories(${LIBRARY_NAME} PUBLIC ${CMAKE_SOURCE_DIR})
   endif()
+
+  # Set C++ standard
+  set_property(TARGET ${LIBRARY_NAME} PROPERTY CXX_STANDARD 20)
 
   # Set compile options and definitions
   target_compile_options(${LIBRARY_NAME}
@@ -631,10 +630,6 @@ function(add_xe_default_kernel_library LIBRARY_NAME)
     set(ARG_DESTINATION "vllm_xpu_kernels")
   endif()
 
-  # Set C++ standard
-  set(CMAKE_CXX_STANDARD 17)
-  set(CMAKE_CXX_STANDARD_REQUIRED ON)
-
   # Find all source files
   file(GLOB_RECURSE KERNEL_SOURCES "*.cpp")
 
@@ -650,6 +645,9 @@ function(add_xe_default_kernel_library LIBRARY_NAME)
   if(ARG_INCLUDE_CMAKE_SOURCE_DIR)
     target_include_directories(${LIBRARY_NAME} PUBLIC ${CMAKE_SOURCE_DIR})
   endif()
+
+  # Set C++ standard
+  set_property(TARGET ${LIBRARY_NAME} PROPERTY CXX_STANDARD 20)
 
   # Set compile options and definitions
   target_compile_options(${LIBRARY_NAME}


### PR DESCRIPTION
`vllm-xpu-kernels` currently fails to compile with `torch>=2.13` after https://github.com/pytorch/pytorch/commit/bab118ec75984d4e852df82e4a2e18ab2050b71d introduced an `#error` guard checking for C++20 support. This PR updates the `cmake` build configuration to mandate C++20 for kernel libraries.

Additionally, `-Werror` currently causes warnings related to SYCL\*TLA's use of deprecated implicit lambda capture by value for `this`. A fix for this is pending (see https://github.com/intel/sycl-tla/pull/841) but, in the meantime, `xpu-kernels` may still be built with support for `torch>=2.13` by omitting `-Werror` until the SYCL\*TLA pin is updated.