### PR TITLE
[Quant] Fix per_token_group_fp8_quant for group_size/VEC > 32

### DIFF
--- a/csrc/quantization/fp8/fp8_quant.cpp
+++ b/csrc/quantization/fp8/fp8_quant.cpp
@@ -770,8 +770,17 @@ void per_token_group_quant_fp8(
   const int hidden = static_cast<int>(input.numel() / num_tokens);
   const int elem_size = input.element_size();
   const int vec_width = 16 / elem_size;
-  const bool use_vec =
-      (group_size % vec_width == 0) && (hidden % vec_width == 0);
+  // The vectorized kernel reduces each group's absmax with a segmented
+  // sub-group XOR shuffle over lanes_per_group = group_size / vec_width lanes.
+  // The sub-group is pinned to 32 lanes (reqd_sub_group_size(32)), so once
+  // lanes_per_group exceeds 32 the XOR partner falls outside the sub-group and
+  // the reduction (and the per-group scale-write predicate) become undefined,
+  // producing wrong scales and corrupted output. Restrict the fast path to
+  // groups that fit inside a single sub-group and fall back to the scalar
+  // kernel (which reduces over the whole sub-group) otherwise.
+  const bool use_vec = (group_size % vec_width == 0) &&
+                       (hidden % vec_width == 0) &&
+                       (group_size / vec_width <= 32);
 
   if (use_vec) {
     const int num_groups_per_row = hidden / group_size;


### PR DESCRIPTION
The vectorized per-token group fp8 quant kernel reduces each group's absmax with a segmented sub-group XOR shuffle over lanes_per_group = group_size / VEC lanes, while the sub-group is pinned to 32 lanes via reqd_sub_group_size(32). Once lanes_per_group exceeds 32, the XOR partner falls outside the sub-group, so both the reduction and the per-group scale-write predicate become undefined. This yields wrong scales (including garbage ~1e19/1e34 values picked up from neighbouring sub-groups) and corrupted quantized output, e.g. bf16 at group_size=512 and fp32 at group_size=256/512.

Restrict the fast vectorized path to groups that fit inside a single sub-group (group_size / vec_width <= 32) and fall back to the scalar per_token_group_quant_8bit_kernel, which reduces over the whole sub-group and is correct for any group_size.

Fix issue: https://github.com/vllm-project/vllm-xpu-kernels/issues/520

