### PR TITLE
Add SITU activation support for fused MoE

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Kernels are written in SYCL/DPC++ and leverage [oneDNN](https://github.com/oneap
 | Category | Operations |
 |---|---|
 | **Normalization** | RMS norm, fused add-RMS norm, layer norm |
-| **Activation** | SiLU-and-mul, mul-and-SiLU, GeLU (fast/new/quick/tanh), SwigluOAI |
+| **Activation** | SiLU-and-mul, mul-and-SiLU, GeLU (fast/new/quick/tanh), SwigluOAI, SituGLU |
 | **Attention** | Flash attention (variable-length), GDN attention, XE2 attention variants |
 | **Positional Encoding** | Rotary embedding (NeoX and GPT-J styles), DeepSeek scaling RoPE |
 | **Mixture of Experts** | TopK scoring (softmax/sigmoid), grouped TopK, fused grouped TopK; MoE align sum, MoE gather, expert remapping |

--- a/csrc/activation.cpp
+++ b/csrc/activation.cpp
@@ -310,6 +310,21 @@ swiglustep_and_mul(const T& gate, const T& up, float limit) {
   return (T)(clamped_gate * clamped_up);
 }
 
+template <typename T>
+[[intel::device_indirectly_callable]] inline __attribute__((always_inline)) T
+situ_and_mul(
+    const T& gate, const T& up, float beta, float linear_beta) {
+  const float gate_f = static_cast<float>(gate);
+  const float up_f = static_cast<float>(up);
+  const float activated_gate =
+      beta * sycl::tanh(gate_f / beta) /
+      (1.0f + sycl::exp(-gate_f));
+  const float activated_up = linear_beta > 0.0f
+      ? linear_beta * sycl::tanh(up_f / linear_beta)
+      : up_f;
+  return static_cast<T>(activated_gate * activated_up);
+}
+
 template <
     typename scalar_t,
     scalar_t (*ACT_FN)(
@@ -374,6 +389,52 @@ class swiglustep_and_mul_kernel {
   const scalar_t* input;
   const int d;
   const float limit;
+};
+
+template <typename scalar_t, int VEC_SIZE>
+class situ_and_mul_kernel {
+ public:
+  situ_and_mul_kernel(
+      scalar_t* __restrict__ out,
+      const scalar_t* __restrict__ input,
+      const int d,
+      const float beta,
+      const float linear_beta)
+      : out(out),
+        input(input),
+        d(d),
+        beta(beta),
+        linear_beta(linear_beta) {}
+
+  void operator()(sycl::nd_item<1> item) const {
+    using vec_t = vllm::xpu::aligned_vec<scalar_t, VEC_SIZE>;
+    const int64_t token_idx = item.get_group(0);
+    const int64_t offset = item.get_local_linear_id();
+    const int64_t step = item.get_local_range(0);
+    const int64_t bound = d / VEC_SIZE;
+    const auto* gate =
+        reinterpret_cast<const vec_t*>(input) + token_idx * bound * 2;
+    const auto* up = gate + bound;
+
+    for (int64_t i = offset; i < bound; i += step) {
+      const vec_t gate_vec = gate[i];
+      const vec_t up_vec = up[i];
+      vec_t out_vec;
+#pragma unroll
+      for (int j = 0; j < VEC_SIZE; ++j) {
+        out_vec[j] = vllm::situ_and_mul(
+            gate_vec[j], up_vec[j], beta, linear_beta);
+      }
+      reinterpret_cast<vec_t*>(out)[token_idx * bound + i] = out_vec;
+    }
+  }
+
+ private:
+  scalar_t* out;
+  const scalar_t* input;
+  const int d;
+  const float beta;
+  const float linear_beta;
 };
 
 }  // namespace vllm
@@ -713,4 +774,94 @@ void swiglustep_and_mul(
     torch::Tensor& input,  // [..., 2 * d]
     double limit) {
   LAUNCH_SWIGLUSTEP_AND_MUL(vllm::swiglustep_and_mul, limit);
+}
+
+void situ_and_mul(
+    torch::Tensor& out,    // [..., d]
+    torch::Tensor& input,  // [..., 2 * d]
+    double beta,
+    double linear_beta) {
+  TORCH_CHECK(
+    std::isfinite(beta) && beta > 0.0,
+    "SITU beta must be finite and greater than zero");
+  TORCH_CHECK(
+    std::isfinite(linear_beta), "SITU linear_beta must be finite");
+  TORCH_CHECK(input.dim() >= 1, "SITU input must have at least one dimension");
+  TORCH_CHECK(
+    input.size(-1) > 0 && input.size(-1) % 2 == 0,
+    "SITU input last dimension must be positive and even");
+  TORCH_CHECK(input.is_contiguous(), "SITU input must be contiguous");
+  TORCH_CHECK(out.is_contiguous(), "SITU output must be contiguous");
+  TORCH_CHECK(
+    out.device() == input.device(),
+    "SITU input and output must be on the same device");
+  TORCH_CHECK(
+    out.scalar_type() == input.scalar_type(),
+    "SITU input and output must have the same dtype");
+  TORCH_CHECK(
+    out.dim() == input.dim(),
+    "SITU input and output must have the same number of dimensions");
+  for (int64_t dim = 0; dim < input.dim() - 1; ++dim) {
+  TORCH_CHECK(
+    out.size(dim) == input.size(dim),
+    "SITU input and output leading dimensions must match");
+  }
+  TORCH_CHECK(
+    out.size(-1) * 2 == input.size(-1),
+    "SITU output last dimension must be half the input last dimension");
+
+  const int d = input.size(-1) / 2;
+  const int64_t num_tokens = input.numel() / input.size(-1);
+  if (num_tokens == 0) {
+    return;
+  }
+  at::DeviceGuard device_guard(input.device());
+  auto& queue = vllm::xpu::vllmGetQueue();
+  VLLM_DISPATCH_FLOATING_TYPES(input.scalar_type(), "situ_and_mul", [&] {
+    using sycl_t = vllm::xpu::SyclTypeTrait<scalar_t>::Type;
+    int vec_size = static_cast<int>(sizeof(float) * 4 / sizeof(sycl_t));
+    int64_t tmp_wg =
+        std::min(static_cast<int64_t>(d), static_cast<int64_t>(1024));
+    while (vec_size > 1 && (vec_size >> 1) * tmp_wg >= d) {
+      vec_size >>= 1;
+    }
+    if (d % vec_size != 0) {
+      vec_size = 1;
+    }
+    const int64_t wg_size = std::min(
+        static_cast<int64_t>(d / vec_size), static_cast<int64_t>(1024));
+
+    auto launch = [&]<int N>() {
+      queue.submit([&](sycl::handler& cgh) {
+        cgh.parallel_for(
+            sycl::nd_range<1>(num_tokens * wg_size, wg_size),
+            vllm::situ_and_mul_kernel<sycl_t, N>(
+                reinterpret_cast<sycl_t*>(out.data_ptr<scalar_t>()),
+                reinterpret_cast<const sycl_t*>(input.data_ptr<scalar_t>()),
+                d,
+                static_cast<float>(beta),
+                static_cast<float>(linear_beta)));
+      });
+    };
+
+    switch (vec_size) {
+      case 1:
+        launch.template operator()<1>();
+        break;
+      case 2:
+        launch.template operator()<2>();
+        break;
+      case 4:
+        launch.template operator()<4>();
+        break;
+      case 8:
+        launch.template operator()<8>();
+        break;
+      case 16:
+        launch.template operator()<16>();
+        break;
+      default:
+        TORCH_CHECK(false, "Unsupported vector size: ", vec_size);
+    }
+  });
 }

--- a/csrc/activation.cpp
+++ b/csrc/activation.cpp
@@ -802,9 +802,9 @@ void situ_and_mul(
     out.dim() == input.dim(),
     "SITU input and output must have the same number of dimensions");
   for (int64_t dim = 0; dim < input.dim() - 1; ++dim) {
-  TORCH_CHECK(
-    out.size(dim) == input.size(dim),
-    "SITU input and output leading dimensions must match");
+    TORCH_CHECK(
+        out.size(dim) == input.size(dim),
+        "SITU input and output leading dimensions must match");
   }
   TORCH_CHECK(
     out.size(-1) * 2 == input.size(-1),

--- a/csrc/activation.cpp
+++ b/csrc/activation.cpp
@@ -312,16 +312,13 @@ swiglustep_and_mul(const T& gate, const T& up, float limit) {
 
 template <typename T>
 [[intel::device_indirectly_callable]] inline __attribute__((always_inline)) T
-situ_and_mul(
-    const T& gate, const T& up, float beta, float linear_beta) {
+situ_and_mul(const T& gate, const T& up, float beta, float linear_beta) {
   const float gate_f = static_cast<float>(gate);
   const float up_f = static_cast<float>(up);
   const float activated_gate =
-      beta * sycl::tanh(gate_f / beta) /
-      (1.0f + sycl::exp(-gate_f));
-  const float activated_up = linear_beta > 0.0f
-      ? linear_beta * sycl::tanh(up_f / linear_beta)
-      : up_f;
+      beta * sycl::tanh(gate_f / beta) / (1.0f + sycl::exp(-gate_f));
+  const float activated_up =
+      linear_beta > 0.0f ? linear_beta * sycl::tanh(up_f / linear_beta) : up_f;
   return static_cast<T>(activated_gate * activated_up);
 }
 
@@ -400,11 +397,7 @@ class situ_and_mul_kernel {
       const int d,
       const float beta,
       const float linear_beta)
-      : out(out),
-        input(input),
-        d(d),
-        beta(beta),
-        linear_beta(linear_beta) {}
+      : out(out), input(input), d(d), beta(beta), linear_beta(linear_beta) {}
 
   void operator()(sycl::nd_item<1> item) const {
     using vec_t = vllm::xpu::aligned_vec<scalar_t, VEC_SIZE>;
@@ -422,8 +415,8 @@ class situ_and_mul_kernel {
       vec_t out_vec;
 #pragma unroll
       for (int j = 0; j < VEC_SIZE; ++j) {
-        out_vec[j] = vllm::situ_and_mul(
-            gate_vec[j], up_vec[j], beta, linear_beta);
+        out_vec[j] =
+            vllm::situ_and_mul(gate_vec[j], up_vec[j], beta, linear_beta);
       }
       reinterpret_cast<vec_t*>(out)[token_idx * bound + i] = out_vec;
     }
@@ -782,33 +775,32 @@ void situ_and_mul(
     double beta,
     double linear_beta) {
   TORCH_CHECK(
-    std::isfinite(beta) && beta > 0.0,
-    "SITU beta must be finite and greater than zero");
-  TORCH_CHECK(
-    std::isfinite(linear_beta), "SITU linear_beta must be finite");
+      std::isfinite(beta) && beta > 0.0,
+      "SITU beta must be finite and greater than zero");
+  TORCH_CHECK(std::isfinite(linear_beta), "SITU linear_beta must be finite");
   TORCH_CHECK(input.dim() >= 1, "SITU input must have at least one dimension");
   TORCH_CHECK(
-    input.size(-1) > 0 && input.size(-1) % 2 == 0,
-    "SITU input last dimension must be positive and even");
+      input.size(-1) > 0 && input.size(-1) % 2 == 0,
+      "SITU input last dimension must be positive and even");
   TORCH_CHECK(input.is_contiguous(), "SITU input must be contiguous");
   TORCH_CHECK(out.is_contiguous(), "SITU output must be contiguous");
   TORCH_CHECK(
-    out.device() == input.device(),
-    "SITU input and output must be on the same device");
+      out.device() == input.device(),
+      "SITU input and output must be on the same device");
   TORCH_CHECK(
-    out.scalar_type() == input.scalar_type(),
-    "SITU input and output must have the same dtype");
+      out.scalar_type() == input.scalar_type(),
+      "SITU input and output must have the same dtype");
   TORCH_CHECK(
-    out.dim() == input.dim(),
-    "SITU input and output must have the same number of dimensions");
+      out.dim() == input.dim(),
+      "SITU input and output must have the same number of dimensions");
   for (int64_t dim = 0; dim < input.dim() - 1; ++dim) {
     TORCH_CHECK(
         out.size(dim) == input.size(dim),
         "SITU input and output leading dimensions must match");
   }
   TORCH_CHECK(
-    out.size(-1) * 2 == input.size(-1),
-    "SITU output last dimension must be half the input last dimension");
+      out.size(-1) * 2 == input.size(-1),
+      "SITU output last dimension must be half the input last dimension");
 
   const int d = input.size(-1) / 2;
   const int64_t num_tokens = input.numel() / input.size(-1);

