### PR TITLE
[MoE] Add TopK-16 support to XPU fused MoE

### DIFF
--- a/csrc/moe/moe_gather.cpp
+++ b/csrc/moe/moe_gather.cpp
@@ -138,6 +138,7 @@ void MoeGatherLauncher(
       CASE_TOPK(7, ElemsPerItem)                                               \
       CASE_TOPK(8, ElemsPerItem)                                               \
       CASE_TOPK(10, ElemsPerItem)                                              \
+      CASE_TOPK(16, ElemsPerItem)                                              \
       default:                                                                 \
         TORCH_CHECK(false, "error: not support TOPK=" + std::to_string(TOPK)); \
     }                                                                          \

--- a/csrc/moe/remap_hidden_states.cpp
+++ b/csrc/moe/remap_hidden_states.cpp
@@ -530,6 +530,8 @@ void remap_hidden_states(
     LAUNCH_REMAP_HIDDEN_STATES(TA, TS, 8);              \
   } else if (TopK == 10) {                              \
     LAUNCH_REMAP_HIDDEN_STATES(TA, TS, 10);             \
+  } else if (TopK == 16) {                              \
+    LAUNCH_REMAP_HIDDEN_STATES(TA, TS, 16);             \
   } else {                                              \
     throw std::runtime_error("Unsupported TopK value"); \
   }

--- a/tests/fused_moe/test_fused_moe.py
+++ b/tests/fused_moe/test_fused_moe.py
@@ -494,6 +494,19 @@ def test_fused_moe_mxfp4(m, n, k, e, topk, dtype, has_bias):
     torch.testing.assert_close(output, ref_out, rtol=rtol, atol=atol)
 
 
