### PR TITLE
Fix getMemoryInfo to work with older PVC drivers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -550,32 +550,6 @@ if(BASIC_KERNELS_ENABLED)
       "csrc/topk_per_row.cpp")
   include_directories("/usr/include")
 
-  # Probe for the Level Zero device-usablemem-size extension instead of gating
-  # on a loader version: the #ifdef in csrc/utils/mem_info.cpp depends on what
-  # the *headers* declare, which need not match the installed loader. Builds
-  # without it fall back to torch's allocator memory info.
-  #
-  # CMAKE_CXX_FLAGS already carries -Werror and -include sycl_first.h by this
-  # point, which makes every try-compile fail; clear it around the probe.
-  include(CheckCXXSourceCompiles)
-  set(_saved_cmake_cxx_flags "${CMAKE_CXX_FLAGS}")
-  set(_saved_cmake_required_includes "${CMAKE_REQUIRED_INCLUDES}")
-  set(CMAKE_CXX_FLAGS "")
-  set(CMAKE_REQUIRED_INCLUDES "${_saved_cmake_required_includes}")
-  list(APPEND CMAKE_REQUIRED_INCLUDES "/usr/include")
-  check_cxx_source_compiles(
-    "#include <level_zero/ze_api.h>
-     int main() {
-       ze_device_usablemem_size_ext_properties_t p{};
-       p.stype = ZE_STRUCTURE_TYPE_DEVICE_USABLEMEM_SIZE_EXT_PROPERTIES;
-       return static_cast<int>(p.currUsableMemSize);
-     }"
-    VLLM_XPU_HAS_ZE_USABLEMEM)
-  set(CMAKE_REQUIRED_INCLUDES "${_saved_cmake_required_includes}")
-  unset(_saved_cmake_required_includes)
-  set(CMAKE_CXX_FLAGS "${_saved_cmake_cxx_flags}")
-  unset(_saved_cmake_cxx_flags)
-
   define_gpu_extension_target(
     _C
     DESTINATION
@@ -595,15 +569,6 @@ if(BASIC_KERNELS_ENABLED)
     USE_SABI
     3
     WITH_SOABI)
-
-  if(VLLM_XPU_HAS_ZE_USABLEMEM)
-    message(STATUS "Level Zero device-usablemem-size extension found; "
-                   "mem_info reports device usable memory.")
-    target_compile_definitions(_C PRIVATE VLLM_XPU_HAS_ZE_USABLEMEM=1)
-  else()
-    message(STATUS "Level Zero device-usablemem-size extension not found; "
-                   "mem_info falls back to torch's allocator.")
-  endif()
 
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -550,6 +550,28 @@ if(BASIC_KERNELS_ENABLED)
       "csrc/topk_per_row.cpp")
   include_directories("/usr/include")
 
+  # Probe for the Level Zero device-usablemem-size extension instead of gating
+  # on a loader version: the #ifdef in csrc/utils/mem_info.cpp depends on what
+  # the *headers* declare, which need not match the installed loader. Builds
+  # without it fall back to torch's allocator memory info.
+  #
+  # CMAKE_CXX_FLAGS already carries -Werror and -include sycl_first.h by this
+  # point, which makes every try-compile fail; clear it around the probe.
+  include(CheckCXXSourceCompiles)
+  set(_saved_cmake_cxx_flags "${CMAKE_CXX_FLAGS}")
+  set(CMAKE_CXX_FLAGS "")
+  set(CMAKE_REQUIRED_INCLUDES "/usr/include")
+  check_cxx_source_compiles(
+    "#include <level_zero/ze_api.h>
+     int main() {
+       ze_device_usablemem_size_ext_properties_t p{};
+       p.stype = ZE_STRUCTURE_TYPE_DEVICE_USABLEMEM_SIZE_EXT_PROPERTIES;
+       return static_cast<int>(p.currUsableMemSize);
+     }"
+    VLLM_XPU_HAS_ZE_USABLEMEM)
+  unset(CMAKE_REQUIRED_INCLUDES)
+  set(CMAKE_CXX_FLAGS "${_saved_cmake_cxx_flags}")
+
   define_gpu_extension_target(
     _C
     DESTINATION
@@ -569,6 +591,15 @@ if(BASIC_KERNELS_ENABLED)
     USE_SABI
     3
     WITH_SOABI)