--- a/csrc/ops.h
+++ b/csrc/ops.h
@@ -92,10 +92,7 @@ void gelu_and_mul(torch::Tensor& out, torch::Tensor& input);
 void gelu_tanh_and_mul(torch::Tensor& out, torch::Tensor& input);
 
 void situ_and_mul(
-    torch::Tensor& out,
-    torch::Tensor& input,
-    double beta,
-    double linear_beta);
+    torch::Tensor& out, torch::Tensor& input, double beta, double linear_beta);
 
 void fatrelu_and_mul(
     torch::Tensor& out, torch::Tensor& input, double threshold);

--- a/csrc/ops.h
+++ b/csrc/ops.h
@@ -91,6 +91,12 @@ void gelu_and_mul(torch::Tensor& out, torch::Tensor& input);
 
 void gelu_tanh_and_mul(torch::Tensor& out, torch::Tensor& input);
 
+void situ_and_mul(
+    torch::Tensor& out,
+    torch::Tensor& input,
+    double beta,
+    double linear_beta);
+
 void fatrelu_and_mul(
     torch::Tensor& out, torch::Tensor& input, double threshold);
 

--- a/csrc/torch_bindings.cpp
+++ b/csrc/torch_bindings.cpp
@@ -115,10 +115,10 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
   ops.def("gelu_tanh_and_mul(Tensor! out, Tensor input) -> ()");
   ops.impl("gelu_tanh_and_mul", torch::kXPU, &gelu_tanh_and_mul);
 