+@pytest.mark.parametrize("num_tokens", [1, 4, 16])
+def test_fused_moe_mxfp4_topk16(num_tokens):
+    test_fused_moe_mxfp4(
+        num_tokens,
+        256,
+        256,
+        32,
+        16,
+        torch.bfloat16,
+        False,
+    )
+
+
 FUSED_MOE_MNK_FACTORS = [
     (1, 1024, 1024),
     (4, 1024, 1024),

--- a/tests/fused_moe/test_remap_hidden_states.py
+++ b/tests/fused_moe/test_remap_hidden_states.py
@@ -11,7 +11,7 @@ DEVICE = "xpu"
 NUM_ROWS = [32, 1024]
 HIDDEN_SIZE = [128]
 TOTAL_EXPERTS_NUM = [32, 128]
-TOP_KS = [1, 8]
+TOP_KS = [1, 8, 16]
 RECIPE_TO_DTYPE = {
     "bf16": (torch.bfloat16, None),
     "fp16": (torch.float16, None),
@@ -233,6 +233,33 @@ def test_remap_hidden_states(num_rows, hidden_size, total_experts_num, topk,
             print("Mismatched scales at indices:", mismatched_indices)
             print("Mismatched scales:", unpermuted_scales[mismatched_indices])
             print("Mismatched ref:", ref_unpermuted_scales[mismatched_indices])
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16, torch.float32])
+def test_moe_gather_topk16(dtype):
+    seed_everything(7)
+    num_tokens, topk, hidden_size = 8, 16, 128
+    moe_output = torch.randn((num_tokens * topk, hidden_size),
+                             dtype=dtype,
+                             device=DEVICE)
+    topk_weights = torch.randn((num_tokens, topk),
+                               dtype=torch.float32,
+                               device=DEVICE)
+    inverse = torch.randperm(num_tokens * topk,
+                             dtype=torch.int32,
+                             device=DEVICE).view(num_tokens, topk)
+    inverse[0, -1] = -1
+    output = torch.empty((num_tokens, hidden_size),
+                         dtype=dtype,
+                         device=DEVICE)
+
+    torch.ops._moe_C.moe_gather(output, moe_output, topk_weights, inverse, 32)
+
+    valid_inverse = inverse.clamp_min(0).to(torch.int64)
+    valid_weights = topk_weights * (inverse >= 0)
+    expected = (moe_output[valid_inverse].float()
+                * valid_weights[..., None]).sum(dim=1).to(dtype)
+    torch.testing.assert_close(output, expected, rtol=1e-2, atol=1e-2)
 
 
 @pytest.mark.parametrize("num_rows", [262144])

--- a/tests/fused_moe/test_remap_hidden_states.py
+++ b/tests/fused_moe/test_remap_hidden_states.py
@@ -235,37 +235,6 @@ def test_remap_hidden_states(num_rows, hidden_size, total_experts_num, topk,
             print("Mismatched ref:", ref_unpermuted_scales[mismatched_indices])
 
 
-@pytest.mark.parametrize(
-    "dtype", [torch.bfloat16, torch.float16, torch.float32]
-)
-def test_moe_gather_topk16(dtype):
-    seed_everything(7)
-    num_tokens, topk, hidden_size = 8, 16, 128
-    moe_output = torch.randn((num_tokens * topk, hidden_size),
-                             dtype=dtype,
-                             device=DEVICE)
-    topk_weights = torch.randn((num_tokens, topk),
-                               dtype=torch.float32,
-                               device=DEVICE)
-    inverse = torch.randperm(num_tokens * topk,
-                             dtype=torch.int32,
-                             device=DEVICE).view(num_tokens, topk)
-    inverse[0, -1] = -1
-    output = torch.empty((num_tokens, hidden_size),
-                         dtype=dtype,
-                         device=DEVICE)
-
-    torch.ops._moe_C.moe_gather(
-        output, moe_output, topk_weights, inverse.view(-1), 32
-    )
-
-    valid_inverse = inverse.clamp_min(0).to(torch.int64)
-    valid_weights = topk_weights * (inverse >= 0)
-    expected = (moe_output[valid_inverse].float()
-                * valid_weights[..., None]).sum(dim=1).to(dtype)
-    torch.testing.assert_close(output, expected, rtol=1e-2, atol=1e-2)
-
-
 @pytest.mark.parametrize("num_rows", [262144])
 @pytest.mark.parametrize("hidden_size", [2048])
 @pytest.mark.parametrize("total_experts_num", [128])

--- a/tests/fused_moe/test_remap_hidden_states.py
+++ b/tests/fused_moe/test_remap_hidden_states.py
@@ -235,7 +235,9 @@ def test_remap_hidden_states(num_rows, hidden_size, total_experts_num, topk,
             print("Mismatched ref:", ref_unpermuted_scales[mismatched_indices])
 
 
-@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16, torch.float32])
+@pytest.mark.parametrize(
+    "dtype", [torch.bfloat16, torch.float16, torch.float32]
+)
 def test_moe_gather_topk16(dtype):
     seed_everything(7)
     num_tokens, topk, hidden_size = 8, 16, 128
@@ -253,7 +255,9 @@ def test_moe_gather_topk16(dtype):
                          dtype=dtype,
                          device=DEVICE)
 
-    torch.ops._moe_C.moe_gather(output, moe_output, topk_weights, inverse, 32)
+    torch.ops._moe_C.moe_gather(
+        output, moe_output, topk_weights, inverse.view(-1), 32
+    )
 
     valid_inverse = inverse.clamp_min(0).to(torch.int64)
     valid_weights = topk_weights * (inverse >= 0)

--- a/tests/test_moe_gather.py
+++ b/tests/test_moe_gather.py
@@ -9,7 +9,7 @@ DEVICE = "xpu"
 INPUT_LENGTHS = [1, 8, 1024, 8192]
 HIDDEN_SIZE = [128, 1024, 8192]
 NUM_EXPERTS = [16, 32, 128]
-TOP_KS = [1, 4, 6, 8]
+TOP_KS = [1, 4, 6, 8, 16]
 EP_RANK = [0, 1, 2, 3]
 EP_SIZE = [4]
 
