### PR TITLE
feat(attn): add paged-decode tuple 16,128,64,false,true,false

### DIFF
--- a/csrc/xpu/attn/kernel_configs/paged_decode_default.conf
+++ b/csrc/xpu/attn/kernel_configs/paged_decode_default.conf
@@ -61,7 +61,9 @@
 # --- GLM / Seed qgroup=16 decode heads --------------------------------------
 # zai-org/GLM-4-9B-chat, zai-org/glm-4-9b-hf
 # ByteDance-Seed/Seed-OSS-36B-Instruct
+# Muse-Glimmer-30B (local attn, qgroup=16, head=128, page=64)
 16,128,64,false,false,false
+16,128,64,false,true,false
 
 # --- Sliding-window/local model coverage ------------------------------------
 # microsoft/Phi-4-multimodal-instruct


### PR DESCRIPTION
Cherry-pick from #524 
Muse-Glimmer-30B uses local attention with qgroup=16, head=128, page=64. The causal=false/local=false/sink=false sibling is already compiled for GLM/Seed. Without the local=true specialization the first paged-decode warmup raises:

  RuntimeError: Paged decode kernel tuple not compiled for this
  configuration. 16,128,64,false,true,false

Format: qgroup,headsize,pagesize,causal,local,sink.

# Essential Elements of an Effective PR Description Checklist

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.

PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS ABOVE HAVE BEEN CONSIDERED.

## Purpose

## Test Plan

## Test Result

## (Optional) Documentation Update

**BEFORE SUBMITTING, PLEASE READ <https://docs.vllm.ai/en/latest/contributing>** (anything written below this line will be removed by GitHub Actions)