-    ops.def(
-            "situ_and_mul(Tensor! out, Tensor input, float beta=1.0, float "
-            "linear_beta=-1.0) -> ()");
-    ops.impl("situ_and_mul", torch::kXPU, &situ_and_mul);
+  ops.def(
+      "situ_and_mul(Tensor! out, Tensor input, float beta=1.0, float "
+      "linear_beta=-1.0) -> ()");
+  ops.impl("situ_and_mul", torch::kXPU, &situ_and_mul);
 
   ops.def("fatrelu_and_mul(Tensor! out, Tensor! input, float threshold) -> ()");
   ops.impl("fatrelu_and_mul", torch::kXPU, &fatrelu_and_mul);

--- a/csrc/torch_bindings.cpp
+++ b/csrc/torch_bindings.cpp
@@ -115,6 +115,11 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
   ops.def("gelu_tanh_and_mul(Tensor! out, Tensor input) -> ()");
   ops.impl("gelu_tanh_and_mul", torch::kXPU, &gelu_tanh_and_mul);
 
+    ops.def(
+            "situ_and_mul(Tensor! out, Tensor input, float beta=1.0, float "
+            "linear_beta=-1.0) -> ()");
+    ops.impl("situ_and_mul", torch::kXPU, &situ_and_mul);
+
   ops.def("fatrelu_and_mul(Tensor! out, Tensor! input, float threshold) -> ()");
   ops.impl("fatrelu_and_mul", torch::kXPU, &fatrelu_and_mul);
 

--- a/tests/fused_moe/test_fused_moe.py
+++ b/tests/fused_moe/test_fused_moe.py
@@ -102,9 +102,23 @@ def ref_fused_moe(x,
                   num_experts,
                   ep_rank=0,
                   ep_size=1,
-                  gemm1_clamp_limit=None,
-                  activation_situ_beta=None,
-                  activation_situ_linear_beta=None):
+                  gemm1_clamp_limit=None):
+    if activation == "silu":
+        act_fn = torch.nn.SiLU()
+        linear_fn = lambda up: up
+    elif activation == "situ":
+
+        def situ(gate):
+            return 4.0 * torch.tanh(gate / 4.0) * torch.sigmoid(gate)
+
+        def situ_linear(up):
+            return 25.0 * torch.tanh(up / 25.0)
+
+        act_fn = situ
+        linear_fn = situ_linear
+    else:
+        raise ValueError(f"Unsupported reference activation: {activation}")
+
     expert_start_id = num_experts * ep_rank
     expert_end_id = expert_start_id + num_experts
     expert_cache = torch.zeros_like(x)
