### PR TITLE
Fix paged decode softmax_lse

### DIFF
--- a/csrc/flash_attn/flash_api.cpp
+++ b/csrc/flash_attn/flash_api.cpp
@@ -8,6 +8,33 @@
 
 namespace FLASH_NAMESPACE {
 
+namespace {
+
+constexpr float kLn2 = 0.6931471805599453f;
+
+void fill_paged_decode_softmax_lse(
+        at::Tensor& softmax_lse,
+        const at::Tensor& max_logits,
+        const at::Tensor& exp_sums) {
+    at::Tensor valid_splits = at::isfinite(max_logits) & at::isfinite(exp_sums) &
+                  exp_sums.gt(0);
+    at::Tensor masked_max_logits = at::where(
+        valid_splits,
+        max_logits,
+        at::full_like(max_logits, -std::numeric_limits<float>::infinity()));
+    at::Tensor global_max_logits = std::get<0>(masked_max_logits.max(-1, true));
+    at::Tensor rescaled_exp_sums = at::where(
+        valid_splits,
+        exp_sums * at::pow(2.0, masked_max_logits - global_max_logits),
+        at::zeros_like(exp_sums));
+    at::Tensor global_exp_sums = rescaled_exp_sums.sum(-1);
+    at::Tensor lse_base2 =
+        global_max_logits.squeeze(-1) + at::log2(global_exp_sums);
+    softmax_lse.copy_(lse_base2.transpose(0, 1).mul_(kLn2));
+}
+
+}  // namespace
+
 inline int get_num_splits(
     const sycl::queue& queue,
     const int& batch_size,
@@ -190,7 +217,8 @@ std::vector<at::Tensor> mha_varlen_fwd(
   bool is_local = (window_size_left != -1) | (window_size_right != -1);
   bool is_sink = softmax_sink_.has_value();
 
-  // Allocated only in chunk_prefill path when return_softmax is true
+    // Allocated whenever softmax LSE is requested. Chunk-prefill writes it
+    // directly; paged decode reconstructs it from per-split stats.
   std::optional<at::Tensor> softmax_lse_opt;
   if (return_softmax) {
     int total_seqlen_q = q.size(0);
@@ -288,10 +316,11 @@ std::vector<at::Tensor> mha_varlen_fwd(
 
     int num_kv_splits = 1;
     at::Tensor tmp_out = out;
-    at::Tensor decode_max_logits = at::empty(
+    at::Tensor decode_max_logits = at::full(
         {num_tokens, num_heads_q, num_kv_splits},
+        -std::numeric_limits<float>::infinity(),
         q.options().dtype(at::kFloat).device(q.device()));
-    at::Tensor decode_exp_sums = at::empty(
+    at::Tensor decode_exp_sums = at::zeros(
         {num_tokens, num_heads_q, num_kv_splits},
         q.options().dtype(at::kFloat).device(q.device()));
 
@@ -324,6 +353,24 @@ std::vector<at::Tensor> mha_varlen_fwd(
         is_prefill_opt,
         splits_per_seq,
         work_list);
+
+    if (return_softmax && softmax_lse_opt.has_value()) {
+      at::Tensor decode_req_indices =
+          at::nonzero(seq_lens_q.eq(1)).squeeze(-1);
+      if (decode_req_indices.numel() > 0) {
+        at::Tensor decode_softmax_lse = torch::empty(
+            {num_heads_q, num_tokens},
+            q.options().dtype(at::kFloat).device(q.device()));
+        fill_paged_decode_softmax_lse(
+            decode_softmax_lse, decode_max_logits, decode_exp_sums);
+        at::Tensor decode_q_indices =
+            cu_seqlens_q.slice(0, 0, batch_size).index_select(
+                0, decode_req_indices);
+        softmax_lse_opt->index_put_(
+            {torch::indexing::Slice(), decode_q_indices},
+            decode_softmax_lse.index_select(1, decode_req_indices));
+      }
+    }
   } else {
     // Normalize -1 (unbounded) to max_seqlen_k for kernel masking logic
     // In decode phase the window_size_right doesn't have effect
@@ -384,10 +431,11 @@ std::vector<at::Tensor> mha_varlen_fwd(
             : at::empty(
                   {num_tokens, num_heads_q * num_kv_splits, v_head_dim},
                   q.options().device(q.device()));
-    at::Tensor max_logits = at::empty(
+    at::Tensor max_logits = at::full(
         {num_tokens, num_heads_q, num_kv_splits},
+        -std::numeric_limits<float>::infinity(),
         q.options().dtype(at::kFloat).device(q.device()));
-    at::Tensor exp_sums = at::empty(
+    at::Tensor exp_sums = at::zeros(
         {num_tokens, num_heads_q, num_kv_splits},
         q.options().dtype(at::kFloat).device(q.device()));
 
@@ -427,6 +475,11 @@ std::vector<at::Tensor> mha_varlen_fwd(
         no_mask,
         splits_per_seq,
         work_list);
+
+    if (return_softmax && softmax_lse_opt.has_value()) {
+      fill_paged_decode_softmax_lse(
+          *softmax_lse_opt, max_logits, exp_sums);
+    }
   }
 
   if (return_softmax) {

--- a/csrc/xpu/attn/kernel_configs/chunk_prefill_default.conf
+++ b/csrc/xpu/attn/kernel_configs/chunk_prefill_default.conf
@@ -24,33 +24,8 @@
 # 128,true,true,true,false,false
 # 128,false,true,true,false,false
 
-# --- DeepSeek MLA latent heads (head_size=192) ------------------------------
-192,true,true,false,false,false
-192,false,true,false,false,false
-192,false,true,false,false,true
-
-# --- Falcon-7B (MQA, head_size=64); GQA ratio handled by per-head grid -------
-# paged (chunked decode/prefill with page table) + non-paged (initial prompt)
-64,true,true,false,false,false
-64,true,false,false,false,false
-64,false,true,false,false,false
-64,false,false,false,false,false
-
-# openai/gpt-oss-20b
-64,true,false,true,true,false
-64,true,true,false,true,false
-
-# --- Qwen3.5 non-causal heads ----------------------------------------------
 # Qwen/Qwen3.5-35B-A3B, Qwen/Qwen3.5-9B
 96,false,false,false,false,false
-
-# --- Sliding-window/local model coverage ------------------------------------
-# google/gemma-3-12b-it, google/gemma-4-26B-A4B-it
-256,true,false,true,false,false
-# google/gemma-3-27b-it
-128,true,false,true,false,false
-# Microsoft/Phi-3.5-mini-instruct
-96,true,false,true,false,false
 
 # --- Qwen3-Next causal heads -------------------------------------------------
 # Qwen/Qwen3-Next-80B-A3B-Instruct, Qwen/Qwen3-Next-80B-A3B-Thinking

--- a/csrc/xpu/attn/kernel_configs/chunk_prefill_qwen_dcp_lse.conf
+++ b/csrc/xpu/attn/kernel_configs/chunk_prefill_qwen_dcp_lse.conf
@@ -1,0 +1,6 @@
+# Minimal chunk-prefill config for Qwen DCP softmax_lse validation.
+# The bare headsize entry expands to all valid (paged, causal, local, sink,
+# lse) combinations for head_size=128, including the newly enabled
+# paged + lse=true tuples.
+128
+

--- a/csrc/xpu/attn/kernel_configs/paged_decode_default.conf
+++ b/csrc/xpu/attn/kernel_configs/paged_decode_default.conf
@@ -32,55 +32,13 @@
 8,128,32,true,false,false
 8,128,64,true,false,false
 8,128,64,false,false,false
+16,128,64,false,false,false
 
 # Sliding window (Qwen2.5, Llama-3.1 long context) — uncomment if needed:
 # 8,128,16,true,true,false
 # 8,128,32,true,true,false
 # 8,128,64,true,true,false
 
-# --- DeepSeek MLA latent heads (head_size=192) ------------------------------
-8,192,16,true,false,false
-8,192,32,true,false,false
-8,192,64,true,false,false
-
-8,64,16,false,false,false
-8,64,64,false,false,false
-
-# --- Falcon-7B (MQA: 71 q heads / 1 kv head → qgroup=16, head_size=64) -------
-16,64,16,true,false,false
-16,64,16,false,false,false
-16,64,32,true,false,false
-16,64,32,false,false,false
-16,64,64,true,false,false
-16,64,64,false,false,false
-
-# openai/gpt-oss-20b
-8,64,64,false,true,true
-8,64,64,false,false,true
-
-# --- GLM / Seed qgroup=16 decode heads --------------------------------------
-# zai-org/GLM-4-9B-chat, zai-org/glm-4-9b-hf
-# ByteDance-Seed/Seed-OSS-36B-Instruct
-# Muse-Glimmer-30B (local attn, qgroup=16, head=128, page=64)
-16,128,64,false,false,false
-16,128,64,false,true,false
-
-# --- Sliding-window/local model coverage ------------------------------------
-# microsoft/Phi-4-multimodal-instruct
-8,128,16,false,true,false
-# TIGER-Lab/VLM2Vec-Full
-8,96,16,false,true,false
-# bigcode/starcoder2-3b
-16,128,16,false,true,false
-# google/gemma-3-12b-it, google/gemma-4-26B-A4B-it
-8,256,64,false,true,false
-# google/gemma-3-27b-it
-8,128,64,false,true,false
-
-# --- Qwen3-Next decode heads -------------------------------------------------
 # Qwen/Qwen3-Next-80B-A3B-Instruct, Qwen/Qwen3-Next-80B-A3B-Thinking
 8,256,64,false,false,false
 
-# --- google/gemma-3-1b-it-512 decode heads ----------------------------------
-8,256,16,false,true,false
-8,256,16,false,false,false

--- a/csrc/xpu/attn/xe_2/chunk_prefill_configure.cmake
+++ b/csrc/xpu/attn/xe_2/chunk_prefill_configure.cmake
@@ -12,9 +12,9 @@
 #
 # Config file format: - Lines starting with # are comments - Empty lines are
 # ignored - 'all' keyword builds everything - Each line:
-# headsize[,paged,causal,local,sink,lse] - If boolean flags omitted, all 18
+# headsize[,paged,causal,local,sink,lse] - If boolean flags omitted, all 20
 # valid combinations are generated - LSE constraint: lse=true only valid when
-# paged=false,local=false,sink=false
+# local=false,sink=false
 #
 # Both standard and b16 policies are generated for each headsize.
 # =============================================================================
@@ -121,8 +121,7 @@ function(fmha_forward_configure FILENAME_SUFFIX)
             foreach(IMPL_KISSINK ${L_BOOLS})
               # LSE constraint
               set(LSE_BOOLS "false")
-              if(IMPL_KISPAGED STREQUAL "false"
-                 AND IMPL_KISLOCAL STREQUAL "false"
+              if(IMPL_KISLOCAL STREQUAL "false"
                  AND IMPL_KISSINK STREQUAL "false")
                 set(LSE_BOOLS ${L_BOOLS})
               endif()
@@ -181,13 +180,10 @@ function(fmha_forward_configure FILENAME_SUFFIX)
 
         # Validate LSE constraint
         if(_lse STREQUAL "true")
-          if(NOT
-             (_paged STREQUAL "false"
-              AND _local STREQUAL "false"
-              AND _sink STREQUAL "false"))
+          if(NOT (_local STREQUAL "false" AND _sink STREQUAL "false"))
             message(
               WARNING
-                "Skipping invalid config: lse=true requires paged=false,local=false,sink=false: ${_entry}"
+                "Skipping invalid config: lse=true requires local=false,sink=false: ${_entry}"
             )
             continue()
           endif()
@@ -205,14 +201,13 @@ function(fmha_forward_configure FILENAME_SUFFIX)
           "${b16_policy_${_headsize}}|${_paged}|${_causal}|${_local}|${_sink}|${_lse}"
         )
       else()
-        # No booleans specified: generate all 18 valid combinations
+        # No booleans specified: generate all 20 valid combinations
         foreach(IMPL_KISPAGED ${L_BOOLS})
           foreach(IMPL_KISCAUSAL ${L_BOOLS})
             foreach(IMPL_KISLOCAL ${L_BOOLS})
               foreach(IMPL_KISSINK ${L_BOOLS})
                 set(LSE_BOOLS "false")
-                if(IMPL_KISPAGED STREQUAL "false"
-                   AND IMPL_KISLOCAL STREQUAL "false"
+                if(IMPL_KISLOCAL STREQUAL "false"
                    AND IMPL_KISSINK STREQUAL "false")
                   set(LSE_BOOLS ${L_BOOLS})
                 endif()

--- a/csrc/xpu/attn/xe_2/chunk_prefill_extern.hpp
+++ b/csrc/xpu/attn/xe_2/chunk_prefill_extern.hpp
@@ -38,12 +38,12 @@
       const chunk_prefill_args_t& args);
 
 // Generate bool combinations for a given policy.
-// softmax_lse (LSE) is only supported on the (Paged=false, Local=false,
-// Sink=false) specialization; for all other combos LSE is forced false.
-// Total per policy: 14 LSE=false combos + 2 LSE=T/F combos
-// (P=F,L=F,S=F × Causal=T/F) × 2 = 4 -> 14 + 4 = 18 instantiations.
+// softmax_lse (LSE) is only supported on the (Local=false, Sink=false)
+// specializations; paged and non-paged prefill share the same LSE writer.
+// Total per policy: 12 LSE=false combos + 4 LSE=T/F combos
+// (P={F,T},L=F,S=F × Causal=T/F) × 2 = 8 -> 12 + 8 = 20 instantiations.
 
-// LSE axis: both true and false (only valid when P=F,L=F,S=F)
+// LSE axis: both true and false (only valid when L=F,S=F)
 #define DECLARE_FOR_LSE_BOTH(POLICY, PAGED, CAUSAL, LOCAL, SINK)            \
   DECLARE_POLICY_DISPATCH_EXTERN(POLICY, PAGED, CAUSAL, LOCAL, SINK, false) \
   DECLARE_POLICY_DISPATCH_EXTERN(POLICY, PAGED, CAUSAL, LOCAL, SINK, true)
@@ -65,10 +65,12 @@
   DECLARE_FOR_LOCAL_FALSEONLY(POLICY, PAGED, false) \
   DECLARE_FOR_LOCAL_FALSEONLY(POLICY, PAGED, true)
 
-// P=F,L=F,S=F branch (LSE=T/F allowed): Causal axis only.
-#define DECLARE_LSE_ALLOWED_BRANCH(POLICY)                 \
+// L=F,S=F branches (LSE=T/F allowed) for both paged and non-paged kernels.
+#define DECLARE_LSE_ALLOWED_BRANCH(POLICY)                \
   DECLARE_FOR_LSE_BOTH(POLICY, false, false, false, false) \
-  DECLARE_FOR_LSE_BOTH(POLICY, false, true, false, false)
+  DECLARE_FOR_LSE_BOTH(POLICY, false, true, false, false)  \
+  DECLARE_FOR_LSE_BOTH(POLICY, true, false, false, false)  \
+  DECLARE_FOR_LSE_BOTH(POLICY, true, true, false, false)
 
 // P=F but (L=true OR S=true): LSE=false only. Causal × Local × Sink (minus
 // the all-false case already covered above).
@@ -86,7 +88,7 @@
   /* Causal=T, Local=T, Sink=T */                          \
   DECLARE_FOR_LSE_FALSE(POLICY, false, true, true, true)
 
-// P=T branch: LSE=false only across all Causal × Local × Sink.
+// P=T branch with Local=true or Sink=true: LSE=false only.
 #define DECLARE_ALL_BOOL_COMBINATIONS(POLICY) \
   DECLARE_LSE_ALLOWED_BRANCH(POLICY)          \
   DECLARE_PAGED_FALSE_OTHER(POLICY)           \

--- a/csrc/xpu/attn/xe_2/chunk_prefill_utils.hpp
+++ b/csrc/xpu/attn/xe_2/chunk_prefill_utils.hpp
@@ -27,8 +27,8 @@ void policy_dispatch_func(
     CutlassQKType& cuQKType,
     const chunk_prefill_args_t& args) {
   // Pack is expected in order: (Paged, Causal, Local, Sink, SoftmaxLSE).
-  // SoftmaxLSE=true is only supported when Paged=false, Local=false,
-  // and Sink=false; other combos are not instantiated (no TUs generated),
+  // SoftmaxLSE=true is only supported when Local=false and Sink=false;
+  // other combos are not instantiated (no TUs generated),
   // so statically skip the call for those to avoid implicit instantiation
   // and guarantee the runtime TORCH_CHECK in fmha_xe2.cpp is the only
   // path that can surface a bad request.
@@ -43,11 +43,11 @@ void policy_dispatch_func(
   // Extract head_size from policy at compile time.
   constexpr int _head_sz = cute::size<1>(typename chunk_policy::ShapeOut{});
 
-  if constexpr (SoftmaxLSE && (Paged || Local || Sink)) {
+  if constexpr (SoftmaxLSE && (Local || Sink)) {
     TORCH_CHECK(
         false,
-        "Unreachable: softmax_lse is only supported when is_paged=false, "
-        "is_local=false, is_sink=false");
+        "Unreachable: softmax_lse is only supported when is_local=false, "
+        "is_sink=false");
   } else if constexpr (!is_chunk_policy_enabled<chunk_policy>::value) {
     TORCH_CHECK(
         false,

--- a/csrc/xpu/attn/xe_2/collective/chunk_prefill_epilogue.hpp
+++ b/csrc/xpu/attn/xe_2/collective/chunk_prefill_epilogue.hpp
@@ -556,15 +556,9 @@ class DecodeFwdEpilogue {
 
     // Always store exp sum and max logits for current KV split.
     // assume seq_len_qo == 1
-    if (row_valid) {
-      if (is_single_split) {
-        // Sentinel values: make ReduceSplitK a pass-through copy.
-        exp_sums(q_row, idx_kv_split) = ElementA(1);
-        max_logits(q_row, idx_kv_split) = ElementA(0);
-      } else if (num_kv_splits > 1) {
-        exp_sums(q_row, idx_kv_split) = rA_sum(0);
-        max_logits(q_row, idx_kv_split) = rA_max(0);
-      }
+    if (active && row_valid) {
+      exp_sums(q_row, idx_kv_split) = rA_sum(0);
+      max_logits(q_row, idx_kv_split) = rA_max(0);
     }
 
     /* Some subgroups may not have any work to do; if so, quit early. */

--- a/csrc/xpu/attn/xe_2/fmha_xe2.cpp
+++ b/csrc/xpu/attn/xe_2/fmha_xe2.cpp
@@ -243,14 +243,14 @@ void cutlass_chunk_prefill_impl(
       "FMHA forward only supports head dimension at most " +
           std::to_string(max_head_size));
 
-  // softmax_lse output is only supported on the
-  // !Paged && !Local && !Sink specialization (template-constrained to
-  // keep kernel instantiation count bounded).
+    // softmax_lse output is only supported on non-local, non-sink
+    // specializations. Paged prefill uses the same per-row softmax stats writer
+    // as non-paged prefill; paged decode reconstructs LSE separately.
   bool is_lse = softmax_lse.has_value();
   TORCH_CHECK(
-      !is_lse || (!is_paged && !is_local && !is_sink),
-      "softmax_lse output is only supported when is_paged=false, "
-      "is_local=false, is_sink=false");
+      !is_lse || (!is_local && !is_sink),
+      "softmax_lse output is only supported when is_local=false, "
+      "is_sink=false");
 
   // Validate block_size: 16, 32, or any positive multiple of 64. Non-paged
   // mode does not use block_size, so only enforce the check when paged.

--- a/csrc/xpu/attn/xe_2/kernel/paged_decode_kernel.hpp
+++ b/csrc/xpu/attn/xe_2/kernel/paged_decode_kernel.hpp
@@ -817,6 +817,15 @@ class ReduceSplitK {
       global_max_logits =
           sycl::group_broadcast(get_work_group<1>(), global_max_logits, 0);
 
+      if (effective_splits == 1) {
+        for (int idx = thr_id; idx < s.head_size_vo;
+             idx += SGPerWG::value * intel::sg_size) {
+          O(seq_idx, idx, head_q, l_coord) = static_cast<ElementO>(
+              Oaccum(seq_idx, idx, head_q, l_coord));
+        }
+        continue;
+      }
+
       for (int idx = thr_id; idx < s.head_size_vo;
            idx += SGPerWG::value * intel::sg_size) {
         ElementLSE acc = 0;

--- a/tests/flash_attn/test_flash_attn_varlen_func.py
+++ b/tests/flash_attn/test_flash_attn_varlen_func.py
@@ -900,8 +900,52 @@ def ref_softmax_lse(
     return torch.cat(lse_list, dim=1)
 
 
+def ref_paged_softmax_lse(
+    query: torch.Tensor,
+    key_cache: torch.Tensor,
+    query_lens: list[int],
+    kv_lens: list[int],
+    block_tables: torch.Tensor,
+    scale: float,
+    casual: bool,
+) -> torch.Tensor:
+    """Reference log-sum-exp for paged KV attention.
+
+    Mirrors the paged path in ref_paged_attn and returns LSE with shape
+    [num_query_heads, sum(query_lens)].
+    """
+    num_query_heads = query.shape[1]
+    _, block_size, num_kv_heads, head_size = key_cache.shape
+    block_tables_np = block_tables.cpu().numpy()
+    lse_list: list[torch.Tensor] = []
+    start_q = 0
+
+    for i, (query_len, kv_len) in enumerate(zip(query_lens, kv_lens)):
+        q = query[start_q:start_q + query_len].float()
+        num_kv_blocks = (kv_len + block_size - 1) // block_size
+        block_indices = block_tables_np[i, :num_kv_blocks]
+        k = key_cache[block_indices].view(-1, num_kv_heads, head_size)[:kv_len]
+        k = k.float()
+        if q.shape[1] != k.shape[1]:
+            k = torch.repeat_interleave(k, q.shape[1] // k.shape[1], dim=1)
+        attn = torch.einsum("qhd,khd->hqk", q, k) * scale
+        if casual:
+            mask = torch.triu(
+                torch.ones(query_len, kv_len, device=attn.device),
+                diagonal=kv_len - query_len + 1,
+            ).bool()
+            attn.masked_fill_(mask, float("-inf"))
+        lse = torch.logsumexp(attn, dim=-1)
+        assert lse.shape == (num_query_heads, query_len)
+        lse_list.append(lse)
+        start_q += query_len
+
+    return torch.cat(lse_list, dim=1)
+
+
 # softmax_lse return is only supported when:
-#   is_paged == False, window_size == (-1,-1) (i.e. !is_local), is_sink == False
+#   window_size == (-1,-1) (i.e. !is_local) and is_sink == False
+# Paged KV is supported for the decode path.
 # Causal is orthogonal. Keep the param grid small since the outer loop count
 # multiplies with these.
 #
@@ -1008,6 +1052,101 @@ def test_varlen_with_softmax_lse(
     torch.testing.assert_close(out, ref_output, atol=atol, rtol=rtol)
     # LSE is float32 and computed in log space — compare with a modest
     # tolerance that covers bf16 Q/K accumulation noise.
+    torch.testing.assert_close(softmax_lse.float(),
+                               ref_lse.float(),
+                               atol=5e-2,
+                               rtol=5e-2)
+    torch.xpu.empty_cache()
+
+
+@pytest.mark.parametrize("seq_lens", [[(1, 1328), (1, 18), (1, 463), (1, 37)]])
+@pytest.mark.parametrize("num_heads", NUM_HEADS)
+@pytest.mark.parametrize("head_size", [128])
+@pytest.mark.parametrize("block_size", [16, 64])
+@pytest.mark.parametrize("dtype", DTYPES, ids=format_tc)
+@pytest.mark.parametrize("is_casual", CASUAL)
+@torch.inference_mode()
+def test_paged_varlen_with_softmax_lse(
+    seq_lens: list[tuple[int, int]],
+    num_heads: tuple[int, int],
+    head_size: int,
+    block_size: int,
+    dtype: torch.dtype,
+    is_casual: bool,
+) -> None:
+    torch.set_default_device("xpu")
+    torch.xpu.set_device("xpu:0")
+    torch.manual_seed(4242)
+
+    query_lens = [x[0] for x in seq_lens]
+    kv_lens = [x[1] for x in seq_lens]
+    num_query_heads, num_kv_heads = num_heads
+    assert num_query_heads % num_kv_heads == 0
+    max_query_len = max(query_lens)
+    max_kv_len = max(kv_lens)
+    scale = head_size**-0.5
+
+    query = torch.randn(sum(query_lens),
+                        num_query_heads,
+                        head_size,
+                        dtype=dtype)
+    num_blocks = max(2048, (sum(kv_lens) + block_size - 1) // block_size)
+    key_cache = torch.randn(num_blocks,
+                            block_size,
+                            num_kv_heads,
+                            head_size,
+                            dtype=dtype)
+    value_cache = torch.randn_like(key_cache)
+
+    cu_query_lens = torch.tensor([0] + query_lens,
+                                 dtype=torch.int32).cumsum(dim=0,
+                                                           dtype=torch.int32)
+    seq_k = torch.tensor(kv_lens, dtype=torch.int32)
+    max_num_blocks_per_seq = (max_kv_len + block_size - 1) // block_size
+    block_tables = torch.randint(0,
+                                 num_blocks,
+                                 (len(seq_lens), max_num_blocks_per_seq),
+                                 dtype=torch.int32)
+
+    out, softmax_lse = flash_attn_varlen_func(query,
+                                              key_cache,
+                                              value_cache,
+                                              max_query_len,
+                                              cu_query_lens,
+                                              max_kv_len,
+                                              seqused_k=seq_k,
+                                              softmax_scale=scale,
+                                              causal=is_casual,
+                                              block_table=block_tables,
+                                              window_size=(-1, -1),
+                                              return_softmax_lse=True)
+
+    ref_output = ref_paged_attn(query=query.contiguous(),
+                                key_cache=key_cache.contiguous(),
+                                value_cache=value_cache.contiguous(),
+                                query_lens=query_lens,
+                                kv_lens=kv_lens,
+                                block_tables=block_tables,
+                                scale=scale,
+                                casual=is_casual,
+                                is_paged=True,
+                                sink=None,
+                                window_size_left=-1,
+                                window_size_right=-1,
+                                dtype=dtype)
+    ref_lse = ref_paged_softmax_lse(query=query.contiguous(),
+                                    key_cache=key_cache.contiguous(),
+                                    query_lens=query_lens,
+                                    kv_lens=kv_lens,
+                                    block_tables=block_tables,
+                                    scale=scale,
+                                    casual=is_casual)
+
+    total_q = sum(query_lens)
+    assert softmax_lse.shape == (num_query_heads, total_q), softmax_lse.shape
+    assert softmax_lse.dtype == torch.float32
+
+    torch.testing.assert_close(out, ref_output, atol=2e-2, rtol=1e-2)
     torch.testing.assert_close(softmax_lse.float(),
                                ref_lse.float(),
                                atol=5e-2,

--- a/vllm_xpu_kernels/flash_attn_interface.py
+++ b/vllm_xpu_kernels/flash_attn_interface.py
@@ -48,7 +48,6 @@ try:
 except ValueError:
     _SPEC_DECODE_MAX_QLEN = 16
 
-
 def _spec_decode_varlen_fwd(
     q,
     k,
@@ -450,6 +449,10 @@ def flash_attn_varlen_func(
             when using paged KV cache. This is forwarded to the underlying
             C++ FlashAttention op as its ``num_splits`` parameter; the split
             unit is KV blocks, not individual tokens or pages.
+        return_softmax_lse: Return per-head log-sum-exp in
+            ``[num_query_heads, total_q]`` layout. Supported for non-local,
+            non-sink attention. With paged KV cache, XPU FA2 currently
+            supports this only for pure decode (``max_seqlen_q == 1``).
         fa_version: FlashAttention backend version selector.
     """
     if host_kv_lens is not None:
@@ -481,6 +484,9 @@ def flash_attn_varlen_func(
     q, k, v = [maybe_contiguous(x) for x in (q, k, v)]
 
     dummy_cu_seqlens_k = torch.empty_like(cu_seqlens_q)
+    is_paged = block_table is not None and seqused_k is not None
+    is_local = real_window_size != (-1, -1)
+    is_sink = s_aux is not None
 
     if fa_version == 2:
         if scheduler_metadata is not None and q_descale is not None \
@@ -555,6 +561,12 @@ def flash_attn_varlen_func(
                 work_list_dev = work_list_cpu.to(
                     device=q.device, non_blocking=True)
 
+        if return_softmax_lse and (is_local or is_sink):
+            raise RuntimeError(
+                "XPU FA2 does not support return_softmax_lse with "
+                f"is_paged={is_paged}, is_local={is_local}, is_sink={is_sink}"
+            )
+
         try:
             out, softmax_lse = torch.ops._vllm_fa2_C.varlen_fwd(
                 q,
@@ -591,26 +603,13 @@ def flash_attn_varlen_func(
         except RuntimeError as e:
             if "not compiled" not in str(e):
                 raise
-            # Fallback to PyTorch reference implementation.
-            import logging
-            logger = logging.getLogger(__name__)
-            logger.warning(
-                "XPU kernel not compiled for this config, falling back "
-                "to PyTorch reference attention. Performance will be "
-                "significantly degraded.\n"
-                "To fix: rebuild with the config line shown above.\n"
-                "If this is unexpected, report at: "
-                "https://github.com/vllm-project/vllm-xpu-kernels/issues/364\n"
-                "Original error: %s", e)
-            out, softmax_lse = _fallback_varlen_attn(
-                q, k, v, cu_seqlens_q, cu_seqlens_k, seqused_k,
-                block_table, softmax_scale, causal,
-                real_window_size, softcap,
-                k_descale=k_descale,
-                v_descale=v_descale,
-                s_aux=s_aux,
-                return_softmax_lse=return_softmax_lse,
-            )
+            raise RuntimeError(
+                "XPU kernel not compiled for this config. Rebuild with the "
+                "required config line shown by the kernel error. If this is "
+                "unexpected, report at: "
+                "https://github.com/vllm-project/vllm-xpu-kernels/issues/364. "
+                f"Original error: {e}"
+            ) from e
     else:
         raise NotImplementedError("not support yet")
     return (out, softmax_lse) if return_softmax_lse else (out)


### PR DESCRIPTION
# Essential Elements of an Effective PR Description Checklist

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.

PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS ABOVE HAVE BEEN CONSIDERED.

## Purpose

This PR change is to support decode context parallel:

1. Reconstruct paged-decode softmax_lse on the host from per-split max_logits and exp_sums, and convert the internal base-2 statistic back to natural-log LSE in flash_api.cpp. 
2. Initialize decode split-stat buffers to -inf and 0 so unused split slots cannot corrupt host-side LSE reconstruction in flash_api.cpp. 
3. Make the decode epilogue always write the real per-split stats for active rows instead of single-split sentinel values in chunk_prefill_epilogue.hpp. 
4. Make split reduction bypass renormalization when effective_splits == 1, preserving the already-normalized decode output in paged_decode_kernel.hpp. 
5. Add a paged-KV regression that checks both output tensors and returned softmax_lse against a reference implementation in test_flash_attn_varlen_func.py.

## Test Plan

## Test Result

## (Optional) Documentation Update

**BEFORE SUBMITTING, PLEASE READ <https://docs.vllm.ai/en/latest/contributing>** (anything written below this line will be removed by GitHub Actions)
