### PR TITLE
Enable XPU view creation from non‑pinned CPU tensors 

### DIFF
--- a/csrc/xpu_view.cpp
+++ b/csrc/xpu_view.cpp
@@ -85,26 +85,47 @@ class XPUHostViewAllocator : public c10::Allocator {
 };
 }  // namespace vllm::xpu
 
-// This function assumes that `cpu_tensor` is a CPU tensor allocated with pinned
-// memory, and that UVA (Unified Virtual Addressing) is enabled.
+// This function assumes that `cpu_tensor` is a CPU tensor,
+// and that UVA (Unified Virtual Addressing) is enabled. If the given
+// `cpu_tensor` is not pinned, a new pinned buffer is allocated and the data is
+// copied into it, mirroring the CUDA implementation's fallback behavior.
 torch::Tensor get_xpu_view_from_cpu_tensor(torch::Tensor& cpu_tensor) {
   TORCH_CHECK(cpu_tensor.device().is_cpu(), "Input tensor must be on CPU");
-  TORCH_CHECK(cpu_tensor.is_contiguous(), "Input tensor must be contiguous");
-  TORCH_CHECK(
-      cpu_tensor.is_pinned(),
-      "Input tensor must be allocated with pinned memory");
-  // Get raw host pointer from CPU tensor
-  void* host_ptr = cpu_tensor.data_ptr();
 
-  // We'll use the same sizes, strides, and dtype as the CPU tensor.
+  auto device_id = c10::xpu::current_device();
+  c10::Device xpu_device(c10::DeviceType::XPU, device_id);
+
+  // Handle empty tensor.
+  if (cpu_tensor.numel() == 0) {
+    return torch::empty(
+        cpu_tensor.sizes(), cpu_tensor.options().device(xpu_device));
+  }
+
+  // If the CPU tensor isn't pinned, allocate a new pinned buffer and copy
+  // the (contiguous) data into it. Keep this pinned tensor alive as the
+  // owner of the resulting view, just like the pinned input tensor would be.
+  torch::Tensor pinned_owner;
+  if (cpu_tensor.is_pinned()) {
+    pinned_owner = cpu_tensor;
+  } else {
+    torch::Tensor contiguous_cpu = cpu_tensor.contiguous();
+    pinned_owner = at::empty_like(
+        contiguous_cpu, contiguous_cpu.options().pinned_memory(true));
+    pinned_owner.copy_(contiguous_cpu);
+  }
+
+  // Get raw host pointer from the pinned tensor.
+  void* host_ptr = pinned_owner.data_ptr();
+
+  // We'll use the same sizes, strides, and dtype as the pinned CPU tensor.
   // TODO: check if layout is respected.
-  auto sizes = cpu_tensor.sizes();
-  auto strides = cpu_tensor.strides();
-  auto scalar_type = cpu_tensor.scalar_type();
+  auto sizes = pinned_owner.sizes();
+  auto strides = pinned_owner.strides();
+  auto scalar_type = pinned_owner.scalar_type();
 
-  size_t byte_size = cpu_tensor.numel() * cpu_tensor.element_size();
-  // Keep `cpu_tensor` storage alive through the view tensor's lifetime.
-  vllm::xpu::XPUHostViewAllocator allocator(host_ptr, byte_size, cpu_tensor);
+  size_t byte_size = pinned_owner.numel() * pinned_owner.element_size();
+  // Keep `pinned_owner` storage alive through the view tensor's lifetime.
+  vllm::xpu::XPUHostViewAllocator allocator(host_ptr, byte_size, pinned_owner);
   c10::DataPtr data_ptr = allocator.allocate(byte_size);
   c10::Storage storage(
       c10::Storage::use_byte_size_t(), byte_size, std::move(data_ptr));

--- a/tests/test_uva.py
+++ b/tests/test_uva.py
@@ -73,6 +73,44 @@ def test_gpu_write(device):
 
 
 @pytest.mark.parametrize("device", XPU_DEVICES)
+def test_non_pinned_cpu_tensor(device):
+    # Non-pinned CPU tensors are internally copied into a pinned buffer,
+    # so the resulting XPU view reflects the values at creation time but
+    # is decoupled from further writes to the original `cpu_tensor`.
+    torch.set_default_device(device)
+    cpu_tensor = torch.arange(100,
+                              dtype=torch.int32,
+                              device="cpu").view(10, 10)
+    assert not cpu_tensor.is_pinned()
+    xpu_view = torch.ops._C.get_xpu_view_from_cpu_tensor(cpu_tensor)
+    assert xpu_view.device.type == "xpu"
+
+    assert xpu_view[0, 0] == 0
+    assert xpu_view[2, 3] == 23
+    assert xpu_view[9, 9] == 99
+
+    # Writes to the original (unpinned) CPU tensor must not affect the view,
+    # since a private pinned copy was made.
+    cpu_tensor[0, 0] = -1
+    assert xpu_view[0, 0] == 0
+
+    # The view itself remains writable and independently usable.
+    xpu_view.mul_(2)
+    assert xpu_view[2, 3] == 46
+    assert xpu_view[9, 9] == 198
+
+
+@pytest.mark.parametrize("device", XPU_DEVICES)
+def test_empty_cpu_tensor(device):
+    torch.set_default_device(device)
+    cpu_tensor = torch.empty(0, dtype=torch.int32, device="cpu")
+    xpu_view = torch.ops._C.get_xpu_view_from_cpu_tensor(cpu_tensor)
+    assert xpu_view.device.type == "xpu"
+    assert xpu_view.numel() == 0
+    assert xpu_view.shape == cpu_tensor.shape
+
+
+@pytest.mark.parametrize("device", XPU_DEVICES)
 def test_view_lifetime_after_owner_drop(device):
     torch.set_default_device(device)
     cpu_tensor = torch.arange(100,


### PR DESCRIPTION
## Summary

- Support non-pinned CPU tensors: if the input tensor is not pinned, a new pinned buffer is allocated. The resulting XPU view is  then constructed from this pinned buffer using the same logic as the  already-pinned path.
- Handle empty tensors by returning an empty XPU tensor directly, matching  the CUDA implementation's early-return for `numel() == 0`.