@@ -136,19 +150,8 @@ def ref_fused_moe(x,
         if gemm1_clamp_limit is not None and gemm1_clamp_limit > 0:
             gemm1.clamp_(max=gemm1_clamp_limit)
             up.clamp_(min=-gemm1_clamp_limit, max=gemm1_clamp_limit)
-        if activation == "silu":
-            gate = torch.nn.functional.silu(gemm1)
-        elif activation == "situ":
-            assert activation_situ_beta is not None
-            gate = (activation_situ_beta
-                    * torch.tanh(gemm1 / activation_situ_beta)
-                    * torch.sigmoid(gemm1))
-            if (activation_situ_linear_beta is not None
-                    and activation_situ_linear_beta > 0):
-                up = (activation_situ_linear_beta
-                      * torch.tanh(up / activation_situ_linear_beta))
-        else:
-            raise ValueError(f"Unsupported reference activation: {activation}")
+        gate = act_fn(gemm1)
+        up = linear_fn(up)
         expert_out = ((gate * up) @ w2[expert_id, :, :].T.to(torch.float32))
         if w2_bias is not None:
             expert_out += w2_bias[expert_id, :].to(torch.float32)
@@ -246,8 +249,6 @@ def test_fused_moe(m, n, k, e, topk, dtype, w_dtype, has_bias, activation):
         ref_w13 = w13
         ref_w2 = w2
 
-    activation_situ_beta = 1.7 if activation == "situ" else None
-    activation_situ_linear_beta = 2.0 if activation == "situ" else None
     ref_out = ref_fused_moe(
         ref_a,
         ref_w13,
@@ -259,8 +260,6 @@ def test_fused_moe(m, n, k, e, topk, dtype, w_dtype, has_bias, activation):
         topk,
         activation,
         e,
-        activation_situ_beta=activation_situ_beta,
-        activation_situ_linear_beta=activation_situ_linear_beta,
     )
 
     w13.data = w13.transpose(-1, -2).contiguous()
@@ -276,8 +275,9 @@ def test_fused_moe(m, n, k, e, topk, dtype, w_dtype, has_bias, activation):
                 n_experts_per_token=topk,
                 activation=activation,
                 num_experts=e,
-                activation_situ_beta=activation_situ_beta,
-                activation_situ_linear_beta=activation_situ_linear_beta,
+                activation_situ_beta=4.0 if activation == "situ" else None,
+                activation_situ_linear_beta=(
+                    25.0 if activation == "situ" else None),
             )
 
     output = torch.empty_like(ref_out)
@@ -491,8 +491,6 @@ def test_fused_moe_mxfp4(m, n, k, e, topk, dtype, has_bias, activation):
         ref_13[i] = dequantize_mxfp4(w13[i], w13_scales[i], group_size, dtype)
         ref_2[i] = dequantize_mxfp4(w2[i], w2_scales[i], group_size, dtype)
 
-    activation_situ_beta = 1.7 if activation == "situ" else None
-    activation_situ_linear_beta = 2.0 if activation == "situ" else None
     ref_out = ref_fused_moe(
         ref_a,
         ref_13,
@@ -504,8 +502,6 @@ def test_fused_moe_mxfp4(m, n, k, e, topk, dtype, has_bias, activation):
         topk,
         activation,
         e,
-        activation_situ_beta=activation_situ_beta,
-        activation_situ_linear_beta=activation_situ_linear_beta,
     )
 
     fused_moe_impl = XpuFusedMoe(
@@ -518,8 +514,9 @@ def test_fused_moe_mxfp4(m, n, k, e, topk, dtype, has_bias, activation):
                 n_experts_per_token=topk,
                 activation=activation,
                 num_experts=e,
-                activation_situ_beta=activation_situ_beta,
-                activation_situ_linear_beta=activation_situ_linear_beta,
+                activation_situ_beta=4.0 if activation == "situ" else None,
+                activation_situ_linear_beta=(
+                    25.0 if activation == "situ" else None),
             )
 
     output = torch.empty_like(ref_out)

--- a/tests/fused_moe/test_fused_moe.py
+++ b/tests/fused_moe/test_fused_moe.py
@@ -102,7 +102,9 @@ def ref_fused_moe(x,
                   num_experts,
                   ep_rank=0,
                   ep_size=1,
-                  gemm1_clamp_limit=None):
+                  gemm1_clamp_limit=None,
+                  activation_situ_beta=None,
+                  activation_situ_linear_beta=None):
     expert_start_id = num_experts * ep_rank
     expert_end_id = expert_start_id + num_experts
     expert_cache = torch.zeros_like(x)
@@ -125,7 +127,6 @@ def ref_fused_moe(x,
                              dim=0)
         if w13_bias is not None:
             w1_bias, w3_bias = w13_bias[expert_id, :].chunk(2)
-        act_fn = torch.nn.SiLU()
         gemm1 = (expert_tokens.to(torch.float32) @ w1.T.to(torch.float32))
         if w13_bias is not None:
             gemm1 += w1_bias.to(torch.float32)
