### PR TITLE
Fix benchmark warmup handling

### DIFF
--- a/benchmark/benchmark_cutlass_flash_attn_decode.py
+++ b/benchmark/benchmark_cutlass_flash_attn_decode.py
@@ -26,6 +26,7 @@ from benchmark.presets import get_hardware_preset
 # isort: on
 
 DEVICE = "xpu"
+WARMUP = 50
 
 
 def clear_xpu_cache():
@@ -175,8 +176,8 @@ def benchmark_decode_with_paged_kv(seq_lens, num_heads, head_size, block_size,
                               fa_versions, q_dtype, \
                               is_sink}, Provider: {provider}",
           flush=True)
-    assert iterations > 5, \
-    "Number of iterations should be greater than 5 to account for warmup"
+    assert iterations > WARMUP, \
+    "Number of iterations should be greater than WARMUP to account for warmup"
     queries = [
         torch.rand_like(maybe_quantized_query) for _ in range(iterations)
     ]
@@ -184,7 +185,7 @@ def benchmark_decode_with_paged_kv(seq_lens, num_heads, head_size, block_size,
     if provider == "flash":
         start_event = torch.xpu.Event(enable_timing=True)
         end_event = torch.xpu.Event(enable_timing=True)
-        for index in range(5):
+        for index in range(WARMUP):
             block_tables = torch.randint(0,
                                          num_blocks,
                                          (num_seqs, max_num_blocks_per_seq),
@@ -202,7 +203,7 @@ def benchmark_decode_with_paged_kv(seq_lens, num_heads, head_size, block_size,
                                    window_size=(-1, -1),
                                    s_aux=sink)
         start_event.record()
-        for index in range(5, iterations):
+        for index in range(WARMUP, iterations):
             block_tables = torch.randint(0,
                                          num_blocks,
                                          (num_seqs, max_num_blocks_per_seq),
@@ -221,25 +222,25 @@ def benchmark_decode_with_paged_kv(seq_lens, num_heads, head_size, block_size,
                                    s_aux=sink)
         end_event.record()
         torch.xpu.synchronize()
-        ms = start_event.elapsed_time(end_event) / (iterations - 5)
+        ms = start_event.elapsed_time(end_event) / (iterations - WARMUP)
         clear_xpu_cache()
         return 1000 * ms
     else:
         start_events = [
             torch.xpu.Event(enable_timing=True)
-            for _ in range(iterations - 5)
+            for _ in range(iterations - WARMUP)
         ]
         end_events = [
             torch.xpu.Event(enable_timing=True)
-            for _ in range(iterations - 5)
+            for _ in range(iterations - WARMUP)
         ]
         for index in range(iterations):
             block_tables = torch.randint(0,
                                          num_blocks,
                                          (num_seqs, max_num_blocks_per_seq),
                                          dtype=torch.int32)
-            se = start_events[index - 5] if index >= 5 else None
-            ee = end_events[index - 5] if index >= 5 else None
+            se = start_events[index - WARMUP] if index >= WARMUP else None
+            ee = end_events[index - WARMUP] if index >= WARMUP else None
             flash_attn_varlen_func_CalKernelTime(queries[index],
                                                  maybe_quantized_key_cache,
                                                  maybe_quantized_value_cache,
@@ -257,9 +258,9 @@ def benchmark_decode_with_paged_kv(seq_lens, num_heads, head_size, block_size,
         torch.xpu.synchronize()
         total_latency = sum(
             start_events[i].elapsed_time(end_events[i])
-            for i in range(iterations - 5)
+            for i in range(iterations - WARMUP)
         )
-        ms = total_latency / (iterations - 5)
+        ms = total_latency / (iterations - WARMUP)
         if provider == "flash_memBandwidth" or provider == "flash_MBU":
             memory_load_GB = calculate_memory_usage(cu_query_lens[-1].item(),
                                                     seq_k.sum().item(),
@@ -283,7 +284,7 @@ def benchmark_decode_with_paged_kv(seq_lens, num_heads, head_size, block_size,
         return 1000 * ms
 
 
-def get_benchmark_decode_with_paged_kv(iterations=20):
+def get_benchmark_decode_with_paged_kv(iterations=200):
 
     @triton.testing.perf_report(
         triton.testing.Benchmark(
@@ -416,16 +417,16 @@ def benchmark_batch_decode(config, iterations=200):
             window_size=(-1, -1), s_aux=sink)
 
     # Warmup
-    for i in range(min(10, iterations)):
+    for i in range(min(WARMUP, iterations)):
         _run(i)
     torch.xpu.synchronize()
 
     # Timed
     start_event = torch.xpu.Event(enable_timing=True)
     end_event = torch.xpu.Event(enable_timing=True)
-    measured = iterations - 10
+    measured = iterations - WARMUP
     start_event.record()
-    for i in range(10, iterations):
+    for i in range(WARMUP, iterations):
         _run(i)
     end_event.record()
     torch.xpu.synchronize()
@@ -446,7 +447,7 @@ if __name__ == "__main__":
     args = parse_args()
     seed = 1234
     seed_everything(seed)
-    iterations = 20
+    iterations = 200
     torch.set_default_device("xpu")
     torch.xpu.set_device("xpu:0")
 

--- a/benchmark/benchmark_cutlass_flash_attn_varlen.py
+++ b/benchmark/benchmark_cutlass_flash_attn_varlen.py
@@ -26,6 +26,7 @@ from benchmark.presets import get_hardware_preset
 # isort: on
 
 DEVICE = "xpu"
+WARMUP = 10
 
 
 def clear_xpu_cache():
@@ -217,7 +218,7 @@ def benchmark_varlen_with_paged_kv(num_seqs,
                                    is_paged,
                                    kv_dtype,
                                    provider,
-                                   iterations=20):
+                                   iterations=200):
     maybe_quantized_query, maybe_quantized_key_cache, \
         maybe_quantized_value_cache, \
         max_query_len, cu_query_lens, max_kv_len, cu_kv_lens, \
@@ -237,8 +238,8 @@ def benchmark_varlen_with_paged_kv(num_seqs,
                               fa_versions, q_dtype, is_sink, is_causal, \
                               is_paged, kv_dtype}, Provider: {provider}",
           flush=True)
-    assert iterations > 5, \
-    "Number of iterations should be greater than 5 to account for warmup"
+    assert iterations > WARMUP, \
+    "Number of iterations should be greater than WARMUP to account for warmup"
 
     queries = [
         torch.rand_like(maybe_quantized_query) for _ in range(iterations)
@@ -250,11 +251,11 @@ def benchmark_varlen_with_paged_kv(num_seqs,
     if is_kernel_time_provider:
         start_events = [
             torch.xpu.Event(enable_timing=True)
-            for _ in range(iterations - 5)
+            for _ in range(iterations - WARMUP)
         ]
         end_events = [
             torch.xpu.Event(enable_timing=True)
-            for _ in range(iterations - 5)
+            for _ in range(iterations - WARMUP)
         ]
         if is_paged:
             for index in range(iterations):
@@ -262,8 +263,8 @@ def benchmark_varlen_with_paged_kv(num_seqs,
                     0, num_blocks,
                     (num_seqs, max_num_blocks_per_seq),
                     dtype=torch.int32)
-                se = start_events[index - 5] if index >= 5 else None
-                ee = end_events[index - 5] if index >= 5 else None
+                se = start_events[index - WARMUP] if index >= WARMUP else None
+                ee = end_events[index - WARMUP] if index >= WARMUP else None
                 flash_attn_varlen_func_CalKernelTime(
                     queries[index],
                     maybe_quantized_key_cache,
@@ -287,8 +288,8 @@ def benchmark_varlen_with_paged_kv(num_seqs,
                     end_event=ee)
         else:
             for index in range(iterations):
-                se = start_events[index - 5] if index >= 5 else None
-                ee = end_events[index - 5] if index >= 5 else None
+                se = start_events[index - WARMUP] if index >= WARMUP else None
+                ee = end_events[index - WARMUP] if index >= WARMUP else None
                 flash_attn_varlen_func_CalKernelTime(
                     queries[index],
                     maybe_quantized_key_cache,
@@ -313,9 +314,9 @@ def benchmark_varlen_with_paged_kv(num_seqs,
         torch.xpu.synchronize()
         total_latency = sum(
             start_events[i].elapsed_time(end_events[i])
-            for i in range(iterations - 5)
+            for i in range(iterations - WARMUP)
         )
-        ms = total_latency / (iterations - 5)
+        ms = total_latency / (iterations - WARMUP)
         if provider == "flash_kernel_TFLOPS" or provider == "flash_kernel_MFU":
             flops = calculate_flops(num_query_heads, query_lens, kv_lens,
                                     head_size, is_causal)
@@ -337,7 +338,7 @@ def benchmark_varlen_with_paged_kv(num_seqs,
         start_event = torch.xpu.Event(enable_timing=True)
         end_event = torch.xpu.Event(enable_timing=True)
         if is_paged:
-            for index in range(5):
+            for index in range(WARMUP):
                 block_tables = torch.randint(
                     0, num_blocks,
                     (num_seqs, max_num_blocks_per_seq),
@@ -361,7 +362,7 @@ def benchmark_varlen_with_paged_kv(num_seqs,
                                        window_size=window_size,
                                        s_aux=sink)
             start_event.record()
-            for index in range(5, iterations):
+            for index in range(WARMUP, iterations):
                 block_tables = torch.randint(
                     0, num_blocks,
                     (num_seqs, max_num_blocks_per_seq),
@@ -386,7 +387,7 @@ def benchmark_varlen_with_paged_kv(num_seqs,
                                        s_aux=sink)
             end_event.record()
         else:
-            for index in range(5):
+            for index in range(WARMUP):
                 flash_attn_varlen_func(queries[index],
                                        maybe_quantized_key_cache,
                                        maybe_quantized_value_cache,
@@ -406,7 +407,7 @@ def benchmark_varlen_with_paged_kv(num_seqs,
                                        window_size=window_size,
                                        s_aux=sink)
             start_event.record()
-            for index in range(5, iterations):
+            for index in range(WARMUP, iterations):
                 flash_attn_varlen_func(queries[index],
                                        maybe_quantized_key_cache,
                                        maybe_quantized_value_cache,
@@ -427,12 +428,12 @@ def benchmark_varlen_with_paged_kv(num_seqs,
                                        s_aux=sink)
             end_event.record()
         torch.xpu.synchronize()
-        ms = start_event.elapsed_time(end_event) / (iterations - 5)
+        ms = start_event.elapsed_time(end_event) / (iterations - WARMUP)
         clear_xpu_cache()
         return 1000 * ms
 
 
-def get_benchmark_varlen_with_paged_kv(iterations=20):
+def get_benchmark_varlen_with_paged_kv(iterations=200):
 
     @triton.testing.perf_report(
         triton.testing.Benchmark(
@@ -500,7 +501,7 @@ if __name__ == "__main__":
     args = parse_args()
     seed = 4242
     seed_everything(seed)
-    iterations = 20
+    iterations = 40
     torch.set_default_device("xpu")
     torch.xpu.set_device("xpu:0")
 

--- a/benchmark/benchmark_gdn_attn.py
+++ b/benchmark/benchmark_gdn_attn.py
@@ -36,6 +36,7 @@ from tests.utils import parse_args, seed_everything
 # isort: on
 
 DEVICE = "xpu"
+WARMUP = 50
 
 
 def clear_xpu_cache():
@@ -405,8 +406,9 @@ def benchmark_gdn(shape_name, workload_name, dtype_str, provider, iterations):
 
     print(f"Running config: shape={shape.name}, workload={workload.name}, "
           f"dtype={dtype_str}, Provider: {provider}", flush=True)
-    assert iterations > 5, \
-        "Number of iterations should be greater than 5 to account for warmup"
+    assert iterations > WARMUP, \
+        "Number of iterations should be greater than WARMUP to account " \
+        "for warmup"
 
     kwargs = make_inputs(shape, workload, dtype)
 
@@ -462,18 +464,18 @@ def benchmark_gdn(shape_name, workload_name, dtype_str, provider, iterations):
             tp_size=kwargs["tp_size"])
 
     # warmup
-    for _ in range(5):
+    for _ in range(WARMUP):
         _run()
     torch.xpu.synchronize()
 
     start_event = torch.xpu.Event(enable_timing=True)
     end_event = torch.xpu.Event(enable_timing=True)
     start_event.record()
-    for _ in range(5, iterations):
+    for _ in range(WARMUP, iterations):
         _run()
     end_event.record()
     torch.xpu.synchronize()
-    ms = start_event.elapsed_time(end_event) / (iterations - 5)
+    ms = start_event.elapsed_time(end_event) / (iterations - WARMUP)
 
     if provider == "gdn":
         clear_xpu_cache()
@@ -499,7 +501,7 @@ def benchmark_gdn(shape_name, workload_name, dtype_str, provider, iterations):
     raise ValueError(f"Unknown provider {provider}")
 
 
-def get_benchmark(configs, iterations=20):
+def get_benchmark(configs, iterations=200):
 
     @triton.testing.perf_report(
         triton.testing.Benchmark(
@@ -538,7 +540,7 @@ if __name__ == "__main__":
     args = parse_args()
     seed = 1234
     seed_everything(seed)
-    iterations = 30
+    iterations = 200
     torch.set_default_device("xpu")
     torch.xpu.set_device("xpu:0")
 

--- a/benchmark/benchmark_gemm_onednn.py
+++ b/benchmark/benchmark_gemm_onednn.py
@@ -39,6 +39,7 @@ ALL_BENCHMARKS = [
 ]
 
 DEVICE = "xpu"
+WARMUP = 50
 
 
 def clear_xpu_cache():
@@ -528,21 +529,21 @@ def get_bf16_gemm_benchmark(configs, iterations):
     )
     def benchmark(m, n, k, dtype, provider, iterations=iterations):
 
-        assert iterations > 5
+        assert iterations > WARMUP
 
         input = torch.randn([m, k], dtype=dtype, device=DEVICE) / 10.0
         weight = torch.randn([n, k], dtype=dtype, device=DEVICE) / 10.0
 
         start_event = torch.xpu.Event(enable_timing=True)
         end_event = torch.xpu.Event(enable_timing=True)
-        for index in range(5):
+        for index in range(WARMUP):
             torch.nn.functional.linear(input, weight)
         start_event.record()
-        for index in range(iterations - 5):
+        for index in range(iterations - WARMUP):
             torch.nn.functional.linear(input, weight)
         end_event.record()
         torch.xpu.synchronize()
-        ms = start_event.elapsed_time(end_event) / (iterations - 5)
+        ms = start_event.elapsed_time(end_event) / (iterations - WARMUP)
         clear_xpu_cache()
 
         if provider == "tflops":
@@ -581,7 +582,7 @@ def get_fp8_gemm_benchmark(configs, iterations):
         m, n, k, out_dtype, fp8_dtype, provider, iterations=iterations
     ):
 
-        assert iterations > 5
+        assert iterations > WARMUP
 
         input = torch.randn([m, k], dtype=out_dtype, device=DEVICE) / 10.0
         weight = torch.randn([n, k], dtype=out_dtype, device=DEVICE) / 10.0
@@ -595,7 +596,7 @@ def get_fp8_gemm_benchmark(configs, iterations):
 
         start_event = torch.xpu.Event(enable_timing=True)
         end_event = torch.xpu.Event(enable_timing=True)
-        for index in range(5):
+        for index in range(WARMUP):
             fp8_gemm(
                 input_fp8,
                 weight_fp8_t,
@@ -604,7 +605,7 @@ def get_fp8_gemm_benchmark(configs, iterations):
                 scale_wei,
             )
         start_event.record()
-        for index in range(iterations - 5):
+        for index in range(iterations - WARMUP):
             fp8_gemm(
                 input_fp8,
                 weight_fp8_t,
@@ -614,7 +615,7 @@ def get_fp8_gemm_benchmark(configs, iterations):
             )
         end_event.record()
         torch.xpu.synchronize()
-        ms = start_event.elapsed_time(end_event) / (iterations - 5)
+        ms = start_event.elapsed_time(end_event) / (iterations - WARMUP)
         clear_xpu_cache()
 
         if provider == "tflops":
@@ -653,7 +654,7 @@ def get_fp8_gemm_w8a16_benchmark(configs, iterations):
         m, n, k, out_dtype, fp8_dtype, provider, iterations=iterations
     ):
 
-        assert iterations > 5
+        assert iterations > WARMUP
 
         input = torch.randn([m, k], dtype=out_dtype, device=DEVICE) / 10.0
         weight = torch.ones([n, k], dtype=out_dtype, device=DEVICE)
@@ -666,14 +667,14 @@ def get_fp8_gemm_w8a16_benchmark(configs, iterations):
 
         start_event = torch.xpu.Event(enable_timing=True)
         end_event = torch.xpu.Event(enable_timing=True)
-        for index in range(5):
+        for index in range(WARMUP):
             fp8_gemm_w8a16(input, weight_fp8_t, scale_wei, torch.Tensor())
         start_event.record()
-        for index in range(iterations - 5):
+        for index in range(iterations - WARMUP):
             fp8_gemm_w8a16(input, weight_fp8_t, scale_wei, torch.Tensor())
         end_event.record()
         torch.xpu.synchronize()
-        ms = start_event.elapsed_time(end_event) / (iterations - 5)
+        ms = start_event.elapsed_time(end_event) / (iterations - WARMUP)
         clear_xpu_cache()
 
         if provider == "tflops":
@@ -712,7 +713,7 @@ def get_fp8_gemm_per_channel_benchmark(configs, iterations):
         m, n, k, out_dtype, fp8_dtype, provider, iterations=iterations
     ):
 
-        assert iterations > 5
+        assert iterations > WARMUP
 
         input = torch.randn([m, k], dtype=out_dtype, device=DEVICE) / 10.0
         weight = torch.randn([n, k], dtype=out_dtype, device=DEVICE) / 10.0
@@ -727,7 +728,7 @@ def get_fp8_gemm_per_channel_benchmark(configs, iterations):
 
         start_event = torch.xpu.Event(enable_timing=True)
         end_event = torch.xpu.Event(enable_timing=True)
-        for index in range(5):
+        for index in range(WARMUP):
             fp8_gemm(
                 input_fp8,
                 weight_fp8_t,
@@ -736,7 +737,7 @@ def get_fp8_gemm_per_channel_benchmark(configs, iterations):
                 scale_wei,
             )
         start_event.record()
-        for index in range(iterations - 5):
+        for index in range(iterations - WARMUP):
             fp8_gemm(
                 input_fp8,
                 weight_fp8_t,
@@ -746,7 +747,7 @@ def get_fp8_gemm_per_channel_benchmark(configs, iterations):
             )
         end_event.record()
         torch.xpu.synchronize()
-        ms = start_event.elapsed_time(end_event) / (iterations - 5)
+        ms = start_event.elapsed_time(end_event) / (iterations - WARMUP)
         clear_xpu_cache()
 
         if provider == "tflops":
@@ -783,7 +784,7 @@ def get_mxfp8_gemm_benchmark(configs, iterations):
     )
     def benchmark(m, n, k, out_dtype, provider, iterations=iterations):
 
-        assert iterations > 5
+        assert iterations > WARMUP
 
         inputs = torch.randn((m, k), dtype=out_dtype, device=DEVICE) * 0.01
         weights = torch.randn((n, k), dtype=out_dtype, device=DEVICE) * 0.01
@@ -797,7 +798,7 @@ def get_mxfp8_gemm_benchmark(configs, iterations):
 
         start_event = torch.xpu.Event(enable_timing=True)
         end_event = torch.xpu.Event(enable_timing=True)
-        for index in range(5):
+        for index in range(WARMUP):
             fp8_gemm(
                 inputs_lp,
                 weights_lp.transpose(0, 1),
@@ -806,7 +807,7 @@ def get_mxfp8_gemm_benchmark(configs, iterations):
                 weights_scale,
             )
         start_event.record()
-        for index in range(iterations - 5):
+        for index in range(iterations - WARMUP):
             fp8_gemm(
                 inputs_lp,
                 weights_lp.transpose(0, 1),
@@ -816,7 +817,7 @@ def get_mxfp8_gemm_benchmark(configs, iterations):
             )
         end_event.record()
         torch.xpu.synchronize()
-        ms = start_event.elapsed_time(end_event) / (iterations - 5)
+        ms = start_event.elapsed_time(end_event) / (iterations - WARMUP)
         clear_xpu_cache()
 
         if provider == "tflops":
@@ -871,7 +872,7 @@ def get_mxfp4_gemm_benchmark(configs, iterations):
     )
     def benchmark(m, n, k, out_dtype, provider, iterations=iterations):
 
-        assert iterations > 5
+        assert iterations > WARMUP
 
         inputs = torch.randn((m, k), dtype=out_dtype, device=DEVICE) * 0.01
         weights = torch.randn((n, k), dtype=out_dtype, device=DEVICE) * 0.01
@@ -885,7 +886,7 @@ def get_mxfp4_gemm_benchmark(configs, iterations):
 
         start_event = torch.xpu.Event(enable_timing=True)
         end_event = torch.xpu.Event(enable_timing=True)
-        for index in range(5):
+        for index in range(WARMUP):
             fp4_gemm(
                 inputs_lp,
                 weights_lp.transpose(0, 1),
@@ -894,7 +895,7 @@ def get_mxfp4_gemm_benchmark(configs, iterations):
                 out_dtype,
             )
         start_event.record()
-        for index in range(iterations - 5):
+        for index in range(iterations - WARMUP):
             fp4_gemm(
                 inputs_lp,
                 weights_lp.transpose(0, 1),
@@ -904,7 +905,7 @@ def get_mxfp4_gemm_benchmark(configs, iterations):
             )
         end_event.record()
         torch.xpu.synchronize()
-        ms = start_event.elapsed_time(end_event) / (iterations - 5)
+        ms = start_event.elapsed_time(end_event) / (iterations - WARMUP)
         clear_xpu_cache()
 
         if provider == "tflops":

--- a/benchmark/src/flash_attn_interface_.py
+++ b/benchmark/src/flash_attn_interface_.py
@@ -275,7 +275,7 @@ def flash_attn_varlen_func_CalKernelTime(
 
         if start_event is not None:
             start_event.record()
-        out, softmax_lse = torch.ops._vllm_fa2_C.varlen_fwd(
+        varlen_fwd_args = [
             q,
             k,
             v,
@@ -306,7 +306,8 @@ def flash_attn_varlen_func_CalKernelTime(
             is_mix_batch,
             splits_per_seq_dev,
             work_list_dev,
-        )
+        ]
+        out, softmax_lse = torch.ops._vllm_fa2_C.varlen_fwd(*varlen_fwd_args)
         if end_event is not None:
             end_event.record()
     else:


### PR DESCRIPTION
## Summary

Fix warmup handling in the benchmark scripts.

Previously the benchmark scripts hard-coded the number of warmup iterations
(`5` in most places, `10` in a few) and used low default iteration counts
(e.g. `20`/`30`). With so few warmup steps the timed region still included
cold-start effects, producing noisy/unstable numbers.

This change:
- Introduces a single configurable `WARMUP` constant per script and replaces
  every hard-coded `5`/`10` warmup reference with it (loop ranges, event
  array sizing, latency averaging denominators, and the iteration assertions).
- Raises the default iteration counts so the timed window (`iterations - WARMUP`)
  is large enough for stable measurements.

Affected files:
- `benchmark/benchmark_cutlass_flash_attn_decode.py`
- `benchmark/benchmark_cutlass_flash_attn_varlen.py`
- `benchmark/benchmark_gdn_attn.py`
- `benchmark/benchmark_gemm_onednn.py`
- `benchmark/src/flash_attn_interface_.py`

### Note

This branch originally also adapted the fused_moe benchmark to reuse
`XpuFusedMoe`. That part has been dropped after #493 refactored the
fused_moe benchmark upstream, so this PR is now scoped to the warmup fix only.
