### PR TITLE
fix fp8 group gemm regression

### DIFF
--- a/csrc/xpu/grouped_gemm/xe_2/gemm_xe2.hpp
+++ b/csrc/xpu/grouped_gemm/xe_2/gemm_xe2.hpp
@@ -52,6 +52,19 @@ namespace MoE {
 
 using namespace cute;
 
+enum class A_DTYPE {
+  BITS16,
+};
+
+enum class B_DTYPE {
+  BITS16,
+  INT4,
+  MXFP4,
+  PER_TENSOR_FP8,
+  MXFP8,
+  BLOCK_FP8,
+};
+
 template <typename TB>
 CUTE_DEVICE TB apply_scale(TB& x, float& y) {
   static_assert(
@@ -237,6 +250,7 @@ template <
     class GmemTiledCopyA,
     class GmemTiledCopyB,
     class GmemTiledCopyC,
+    B_DTYPE TENSOR_B_DTYPE,
     int GroupSize,
     class ATensor,
     class BTensor,
@@ -357,7 +371,7 @@ CUTE_DEVICE void xe_gemm_4bits(
     if (k_tile_prefetch * group_size < shape<1>(A)) {
       // MXFP8 / int4 1D scale prefetch ([N, K/gs]). Skip for float ElementS
       // (block-FP8 uses 2D [K/gs, N/gs] indexing).
-      if constexpr (!std::is_same_v<ElementS, float>) {
+      if constexpr (!(TENSOR_B_DTYPE == B_DTYPE::BLOCK_FP8)) {
         auto next_scales_tensor = make_tensor(
             make_gmem_ptr(
                 reinterpret_cast<const ElementS*>(
@@ -400,7 +414,7 @@ CUTE_DEVICE void xe_gemm_4bits(
               std::is_same_v<TB, float_e2m1_t> ||
               std::is_same_v<TB, float_e4m3_t> ||
               std::is_same_v<TB, float_e5m2_t>) {
-            if constexpr (std::is_same_v<ElementS, float>) {
+            if constexpr (TENSOR_B_DTYPE == B_DTYPE::BLOCK_FP8) {
               // Block-FP8: float32 scales [K/128, N/128] (B is (N,K)).
               int n_global = n_tile_start + n_sg_start + sg_local_n;
               int n_blocks = static_cast<int>(get<0>(B.shape())) / group_size;
@@ -425,7 +439,7 @@ CUTE_DEVICE void xe_gemm_4bits(
       }
 
       if ((group_idx + prefetch_dist) * group_size < shape<1>(A)) {
-        if constexpr (!std::is_same_v<ElementS, float>) {
+        if constexpr (!(TENSOR_B_DTYPE == B_DTYPE::BLOCK_FP8)) {
           auto next_scales_tensor = make_tensor(
               make_gmem_ptr(
                   reinterpret_cast<const ElementS*>(

--- a/csrc/xpu/grouped_gemm/xe_2/grouped_gemm_xe2.hpp
+++ b/csrc/xpu/grouped_gemm/xe_2/grouped_gemm_xe2.hpp
@@ -59,6 +59,8 @@ CUTE_DEVICE auto make_moe_tensor(T* ptr, int r, int c) {
 }
 
 template <
+    A_DTYPE TENSOR_A_DTYPE,
+    B_DTYPE TENSOR_B_DTYPE,
     class GmemTiledCopyA,
     class GmemTiledCopyB,
     class GmemTiledCopyD,
@@ -86,21 +88,8 @@ CUTE_DEVICE void MoEGEMM(
     int32_t* atomic_buffer,
     const sycl::local_accessor<int32_t, 1>& slm_mem_const) {
   constexpr char actual_layout_of_B = LayoutKindB ^ ('R' ^ 'C');
-  static constexpr bool is_B_int4 = (std::is_same_v<ElementB, uint8_t>) &&
-                                    (!std::is_same_v<ElementS, uint8_t>);
-  static constexpr bool is_B_mxfp4 = (std::is_same_v<ElementB, uint8_t>) &&
-                                     (std::is_same_v<ElementS, uint8_t>);
-  static constexpr bool is_B_4bits = std::is_same_v<ElementB, uint8_t>;
-  // MXFP8: FP8 weights + uint8 E8M0 block scales (group_size=32).
-  static constexpr bool is_B_mxfp8 = (std::is_same_v<ElementB, float_e4m3_t> ||
-                                      std::is_same_v<ElementB, float_e5m2_t>) &&
-                                     std::is_same_v<ElementS, uint8_t>;
-  // FP8 weights + float scales: per-tensor (group_size<=0) or block-FP8
-  // 2D gs=128 (group_size>0). Distinguished at runtime via group_size.
-  static constexpr bool is_B_fp8_float_scale =
-      (std::is_same_v<ElementB, float_e4m3_t> ||
-       std::is_same_v<ElementB, float_e5m2_t>) &&
-      std::is_same_v<ElementS, float>;
+  static constexpr bool is_B_4bits =
+      (TENSOR_B_DTYPE == B_DTYPE::INT4 || TENSOR_B_DTYPE == B_DTYPE::MXFP4);
 
   auto item = sycl::ext::oneapi::this_work_item::get_nd_item<3>();
   auto wg_tile = mma.tile_mnk();
@@ -157,21 +146,16 @@ CUTE_DEVICE void MoEGEMM(
       // Scales layout [E, N, K/group_size] packed with 4-bit B.
       ptr_Scales_curr_batch =
           const_cast<ElementS*>(Scales) + B_offset * 2 / group_size;
-    } else if constexpr (is_B_mxfp8) {
+    } else if constexpr (TENSOR_B_DTYPE == B_DTYPE::MXFP8) {
       // Scales layout [E, N, K/group_size] (host transposes from [E,K/32,N]).
       ptr_Scales_curr_batch =
           const_cast<ElementS*>(Scales) + B_offset / group_size;
-    } else if constexpr (is_B_fp8_float_scale) {
-      if (group_size > 0) {
-        // Block-FP8: scales [E, K/128, N/128] kept in that order.
-        ptr_Scales_curr_batch = const_cast<ElementS*>(Scales) +
-                                static_cast<int64_t>(expert_id) *
-                                    static_cast<int64_t>(gemm_k / group_size) *
-                                    static_cast<int64_t>(gemm_n / group_size);
-      } else {
-        // Per-tensor FP8: one float scale per expert.
-        ptr_Scales_curr_batch = const_cast<ElementS*>(Scales) + expert_id;
-      }
+    } else if constexpr (TENSOR_B_DTYPE == B_DTYPE::BLOCK_FP8) {
+      // Block-FP8: scales [E, K/128, N/128] kept in that order.
+      ptr_Scales_curr_batch = const_cast<ElementS*>(Scales) +
+                              static_cast<int64_t>(expert_id) *
+                                  static_cast<int64_t>(gemm_k / group_size) *
+                                  static_cast<int64_t>(gemm_n / group_size);
     }
     ElementBI* ptr_Bias_curr_batch = nullptr;
     if (Bias != static_cast<ElementBI*>(nullptr)) {
@@ -181,10 +165,10 @@ CUTE_DEVICE void MoEGEMM(
     auto A_tensor = make_moe_tensor<ElementA, LayoutKindA>(
         ptr_A_curr_batch, gemm_m, gemm_k);
     auto B_tensor = [&]() {
-      if constexpr (is_B_int4) {
+      if constexpr (TENSOR_B_DTYPE == B_DTYPE::INT4) {
         return make_moe_tensor<int4_t, actual_layout_of_B>(
             reinterpret_cast<int4_t*>(ptr_B_curr_batch), gemm_n, gemm_k);
-      } else if constexpr (is_B_mxfp4) {
+      } else if constexpr (TENSOR_B_DTYPE == B_DTYPE::MXFP4) {
         return make_moe_tensor<float_e2m1_t, actual_layout_of_B>(
             reinterpret_cast<float_e2m1_t*>(ptr_B_curr_batch), gemm_n, gemm_k);
       } else {
@@ -200,18 +184,25 @@ CUTE_DEVICE void MoEGEMM(
       int m_coord = (group_m_id - pre_tiles);
       auto tile_coord = make_coord(m_coord, n_coord, _, 0);
 
-      if constexpr (is_B_4bits || is_B_mxfp8) {
+      if constexpr (
+          is_B_4bits || TENSOR_B_DTYPE == B_DTYPE::MXFP8 ||
+          TENSOR_B_DTYPE == B_DTYPE::BLOCK_FP8) {
         // MXFP8 reuses the 4-bit block-scale mainloop (E8M0 decode + per-K
         // group B scaling) with float_e4m3/e5m2 weights instead of packed
         // 4-bit. Scale layout must be [N, K/group_size] per expert.
-#define XE_GEMM_4BITS_CALLER(GroupSize)                                     \
-  xe_gemm_4bits<GmemTiledCopyA, GmemTiledCopyB, GmemTiledCopyD, GroupSize>( \
-      A_tensor,                                                             \
-      B_tensor,                                                             \
-      ptr_Scales_curr_batch,                                                \
-      ptr_Bias_curr_batch,                                                  \
-      D_tensor,                                                             \
-      tile_coord,                                                           \
+#define XE_GEMM_4BITS_CALLER(GroupSize) \
+  xe_gemm_4bits<                        \
+      GmemTiledCopyA,                   \
+      GmemTiledCopyB,                   \
+      GmemTiledCopyD,                   \
+      TENSOR_B_DTYPE,                   \
+      GroupSize>(                       \
+      A_tensor,                         \
+      B_tensor,                         \
+      ptr_Scales_curr_batch,            \
+      ptr_Bias_curr_batch,              \
+      D_tensor,                         \
+      tile_coord,                       \
       mma);
         if (group_size == 32) {
           XE_GEMM_4BITS_CALLER(32)
@@ -223,31 +214,6 @@ CUTE_DEVICE void MoEGEMM(
           XE_GEMM_4BITS_CALLER(256)
         }
 #undef XE_GEMM_4BITS_CALLER
-      } else if constexpr (is_B_fp8_float_scale) {
-        if (group_size == 128) {
-          // Block-FP8: float32 2D scales [K/128, N/128] per expert.
-#define XE_GEMM_BLOCK_FP8_CALLER(GroupSize)                                 \
-  xe_gemm_4bits<GmemTiledCopyA, GmemTiledCopyB, GmemTiledCopyD, GroupSize>( \
-      A_tensor,                                                             \
-      B_tensor,                                                             \
-      ptr_Scales_curr_batch,                                                \
-      ptr_Bias_curr_batch,                                                  \
-      D_tensor,                                                             \
-      tile_coord,                                                           \
-      mma);
-          XE_GEMM_BLOCK_FP8_CALLER(128)
-#undef XE_GEMM_BLOCK_FP8_CALLER
-        } else {
-          // Per-tensor FP8 (one float scale per expert).
-          xe_gemm<GmemTiledCopyA, GmemTiledCopyB, GmemTiledCopyD>(
-              A_tensor,
-              B_tensor,
-              ptr_Scales_curr_batch,
-              ptr_Bias_curr_batch,
-              D_tensor,
-              tile_coord,
-              mma);
-        }
       } else {
         xe_gemm<GmemTiledCopyA, GmemTiledCopyB, GmemTiledCopyD>(
             A_tensor,

--- a/csrc/xpu/grouped_gemm/xe_2/grouped_gemm_xe2_interface.hpp
+++ b/csrc/xpu/grouped_gemm/xe_2/grouped_gemm_xe2_interface.hpp
@@ -64,13 +64,24 @@ namespace MoE {
 using namespace cute;
 
 // type tag to define a unique sycl kernel name
-template <typename, typename, typename, typename, char, char, class>
+template <
+    typename,
+    typename,
+    typename,
+    typename,
+    char,
+    char,
+    class,
+    A_DTYPE,
+    B_DTYPE>
 class GemmCuteName;
 
 template <
     char layoutA,
     char layoutB,
     class policy,
+    A_DTYPE TENSOR_A_DTYPE,
+    B_DTYPE TENSOR_B_DTYPE,
     typename ElementA,
     typename ElementB,
     typename ElementS,
@@ -133,9 +144,13 @@ void MoEGEMMLauncher(
         ElementD,
         layoutA,
         layoutB,
-        policy>>(
+        policy,
+        TENSOR_A_DTYPE,
+        TENSOR_B_DTYPE>>(
         sycl::nd_range<3>{global * local, local}, kernel_props, [=](auto) {
           MoE::MoEGEMM<
+              TENSOR_A_DTYPE,
+              TENSOR_B_DTYPE,
               GmemTiledCopyA,
               GmemTiledCopyB,
               GmemTiledCopyD,
@@ -238,8 +253,15 @@ at::Tensor cutlass_grouped_gemm_xe2_impl(
       at::empty({static_cast<long>(1)}, ptr_A.options().dtype(at::kInt));
 
 #define MoEGEMMLauncherCallER(                                                 \
-    LayoutA, LayoutB, Policy, ElementA, ElementB, ElementS)                    \
-  MoEGEMMLauncher<LayoutA, LayoutB, Policy>(                                   \
+    LayoutA,                                                                   \
+    LayoutB,                                                                   \
+    Policy,                                                                    \
+    TENSOR_A_DTYPE,                                                            \
+    TENSOR_B_DTYPE,                                                            \
+    ElementA,                                                                  \
+    ElementB,                                                                  \
+    ElementS)                                                                  \
+  MoEGEMMLauncher<LayoutA, LayoutB, Policy, TENSOR_A_DTYPE, TENSOR_B_DTYPE>(   \
       dpcpp_queue,                                                             \
       reinterpret_cast<ElementA*>(ptr_A.data_ptr()),                           \
       reinterpret_cast<ElementB*>(ptr_B.data_ptr()),                           \
@@ -278,23 +300,55 @@ at::Tensor cutlass_grouped_gemm_xe2_impl(
             group_size == 256,
         "group_size must be 32, 64, 128 or 256");
 
-#define W4A16LauncherCallER(policy)                                         \
-  if (is_B_int4) {                                                          \
-    if (A_dtype == at::kBFloat16) {                                         \
-      using scalar_t = bfloat16_t;                                          \
-      MoEGEMMLauncherCallER('R', 'C', policy, scalar_t, uint8_t, scalar_t); \
-    } else if (A_dtype == at::kHalf) {                                      \
-      using scalar_t = half_t;                                              \
-      MoEGEMMLauncherCallER('R', 'C', policy, scalar_t, uint8_t, scalar_t); \
-    }                                                                       \
-  } else if (is_B_mxfp4) {                                                  \
-    if (A_dtype == at::kBFloat16) {                                         \
-      using scalar_t = bfloat16_t;                                          \
-      MoEGEMMLauncherCallER('R', 'C', policy, scalar_t, uint8_t, uint8_t);  \
-    } else if (A_dtype == at::kHalf) {                                      \
-      using scalar_t = half_t;                                              \
-      MoEGEMMLauncherCallER('R', 'C', policy, scalar_t, uint8_t, uint8_t);  \
-    }                                                                       \
+#define W4A16LauncherCallER(policy)    \
+  if (is_B_int4) {                     \
+    if (A_dtype == at::kBFloat16) {    \
+      using scalar_t = bfloat16_t;     \
+      MoEGEMMLauncherCallER(           \
+          'R',                         \
+          'C',                         \
+          policy,                      \
+          A_DTYPE::BITS16,             \
+          B_DTYPE::INT4,               \
+          scalar_t,                    \
+          uint8_t,                     \
+          scalar_t);                   \
+    } else if (A_dtype == at::kHalf) { \
+      using scalar_t = half_t;         \
+      MoEGEMMLauncherCallER(           \
+          'R',                         \
+          'C',                         \
+          policy,                      \
+          A_DTYPE::BITS16,             \
+          B_DTYPE::INT4,               \
+          scalar_t,                    \
+          uint8_t,                     \
+          scalar_t);                   \
+    }                                  \
+  } else if (is_B_mxfp4) {             \
+    if (A_dtype == at::kBFloat16) {    \
+      using scalar_t = bfloat16_t;     \
+      MoEGEMMLauncherCallER(           \
+          'R',                         \
+          'C',                         \
+          policy,                      \
+          A_DTYPE::BITS16,             \
+          B_DTYPE::MXFP4,              \
+          scalar_t,                    \
+          uint8_t,                     \
+          uint8_t);                    \
+    } else if (A_dtype == at::kHalf) { \
+      using scalar_t = half_t;         \
+      MoEGEMMLauncherCallER(           \
+          'R',                         \
+          'C',                         \
+          policy,                      \
+          A_DTYPE::BITS16,             \
+          B_DTYPE::MXFP4,              \
+          scalar_t,                    \
+          uint8_t,                     \
+          uint8_t);                    \
+    }                                  \
   }
 
     if (A_avg_M <= 4) {
@@ -352,8 +406,15 @@ at::Tensor cutlass_grouped_gemm_xe2_impl(
     const c10::optional<at::Tensor>& ptr_scales_mx = scales_opt;
 #undef MoEGEMMLauncherCallER
 #define MoEGEMMLauncherCallER(                                                 \
-    LayoutA, LayoutB, Policy, ElementA, ElementB, ElementS)                    \
-  MoEGEMMLauncher<LayoutA, LayoutB, Policy>(                                   \
+    LayoutA,                                                                   \
+    LayoutB,                                                                   \
+    Policy,                                                                    \
+    TENSOR_A_DTYPE,                                                            \
+    TENSOR_B_DTYPE,                                                            \
+    ElementA,                                                                  \
+    ElementB,                                                                  \
+    ElementS)                                                                  \
+  MoEGEMMLauncher<LayoutA, LayoutB, Policy, TENSOR_A_DTYPE, TENSOR_B_DTYPE>(   \
       dpcpp_queue,                                                             \
       reinterpret_cast<ElementA*>(ptr_A.data_ptr()),                           \
       reinterpret_cast<ElementB*>(ptr_B.data_ptr()),                           \
@@ -370,24 +431,56 @@ at::Tensor cutlass_grouped_gemm_xe2_impl(
       group_size,                                                              \
       static_cast<int*>(atomic_buffer.data_ptr()));
 
-#define W8MXFP8LauncherCallER(policy)                                         \
-  if (B_dtype == at::kFloat8_e4m3fn && A_dtype == at::kHalf) {                \
-    using scalar_t = half_t;                                                  \
-    MoEGEMMLauncherCallER('R', 'R', policy, scalar_t, float_e4m3_t, uint8_t); \
-  } else if (B_dtype == at::kFloat8_e5m2 && A_dtype == at::kHalf) {           \
-    using scalar_t = half_t;                                                  \
-    MoEGEMMLauncherCallER('R', 'R', policy, scalar_t, float_e5m2_t, uint8_t); \
-  } else if (B_dtype == at::kFloat8_e4m3fn && A_dtype == at::kBFloat16) {     \
-    using scalar_t = bfloat16_t;                                              \
-    MoEGEMMLauncherCallER('R', 'R', policy, scalar_t, float_e4m3_t, uint8_t); \
-  } else if (B_dtype == at::kFloat8_e5m2 && A_dtype == at::kBFloat16) {       \
-    using scalar_t = bfloat16_t;                                              \
-    MoEGEMMLauncherCallER('R', 'R', policy, scalar_t, float_e5m2_t, uint8_t); \
-  } else {                                                                    \
-    TORCH_CHECK(                                                              \
-        false,                                                                \
-        "mxfp8 grouped gemm requires A in {fp16,bf16} and B in "              \
-        "{float8_e4m3fn, float8_e5m2}");                                      \
+#define W8MXFP8LauncherCallER(policy)                                     \
+  if (B_dtype == at::kFloat8_e4m3fn && A_dtype == at::kHalf) {            \
+    using scalar_t = half_t;                                              \
+    MoEGEMMLauncherCallER(                                                \
+        'R',                                                              \
+        'R',                                                              \
+        policy,                                                           \
+        A_DTYPE::BITS16,                                                  \
+        B_DTYPE::MXFP8,                                                   \
+        scalar_t,                                                         \
+        float_e4m3_t,                                                     \
+        uint8_t);                                                         \
+  } else if (B_dtype == at::kFloat8_e5m2 && A_dtype == at::kHalf) {       \
+    using scalar_t = half_t;                                              \
+    MoEGEMMLauncherCallER(                                                \
+        'R',                                                              \
+        'R',                                                              \
+        policy,                                                           \
+        A_DTYPE::BITS16,                                                  \
+        B_DTYPE::MXFP8,                                                   \
+        scalar_t,                                                         \
+        float_e5m2_t,                                                     \
+        uint8_t);                                                         \
+  } else if (B_dtype == at::kFloat8_e4m3fn && A_dtype == at::kBFloat16) { \
+    using scalar_t = bfloat16_t;                                          \
+    MoEGEMMLauncherCallER(                                                \
+        'R',                                                              \
+        'R',                                                              \
+        policy,                                                           \
+        A_DTYPE::BITS16,                                                  \
+        B_DTYPE::MXFP8,                                                   \
+        scalar_t,                                                         \
+        float_e4m3_t,                                                     \
+        uint8_t);                                                         \
+  } else if (B_dtype == at::kFloat8_e5m2 && A_dtype == at::kBFloat16) {   \
+    using scalar_t = bfloat16_t;                                          \
+    MoEGEMMLauncherCallER(                                                \
+        'R',                                                              \
+        'R',                                                              \
+        policy,                                                           \
+        A_DTYPE::BITS16,                                                  \
+        B_DTYPE::MXFP8,                                                   \
+        scalar_t,                                                         \
+        float_e5m2_t,                                                     \
+        uint8_t);                                                         \
+  } else {                                                                \
+    TORCH_CHECK(                                                          \
+        false,                                                            \
+        "mxfp8 grouped gemm requires A in {fp16,bf16} and B in "          \
+        "{float8_e4m3fn, float8_e5m2}");                                  \
   }
 
     if (A_avg_M <= 8) {
@@ -404,8 +497,15 @@ at::Tensor cutlass_grouped_gemm_xe2_impl(
 // Restore the default launcher macro for subsequent branches.
 #undef MoEGEMMLauncherCallER
 #define MoEGEMMLauncherCallER(                                                 \
-    LayoutA, LayoutB, Policy, ElementA, ElementB, ElementS)                    \
-  MoEGEMMLauncher<LayoutA, LayoutB, Policy>(                                   \
+    LayoutA,                                                                   \
+    LayoutB,                                                                   \
+    Policy,                                                                    \
+    TENSOR_A_DTYPE,                                                            \
+    TENSOR_B_DTYPE,                                                            \
+    ElementA,                                                                  \
+    ElementB,                                                                  \
+    ElementS)                                                                  \
+  MoEGEMMLauncher<LayoutA, LayoutB, Policy, TENSOR_A_DTYPE, TENSOR_B_DTYPE>(   \
       dpcpp_queue,                                                             \
       reinterpret_cast<ElementA*>(ptr_A.data_ptr()),                           \
       reinterpret_cast<ElementB*>(ptr_B.data_ptr()),                           \
@@ -449,24 +549,56 @@ at::Tensor cutlass_grouped_gemm_xe2_impl(
         ptr_scales->dtype() == at::kFloat, "block-fp8 scales must be float32");
     group_size = 128;
 
-#define W8BLOCKFP8LauncherCallER(policy)                                    \
-  if (B_dtype == at::kFloat8_e4m3fn && A_dtype == at::kHalf) {              \
-    using scalar_t = half_t;                                                \
-    MoEGEMMLauncherCallER('R', 'R', policy, scalar_t, float_e4m3_t, float); \
-  } else if (B_dtype == at::kFloat8_e5m2 && A_dtype == at::kHalf) {         \
-    using scalar_t = half_t;                                                \
-    MoEGEMMLauncherCallER('R', 'R', policy, scalar_t, float_e5m2_t, float); \
-  } else if (B_dtype == at::kFloat8_e4m3fn && A_dtype == at::kBFloat16) {   \
-    using scalar_t = bfloat16_t;                                            \
-    MoEGEMMLauncherCallER('R', 'R', policy, scalar_t, float_e4m3_t, float); \
-  } else if (B_dtype == at::kFloat8_e5m2 && A_dtype == at::kBFloat16) {     \
-    using scalar_t = bfloat16_t;                                            \
-    MoEGEMMLauncherCallER('R', 'R', policy, scalar_t, float_e5m2_t, float); \
-  } else {                                                                  \
-    TORCH_CHECK(                                                            \
-        false,                                                              \
-        "block-fp8 grouped gemm requires A in {fp16,bf16} and B in "        \
-        "{float8_e4m3fn, float8_e5m2}");                                    \
+#define W8BLOCKFP8LauncherCallER(policy)                                  \
+  if (B_dtype == at::kFloat8_e4m3fn && A_dtype == at::kHalf) {            \
+    using scalar_t = half_t;                                              \
+    MoEGEMMLauncherCallER(                                                \
+        'R',                                                              \
+        'R',                                                              \
+        policy,                                                           \
+        A_DTYPE::BITS16,                                                  \
+        B_DTYPE::BLOCK_FP8,                                               \
+        scalar_t,                                                         \
+        float_e4m3_t,                                                     \
+        float);                                                           \
+  } else if (B_dtype == at::kFloat8_e5m2 && A_dtype == at::kHalf) {       \
+    using scalar_t = half_t;                                              \
+    MoEGEMMLauncherCallER(                                                \
+        'R',                                                              \
+        'R',                                                              \
+        policy,                                                           \
+        A_DTYPE::BITS16,                                                  \
+        B_DTYPE::BLOCK_FP8,                                               \
+        scalar_t,                                                         \
+        float_e5m2_t,                                                     \
+        float);                                                           \
+  } else if (B_dtype == at::kFloat8_e4m3fn && A_dtype == at::kBFloat16) { \
+    using scalar_t = bfloat16_t;                                          \
+    MoEGEMMLauncherCallER(                                                \
+        'R',                                                              \
+        'R',                                                              \
+        policy,                                                           \
+        A_DTYPE::BITS16,                                                  \
+        B_DTYPE::BLOCK_FP8,                                               \
+        scalar_t,                                                         \
+        float_e4m3_t,                                                     \
+        float);                                                           \
+  } else if (B_dtype == at::kFloat8_e5m2 && A_dtype == at::kBFloat16) {   \
+    using scalar_t = bfloat16_t;                                          \
+    MoEGEMMLauncherCallER(                                                \
+        'R',                                                              \
+        'R',                                                              \
+        policy,                                                           \
+        A_DTYPE::BITS16,                                                  \
+        B_DTYPE::BLOCK_FP8,                                               \
+        scalar_t,                                                         \
+        float_e5m2_t,                                                     \
+        float);                                                           \
+  } else {                                                                \
+    TORCH_CHECK(                                                          \
+        false,                                                            \
+        "block-fp8 grouped gemm requires A in {fp16,bf16} and B in "      \
+        "{float8_e4m3fn, float8_e5m2}");                                  \
   }
 
     if (A_avg_M <= 8) {
@@ -490,19 +622,51 @@ at::Tensor cutlass_grouped_gemm_xe2_impl(
         "ptr_scales.size(0) of fp8 must match num_experts");
     TORCH_CHECK(ptr_scales->dtype() == at::kFloat, "ptr_scales must be float");
 
-#define W8A16LauncherCallER(policy)                                         \
-  if (B_dtype == at::kFloat8_e4m3fn && A_dtype == at::kHalf) {              \
-    using scalar_t = half_t;                                                \
-    MoEGEMMLauncherCallER('R', 'R', policy, scalar_t, float_e4m3_t, float); \
-  } else if (B_dtype == at::kFloat8_e5m2 && A_dtype == at::kHalf) {         \
-    using scalar_t = half_t;                                                \
-    MoEGEMMLauncherCallER('R', 'R', policy, scalar_t, float_e5m2_t, float); \
-  } else if (B_dtype == at::kFloat8_e4m3fn && A_dtype == at::kBFloat16) {   \
-    using scalar_t = bfloat16_t;                                            \
-    MoEGEMMLauncherCallER('R', 'R', policy, scalar_t, float_e4m3_t, float); \
-  } else if (B_dtype == at::kFloat8_e5m2 && A_dtype == at::kBFloat16) {     \
-    using scalar_t = bfloat16_t;                                            \
-    MoEGEMMLauncherCallER('R', 'R', policy, scalar_t, float_e5m2_t, float); \
+#define W8A16LauncherCallER(policy)                                       \
+  if (B_dtype == at::kFloat8_e4m3fn && A_dtype == at::kHalf) {            \
+    using scalar_t = half_t;                                              \
+    MoEGEMMLauncherCallER(                                                \
+        'R',                                                              \
+        'R',                                                              \
+        policy,                                                           \
+        A_DTYPE::BITS16,                                                  \
+        B_DTYPE::PER_TENSOR_FP8,                                          \
+        scalar_t,                                                         \
+        float_e4m3_t,                                                     \
+        float);                                                           \
+  } else if (B_dtype == at::kFloat8_e5m2 && A_dtype == at::kHalf) {       \
+    using scalar_t = half_t;                                              \
+    MoEGEMMLauncherCallER(                                                \
+        'R',                                                              \
+        'R',                                                              \
+        policy,                                                           \
+        A_DTYPE::BITS16,                                                  \
+        B_DTYPE::PER_TENSOR_FP8,                                          \
+        scalar_t,                                                         \
+        float_e5m2_t,                                                     \
+        float);                                                           \
+  } else if (B_dtype == at::kFloat8_e4m3fn && A_dtype == at::kBFloat16) { \
+    using scalar_t = bfloat16_t;                                          \
+    MoEGEMMLauncherCallER(                                                \
+        'R',                                                              \
+        'R',                                                              \
+        policy,                                                           \
+        A_DTYPE::BITS16,                                                  \
+        B_DTYPE::PER_TENSOR_FP8,                                          \
+        scalar_t,                                                         \
+        float_e4m3_t,                                                     \
+        float);                                                           \
+  } else if (B_dtype == at::kFloat8_e5m2 && A_dtype == at::kBFloat16) {   \
+    using scalar_t = bfloat16_t;                                          \
+    MoEGEMMLauncherCallER(                                                \
+        'R',                                                              \
+        'R',                                                              \
+        policy,                                                           \
+        A_DTYPE::BITS16,                                                  \
+        B_DTYPE::PER_TENSOR_FP8,                                          \
+        scalar_t,                                                         \
+        float_e5m2_t,                                                     \
+        float);                                                           \
   }
 
     if (A_avg_M <= 8) {
@@ -520,13 +684,29 @@ at::Tensor cutlass_grouped_gemm_xe2_impl(
     TORCH_CHECK(
         !ptr_scales.has_value(), "w16a16 grouped gemm must not have scales");
 
-#define W16A16LauncherCallER(policy)                                       \
-  if (A_dtype == at::kBFloat16) {                                          \
-    using scalar_t = bfloat16_t;                                           \
-    MoEGEMMLauncherCallER('R', 'R', policy, scalar_t, scalar_t, scalar_t); \
-  } else if (A_dtype == at::kHalf) {                                       \
-    using scalar_t = half_t;                                               \
-    MoEGEMMLauncherCallER('R', 'R', policy, scalar_t, scalar_t, scalar_t); \
+#define W16A16LauncherCallER(policy) \
+  if (A_dtype == at::kBFloat16) {    \
+    using scalar_t = bfloat16_t;     \
+    MoEGEMMLauncherCallER(           \
+        'R',                         \
+        'R',                         \
+        policy,                      \
+        A_DTYPE::BITS16,             \
+        B_DTYPE::BITS16,             \
+        scalar_t,                    \
+        scalar_t,                    \
+        scalar_t);                   \
+  } else if (A_dtype == at::kHalf) { \
+    using scalar_t = half_t;         \
+    MoEGEMMLauncherCallER(           \
+        'R',                         \
+        'R',                         \
+        policy,                      \
+        A_DTYPE::BITS16,             \
+        B_DTYPE::BITS16,             \
+        scalar_t,                    \
+        scalar_t,                    \
+        scalar_t);                   \
   }
 
     if (A_avg_M <= 8) {


### PR DESCRIPTION
**Regression**: fp8 group gemm performance reduce about 20%
**Root cause**: non-template dispatch when block fp8 or per tensor fp8
**Fix**: refactor files to use template dispatch 