### PR TITLE
fix(grouped_gemm): initialize Xe2 scheduler counter before launch

### DIFF
--- a/csrc/xpu/grouped_gemm/xe_2/grouped_gemm_xe2.hpp
+++ b/csrc/xpu/grouped_gemm/xe_2/grouped_gemm_xe2.hpp
@@ -102,15 +102,6 @@ CUTE_DEVICE void MoEGEMM(
   int group_range = item.get_group_range(1);
   int local_id = item.get_local_linear_id();
 
-  if (group_id == 0 && local_id == 0) {
-    auto atm = sycl::atomic_ref<
-        int,
-        sycl::memory_order::relaxed,
-        sycl::memory_scope::device,
-        sycl::access::address_space::global_space>(atomic_buffer[0]);
-    atm.store(0);
-  }
-
   int pre_rows = 0;
   int pre_tiles = 0;
 

--- a/csrc/xpu/grouped_gemm/xe_2/grouped_gemm_xe2_interface.hpp
+++ b/csrc/xpu/grouped_gemm/xe_2/grouped_gemm_xe2_interface.hpp
@@ -249,8 +249,11 @@ at::Tensor cutlass_grouped_gemm_xe2_impl(
     TORCH_CHECK(ptr_bias->size(1) == N, "ptr_bias.size(1) must match N");
   }
 
+  // Initialize the persistent scheduler counter before launching the kernel.
+  // An in-kernel store by work-group 0 cannot order other work-groups before
+  // their atomicAdd operations.
   at::Tensor atomic_buffer =
-      at::empty({static_cast<long>(1)}, ptr_A.options().dtype(at::kInt));
+      at::zeros({static_cast<long>(1)}, ptr_A.options().dtype(at::kInt));
 
 #define MoEGEMMLauncherCallER(                                                 \
     LayoutA,                                                                   \


### PR DESCRIPTION
## Purpose

Initialize the Xe2 grouped-GEMM persistent scheduler counter before launching the kernel, and remove the now-redundant in-kernel zero store.

The previous initialization was performed only by work-group 0, local thread 0. There is no device-wide barrier before other work-groups execute `atomicAdd`, so another work-group can observe stale state, or a late store can reset a counter that has already been incremented.

Using `at::zeros` queues initialization before the grouped-GEMM launch. The in-kernel `atomic_ref::store(0)` is removed as requested in review. The local barrier after each work-group obtains a scheduler ticket remains unchanged.

The paged-decode tuple originally included in this PR was cherry-picked and merged separately in #526. This PR is now rebased onto that commit and contains only the grouped-GEMM fix.

## Performance consideration

Although the buffer is one `int32`, `at::zeros` may add a fixed dispatch/dependency cost, most visible for small grouped-GEMM calls. Removing the in-kernel store avoids paying both initialization paths. This PR does not claim zero overhead without a matched measurement.

## Test plan

- Existing Xe grouped-GEMM unit-test matrix on BMG/PVC CI.
- Repeated-call correctness and XPU graph replay validation.
- End-to-end eager and graph-replay latency comparison, emphasizing small-M calls.

## Current validation status

- Branch rebased onto current upstream `main` / merged #526.
- `paged_decode_default.conf` has no PR diff.
- `git diff --check`: pass.
- BMG/PVC builds and unit-test workflows were retriggered by the rewritten branch.
- Fresh graph/performance measurements are still required before making a quantitative overhead claim.