+
+  if(VLLM_XPU_HAS_ZE_USABLEMEM)
+    message(STATUS "Level Zero device-usablemem-size extension found; "
+                   "mem_info reports device usable memory.")
+    target_compile_definitions(_C PRIVATE VLLM_XPU_HAS_ZE_USABLEMEM=1)
+  else()
+    message(STATUS "Level Zero device-usablemem-size extension not found; "
+                   "mem_info falls back to torch's allocator.")
+  endif()
 
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -559,8 +559,10 @@ if(BASIC_KERNELS_ENABLED)
   # point, which makes every try-compile fail; clear it around the probe.
   include(CheckCXXSourceCompiles)
   set(_saved_cmake_cxx_flags "${CMAKE_CXX_FLAGS}")
+  set(_saved_cmake_required_includes "${CMAKE_REQUIRED_INCLUDES}")
   set(CMAKE_CXX_FLAGS "")
-  set(CMAKE_REQUIRED_INCLUDES "/usr/include")
+  set(CMAKE_REQUIRED_INCLUDES "${_saved_cmake_required_includes}")
+  list(APPEND CMAKE_REQUIRED_INCLUDES "/usr/include")
   check_cxx_source_compiles(
     "#include <level_zero/ze_api.h>
      int main() {
@@ -569,8 +571,10 @@ if(BASIC_KERNELS_ENABLED)
        return static_cast<int>(p.currUsableMemSize);
      }"
     VLLM_XPU_HAS_ZE_USABLEMEM)
-  unset(CMAKE_REQUIRED_INCLUDES)
+  set(CMAKE_REQUIRED_INCLUDES "${_saved_cmake_required_includes}")
+  unset(_saved_cmake_required_includes)
   set(CMAKE_CXX_FLAGS "${_saved_cmake_cxx_flags}")