@@ -135,7 +136,19 @@ def ref_fused_moe(x,
         if gemm1_clamp_limit is not None and gemm1_clamp_limit > 0:
             gemm1.clamp_(max=gemm1_clamp_limit)
             up.clamp_(min=-gemm1_clamp_limit, max=gemm1_clamp_limit)
-        gate = act_fn(gemm1)
+        if activation == "silu":
+            gate = torch.nn.functional.silu(gemm1)
+        elif activation == "situ":
+            assert activation_situ_beta is not None
+            gate = (activation_situ_beta
+                    * torch.tanh(gemm1 / activation_situ_beta)
+                    * torch.sigmoid(gemm1))
+            if (activation_situ_linear_beta is not None
+                    and activation_situ_linear_beta > 0):
+                up = (activation_situ_linear_beta
+                      * torch.tanh(up / activation_situ_linear_beta))
+        else:
+            raise ValueError(f"Unsupported reference activation: {activation}")
         expert_out = ((gate * up) @ w2[expert_id, :, :].T.to(torch.float32))
         if w2_bias is not None:
             expert_out += w2_bias[expert_id, :].to(torch.float32)
@@ -159,7 +172,8 @@ def ref_fused_moe(x,
                          [torch.float8_e5m2, torch.float8_e4m3fn, None],
                          ids=format_tc)
 @pytest.mark.parametrize("has_bias", [True, False])
-def test_fused_moe(m, n, k, e, topk, dtype, w_dtype, has_bias):
+@pytest.mark.parametrize("activation", ["silu", "situ"])
+def test_fused_moe(m, n, k, e, topk, dtype, w_dtype, has_bias, activation):
     seed_everything(7)
 
     input_len = m
@@ -232,9 +246,22 @@ def test_fused_moe(m, n, k, e, topk, dtype, w_dtype, has_bias):
         ref_w13 = w13
         ref_w2 = w2
 
-    ref_out = ref_fused_moe(ref_a, ref_w13, w13_bias, ref_w2, w2_bias,
-                            flat_expert_weights, flat_expert_indices, topk,
-                            "silu", e)
+    activation_situ_beta = 1.7 if activation == "situ" else None
+    activation_situ_linear_beta = 2.0 if activation == "situ" else None
+    ref_out = ref_fused_moe(
+        ref_a,
+        ref_w13,
+        w13_bias,
+        ref_w2,
+        w2_bias,
+        flat_expert_weights,
+        flat_expert_indices,
+        topk,
+        activation,
+        e,
+        activation_situ_beta=activation_situ_beta,
+        activation_situ_linear_beta=activation_situ_linear_beta,
+    )
 
     w13.data = w13.transpose(-1, -2).contiguous()
     w2.data = w2.transpose(-1, -2).contiguous()
@@ -247,8 +274,10 @@ def test_fused_moe(m, n, k, e, topk, dtype, w_dtype, has_bias):
                 w2_scales=w2_scales,
                 w2_bias=w2_bias,
                 n_experts_per_token=topk,
-                activation="silu",
+                activation=activation,
                 num_experts=e,
+                activation_situ_beta=activation_situ_beta,
+                activation_situ_linear_beta=activation_situ_linear_beta,
             )
 
     output = torch.empty_like(ref_out)
@@ -389,7 +418,8 @@ def test_fused_moe_int4(m, n, k, e, topk, dtype, has_bias):
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16],
                          ids=format_tc)
 @pytest.mark.parametrize("has_bias", [True, False])
-def test_fused_moe_mxfp4(m, n, k, e, topk, dtype, has_bias):
+@pytest.mark.parametrize("activation", ["silu", "situ"])
+def test_fused_moe_mxfp4(m, n, k, e, topk, dtype, has_bias, activation):
     seed_everything(7)
 
     torch.xpu.empty_cache()
@@ -461,9 +491,22 @@ def test_fused_moe_mxfp4(m, n, k, e, topk, dtype, has_bias):
         ref_13[i] = dequantize_mxfp4(w13[i], w13_scales[i], group_size, dtype)
         ref_2[i] = dequantize_mxfp4(w2[i], w2_scales[i], group_size, dtype)
 
-    ref_out = ref_fused_moe(ref_a, ref_13, w13_bias, ref_2, w2_bias,
-                            flat_expert_weights, flat_expert_indices, topk,
-                            "silu", e)
+    activation_situ_beta = 1.7 if activation == "situ" else None
+    activation_situ_linear_beta = 2.0 if activation == "situ" else None
+    ref_out = ref_fused_moe(
+        ref_a,
+        ref_13,
+        w13_bias,
+        ref_2,
+        w2_bias,
+        flat_expert_weights,
+        flat_expert_indices,
+        topk,
+        activation,
+        e,
+        activation_situ_beta=activation_situ_beta,
+        activation_situ_linear_beta=activation_situ_linear_beta,
+    )
 
     fused_moe_impl = XpuFusedMoe(
                 w13=w13.view(torch.float4_e2m1fn_x2),
@@ -473,8 +516,10 @@ def test_fused_moe_mxfp4(m, n, k, e, topk, dtype, has_bias):
                 w2_scales=w2_scales,
                 w2_bias=w2_bias,
                 n_experts_per_token=topk,
-                activation="silu",
+                activation=activation,
                 num_experts=e,
+                activation_situ_beta=activation_situ_beta,
+                activation_situ_linear_beta=activation_situ_linear_beta,
             )
 
     output = torch.empty_like(ref_out)

--- a/tests/register_ops.py
+++ b/tests/register_ops.py
@@ -99,6 +99,15 @@ def gelu_tanh_and_mul(out: torch.Tensor, input: torch.Tensor) -> None:
     torch.ops._C.gelu_tanh_and_mul(out, input)
 
 
+def situ_and_mul(
+    out: torch.Tensor,
+    input: torch.Tensor,
+    beta: float = 1.0,
+    linear_beta: float = -1.0,
+) -> None:
+    torch.ops._C.situ_and_mul(out, input, beta, linear_beta)
+
+
 def fatrelu_and_mul(out: torch.Tensor, input: torch.Tensor,
                     threshold: float) -> None:
     torch.ops._C.fatrelu_and_mul(out, input, threshold)

--- a/tests/test_activation.py
+++ b/tests/test_activation.py
@@ -12,7 +12,7 @@ from tests.utils import opcheck, seed_everything
 
 DTYPES = [torch.half, torch.bfloat16, torch.float]
 NUM_TOKENS = [7, 83, 2048]  # Arbitrary values for testing
