### PR TITLE
[OneDNN] add contiguity checks for scale inputs in onednn gemm

### DIFF
--- a/csrc/xpu/onednn/onednn_matmul.cpp
+++ b/csrc/xpu/onednn/onednn_matmul.cpp
@@ -74,6 +74,17 @@ torch::Tensor fp8_gemm(
     const std::optional<torch::Tensor>& B_scale_,
     const std::optional<torch::Tensor>& bias_) {
   const at::DeviceGuard device_guard(A.device());
+  // The weight B may be provided in a transposed (NT) layout, and A supports
+  // strided layouts, so both are excluded from the contiguity check.
+  TORCH_CHECK(
+      !A_scale_.has_value() || A_scale_.value().is_contiguous(),
+      "A_scale must be contiguous for fp8 matmul");
+  TORCH_CHECK(
+      !B_scale_.has_value() || B_scale_.value().is_contiguous(),
+      "B_scale must be contiguous for fp8 matmul");
+  TORCH_CHECK(
+      !bias_.has_value() || bias_.value().is_contiguous(),
+      "bias must be contiguous for fp8 matmul");
   torch::Tensor result = check_and_create_output_tensor(A, B, out_dtype);
   auto a_st = A.scalar_type();
   auto b_st = B.scalar_type();
@@ -103,6 +114,12 @@ torch::Tensor fp8_bmm(
   const at::DeviceGuard device_guard(A.device());
   TORCH_CHECK(A.dim() == 3, "fp8_bmm expects A to be a 3D tensor");
   TORCH_CHECK(B.dim() == 3, "fp8_bmm expects B to be a 3D tensor");
+  TORCH_CHECK(
+      !A_scale_.has_value() || A_scale_.value().is_contiguous(),
+      "A_scale must be contiguous for fp8 matmul");
+  TORCH_CHECK(
+      !B_scale_.has_value() || B_scale_.value().is_contiguous(),
+      "B_scale must be contiguous for fp8 matmul");
   torch::Tensor result = check_and_create_output_tensor(A, B, out_dtype);
   auto a_st = A.scalar_type();
   auto b_st = B.scalar_type();
@@ -129,6 +146,14 @@ torch::Tensor fp8_gemm_w8a16(
     const std::optional<torch::Tensor>& B_scale_,
     const std::optional<torch::Tensor>& bias_) {
   const at::DeviceGuard device_guard(A.device());
+  // The weight B may be provided in a transposed (NT) layout, and A supports
+  // strided layouts, so both are excluded from the contiguity check.
+  TORCH_CHECK(
+      !B_scale_.has_value() || B_scale_.value().is_contiguous(),
+      "B_scale must be contiguous for fp8 matmul");
+  TORCH_CHECK(
+      !bias_.has_value() || bias_.value().is_contiguous(),
+      "bias must be contiguous for fp8 matmul");
   torch::Tensor result = check_and_create_output_tensor(A, B, A.scalar_type());
   TORCH_CHECK(
       is_supported_fp8(B.scalar_type()),
@@ -151,6 +176,10 @@ torch::Tensor fp4_gemm(
     std::optional<c10::ScalarType> out_dtype,
     const std::optional<torch::Tensor>& bias) {
   const at::DeviceGuard device_guard(A.device());
+  TORCH_CHECK(
+      A_scale.is_contiguous(), "A_scale must be contiguous for fp4 matmul");
+  TORCH_CHECK(
+      B_scale.is_contiguous(), "B_scale must be contiguous for fp4 matmul");
   torch::Tensor result = check_and_create_output_tensor(A, B, out_dtype);
   auto a_st = A.scalar_type();
   auto b_st = B.scalar_type();
@@ -177,6 +206,9 @@ torch::Tensor int4_gemm_w4a16(
     const std::optional<torch::Tensor>& g_idx) {
   const at::DeviceGuard device_guard(A_.device());
 
+  TORCH_CHECK(
+      B_scale.is_contiguous(), "B_scale must be contiguous for int4 matmul");
+
   // For GPTQ with desc_act=True scenario
   auto A = g_idx.has_value() ? A_.index_select(-1, g_idx.value()) : A_;
   torch::Tensor result = check_and_create_output_tensor(A, B, A.scalar_type());
@@ -196,6 +228,11 @@ torch::Tensor int4_gemm_w4a8(
     const std::optional<torch::Tensor>& g_idx,
     const std::optional<torch::Tensor>& bias) {
   const at::DeviceGuard device_guard(A_.device());
+
+  TORCH_CHECK(
+      A_scale.is_contiguous(), "A_scale must be contiguous for int4 matmul");
+  TORCH_CHECK(
+      B_scale.is_contiguous(), "B_scale must be contiguous for int4 matmul");
 
   // Select indices if provided (for GPTQ with desc_act=True)
   const torch::Tensor& A =


### PR DESCRIPTION
This pull request strengthens input validation in several matrix multiplication kernels by adding contiguity checks for scaling and bias tensors. These checks ensure that the relevant tensors are contiguous in memory before computation, which can prevent subtle bugs and improve performance.

**Input validation improvements:**

* Added `is_contiguous()` checks for `A_scale`, `B_scale`, and `bias` tensors in `fp8_gemm`, `fp8_bmm`, and `fp8_gemm_w8a16` to ensure they are contiguous before performing the operation. (`csrc/xpu/onednn/onednn_matmul.cpp`) [[1]](diffhunk://#diff-1704b1e0cdd242b2cd54649e7fc107bfedb8e73fdf57cf5d5e10b4cfc31a7b05R77-R87) [[2]](diffhunk://#diff-1704b1e0cdd242b2cd54649e7fc107bfedb8e73fdf57cf5d5e10b4cfc31a7b05R117-R122) [[3]](diffhunk://#diff-1704b1e0cdd242b2cd54649e7fc107bfedb8e73fdf57cf5d5e10b4cfc31a7b05R149-R156)
* Added `is_contiguous()` checks for `A_scale` and `B_scale` in `fp4_gemm` to guarantee contiguous memory layout. (`csrc/xpu/onednn/onednn_matmul.cpp`)
* Added `is_contiguous()` checks for `A_scale` and `B_scale` in `int4_gemm_w4a8`, and for `B_scale` in `int4_gemm_w4a16`, to enforce contiguous input tensors. (`csrc/xpu/onednn/onednn_matmul.cpp`) [[1]](diffhunk://#diff-1704b1e0cdd242b2cd54649e7fc107bfedb8e73fdf57cf5d5e10b4cfc31a7b05R209-R211) [[2]](diffhunk://#diff-1704b1e0cdd242b2cd54649e7fc107bfedb8e73fdf57cf5d5e10b4cfc31a7b05R232-R236)

These changes help catch incorrect usage early and may improve kernel execution reliability.