### PR TITLE
[Build] Support Python 3.14

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ install(CODE "set(CMAKE_INSTALL_LOCAL_ONLY TRUE)" ALL_COMPONENTS)
 # Supported python versions.  These versions will be searched in order, the
 # first match will be selected.  These should be kept in sync with setup.py.
 #
-set(PYTHON_SUPPORTED_VERSIONS "3.9" "3.10" "3.11" "3.12")
+set(PYTHON_SUPPORTED_VERSIONS "3.9" "3.10" "3.11" "3.12" "3.13" "3.14")
 
 # Supported Intel GPU architectures.
 set(SYCL_SUPPORTED_ARCHS "intel_gpu_pvc;intel_gpu_bmg_g21;intel_gpu_bmg_g31")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
     "Topic :: Scientific/Engineering :: Information Analysis",
 ]
-requires-python = ">=3.9,<3.14"
+requires-python = ">=3.9,<3.15"
 dynamic = [ "version", "dependencies", "optional-dependencies"]
 
 [project.urls]


### PR DESCRIPTION
Enable Python 3.13 and 3.14 discovery in CMake and allow Python 3.14 package installs.

Validated on vLLM testing across MXFP4, GPTQ, and INT4 AutoRound Qwen models.

## Purpose

Add Python 3.14 support by allowing Python versions `<3.15` in package metadata and enabling CMake discovery for Python 3.13 and 3.14.

## Test Plan

- Ran vLLM end-to-end inference testing over one week with Qwen models using:
    - MXFP4
    - int4 GPTQ
    - int4 AutoRound

## Test Result

All tested Qwen model configurations completed successfully with no observed regressions.

## (Optional) Documentation Update

Not needed. This change updates build/package compatibility metadata only.

BTW I also tested it with torch 2.14rc3 and nightly 2.15 - also works (but sometimes it's too slow)