-D = [512, 13824]  # Arbitrary values for testing
+D = [512, 1800, 3000, 13824]  # Cover scalar and vectorized kernels
 SEEDS = [0]
 XPU_DEVICES = [
     f"xpu:{i}" for i in range(1 if torch.xpu.device_count() == 1 else 2)
@@ -78,6 +78,102 @@ def test_act_and_mul(
         opcheck(fn, (out, x, threshold))
     else:
         opcheck(fn, (out, x))
+
+
+@pytest.mark.parametrize("num_tokens", NUM_TOKENS)
+@pytest.mark.parametrize("d", D)
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("linear_beta", [-1.0, 2.0])
+@pytest.mark.parametrize("device", XPU_DEVICES)
+@torch.inference_mode()
+def test_situ_and_mul(
+    num_tokens: int,
+    d: int,
+    dtype: torch.dtype,
+    linear_beta: float,
+    device: str,
+) -> None:
+    seed_everything(0)
+    beta = 1.7
+    x = torch.randn(num_tokens, 2 * d, dtype=dtype, device=device)
+    gate, up = x.float().chunk(2, dim=-1)
+    gate = beta * torch.tanh(gate / beta) * torch.sigmoid(gate)
+    if linear_beta > 0:
+        up = linear_beta * torch.tanh(up / linear_beta)
+    ref_out = (gate * up).to(dtype)
+    out = torch.empty_like(ref_out)
+
+    torch.ops._C.situ_and_mul(out, x, beta, linear_beta)
+
+    torch.testing.assert_close(
+        out,
+        ref_out,
+        atol=get_default_atol(out),
+        rtol=get_default_rtol(out),
+    )
+    opcheck(torch.ops._C.situ_and_mul, (out, x, beta, linear_beta))
+
+
+@pytest.mark.parametrize(
+    ("case", "error"),
+    [
+        ("odd_width", "last dimension must be positive and even"),
+        ("noncontiguous_input", "input must be contiguous"),
+        ("noncontiguous_output", "output must be contiguous"),
+        ("wrong_output_shape", "output last dimension must be half"),
+        ("wrong_output_dtype", "input and output must have the same dtype"),
+    ],
+)
+@pytest.mark.parametrize("device", XPU_DEVICES)
+def test_situ_and_mul_rejects_invalid_tensor_contract(
+    case: str,
+    error: str,
+    device: str,
+) -> None:
+    x = torch.randn(2, 8, device=device)
+    out = torch.empty(2, 4, device=device)
+    if case == "odd_width":
+        x = torch.randn(2, 7, device=device)
+        out = torch.empty(2, 3, device=device)
+    elif case == "noncontiguous_input":
+        x = torch.randn(2, 16, device=device)[:, ::2]
+    elif case == "noncontiguous_output":
+        out = torch.empty(2, 8, device=device)[:, ::2]
+    elif case == "wrong_output_shape":
+        out = torch.empty(2, 3, device=device)
+    elif case == "wrong_output_dtype":
+        out = out.to(torch.bfloat16)
+
+    with pytest.raises(RuntimeError, match=error):
+        torch.ops._C.situ_and_mul(out, x, 1.7, 2.0)
+
+
+@pytest.mark.parametrize("beta", [0.0, -1.0, float("nan"), float("inf")])
+@pytest.mark.parametrize("device", XPU_DEVICES)
+def test_situ_and_mul_rejects_invalid_beta(
+    beta: float,
+    device: str,
+) -> None:
+    x = torch.randn(2, 8, device=device)
+    out = torch.empty(2, 4, device=device)
+
+    with pytest.raises(RuntimeError, match="finite and greater than zero"):
+        torch.ops._C.situ_and_mul(out, x, beta, 2.0)
+
+
+@pytest.mark.parametrize(
+    "linear_beta", [float("nan"), float("inf"), float("-inf")]
+)
+@pytest.mark.parametrize("device", XPU_DEVICES)
+def test_situ_and_mul_rejects_invalid_linear_beta(
+    linear_beta: float,
+    device: str,
+) -> None:
+    x = torch.randn(2, 8, device=device)
+    out = torch.empty(2, 4, device=device)
+
+    with pytest.raises(RuntimeError, match="linear_beta must be finite"):
+        torch.ops._C.situ_and_mul(out, x, 1.7, linear_beta)
 
 
 @pytest.mark.parametrize("activation",

--- a/vllm_xpu_kernels/fused_moe_interface.py
+++ b/vllm_xpu_kernels/fused_moe_interface.py
@@ -239,8 +239,13 @@ class XpuFusedMoe:
         self.activation_situ_beta = activation_situ_beta
         self.activation_situ_linear_beta = activation_situ_linear_beta
         if self.activation == "situ":
+            import math
+
             if self.activation_situ_beta is None:
                 raise ValueError("SITU requires activation_situ_beta")
+            if not math.isfinite(self.activation_situ_beta):
+                raise ValueError(
+                    "SITU activation_situ_beta must be finite")
             if self.activation_situ_beta <= 0:
                 raise ValueError("SITU activation_situ_beta must be positive")
         self.inter_size_scale = 2 if self.activation == "relu2_no_mul" else 1

--- a/vllm_xpu_kernels/fused_moe_interface.py
+++ b/vllm_xpu_kernels/fused_moe_interface.py
@@ -107,7 +107,13 @@ def compute_num_tokens_per_block(num_tokens, num_experts_per_node):
     return 1024
 
 
-def fused_moe_activation(act_output, gemm1_output, activation):
+def fused_moe_activation(
+    act_output,
+    gemm1_output,
+    activation,
+    activation_situ_beta=None,
+    activation_situ_linear_beta=None,
+):
     if activation == "silu":
         torch.ops._C.silu_and_mul(act_output, gemm1_output)
     elif activation == "gelu":
@@ -120,6 +126,17 @@ def fused_moe_activation(act_output, gemm1_output, activation):
         torch.ops._C.relu2_no_mul(act_output, gemm1_output)
     elif activation == "swiglustep":
         torch.ops._C.swiglustep_and_mul(act_output, gemm1_output, 7.0)
+    elif activation == "situ":
+        if activation_situ_beta is None:
+            raise ValueError("SITU requires activation_situ_beta")
+        torch.ops._C.situ_and_mul(
+            act_output,
+            gemm1_output,
+            activation_situ_beta,
+            -1.0
+            if activation_situ_linear_beta is None
+            else activation_situ_linear_beta,
+        )
     else:
         raise ValueError(f"Unsupported FusedMoe activation: {activation}.")
 
@@ -169,6 +186,8 @@ class XpuFusedMoe:
         ep_size=1,
         expert_map=None,
         gemm1_clamp_limit: Optional[float]=None,
+        activation_situ_beta: Optional[float]=None,
+        activation_situ_linear_beta: Optional[float]=None,
     ):
         assert w13.is_contiguous() and w2.is_contiguous()
 
@@ -217,6 +236,13 @@ class XpuFusedMoe:
 
         self.n_experts_per_token = n_experts_per_token
         self.activation = activation
+        self.activation_situ_beta = activation_situ_beta
+        self.activation_situ_linear_beta = activation_situ_linear_beta
+        if self.activation == "situ":
+            if self.activation_situ_beta is None:
+                raise ValueError("SITU requires activation_situ_beta")
+            if self.activation_situ_beta <= 0:
+                raise ValueError("SITU activation_situ_beta must be positive")
         self.inter_size_scale = 2 if self.activation == "relu2_no_mul" else 1
         self.num_experts = num_experts
         self.ep_rank = ep_rank
@@ -243,6 +269,8 @@ class XpuFusedMoe:
             self.act_func = torch.ops._C.relu2_no_mul
         elif self.activation == "swiglustep":
             self.act_func = torch.ops._C.swiglustep_and_mul
+        elif self.activation == "situ":
+            self.act_func = torch.ops._C.situ_and_mul
         else:
             raise ValueError(
                 f"Unsupported FusedMoe activation: {self.activation}.")
@@ -308,7 +336,10 @@ class XpuFusedMoe:
                             ep_rank=self.ep_rank,
                             ep_size=self.ep_size,
                             expert_map=expert_map,
-                            a1q_scale=a1q_scale)
+                            a1q_scale=a1q_scale,
+                            activation_situ_beta=self.activation_situ_beta,
+                            activation_situ_linear_beta=(
+                                self.activation_situ_linear_beta))
 
     def _apply_kernel(
         self,
@@ -385,7 +416,17 @@ class XpuFusedMoe:
             (num_moe_inputs, self.inter_size * self.inter_size_scale),
             dtype=gemm1_output.dtype,
             device=gemm1_output.device)