@@ -31,16 +31,14 @@ def ref_moe_gather(output, moe_output, topk_weights,
     topk = topk_weights.shape[1]
     moe_indices = unpermuted_row_to_permuted_row.view(input_len, topk)
 
-    selected_outputs = moe_output[
-        moe_indices]  # (input_len, topk, hidden_size)
-    mask = (moe_indices != -1).unsqueeze(-1)
-    selected_outputs = selected_outputs * mask
-    selected_outputs = selected_outputs.contiguous()
+    output_fp32 = torch.zeros_like(output, dtype=torch.float32)
+    for topk_idx in range(topk):
+        indices = moe_indices[:, topk_idx]
+        valid_weights = topk_weights[:, topk_idx] * (indices >= 0)
+        selected_output = moe_output[indices.clamp_min(0)].float()
+        selected_output.mul_(valid_weights[:, None])
+        output_fp32.add_(selected_output)
 
-    selected_outputs_fp32 = selected_outputs.float()
-    topk_weights_fp32 = topk_weights.float()
-    output_fp32 = torch.einsum('ijk,ij->ik', selected_outputs_fp32,
-                               topk_weights_fp32)
     output.copy_(output_fp32.to(output.dtype))
 
 


### PR DESCRIPTION
# Essential Elements of an Effective PR Description Checklist

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.

PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS ABOVE HAVE BEEN CONSIDERED.

## Purpose
Kimi-K3 selects 16 routed experts per token, so TopK-16 support is required to execute its MoE layers correctly. Extend the XPU fused MoE remap and gather kernels to support TopK-16 routing. Add correctness tests for token remapping, expert execution, and output gathering.

## Test Plan
```
python -m pytest -v tests/test_moe_gather.py::test_moe_gather
python -m pytest -v tests/fused_moe/test_fused_moe.py::test_fused_moe_mxfp4_topk16
```

## Test Result
```
# /opt/venv/bin/python -m pytest -v tests/fused_moe/test_fused_moe.py::test_fused_moe_mxfp4_topk16
=================================================== test session starts ====================================================
platform linux -- Python 3.12.3, pytest-9.1.0, pluggy-1.6.0 -- /opt/venv/bin/python
cachedir: .pytest_cache
rootdir: /home/mjc/vllm-xpu-kernels-kda
configfile: pyproject.toml
plugins: anyio-4.14.0
collected 3 items

tests/fused_moe/test_fused_moe.py::test_fused_moe_mxfp4_topk16[1] PASSED                                             [ 33%]
tests/fused_moe/test_fused_moe.py::test_fused_moe_mxfp4_topk16[4] PASSED                                             [ 66%]
tests/fused_moe/test_fused_moe.py::test_fused_moe_mxfp4_topk16[16] PASSED                                            [100%]

==================================================== 3 passed in 2.84s =====================================================
```
```
# /opt/venv/bin/python -m pytest -v tests/test_moe_gather.py::test_moe_gather
.................................................................................................................... [  5%]
.................................................................................................................... [ 10%]
.................................................................................................................... [ 16%]
.................................................................................................................... [ 21%]
.................................................................................................................... [ 26%]
.................................................................................................................... [ 32%]
.................................................................................................................... [ 37%]
.................................................................................................................... [ 42%]
.................................................................................................................... [ 48%]
.................................................................................................................... [ 53%]
.................................................................................................................... [ 59%]
.................................................................................................................... [ 64%]
.................................................................................................................... [ 69%]
.................................................................................................................... [ 75%]
.................................................................................................................... [ 80%]
.................................................................................................................... [ 85%]
.................................................................................................................... [ 91%]
.................................................................................................................... [ 96%]
........................................................................                                             [100%]
2160 passed in 21.06s
```

## (Optional) Documentation Update

**BEFORE SUBMITTING, PLEASE READ <https://docs.vllm.ai/en/latest/contributing>** (anything written below this line will be removed by GitHub Actions)
