### PR TITLE
[XPU] Add fp8_gemm_out out-variant for zero-copy AsyncTP shard writes

### DIFF
--- a/csrc/xpu/onednn/onednn_matmul.cpp
+++ b/csrc/xpu/onednn/onednn_matmul.cpp
@@ -14,10 +14,15 @@ inline bool is_supported_fp4(at::ScalarType t) {
   return t == at::ScalarType::Float4_e2m1fn_x2;
 }
 
+// If `out` is given, it is validated against A/B (device, dtype, and shape)
+// and returned as-is so the result can be written in place into it;
+// otherwise a new output tensor is allocated using `out_dtype` (defaulting
+// to fp16).
 torch::Tensor check_and_create_output_tensor(
     const torch::Tensor& A,
     const torch::Tensor& B,
-    std::optional<c10::ScalarType> out_dtype) {
+    std::optional<c10::ScalarType> out_dtype,
+    const std::optional<torch::Tensor>& out = std::nullopt) {
   TORCH_CHECK(
       A.dim() == 2 || A.dim() == 3,
       "OneDNN Matmul only support 2D and 3D inputs!\n");
@@ -52,6 +57,10 @@ torch::Tensor check_and_create_output_tensor(
     // src{b, m, k}, wei{k, n}, bias{n}, dst{b, m, n}
   }
 
+  if (out.has_value()) {
+    return out.value();
+  }
+
   // deal with input shape [m, b, k] stride [k, m * k, 1]
   auto k = A.size(A.dim() - 1);
   auto n = result_shape.back();
@@ -66,13 +75,14 @@ torch::Tensor check_and_create_output_tensor(
   return at::empty_strided(result_shape, res_stride, options);
 }
 
-torch::Tensor fp8_gemm(
+static torch::Tensor fp8_gemm_common(
     const torch::Tensor& A,  // [b, m ,k]
     const torch::Tensor& B,  // [k, n]
     std::optional<c10::ScalarType> out_dtype,
     const std::optional<torch::Tensor>& A_scale_,
     const std::optional<torch::Tensor>& B_scale_,
-    const std::optional<torch::Tensor>& bias_) {
+    const std::optional<torch::Tensor>& bias_,
+    std::optional<torch::Tensor> out) {
   const at::DeviceGuard device_guard(A.device());
   // The weight B may be provided in a transposed (NT) layout, and A supports
   // strided layouts, so both are excluded from the contiguity check.
@@ -85,7 +95,9 @@ torch::Tensor fp8_gemm(
   TORCH_CHECK(
       !bias_.has_value() || bias_.value().is_contiguous(),
       "bias must be contiguous for fp8 matmul");
-  torch::Tensor result = check_and_create_output_tensor(A, B, out_dtype);
+  // When `out` is given, it is validated and written in place; otherwise a
+  // new output tensor is allocated.
+  torch::Tensor result = check_and_create_output_tensor(A, B, out_dtype, out);
   auto a_st = A.scalar_type();
   auto b_st = B.scalar_type();
   TORCH_CHECK(
@@ -102,6 +114,29 @@ torch::Tensor fp8_gemm(
   torch::Tensor B_scale = B_scale_.value_or(at::ones({1}, torch::kFloat));
   oneDNN::dnnl_matmul_w8a8_fp8(result, A, B, is_nt, bias_, A_scale, B_scale);
   return result;
+}
+
+torch::Tensor fp8_gemm(
+    const torch::Tensor& A,
+    const torch::Tensor& B,
+    std::optional<c10::ScalarType> out_dtype,
+    const std::optional<torch::Tensor>& A_scale_,
+    const std::optional<torch::Tensor>& B_scale_,
+    const std::optional<torch::Tensor>& bias_) {
+  return fp8_gemm_common(
+      A, B, out_dtype, A_scale_, B_scale_, bias_, std::nullopt);
+}
+
+torch::Tensor fp8_gemm_out(
+    torch::Tensor out,
+    const torch::Tensor& A,
+    const torch::Tensor& B,
+    std::optional<c10::ScalarType> out_dtype,
+    const std::optional<torch::Tensor>& A_scale_,
+    const std::optional<torch::Tensor>& B_scale_,
+    const std::optional<torch::Tensor>& bias_) {
+  return fp8_gemm_common(
+      A, B, out_dtype, A_scale_, B_scale_, bias_, std::move(out));
 }
 
 torch::Tensor fp8_bmm(

--- a/csrc/xpu/onednn/onednn_matmul.cpp
+++ b/csrc/xpu/onednn/onednn_matmul.cpp
@@ -58,7 +58,30 @@ torch::Tensor check_and_create_output_tensor(
   }
 
   if (out.has_value()) {
-    return out.value();
+    const auto& out_ = out.value();
+    const c10::IntArrayRef expected_shape(result_shape);
+    TORCH_CHECK(
+        out_.device() == A.device(),
+        "OneDNN Matmul expects out on device ",
+        A.device(),
+        ", got ",
+        out_.device(),
+        ".");
+    TORCH_CHECK(
+        out_.sizes() == expected_shape,
+        "OneDNN Matmul expects out of shape ",
+        expected_shape,
+        ", got ",
+        out_.sizes(),
+        ".");
+    TORCH_CHECK(
+        !out_dtype.has_value() || out_.scalar_type() == out_dtype.value(),
+        "OneDNN Matmul expects out of dtype ",
+        out_dtype.value_or(out_.scalar_type()),
+        ", got ",
+        out_.scalar_type(),
+        ".");
+    return out_;
   }
 
   // deal with input shape [m, b, k] stride [k, m * k, 1]

--- a/csrc/xpu/ops.h
+++ b/csrc/xpu/ops.h
@@ -10,7 +10,20 @@
  * a packed representation with 8 int4 values packed into one byte along the k
  * dimension.
  */
+// Computes A @ B into a newly allocated output tensor using `out_dtype`
+// (defaulting to fp16).
 torch::Tensor fp8_gemm(
+    const torch::Tensor& A,
+    const torch::Tensor& B,
+    std::optional<c10::ScalarType> out_dtype,
+    const std::optional<torch::Tensor>& A_scale_,
+    const std::optional<torch::Tensor>& B_scale_,
+    const std::optional<torch::Tensor>& bias_);
+
+// Same as fp8_gemm, but writes the result in place into `out` (its dtype,
+// shape and device must already match A/B) and returns `out` itself.
+torch::Tensor fp8_gemm_out(
+    torch::Tensor out,
     const torch::Tensor& A,
     const torch::Tensor& B,
     std::optional<c10::ScalarType> out_dtype,

--- a/csrc/xpu/torch_bindings.cpp
+++ b/csrc/xpu/torch_bindings.cpp
@@ -11,10 +11,23 @@
 TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, xpu_ops) {
   at::Tag stride_tag = at::Tag::needs_fixed_stride_order;
 
+  // fp8_gemm is exposed as two schemas sharing one C++ implementation:
+  // a pure functional variant, and an explicit out-variant. Keeping the
+  // mutable `out` out of the functional schema is required for
+  // torch.compile: a `Tensor(a!)?` argument makes functionalization wrap
+  // every call in `auto_functionalized`, which Inductor cannot decompose
+  // for optional mutable tensors.
   xpu_ops.def(
       "fp8_gemm(Tensor A, Tensor B, ScalarType? out_dtype, Tensor? A_scale_, "
       "Tensor? B_scale_, Tensor? bias_) -> Tensor");
   xpu_ops.impl("fp8_gemm", torch::kXPU, &fp8_gemm);
+
+  // Writes the result in place into `out` (whose shape and device must
+  // already match A/B) and returns it.
+  xpu_ops.def(
+      "fp8_gemm_out(Tensor(a!) out, Tensor A, Tensor B, ScalarType? out_dtype, "
+      "Tensor? A_scale_, Tensor? B_scale_, Tensor? bias_) -> Tensor");
+  xpu_ops.impl("fp8_gemm_out", torch::kXPU, &fp8_gemm_out);
 
   xpu_ops.def(
       "fp8_bmm(Tensor A, Tensor B, ScalarType? out_dtype, Tensor? A_scale_, "

--- a/tests/register_ops.py
+++ b/tests/register_ops.py
@@ -406,8 +406,29 @@ def fp8_gemm(input: torch.Tensor, weight: torch.Tensor,
              scale_act: Optional[torch.Tensor],
              scale_wei: Optional[torch.Tensor],
              bias: Optional[torch.Tensor] = None):
+    """fp8 (w8a8) GEMM, allocating the output using `out_dtype`.
+
+    This functional variant carries no mutable argument, which is what keeps
+    it usable under torch.compile. Use `fp8_gemm_out` to write into a
+    caller-provided buffer.
+    """
     return torch.ops._xpu_C.fp8_gemm(input, weight, out_dtype, scale_act,
                                      scale_wei, bias)
+
+
+def fp8_gemm_out(out: torch.Tensor, input: torch.Tensor,
+                 weight: torch.Tensor,
+                 out_dtype: Optional[torch.dtype],
+                 scale_act: Optional[torch.Tensor],
+                 scale_wei: Optional[torch.Tensor],
+                 bias: Optional[torch.Tensor] = None):
+    """fp8 (w8a8) GEMM writing in place into `out`.
+
+    `out` must already match the expected dtype, shape and device; it is
+    returned unchanged.
+    """
+    return torch.ops._xpu_C.fp8_gemm_out(out, input, weight, out_dtype,
+                                         scale_act, scale_wei, bias)
 
 
 def fp8_bmm(input: torch.Tensor, weight: torch.Tensor,

--- a/tests/test_fp8_gemm_onednn.py
+++ b/tests/test_fp8_gemm_onednn.py
@@ -213,6 +213,43 @@ def test_fp8_gemm_out_arg_per_tensor(fp8_dtype, out_dtype, is_nt, batch,
     torch.testing.assert_close(output, output_ref, atol=0, rtol=0)
 
 
+def test_fp8_gemm_out_arg_validates_out():
+    """`out` must match the expected result shape and dtype.
+
+    oneDNN derives `n` from `out.sizes()`, so an unvalidated `out` would
+    silently configure the matmul with the wrong problem size.
+    """
+    torch.manual_seed(1234)
+    out_dtype = torch.float16
+    m, n, k = 32, 64, 128
+
+    input = torch.randn([m, k], dtype=out_dtype, device="xpu") / 10.0
+    weight = torch.randn([n, k], dtype=out_dtype, device="xpu") / 10.0
+
+    scale_src = torch.tensor(4.0).xpu()
+    scale_wei = torch.tensor(4.0).xpu()
+
+    input_fp8, _ = scaled_fp8_quant(input, scale_src)
+    weight_fp8, _ = scaled_fp8_quant(weight, scale_wei)
+    weight_fp8 = weight_fp8.transpose(0, 1)
+
+    def run(out, dtype=out_dtype):
+        fp8_gemm_out(out, input_fp8, weight_fp8, dtype, scale_src, scale_wei,
+                     torch.Tensor())
+
+    with pytest.raises(RuntimeError, match="shape"):
+        run(torch.empty((m, n * 2), dtype=out_dtype, device="xpu"))
+
+    with pytest.raises(RuntimeError, match="shape"):
+        run(torch.empty((m, n, 1), dtype=out_dtype, device="xpu"))
+
+    with pytest.raises(RuntimeError, match="dtype"):
+        run(torch.empty((m, n), dtype=torch.bfloat16, device="xpu"))
+
+    with pytest.raises(RuntimeError, match="device"):
+        run(torch.empty((m, n), dtype=out_dtype, device="cpu"))
+
+
 @pytest.mark.parametrize("fp8_dtype", [torch.float8_e4m3fn])
 @pytest.mark.parametrize("out_dtype", OUT_DTYPES)
 @pytest.mark.parametrize("is_nt", [True, False])

--- a/tests/test_fp8_gemm_onednn.py
+++ b/tests/test_fp8_gemm_onednn.py
@@ -7,7 +7,7 @@ from tests.ops.fp8_quant_op import (fp8_block_dequant_2d, fp8_block_quant_2d,
                                     per_token_group_quant_fp8,
                                     scaled_fp8_quant)
 from tests.ops.mx_utils import from_blocked_format, to_mxfp
-from tests.register_ops import fp8_bmm, fp8_gemm, fp8_gemm_w8a16
+from tests.register_ops import fp8_bmm, fp8_gemm, fp8_gemm_out, fp8_gemm_w8a16
 
 BATCHES = [1, 2, 8]
 OUT_DTYPES = [torch.float16, torch.bfloat16]
@@ -173,6 +173,44 @@ def test_fp8_gemm_per_tensor(fp8_dtype, out_dtype, is_nt, batch, mnk_factors):
     )
 
     torch.testing.assert_close(output_fp8, output_ref, atol=6e-2, rtol=6e-2)
+
+
+@pytest.mark.parametrize("fp8_dtype", [torch.float8_e4m3fn])
+@pytest.mark.parametrize("out_dtype", OUT_DTYPES)
+@pytest.mark.parametrize("is_nt", [True, False])
+@pytest.mark.parametrize("batch", [1])
+@pytest.mark.parametrize("mnk_factors", MINI_MNK_FACTORS)
+def test_fp8_gemm_out_arg_per_tensor(fp8_dtype, out_dtype, is_nt, batch,
+                                     mnk_factors):
+    seed = 1234
+    torch.manual_seed(seed)
+
+    m, n, k = mnk_factors
+
+    input = torch.randn(
+        [batch, m, k], dtype=out_dtype, device=torch.device("xpu")) / 10.0
+    weight = torch.randn([n, k], dtype=out_dtype).xpu() / 10.0
+
+    scale_src = torch.tensor(4.0).xpu()
+    scale_wei = torch.tensor(4.0).xpu()
+
+    input_fp8, _ = scaled_fp8_quant(input.reshape(-1, k),
+                                    scale_src,
+                                    fp8_dtype=fp8_dtype)
+    weight_fp8, _ = scaled_fp8_quant(weight, scale_wei, fp8_dtype=fp8_dtype)
+
+    weight_fp8 = weight_fp8.transpose(0, 1)
+    if is_nt:
+        weight_fp8 = weight_fp8.contiguous()
+
+    output = torch.empty((batch * m, n), dtype=out_dtype, device="xpu")
+    returned = fp8_gemm_out(output, input_fp8, weight_fp8, out_dtype,
+                            scale_src, scale_wei, torch.Tensor())
+
+    output_ref = fp8_gemm(input_fp8, weight_fp8, out_dtype, scale_src,
+                          scale_wei, torch.Tensor())
+    assert returned.data_ptr() == output.data_ptr()
+    torch.testing.assert_close(output, output_ref, atol=0, rtol=0)
 
 
 @pytest.mark.parametrize("fp8_dtype", [torch.float8_e4m3fn])


### PR DESCRIPTION
## Purpose

Add `fp8_gemm_out`, an out-variant of `fp8_gemm` that writes into a caller-provided buffer instead of allocating a new one.

### Motivation

- Enable **AsyncTP collective fusion** on XPU in vLLM.
- Each rank computes one output shard; `fp8_gemm_out` writes directly into a pre-allocated shard slice.
- Avoids an extra allocation and a full-size copy per shard per layer.

### Solution

- Add a separate `fp8_gemm_out` schema (always-mutating) rather than adding an optional `out` to the existing functional op.
- **Why separate?** An optional mutable `Tensor(a!)?` would trigger functionalization wrapping (`auto_functionalized`), which Inductor cannot decompose for optional mutable tensors 

### API Changes

```python
fp8_gemm(...) -> Tensor              # functional, unchanged
fp8_gemm_out(out, ...) -> Tensor     # out-variant, always mutates