### PR TITLE
fix(mem_cpy): use get_pointer_device to infer XPU device, fixing D2H ordering

### DIFF
--- a/csrc/utils/mem_cpy.cpp
+++ b/csrc/utils/mem_cpy.cpp
@@ -151,16 +151,27 @@ void xpuAsyncMemcpy(
   }
 }
 
-// Infer which XPU device a USM device pointer was allocated on by probing
-// each device's SYCL context.  Returns the device index on success.
-// This is O(num_xpu_devices) but avoids threading an explicit device argument
-// through the entire call chain when all callers already have the pointer.
+// Infer which XPU device a USM device pointer was allocated on.
+// Returns the device index on success.
+//
+// NOTE: on Intel GPUs all XPU (sub-)devices share a single SYCL/Level-Zero
+// context, so sycl::get_pointer_type() reports usm::alloc::device for a given
+// device pointer against EVERY device's context.  A first-match loop over
+// get_pointer_type() therefore always returns device 0, no matter which device
+// actually owns the allocation.  The DeviceGuard installed by the caller would
+// then flip the current device to 0 and vllmGetQueue() would return device 0's
+// in-order queue -- a queue with no ordering relationship to the compute stream
+// that produced/consumes the data on the true device.  For a D2H KV-cache store
+// this silently defeats the stream.wait_stream(compute) fence in gpu_worker.py
+// and races the copy against the still-live cache write (nondeterministic
+// corruption).  Use get_pointer_device(), which returns the actual owning
+// device, and map it back to the c10 device index.
 static at::DeviceIndex infer_xpu_device_from_ptr(const void* device_ptr) {
   const int n_devs = c10::xpu::device_count();
+  auto ctx = vllm::xpu::vllmGetQueue(0).get_context();
+  sycl::device owner = sycl::get_pointer_device(device_ptr, ctx);
   for (int i = 0; i < n_devs; i++) {
-    auto ctx = vllm::xpu::vllmGetQueue(i).get_context();
-    auto type = sycl::get_pointer_type(device_ptr, ctx);
-    if (type == sycl::usm::alloc::device || type == sycl::usm::alloc::shared) {
+    if (vllm::xpu::vllmGetQueue(i).get_device() == owner) {
       return static_cast<at::DeviceIndex>(i);
     }
   }

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1114,3 +1114,72 @@ def test_swap_blocks_batch_h2d_mutation_race(device: str) -> None:
             dst_val[0][db].cpu(),
             msg=f"Value block {sb}→{db} corrupted by post-call mutation",
         )
+
+
+@pytest.mark.skipif(torch.xpu.device_count() < 2,
+                    reason="device-inference bug only manifests on a "
+                    "non-zero XPU device (needs >= 2 devices)")
+@torch.inference_mode()
+def test_swap_blocks_batch_d2h_stream_ordering() -> None:
+    """D2H swap_blocks_batch must run on the SOURCE device's stream, ordered
+    behind a still-in-flight write to the source.
+
+    Regression test for a device-inference bug: on Intel GPUs all XPU
+    sub-devices share one Level-Zero/SYCL context, so probing the pointer
+    *type* against each device's context reports ``usm::alloc::device`` for
+    every device and a first-match loop always resolves device 0.  The
+    resulting ``DeviceGuard(0)`` then submits the D2H copy on device 0's queue
+    instead of the source device's, so the copy is unordered w.r.t. the
+    compute stream that is still writing the source (the store-side
+    ``stream.wait_stream(compute)`` fence in the offloading worker is silently
+    defeated) and reads stale/partial data.
+
+    This only reproduces on a non-zero device with an in-flight write: the
+    plain ``test_swap_blocks_batch`` D2H case passes on the buggy kernel
+    because it copies fully-settled data with no concurrent writer.
+    """
+    device = "xpu:1"
+    torch.xpu.set_device(device)
+
+    n_blocks = 32
+    block_elems = 1 << 12  # 4096 floats/block
+    mm = 2048  # matmul dim -> slow, long in-flight write window
+    trials = 32
+    poison, value = -7.0, 3.0
+
+    src = torch.empty(n_blocks * block_elems, device=device,
+                      dtype=torch.float32)
+    dst = torch.empty(n_blocks * block_elems, device="cpu",
+                      dtype=torch.float32, pin_memory=True)
+    stride_bytes = block_elems * src.element_size()
+
+    sp = np.empty(n_blocks, dtype=np.uint64)
+    dp = np.empty(n_blocks, dtype=np.uint64)
+    sz = np.full(n_blocks, stride_bytes, dtype=np.uint64)
+    for i in range(n_blocks):
+        sp[i] = src.data_ptr() + i * stride_bytes
+        dp[i] = dst.data_ptr() + i * stride_bytes
+    sp = torch.from_numpy(sp)
+    dp = torch.from_numpy(dp)
+    sz = torch.from_numpy(sz)
+
+    a = torch.randn(mm, mm, device=device, dtype=torch.float32)
+    b = torch.randn(mm, mm, device=device, dtype=torch.float32)
+
+    stream = torch.xpu.current_stream(device)
+    for t in range(trials):
+        with torch.xpu.stream(stream):
+            src.fill_(poison)
+            # Slow producer keeps `src` in-flight while the copy is enqueued.
+            c = a
+            for _ in range(6):
+                c = torch.mm(c, b)
+            src.fill_(value)
+            # Same-stream program order: an in-order queue must run the copy
+            # AFTER the fill above.  If the copy is diverted to another
+            # device's queue it races the fill and observes `poison`.
+            ops.swap_blocks_batch(sp, dp, sz)
+        torch.xpu.synchronize(device)
+        assert torch.all(dst == value), (
+            f"trial {t}: D2H copy read stale data -> copy ran on the wrong "
+            f"device's queue (device inference resolved the wrong XPU)")


### PR DESCRIPTION
On Intel GPUs all XPU sub-devices share a single Level-Zero/SYCL context, so sycl::get_pointer_type(ptr, ctx) reports usm::alloc::device for a given device pointer against every device's context.  The previous first-match loop in infer_xpu_device_from_ptr() therefore always returned device 0 regardless of which device actually owns the allocation.

The resulting DeviceGuard(0) flipped the current device to 0 and vllmGetQueue() returned device 0's in-order queue -- a queue with no ordering relationship to the compute/transfer stream on the true device.  For the D2H KV-cache offload store this silently defeated the stream.wait_stream(compute) fence in gpu_worker.py, racing the D2H copy against the still-in-flight cache write and producing nondeterministic KV-restore corruption.  Under tensor parallelism ranks > 0 were affected deterministically (their cache shards always mis-inferred to device 0), which explains why the corruption was reproducible per-prompt across runs.

Fix: replace the get_pointer_type first-match loop with sycl::get_pointer_device(), which returns the actual owning device, then map the returned sycl::device back to the c10 device index.  The copy now lands on the correct device's in-order queue that wait_stream already fenced.

The fix is async and introduces no host stall or performance regression.

Verified:
- Isolated probe (qprobe3): buggy 388/400 CORRUPT -> fixed 0/400 CLEAN
- Real swap_blocks_batch under production wait_stream race: 399/400 -> 0/400
- In-tree coherent_parity self-consistency (W4A16 TP2 native offload): R1 vs R2 1/16 token-exact -> 16/16 token-exact after restore
- Full test_cache.py + test_xpu_memcpy_sync.py suites: all pass

Adds test_swap_blocks_batch_d2h_stream_ordering: a regression test that reproduces the race (concurrent slow writer + D2H on a non-zero device) and fails on the old code / passes on the fixed code.  Skipped when device_count() < 2 since the bug is invisible on single-device systems (device 0 is inferred correctly by accident).

# Essential Elements of an Effective PR Description Checklist

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.

PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS ABOVE HAVE BEEN CONSIDERED.

## Purpose

## Test Plan

## Test Result

## (Optional) Documentation Update

**BEFORE SUBMITTING, PLEASE READ <https://docs.vllm.ai/en/latest/contributing>** (anything written below this line will be removed by GitHub Actions)