+  unset(_saved_cmake_cxx_flags)
 
   define_gpu_extension_target(
     _C

--- a/csrc/utils/mem_info.cpp
+++ b/csrc/utils/mem_info.cpp
@@ -5,19 +5,6 @@
 
 #include <iostream>
 
-// Level Zero headers predating the device-usablemem-size-properties extension
-// declare neither of these, which is a compile error rather than something a
-// runtime check can guard, so spell out the spec-fixed stype and layout here.
-namespace {
-constexpr auto kUsableMemStype = static_cast<ze_structure_type_t>(0x00020041);
-
-struct UsableMemProps {
-  ze_structure_type_t stype;
-  void* pNext;
-  uint64_t currUsableMemSize;
-};
-}  // namespace
-
 size_t getTotalMemory(ze_device_handle_t& device) {
   uint32_t memoryCount = 0;
   zeDeviceGetMemoryProperties(device, &memoryCount, nullptr);
@@ -36,21 +23,22 @@ size_t getTotalMemory(ze_device_handle_t& device) {
   return totalMemory;
 }
 
-// Zero means the extension is unavailable: a driver that does not implement it
-// ignores the unrecognized pNext and still reports success, leaving the
-// zero-initialized field untouched.
+// A driver that does not implement the extension leaves the zero-initialized
+// size untouched and still returns success, so zero means unavailable.
 size_t getUsableMemory(ze_device_handle_t& device) {
+#ifdef ZE_DEVICE_USABLEMEM_SIZE_PROPERTIES_EXT_NAME
   ze_device_properties_t deviceProperties{};
-  UsableMemProps usableMemProps{};
+  ze_device_usablemem_size_ext_properties_t usableMemProps{};
 
-  usableMemProps.stype = kUsableMemStype;
+  usableMemProps.stype = ZE_STRUCTURE_TYPE_DEVICE_USABLEMEM_SIZE_EXT_PROPERTIES;
   deviceProperties.stype = ZE_STRUCTURE_TYPE_DEVICE_PROPERTIES;
   deviceProperties.pNext = &usableMemProps;
 
-  if (zeDeviceGetProperties(device, &deviceProperties) != ZE_RESULT_SUCCESS) {
-    return 0;
-  }
+  zeDeviceGetProperties(device, &deviceProperties);
   return usableMemProps.currUsableMemSize;
+#else
+  return 0;
+#endif
 }
 
 std::tuple<int64_t, int64_t> getMemoryInfo(int64_t device_index) {

--- a/csrc/utils/mem_info.cpp
+++ b/csrc/utils/mem_info.cpp
@@ -4,7 +4,8 @@
 #include <sycl/sycl.hpp>
 
 #include <iostream>
-
+#include <limits>
+#include <tuple>
 #ifdef VLLM_XPU_HAS_ZE_USABLEMEM
 size_t getTotalMemory(ze_device_handle_t& device) {
   uint32_t memoryCount = 0;

--- a/csrc/utils/mem_info.cpp
+++ b/csrc/utils/mem_info.cpp
@@ -1,9 +1,11 @@
+#include <c10/xpu/XPUCachingAllocator.h>
 #include <c10/xpu/XPUFunctions.h>
 #include <level_zero/ze_api.h>
 #include <sycl/sycl.hpp>
 
 #include <iostream>
 
+#ifdef VLLM_XPU_HAS_ZE_USABLEMEM
 size_t getTotalMemory(ze_device_handle_t& device) {
   uint32_t memoryCount = 0;
   zeDeviceGetMemoryProperties(device, &memoryCount, nullptr);
@@ -33,14 +35,26 @@ size_t getUsableMemory(ze_device_handle_t& device) {
   zeDeviceGetProperties(device, &deviceProperties);
   return usableMemProps.currUsableMemSize;
 }
+#endif
 
 std::tuple<int64_t, int64_t> getMemoryInfo(int64_t device_index) {
+#ifdef VLLM_XPU_HAS_ZE_USABLEMEM
   const auto& device =
       c10::xpu::get_raw_device(static_cast<c10::DeviceIndex>(device_index));
   auto level_zero_device =
       sycl::get_native<sycl::backend::ext_oneapi_level_zero>(device);
   const size_t free = getUsableMemory(level_zero_device);
   const size_t total = getTotalMemory(level_zero_device);
+#else
+  // Level Zero loader < 1.27.0: the device-usablemem-size extension is not
+  // available in the headers. Defer to PyTorch's XPU caching allocator, which
+  // reports {free, total} and raises a descriptive error if the device cannot
+  // report free memory.
+  const auto [free, total] =
+      c10::xpu::XPUCachingAllocator::get()->getMemoryInfo(
+          static_cast<c10::DeviceIndex>(device_index));
+#endif
+
   if (total > static_cast<size_t>(std::numeric_limits<int64_t>::max()) ||
       free > static_cast<size_t>(std::numeric_limits<int64_t>::max())) {
     std::cerr << "Memory size exceeds int64_t max value!" << std::endl;

--- a/csrc/utils/mem_info.cpp
+++ b/csrc/utils/mem_info.cpp
@@ -4,14 +4,11 @@
 #include <sycl/sycl.hpp>
 
 #include <iostream>
-#include <limits>
-#include <tuple>
-
-namespace {
 
 // Level Zero headers predating the device-usablemem-size-properties extension
 // declare neither of these, which is a compile error rather than something a
 // runtime check can guard, so spell out the spec-fixed stype and layout here.
+namespace {
 constexpr auto kUsableMemStype = static_cast<ze_structure_type_t>(0x00020041);
 
 struct UsableMemProps {
@@ -19,6 +16,7 @@ struct UsableMemProps {
   void* pNext;
   uint64_t currUsableMemSize;
 };
+}  // namespace
 
 size_t getTotalMemory(ze_device_handle_t& device) {
   uint32_t memoryCount = 0;
@@ -54,8 +52,6 @@ size_t getUsableMemory(ze_device_handle_t& device) {
   }
   return usableMemProps.currUsableMemSize;
 }
-
-}  // namespace
 
 std::tuple<int64_t, int64_t> getMemoryInfo(int64_t device_index) {
   const auto& device =

--- a/csrc/utils/mem_info.cpp
+++ b/csrc/utils/mem_info.cpp
@@ -3,7 +3,10 @@
 #include <level_zero/ze_api.h>
 #include <sycl/sycl.hpp>
 
+#include <cstring>
 #include <iostream>
+#include <optional>
+#include <vector>
 
 size_t getTotalMemory(ze_device_handle_t& device) {
   uint32_t memoryCount = 0;
@@ -23,10 +26,37 @@ size_t getTotalMemory(ze_device_handle_t& device) {
   return totalMemory;
 }
 
-// A driver that does not implement the extension leaves the zero-initialized
-// size untouched and still returns success, so zero means unavailable.
-size_t getUsableMemory(ze_device_handle_t& device) {
 #ifdef ZE_DEVICE_USABLEMEM_SIZE_PROPERTIES_EXT_NAME
+static bool driverSupportsUsableMem(ze_driver_handle_t driver) {
+  uint32_t extCount = 0;
+  if (zeDriverGetExtensionProperties(driver, &extCount, nullptr) !=
+      ZE_RESULT_SUCCESS) {
+    return false;
+  }
+  std::vector<ze_driver_extension_properties_t> extProps(extCount);
+  if (zeDriverGetExtensionProperties(driver, &extCount, extProps.data()) !=
+      ZE_RESULT_SUCCESS) {
+    return false;
+  }
+  for (const auto& ext : extProps) {
+    if (std::strcmp(ext.name, ZE_DEVICE_USABLEMEM_SIZE_PROPERTIES_EXT_NAME) ==
+            0 &&
+        ext.version >= ZE_DEVICE_USABLEMEM_SIZE_PROPERTIES_EXT_VERSION_1_0) {
+      return true;
+    }
+  }
+  return false;
+}
+#endif
+
+// Returns nullopt when the usable-memory extension is unavailable, which is a
+// different thing from a device that genuinely has zero usable memory left.
+std::optional<size_t>
+getUsableMemory(ze_device_handle_t& device, ze_driver_handle_t& driver) {
+#ifdef ZE_DEVICE_USABLEMEM_SIZE_PROPERTIES_EXT_NAME
+  if (!driverSupportsUsableMem(driver)) {
+    return std::nullopt;
+  }
   ze_device_properties_t deviceProperties{};
   ze_device_usablemem_size_ext_properties_t usableMemProps{};
 
@@ -34,10 +64,12 @@ size_t getUsableMemory(ze_device_handle_t& device) {
   deviceProperties.stype = ZE_STRUCTURE_TYPE_DEVICE_PROPERTIES;
   deviceProperties.pNext = &usableMemProps;
 
-  zeDeviceGetProperties(device, &deviceProperties);
+  if (zeDeviceGetProperties(device, &deviceProperties) != ZE_RESULT_SUCCESS) {
+    return std::nullopt;
+  }
   return usableMemProps.currUsableMemSize;
 #else
-  return 0;
+  return std::nullopt;
 #endif
 }
 
@@ -46,14 +78,18 @@ std::tuple<int64_t, int64_t> getMemoryInfo(int64_t device_index) {
       c10::xpu::get_raw_device(static_cast<c10::DeviceIndex>(device_index));
   auto level_zero_device =
       sycl::get_native<sycl::backend::ext_oneapi_level_zero>(device);
+  auto level_zero_driver =
+      sycl::get_native<sycl::backend::ext_oneapi_level_zero>(
+          device.get_platform());
 
-  size_t free = getUsableMemory(level_zero_device);
+  size_t free = 0;
   size_t total = 0;
-  if (free == 0) {
+  if (auto usable = getUsableMemory(level_zero_device, level_zero_driver)) {
+    free = *usable;
+    total = getTotalMemory(level_zero_device);
+  } else {
     std::tie(free, total) = c10::xpu::XPUCachingAllocator::get()->getMemoryInfo(
         static_cast<c10::DeviceIndex>(device_index));
-  } else {
-    total = getTotalMemory(level_zero_device);
   }
 
   if (total > static_cast<size_t>(std::numeric_limits<int64_t>::max()) ||

--- a/csrc/utils/mem_info.cpp
+++ b/csrc/utils/mem_info.cpp
@@ -6,7 +6,20 @@
 #include <iostream>
 #include <limits>
 #include <tuple>
-#ifdef VLLM_XPU_HAS_ZE_USABLEMEM
+
+namespace {
+
+// Level Zero headers predating the device-usablemem-size-properties extension
+// declare neither of these, which is a compile error rather than something a
+// runtime check can guard, so spell out the spec-fixed stype and layout here.
+constexpr auto kUsableMemStype = static_cast<ze_structure_type_t>(0x00020041);
+
+struct UsableMemProps {
+  ze_structure_type_t stype;
+  void* pNext;
+  uint64_t currUsableMemSize;
+};
+
 size_t getTotalMemory(ze_device_handle_t& device) {
   uint32_t memoryCount = 0;
   zeDeviceGetMemoryProperties(device, &memoryCount, nullptr);
@@ -25,36 +38,39 @@ size_t getTotalMemory(ze_device_handle_t& device) {
   return totalMemory;
 }
 
+// Zero means the extension is unavailable: a driver that does not implement it
+// ignores the unrecognized pNext and still reports success, leaving the
+// zero-initialized field untouched.
 size_t getUsableMemory(ze_device_handle_t& device) {
   ze_device_properties_t deviceProperties{};
-  ze_device_usablemem_size_ext_properties_t usableMemProps{};
+  UsableMemProps usableMemProps{};
 
-  usableMemProps.stype = ZE_STRUCTURE_TYPE_DEVICE_USABLEMEM_SIZE_EXT_PROPERTIES;
+  usableMemProps.stype = kUsableMemStype;
   deviceProperties.stype = ZE_STRUCTURE_TYPE_DEVICE_PROPERTIES;
   deviceProperties.pNext = &usableMemProps;
 
-  zeDeviceGetProperties(device, &deviceProperties);
+  if (zeDeviceGetProperties(device, &deviceProperties) != ZE_RESULT_SUCCESS) {
+    return 0;
+  }
   return usableMemProps.currUsableMemSize;
 }
-#endif
+
+}  // namespace
 
 std::tuple<int64_t, int64_t> getMemoryInfo(int64_t device_index) {
-#ifdef VLLM_XPU_HAS_ZE_USABLEMEM
   const auto& device =
       c10::xpu::get_raw_device(static_cast<c10::DeviceIndex>(device_index));
   auto level_zero_device =
       sycl::get_native<sycl::backend::ext_oneapi_level_zero>(device);
-  const size_t free = getUsableMemory(level_zero_device);
-  const size_t total = getTotalMemory(level_zero_device);
-#else
-  // Level Zero loader < 1.27.0: the device-usablemem-size extension is not
-  // available in the headers. Defer to PyTorch's XPU caching allocator, which
-  // reports {free, total} and raises a descriptive error if the device cannot
-  // report free memory.
-  const auto [free, total] =
-      c10::xpu::XPUCachingAllocator::get()->getMemoryInfo(
-          static_cast<c10::DeviceIndex>(device_index));
-#endif
+
+  size_t free = getUsableMemory(level_zero_device);
+  size_t total = 0;
+  if (free == 0) {
+    std::tie(free, total) = c10::xpu::XPUCachingAllocator::get()->getMemoryInfo(
+        static_cast<c10::DeviceIndex>(device_index));
+  } else {
+    total = getTotalMemory(level_zero_device);
+  }
 
   if (total > static_cast<size_t>(std::numeric_limits<int64_t>::max()) ||
       free > static_cast<size_t>(std::numeric_limits<int64_t>::max())) {

--- a/tests/test_get_memory_info.py
+++ b/tests/test_get_memory_info.py
@@ -12,6 +12,11 @@ DEVICES = [i for i in range(torch.xpu.device_count())]
 def test_get_memory_info(device) -> None:
     free, total = torch.ops._C_cache_ops.getMemoryInfo(device)
 
+    # Drivers without the usable-memory extension report 0; the fallback must
+    # still produce real numbers on every device.
+    assert free > 0
+    assert total > 0
+
     # FIXME:
     # After update neo, the results of torch is changed
     # ref_free 24385683456


### PR DESCRIPTION
## Purpose
`csrc/utils/mem_info.cpp` unconditionally used  `ze_device_usablemem_size_ext_properties_t`, which only exists in newer Level Zero headers. On stacks that predate the device-usablemem-size extension the `_C` extension fails to compile outright.

This PR instead falls back to the torch `c10::xpu::XPUCachingAllocator::get()->getMemoryInfo()` if usablemem is not supported.

This is required for Max 1550 GPUs  (PVC) since L0 is only updated for bug fixes, no version upgrades.

~~I used a cmake compile test to define `VLLM_XPU_HAS_ZE_USABLEMEM`. If you'd prefer gating by a specific level-zero version, let me know.~~

UPDATE: New approach is to define the missing types in a way that only changes behavior at runtime, rather than build.