-        self.act_func(act_output, gemm1_output)
+        if self.activation == "situ":
+            self.act_func(
+                act_output,
+                gemm1_output,
+                self.activation_situ_beta,
+                -1.0
+                if self.activation_situ_linear_beta is None
+                else self.activation_situ_linear_beta,
+            )
+        else:
+            self.act_func(act_output, gemm1_output)
 
         ########### gemm2 ##################
         gemm2_output = torch.empty((num_moe_inputs, hidden_size),

--- a/vllm_xpu_kernels/fused_moe_interface.py
+++ b/vllm_xpu_kernels/fused_moe_interface.py
@@ -107,13 +107,7 @@ def compute_num_tokens_per_block(num_tokens, num_experts_per_node):
     return 1024
 
 
-def fused_moe_activation(
-    act_output,
-    gemm1_output,
-    activation,
-    activation_situ_beta=None,
-    activation_situ_linear_beta=None,
-):
+def fused_moe_activation(act_output, gemm1_output, activation):
     if activation == "silu":
         torch.ops._C.silu_and_mul(act_output, gemm1_output)
     elif activation == "gelu":
@@ -127,15 +121,11 @@ def fused_moe_activation(
     elif activation == "swiglustep":
         torch.ops._C.swiglustep_and_mul(act_output, gemm1_output, 7.0)
     elif activation == "situ":
-        if activation_situ_beta is None:
-            raise ValueError("SITU requires activation_situ_beta")
         torch.ops._C.situ_and_mul(
             act_output,
             gemm1_output,
-            activation_situ_beta,
-            -1.0
-            if activation_situ_linear_beta is None
-            else activation_situ_linear_beta,
+            4.0,
+            25.0,
         )
     else:
         raise ValueError(f"Unsupported FusedMoe activation: {activation}.")
@@ -341,10 +331,7 @@ class XpuFusedMoe:
                             ep_rank=self.ep_rank,
                             ep_size=self.ep_size,
                             expert_map=expert_map,
-                            a1q_scale=a1q_scale,
-                            activation_situ_beta=self.activation_situ_beta,
-                            activation_situ_linear_beta=(
-                                self.activation_situ_linear_beta))
+                            a1q_scale=a1q_scale)
 
     def _apply_kernel(
         self,

--- a/vllm_xpu_kernels/moe_utils.py
+++ b/vllm_xpu_kernels/moe_utils.py
@@ -220,8 +220,6 @@ def ref_fused_moe_activation(
     act_output,
     gemm1_output,
     activation,
-    activation_situ_beta=None,
-    activation_situ_linear_beta=None,
 ):
     if activation == "silu":
         torch.ops._C.silu_and_mul(act_output, gemm1_output)
@@ -236,15 +234,11 @@ def ref_fused_moe_activation(
     elif activation == "swiglustep":
         torch.ops._C.swiglustep_and_mul(act_output, gemm1_output, 7.0)
     elif activation == "situ":
-        if activation_situ_beta is None:
-            raise ValueError("SITU requires activation_situ_beta")
         torch.ops._C.situ_and_mul(
             act_output,
             gemm1_output,
-            activation_situ_beta,
-            -1.0
-            if activation_situ_linear_beta is None
-            else activation_situ_linear_beta,
+            4.0,
+            25.0,
         )
     else:
         raise ValueError(f"Unsupported FusedMoe activation: {activation}.")
@@ -268,8 +262,6 @@ def ref_fused_moe(recipe,
                   ep_size=1,
                   expert_map=None,
                   a1q_scale=None,
-                  activation_situ_beta=None,
-                  activation_situ_linear_beta=None,
 ):
     """
     Reference fused MoE implementation with quantization simulation.
@@ -391,8 +383,6 @@ def ref_fused_moe(recipe,
         act_output,
         gemm1_output,
         activation,
-        activation_situ_beta,
-        activation_situ_linear_beta,
     )
 
     # ---- GEMM2: cutlass grouped GEMM replaced by torch matmul ----

--- a/vllm_xpu_kernels/moe_utils.py
+++ b/vllm_xpu_kernels/moe_utils.py
@@ -216,7 +216,13 @@ def dequant_wei(wei, wei_scale, recipe):
         return wei
 
 
-def ref_fused_moe_activation(act_output, gemm1_output, activation):
+def ref_fused_moe_activation(
+    act_output,
+    gemm1_output,
+    activation,
+    activation_situ_beta=None,
+    activation_situ_linear_beta=None,
+):
     if activation == "silu":
         torch.ops._C.silu_and_mul(act_output, gemm1_output)
     elif activation == "gelu":
@@ -229,6 +235,17 @@ def ref_fused_moe_activation(act_output, gemm1_output, activation):
         torch.ops._C.relu2_no_mul(act_output, gemm1_output)
     elif activation == "swiglustep":
         torch.ops._C.swiglustep_and_mul(act_output, gemm1_output, 7.0)
+    elif activation == "situ":
+        if activation_situ_beta is None:
+            raise ValueError("SITU requires activation_situ_beta")
+        torch.ops._C.situ_and_mul(
+            act_output,
+            gemm1_output,
+            activation_situ_beta,
+            -1.0
+            if activation_situ_linear_beta is None
+            else activation_situ_linear_beta,
+        )
     else:
         raise ValueError(f"Unsupported FusedMoe activation: {activation}.")
 
@@ -251,6 +268,8 @@ def ref_fused_moe(recipe,
                   ep_size=1,
                   expert_map=None,
                   a1q_scale=None,
+                  activation_situ_beta=None,
+                  activation_situ_linear_beta=None,
 ):
     """
     Reference fused MoE implementation with quantization simulation.
@@ -368,7 +387,13 @@ def ref_fused_moe(recipe,
         (num_moe_inputs, inter_size * inter_size_scale),
         dtype=compute_dtype,
         device=hidden_states.device)
-    ref_fused_moe_activation(act_output, gemm1_output, activation)
+    ref_fused_moe_activation(
+        act_output,
+        gemm1_output,
+        activation,
+        activation_situ_beta,
+        activation_situ_linear_beta,
+    )
 
     # ---- GEMM2: cutlass grouped GEMM replaced by torch matmul ----
     gemm2_output = torch.zeros((num_moe_inputs, hidden_size),

--- a/vllm_xpu_kernels/moe_utils.py
+++ b/vllm_xpu_kernels/moe_utils.py
@@ -216,11 +216,7 @@ def dequant_wei(wei, wei_scale, recipe):
         return wei
 
 
-def ref_fused_moe_activation(
-    act_output,
-    gemm1_output,
-    activation,
-):
+def ref_fused_moe_activation(act_output, gemm1_output, activation):
     if activation == "silu":
         torch.ops._C.silu_and_mul(act_output, gemm1_output)
     elif activation == "gelu":
@@ -379,11 +375,7 @@ def ref_fused_moe(recipe,
         (num_moe_inputs, inter_size * inter_size_scale),
         dtype=compute_dtype,
         device=hidden_states.device)
-    ref_fused_moe_activation(
-        act_output,
-        gemm1_output,
-        activation,
-    )
+    ref_fused_moe_activation(act_output, gemm1_output, activation)
 
     # ---- GEMM2: cutlass grouped GEMM replaced by torch matmul ----
     gemm2_output = torch.zeros((num_moe_inputs, hidden_size),


### PR DESCRIPTION
# Essential Elements of an Effective PR Description Checklist

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.

PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS ABOVE HAVE BEEN CONSIDERED.

## Purpose
Add the `situ_and_mul` XPU custom op and integrate SITU activation into the fused MoE path.

SITU is needed to support MoE model configurations that use its smooth, bounded gate activation instead of SiLU. The implementation also supports an optional bounded linear branch controlled by `linear_beta`.

- Add and register the `situ_and_mul` XPU kernel.
- Add SITU support and parameter validation in `XpuFusedMoe`.
- Add direct activation tests for supported dtypes, shapes, and invalid inputs.
- Add fused MoE coverage for SITU with regular and MXFP4 weights.
- Document SituGLU in the README.

## Test Plan
```
python -m pytest tests/test_activation.py -k "situ_and_mul"
python -m pytest tests/fused_moe/test_fused_moe.py -k "situ"
```
## Test Result
```
# python -m pytest tests/test_activation.py -k "situ_and_mul"
=================================================== test session starts ====================================================
platform linux -- Python 3.12.3, pytest-9.1.0, pluggy-1.6.0
rootdir: /home/mjc/vllm-xpu-kernels-kda
configfile: pyproject.toml
plugins: anyio-4.14.0
collected 816 items / 648 deselected / 168 selected

tests/test_activation.py ........................................................................................... [ 54%]
.............................................................................                                        [100%]

=========================================== 168 passed, 648 deselected in 9.49s ============================================
# python -m pytest tests/fused_moe/test_fused_moe.py -k "situ"
=================================================== test session starts ====================================================
platform linux -- Python 3.12.3, pytest-9.1.0, pluggy-1.6.0
rootdir: /home/mjc/vllm-xpu-kernels-kda
configfile: pyproject.toml
plugins: anyio-4.14.0
collected 272 items / 208 deselected / 64 selected

tests/fused_moe/test_fused_moe.py ................................................................                   [100%]

=========================================== 64 passed, 208 deselected in 32.18s ============================================
```

## (Optional) Documentation Update

**BEFORE SUBMITTING, PLEASE READ <https://docs.vllm.ai/en/latest/contributing>** (anything written below this line will be removed by GitHub Actions)
