### PR TITLE
[Qwen3.5] feat(layernorm): add fused XPU GemmaRMSNorm kernels

### DIFF
--- a/csrc/layernorm.cpp
+++ b/csrc/layernorm.cpp
@@ -9,12 +9,7 @@
 
 namespace vllm {
 
-template <
-    typename scalar_t,
-    int NUM_DIMS,
-    int VEC_SIZE,
-    bool HasWeight,
-    bool IS_GEMMA = false>
+template <typename scalar_t, int NUM_DIMS, int VEC_SIZE, bool HasWeight>
 class rms_norm_kernel {
  public:
   rms_norm_kernel(
@@ -29,7 +24,8 @@ class rms_norm_kernel {
       const float epsilon_,
       const int num_tokens_,
       const int hidden_size_,
-      sycl::local_accessor<float, 1> s_variance_)
+      sycl::local_accessor<float, 1> s_variance_,
+      const float weight_bias_ = 0.0f)
       : out(out_),
         input(input_),
         input_stride_d2(input_stride_d2_),
@@ -41,6 +37,7 @@ class rms_norm_kernel {
         epsilon(epsilon_),
         num_tokens(num_tokens_),
         hidden_size(hidden_size_),
+        weight_bias(weight_bias_),
         s_variance(s_variance_) {}
 
   void operator() [[sycl::reqd_sub_group_size(32)]] (
@@ -115,13 +112,9 @@ class rms_norm_kernel {
       for (int j = 0; j < VEC_SIZE; j++) {
         float x = static_cast<float>(src1.val[j]);
         if constexpr (HasWeight) {
-          if constexpr (IS_GEMMA) {
-            dst.val[j] = static_cast<scalar_t>(
-                x * s_variance_val * (static_cast<float>(src2.val[j]) + 1.0f));
-          } else {
-            float w = static_cast<float>(src2.val[j]);
-            dst.val[j] = static_cast<scalar_t>(x * s_variance_val * w);
-          }
+          dst.val[j] = static_cast<scalar_t>(
+              x * s_variance_val *
+              (static_cast<float>(src2.val[j]) + weight_bias));
         } else {
           dst.val[j] = static_cast<scalar_t>(x * s_variance_val);
         }
@@ -142,11 +135,12 @@ class rms_norm_kernel {
   const float epsilon;
   const int num_tokens;
   const int hidden_size;
+  const float weight_bias;
   sycl::local_accessor<float, 1> s_variance;
 };
 
-template <typename scalar_t, int NUM_DIMS, bool HasWeight, bool IS_GEMMA>
-class rms_norm_kernel<scalar_t, NUM_DIMS, 0, HasWeight, IS_GEMMA> {
+template <typename scalar_t, int NUM_DIMS, bool HasWeight>
+class rms_norm_kernel<scalar_t, NUM_DIMS, 0, HasWeight> {
  public:
   rms_norm_kernel(
       scalar_t* out_,
@@ -160,7 +154,8 @@ class rms_norm_kernel<scalar_t, NUM_DIMS, 0, HasWeight, IS_GEMMA> {
       const float epsilon_,
       const int num_tokens_,
       const int hidden_size_,
-      sycl::local_accessor<float, 1> s_variance_)
+      sycl::local_accessor<float, 1> s_variance_,
+      const float weight_bias_ = 0.0f)
       : out(out_),
         input(input_),
         input_stride_d2(input_stride_d2_),
@@ -172,6 +167,7 @@ class rms_norm_kernel<scalar_t, NUM_DIMS, 0, HasWeight, IS_GEMMA> {
         epsilon(epsilon_),
         num_tokens(num_tokens_),
         hidden_size(hidden_size_),
+        weight_bias(weight_bias_),
         s_variance(s_variance_) {}
 
   void operator() [[sycl::reqd_sub_group_size(32)]] (
@@ -226,16 +222,12 @@ class rms_norm_kernel<scalar_t, NUM_DIMS, 0, HasWeight, IS_GEMMA> {
     for (int idx = item_ct1.get_local_id(2); idx < hidden_size;
          idx += item_ct1.get_local_range(2)) {
       float x = (float)input_row[idx];
+      float inv_rms = *s_variance_ptr;
       if constexpr (HasWeight) {
-        if constexpr (IS_GEMMA) {
-          out_row[idx] = static_cast<scalar_t>(
-              x * (*s_variance_ptr) * (static_cast<float>(weight[idx]) + 1.0f));
-        } else {
-          float w = static_cast<float>(weight[idx]);
-          out_row[idx] = static_cast<scalar_t>(x * (*s_variance_ptr) * w);
-        }
+        out_row[idx] = static_cast<scalar_t>(
+            x * inv_rms * (static_cast<float>(weight[idx]) + weight_bias));
       } else {
-        out_row[idx] = static_cast<scalar_t>(x * (*s_variance_ptr));
+        out_row[idx] = static_cast<scalar_t>(x * inv_rms);
       }
     }
   }
@@ -252,6 +244,7 @@ class rms_norm_kernel<scalar_t, NUM_DIMS, 0, HasWeight, IS_GEMMA> {
   const float epsilon;
   const int num_tokens;
   const int hidden_size;
+  const float weight_bias;
   sycl::local_accessor<float, 1> s_variance;
 };
 
@@ -264,8 +257,7 @@ template <
     int NUM_DIMS,
     int VEC_SIZE,
     int ROWS_PER_WG,
-    bool HasWeight,
-    bool IS_GEMMA = false>
+    bool HasWeight>
 class rms_norm_multi_row_kernel {
  public:
   rms_norm_multi_row_kernel(
@@ -280,7 +272,8 @@ class rms_norm_multi_row_kernel {
       const float epsilon_,
       const int num_tokens_,
       const int hidden_size_,
-      sycl::local_accessor<float, 1> s_variance_)
+      sycl::local_accessor<float, 1> s_variance_,
+      const float weight_bias_ = 0.0f)
       : out(out_),
         input(input_),
         input_stride_d2(input_stride_d2_),
@@ -292,6 +285,7 @@ class rms_norm_multi_row_kernel {
         epsilon(epsilon_),
         num_tokens(num_tokens_),
         hidden_size(hidden_size_),
+        weight_bias(weight_bias_),
         s_variance(s_variance_) {}
 
   void operator() [[sycl::reqd_sub_group_size(32)]] (
@@ -380,13 +374,8 @@ class rms_norm_multi_row_kernel {
       for (int j = 0; j < VEC_SIZE; j++) {
         float x = static_cast<float>(src1.val[j]);
         if constexpr (HasWeight) {
-          if constexpr (IS_GEMMA) {
-            dst.val[j] = static_cast<scalar_t>(
-                x * s_var * (static_cast<float>(src2.val[j]) + 1.0f));
-          } else {
-            float w = static_cast<float>(src2.val[j]);
-            dst.val[j] = static_cast<scalar_t>(x * s_var * w);
-          }
+          dst.val[j] = static_cast<scalar_t>(
+              x * s_var * (static_cast<float>(src2.val[j]) + weight_bias));
         } else {
           dst.val[j] = static_cast<scalar_t>(x * s_var);
         }
@@ -407,15 +396,17 @@ class rms_norm_multi_row_kernel {
   const float epsilon;
   const int num_tokens;
   const int hidden_size;
+  const float weight_bias;
   sycl::local_accessor<float, 1> s_variance;
 };
 
-template <typename scalar_t, bool HasWeight, bool IS_GEMMA = false>
+template <typename scalar_t, bool HasWeight>
 void call_rms_norm_kernel(
     torch::Tensor& out,
     torch::Tensor& input,
     const scalar_t* weight_ptr,
-    float epsilon) {
+    float epsilon,
+    float weight_bias = 0.0f) {
   using sycl_t = typename vllm::xpu::SyclTypeTrait<scalar_t>::Type;
   int hidden_size = input.size(-1);
   int num_tokens = input.numel() / hidden_size;
@@ -481,8 +472,7 @@ void call_rms_norm_kernel(
                   tensor_rank,
                   vec_size,
                   ROWS_PER_WG,
-                  HasWeight,
-                  IS_GEMMA>(
+                  HasWeight>(
                   (sycl_t*)out_ptr,
                   (const sycl_t*)input_ptr,
                   input_stride_d2,
@@ -494,7 +484,8 @@ void call_rms_norm_kernel(
                   epsilon,
                   num_tokens,
                   hidden_size,
-                  s_variance));
+                  s_variance,
+                  weight_bias));
         });
       });
       return;
@@ -507,7 +498,7 @@ void call_rms_norm_kernel(
         sycl::local_accessor<float, 1> s_variance(sycl::range<1>(1), cgh);
         cgh.parallel_for(
             sycl::nd_range<3>(grid * block, block),
-            rms_norm_kernel<sycl_t, tensor_rank, vec_size, HasWeight, IS_GEMMA>(
+            rms_norm_kernel<sycl_t, tensor_rank, vec_size, HasWeight>(
                 (sycl_t*)out_ptr,
                 (const sycl_t*)input_ptr,
                 input_stride_d2,
@@ -519,7 +510,8 @@ void call_rms_norm_kernel(
                 epsilon,
                 num_tokens,
                 hidden_size,
-                s_variance));
+                s_variance,
+                weight_bias));
       });
     });
   } else {
@@ -530,7 +522,7 @@ void call_rms_norm_kernel(
         sycl::local_accessor<float, 1> s_variance(sycl::range<1>(1), cgh);
         cgh.parallel_for(
             sycl::nd_range<3>(grid * block, block),
-            rms_norm_kernel<sycl_t, tensor_rank, 0, HasWeight, IS_GEMMA>(
+            rms_norm_kernel<sycl_t, tensor_rank, 0, HasWeight>(
                 (sycl_t*)out_ptr,
                 (const sycl_t*)input_ptr,
                 input_stride_d2,
@@ -542,13 +534,14 @@ void call_rms_norm_kernel(
                 epsilon,
                 num_tokens,
                 hidden_size,
-                s_variance));
+                s_variance,
+                weight_bias));
       });
     });
   }
 }
 
-template <typename scalar_t, int width, bool HasWeight, bool IS_GEMMA = false>
+template <typename scalar_t, int width, bool HasWeight>
 class fused_add_rms_norm_kernel {
  public:
   fused_add_rms_norm_kernel(
@@ -559,7 +552,8 @@ class fused_add_rms_norm_kernel {
       const float epsilon_,
       const int num_tokens_,
       const int hidden_size_,
-      sycl::local_accessor<float, 1> s_variance_)
+      sycl::local_accessor<float, 1> s_variance_,
+      const float weight_bias_ = 0.0f)
       : input(input_),
         residual(residual_),
         input_stride(input_stride_),
@@ -567,6 +561,7 @@ class fused_add_rms_norm_kernel {
         epsilon(epsilon_),
         num_tokens(num_tokens_),
         hidden_size(hidden_size_),
+        weight_bias(weight_bias_),
         s_variance(s_variance_) {}
 
   void operator() [[sycl::reqd_sub_group_size(32)]] (
@@ -625,13 +620,8 @@ class fused_add_rms_norm_kernel {
       for (int i = 0; i < width; i++) {
         float x = static_cast<float>(res.val[i]);
         if constexpr (HasWeight) {
-          if constexpr (IS_GEMMA) {
-            out.val[i] = static_cast<scalar_t>(
-                x * s_var * (static_cast<float>(w.val[i]) + 1.0f));
-          } else {
-            float wf = static_cast<float>(w.val[i]);
-            out.val[i] = static_cast<scalar_t>(x * s_var * wf);
-          }
+          out.val[i] = static_cast<scalar_t>(
+              x * s_var * (static_cast<float>(w.val[i]) + weight_bias));
         } else {
           out.val[i] = static_cast<scalar_t>(x * s_var);
         }
@@ -648,11 +638,12 @@ class fused_add_rms_norm_kernel {
   const float epsilon;
   const int num_tokens;
   const int hidden_size;
+  const float weight_bias;
   sycl::local_accessor<float, 1> s_variance;  // local memory for variance
 };
 
-template <typename scalar_t, bool HasWeight, bool IS_GEMMA>
-class fused_add_rms_norm_kernel<scalar_t, 0, HasWeight, IS_GEMMA> {
+template <typename scalar_t, bool HasWeight>
+class fused_add_rms_norm_kernel<scalar_t, 0, HasWeight> {
  public:
   fused_add_rms_norm_kernel(
       scalar_t* __restrict__ input_,     // [..., hidden_size]
@@ -662,7 +653,8 @@ class fused_add_rms_norm_kernel<scalar_t, 0, HasWeight, IS_GEMMA> {
       const float epsilon_,
       const int num_tokens_,
       const int hidden_size_,
-      sycl::local_accessor<float, 1> s_variance_)
+      sycl::local_accessor<float, 1> s_variance_,
+      const float weight_bias_ = 0.0f)
       : input(input_),
         residual(residual_),
         input_stride(input_stride_),
@@ -670,6 +662,7 @@ class fused_add_rms_norm_kernel<scalar_t, 0, HasWeight, IS_GEMMA> {
         epsilon(epsilon_),
         num_tokens(num_tokens_),
         hidden_size(hidden_size_),
+        weight_bias(weight_bias_),
         s_variance(s_variance_) {}
 
   void operator() [[sycl::reqd_sub_group_size(32)]] (
@@ -700,20 +693,14 @@ class fused_add_rms_norm_kernel<scalar_t, 0, HasWeight, IS_GEMMA> {
     for (int idx = item_ct1.get_local_id(2); idx < hidden_size;
          idx += item_ct1.get_local_range(2)) {
       float x = (float)residual[item_ct1.get_group(2) * hidden_size + idx];
+      float inv_rms = *s_variance_ptr;
       if constexpr (HasWeight) {
-        if constexpr (IS_GEMMA) {
-          input[item_ct1.get_group(2) * input_stride + idx] =
-              static_cast<scalar_t>(
-                  x * (*s_variance_ptr) *
-                  (static_cast<float>(weight[idx]) + 1.0f));
-        } else {
-          float w = static_cast<float>(weight[idx]);
-          input[item_ct1.get_group(2) * input_stride + idx] =
-              static_cast<scalar_t>(x * (*s_variance_ptr) * w);
-        }
+        input[item_ct1.get_group(2) * input_stride + idx] =
+            static_cast<scalar_t>(
+                x * inv_rms * (static_cast<float>(weight[idx]) + weight_bias));
       } else {
         input[item_ct1.get_group(2) * input_stride + idx] =
-            static_cast<scalar_t>(x * (*s_variance_ptr));
+            static_cast<scalar_t>(x * inv_rms);
       }
     }
   }
@@ -726,15 +713,17 @@ class fused_add_rms_norm_kernel<scalar_t, 0, HasWeight, IS_GEMMA> {
   const float epsilon;
   const int num_tokens;
   const int hidden_size;
+  const float weight_bias;
   sycl::local_accessor<float, 1> s_variance;  // local memory for variance
 };
 
-template <typename scalar_t, bool HasWeight, bool IS_GEMMA = false>
+template <typename scalar_t, bool HasWeight>
 void call_fused_add_rms_norm_kernel(
     torch::Tensor& input,
     torch::Tensor& residual,
     const scalar_t* weight_ptr,
-    float epsilon) {
+    float epsilon,
+    float weight_bias = 0.0f) {
   using sycl_t = typename vllm::xpu::SyclTypeTrait<scalar_t>::Type;
   int hidden_size = input.size(-1);
   int num_tokens = input.numel() / hidden_size;
@@ -766,7 +755,7 @@ void call_fused_add_rms_norm_kernel(
       sycl::local_accessor<float, 1> s_variance(sycl::range<1>(1), cgh);
       cgh.parallel_for(
           sycl::nd_range<3>(grid * block, block),
-          fused_add_rms_norm_kernel<sycl_t, vector_width, HasWeight, IS_GEMMA>(
+          fused_add_rms_norm_kernel<sycl_t, vector_width, HasWeight>(
               (sycl_t*)input_ptr,
               (sycl_t*)residual_ptr,
               input_stride,
@@ -774,7 +763,8 @@ void call_fused_add_rms_norm_kernel(
               epsilon,
               num_tokens,
               hidden_size,
-              s_variance));
+              s_variance,
+              weight_bias));
     });
   } else {
     sycl::range<3> block(1, 1, std::min(hidden_size, max_block_size));
@@ -782,7 +772,7 @@ void call_fused_add_rms_norm_kernel(
       sycl::local_accessor<float, 1> s_variance(sycl::range<1>(1), cgh);
       cgh.parallel_for(
           sycl::nd_range<3>(grid * block, block),
-          fused_add_rms_norm_kernel<sycl_t, 0, HasWeight, IS_GEMMA>(
+          fused_add_rms_norm_kernel<sycl_t, 0, HasWeight>(
               (sycl_t*)input_ptr,
               (sycl_t*)residual_ptr,
               input_stride,
@@ -790,7 +780,8 @@ void call_fused_add_rms_norm_kernel(
               epsilon,
               num_tokens,
               hidden_size,
-              s_variance));
+              s_variance,
+              weight_bias));
     });
   }
 }
@@ -869,10 +860,8 @@ void gemma_rms_norm(
   VLLM_DISPATCH_FLOATING_TYPES(
       input.scalar_type(), "call_gemma_rms_norm_kernel", [&] {
         const scalar_t* weight_ptr = weight.data_ptr<scalar_t>();
-        vllm::call_rms_norm_kernel<
-            scalar_t,
-            /*HasWeight=*/true,
-            /*IS_GEMMA=*/true>(out, input, weight_ptr, epsilon);
+        vllm::call_rms_norm_kernel<scalar_t, /*HasWeight=*/true>(
+            out, input, weight_ptr, epsilon, /*weight_bias=*/1.0f);
       });
 }
 
@@ -889,9 +878,7 @@ void fused_add_gemma_rms_norm(
   VLLM_DISPATCH_FLOATING_TYPES(
       input.scalar_type(), "call_fused_add_gemma_rms_norm_kernel", [&] {
         const scalar_t* weight_ptr = weight.data_ptr<scalar_t>();
-        vllm::call_fused_add_rms_norm_kernel<
-            scalar_t,
-            /*HasWeight=*/true,
-            /*IS_GEMMA=*/true>(input, residual, weight_ptr, epsilon);
+        vllm::call_fused_add_rms_norm_kernel<scalar_t, /*HasWeight=*/true>(
+            input, residual, weight_ptr, epsilon, /*weight_bias=*/1.0f);
       });
 }

--- a/csrc/layernorm.cpp
+++ b/csrc/layernorm.cpp
@@ -9,7 +9,12 @@
 
 namespace vllm {
 
-template <typename scalar_t, int NUM_DIMS, int VEC_SIZE, bool HasWeight>
+template <
+    typename scalar_t,
+    int NUM_DIMS,
+    int VEC_SIZE,
+    bool HasWeight,
+    bool IS_GEMMA = false>
 class rms_norm_kernel {
  public:
   rms_norm_kernel(
@@ -110,8 +115,13 @@ class rms_norm_kernel {
       for (int j = 0; j < VEC_SIZE; j++) {
         float x = static_cast<float>(src1.val[j]);
         if constexpr (HasWeight) {
-          float w = static_cast<float>(src2.val[j]);
-          dst.val[j] = static_cast<scalar_t>(x * s_variance_val * w);
+          if constexpr (IS_GEMMA) {
+            dst.val[j] = static_cast<scalar_t>(
+                x * s_variance_val * (static_cast<float>(src2.val[j]) + 1.0f));
+          } else {
+            float w = static_cast<float>(src2.val[j]);
+            dst.val[j] = static_cast<scalar_t>(x * s_variance_val * w);
+          }
         } else {
           dst.val[j] = static_cast<scalar_t>(x * s_variance_val);
         }
@@ -135,8 +145,8 @@ class rms_norm_kernel {
   sycl::local_accessor<float, 1> s_variance;
 };
 
-template <typename scalar_t, int NUM_DIMS, bool HasWeight>
-class rms_norm_kernel<scalar_t, NUM_DIMS, 0, HasWeight> {
+template <typename scalar_t, int NUM_DIMS, bool HasWeight, bool IS_GEMMA>
+class rms_norm_kernel<scalar_t, NUM_DIMS, 0, HasWeight, IS_GEMMA> {
  public:
   rms_norm_kernel(
       scalar_t* out_,
@@ -217,8 +227,13 @@ class rms_norm_kernel<scalar_t, NUM_DIMS, 0, HasWeight> {
          idx += item_ct1.get_local_range(2)) {
       float x = (float)input_row[idx];
       if constexpr (HasWeight) {
-        float w = static_cast<float>(weight[idx]);
-        out_row[idx] = static_cast<scalar_t>(x * (*s_variance_ptr) * w);
+        if constexpr (IS_GEMMA) {
+          out_row[idx] = static_cast<scalar_t>(
+              x * (*s_variance_ptr) * (static_cast<float>(weight[idx]) + 1.0f));
+        } else {
+          float w = static_cast<float>(weight[idx]);
+          out_row[idx] = static_cast<scalar_t>(x * (*s_variance_ptr) * w);
+        }
       } else {
         out_row[idx] = static_cast<scalar_t>(x * (*s_variance_ptr));
       }
@@ -249,7 +264,8 @@ template <
     int NUM_DIMS,
     int VEC_SIZE,
     int ROWS_PER_WG,
-    bool HasWeight>
+    bool HasWeight,
+    bool IS_GEMMA = false>
 class rms_norm_multi_row_kernel {
  public:
   rms_norm_multi_row_kernel(
@@ -364,8 +380,13 @@ class rms_norm_multi_row_kernel {
       for (int j = 0; j < VEC_SIZE; j++) {
         float x = static_cast<float>(src1.val[j]);
         if constexpr (HasWeight) {
-          float w = static_cast<float>(src2.val[j]);
-          dst.val[j] = static_cast<scalar_t>(x * s_var * w);
+          if constexpr (IS_GEMMA) {
+            dst.val[j] = static_cast<scalar_t>(
+                x * s_var * (static_cast<float>(src2.val[j]) + 1.0f));
+          } else {
+            float w = static_cast<float>(src2.val[j]);
+            dst.val[j] = static_cast<scalar_t>(x * s_var * w);
+          }
         } else {
           dst.val[j] = static_cast<scalar_t>(x * s_var);
         }
@@ -389,7 +410,7 @@ class rms_norm_multi_row_kernel {
   sycl::local_accessor<float, 1> s_variance;
 };
 
-template <typename scalar_t, bool HasWeight>
+template <typename scalar_t, bool HasWeight, bool IS_GEMMA = false>
 void call_rms_norm_kernel(
     torch::Tensor& out,
     torch::Tensor& input,
@@ -460,7 +481,8 @@ void call_rms_norm_kernel(
                   tensor_rank,
                   vec_size,
                   ROWS_PER_WG,
-                  HasWeight>(
+                  HasWeight,
+                  IS_GEMMA>(
                   (sycl_t*)out_ptr,
                   (const sycl_t*)input_ptr,
                   input_stride_d2,
@@ -485,7 +507,7 @@ void call_rms_norm_kernel(
         sycl::local_accessor<float, 1> s_variance(sycl::range<1>(1), cgh);
         cgh.parallel_for(
             sycl::nd_range<3>(grid * block, block),
-            rms_norm_kernel<sycl_t, tensor_rank, vec_size, HasWeight>(
+            rms_norm_kernel<sycl_t, tensor_rank, vec_size, HasWeight, IS_GEMMA>(
                 (sycl_t*)out_ptr,
                 (const sycl_t*)input_ptr,
                 input_stride_d2,
@@ -508,7 +530,7 @@ void call_rms_norm_kernel(
         sycl::local_accessor<float, 1> s_variance(sycl::range<1>(1), cgh);
         cgh.parallel_for(
             sycl::nd_range<3>(grid * block, block),
-            rms_norm_kernel<sycl_t, tensor_rank, 0, HasWeight>(
+            rms_norm_kernel<sycl_t, tensor_rank, 0, HasWeight, IS_GEMMA>(
                 (sycl_t*)out_ptr,
                 (const sycl_t*)input_ptr,
                 input_stride_d2,
@@ -526,7 +548,7 @@ void call_rms_norm_kernel(
   }
 }
 
-template <typename scalar_t, int width, bool HasWeight>
+template <typename scalar_t, int width, bool HasWeight, bool IS_GEMMA = false>
 class fused_add_rms_norm_kernel {
  public:
   fused_add_rms_norm_kernel(
@@ -603,8 +625,13 @@ class fused_add_rms_norm_kernel {
       for (int i = 0; i < width; i++) {
         float x = static_cast<float>(res.val[i]);
         if constexpr (HasWeight) {
-          float wf = static_cast<float>(w.val[i]);
-          out.val[i] = static_cast<scalar_t>(x * s_var * wf);
+          if constexpr (IS_GEMMA) {
+            out.val[i] = static_cast<scalar_t>(
+                x * s_var * (static_cast<float>(w.val[i]) + 1.0f));
+          } else {
+            float wf = static_cast<float>(w.val[i]);
+            out.val[i] = static_cast<scalar_t>(x * s_var * wf);
+          }
         } else {
           out.val[i] = static_cast<scalar_t>(x * s_var);
         }
@@ -624,8 +651,8 @@ class fused_add_rms_norm_kernel {
   sycl::local_accessor<float, 1> s_variance;  // local memory for variance
 };
 
-template <typename scalar_t, bool HasWeight>
-class fused_add_rms_norm_kernel<scalar_t, 0, HasWeight> {
+template <typename scalar_t, bool HasWeight, bool IS_GEMMA>
+class fused_add_rms_norm_kernel<scalar_t, 0, HasWeight, IS_GEMMA> {
  public:
   fused_add_rms_norm_kernel(
       scalar_t* __restrict__ input_,     // [..., hidden_size]
@@ -674,9 +701,16 @@ class fused_add_rms_norm_kernel<scalar_t, 0, HasWeight> {
          idx += item_ct1.get_local_range(2)) {
       float x = (float)residual[item_ct1.get_group(2) * hidden_size + idx];
       if constexpr (HasWeight) {
-        float w = static_cast<float>(weight[idx]);
-        input[item_ct1.get_group(2) * input_stride + idx] =
-            static_cast<scalar_t>(x * (*s_variance_ptr) * w);
+        if constexpr (IS_GEMMA) {
+          input[item_ct1.get_group(2) * input_stride + idx] =
+              static_cast<scalar_t>(
+                  x * (*s_variance_ptr) *
+                  (static_cast<float>(weight[idx]) + 1.0f));
+        } else {
+          float w = static_cast<float>(weight[idx]);
+          input[item_ct1.get_group(2) * input_stride + idx] =
+              static_cast<scalar_t>(x * (*s_variance_ptr) * w);
+        }
       } else {
         input[item_ct1.get_group(2) * input_stride + idx] =
             static_cast<scalar_t>(x * (*s_variance_ptr));
@@ -695,7 +729,7 @@ class fused_add_rms_norm_kernel<scalar_t, 0, HasWeight> {
   sycl::local_accessor<float, 1> s_variance;  // local memory for variance
 };
 
-template <typename scalar_t, bool HasWeight>
+template <typename scalar_t, bool HasWeight, bool IS_GEMMA = false>
 void call_fused_add_rms_norm_kernel(
     torch::Tensor& input,
     torch::Tensor& residual,
@@ -732,7 +766,7 @@ void call_fused_add_rms_norm_kernel(
       sycl::local_accessor<float, 1> s_variance(sycl::range<1>(1), cgh);
       cgh.parallel_for(
           sycl::nd_range<3>(grid * block, block),
-          fused_add_rms_norm_kernel<sycl_t, vector_width, HasWeight>(
+          fused_add_rms_norm_kernel<sycl_t, vector_width, HasWeight, IS_GEMMA>(
               (sycl_t*)input_ptr,
               (sycl_t*)residual_ptr,
               input_stride,
@@ -748,7 +782,7 @@ void call_fused_add_rms_norm_kernel(
       sycl::local_accessor<float, 1> s_variance(sycl::range<1>(1), cgh);
       cgh.parallel_for(
           sycl::nd_range<3>(grid * block, block),
-          fused_add_rms_norm_kernel<sycl_t, 0, HasWeight>(
+          fused_add_rms_norm_kernel<sycl_t, 0, HasWeight, IS_GEMMA>(
               (sycl_t*)input_ptr,
               (sycl_t*)residual_ptr,
               input_stride,
@@ -814,5 +848,50 @@ void fused_add_rms_norm(
           vllm::call_fused_add_rms_norm_kernel<scalar_t, false>(
               input, residual, weight_ptr, epsilon);
         }
+      });
+}
+
+void gemma_rms_norm(
+    torch::Tensor& out,
+    torch::Tensor& input,
+    torch::Tensor& weight,
+    double epsilon) {
+  const at::DeviceGuard device_guard(input.device());
+  TORCH_CHECK(out.is_contiguous());
+  if (input.stride(-1) != 1) {
+    input = input.contiguous();
+  }
+  TORCH_CHECK(input.stride(-1) == 1);
+  TORCH_CHECK(weight.is_contiguous());
+  TORCH_CHECK(
+      weight.scalar_type() == input.scalar_type(),
+      "gemma_rms_norm expects weight dtype to match input dtype");
+  VLLM_DISPATCH_FLOATING_TYPES(
+      input.scalar_type(), "call_gemma_rms_norm_kernel", [&] {
+        const scalar_t* weight_ptr = weight.data_ptr<scalar_t>();
+        vllm::call_rms_norm_kernel<
+            scalar_t,
+            /*HasWeight=*/true,
+            /*IS_GEMMA=*/true>(out, input, weight_ptr, epsilon);
+      });
+}
+
+void fused_add_gemma_rms_norm(
+    torch::Tensor& input,
+    torch::Tensor& residual,
+    torch::Tensor& weight,
+    double epsilon) {
+  const at::DeviceGuard device_guard(input.device());
+  TORCH_CHECK(weight.is_contiguous());
+  TORCH_CHECK(
+      weight.scalar_type() == input.scalar_type(),
+      "fused_add_gemma_rms_norm expects weight dtype to match input dtype");
+  VLLM_DISPATCH_FLOATING_TYPES(
+      input.scalar_type(), "call_fused_add_gemma_rms_norm_kernel", [&] {
+        const scalar_t* weight_ptr = weight.data_ptr<scalar_t>();
+        vllm::call_fused_add_rms_norm_kernel<
+            scalar_t,
+            /*HasWeight=*/true,
+            /*IS_GEMMA=*/true>(input, residual, weight_ptr, epsilon);
       });
 }

--- a/csrc/layernorm.cpp
+++ b/csrc/layernorm.cpp
@@ -9,7 +9,12 @@
 
 namespace vllm {
 
-template <typename scalar_t, int NUM_DIMS, int VEC_SIZE, bool HasWeight>
+template <
+    typename scalar_t,
+    int NUM_DIMS,
+    int VEC_SIZE,
+    bool HasWeight,
+    bool IS_GEMMA = false>
 class rms_norm_kernel {
  public:
   rms_norm_kernel(
@@ -111,7 +116,12 @@ class rms_norm_kernel {
         float x = static_cast<float>(src1.val[j]);
         scalar_t normalized = static_cast<scalar_t>(x * s_variance_val);
         if constexpr (HasWeight) {
-          dst.val[j] = normalized * src2.val[j];
+          if constexpr (IS_GEMMA) {
+            dst.val[j] = static_cast<scalar_t>(
+                x * s_variance_val * (static_cast<float>(src2.val[j]) + 1.0f));
+          } else {
+            dst.val[j] = normalized * src2.val[j];
+          }
         } else {
           dst.val[j] = normalized;
         }
@@ -135,8 +145,8 @@ class rms_norm_kernel {
   sycl::local_accessor<float, 1> s_variance;
 };
 
-template <typename scalar_t, int NUM_DIMS, bool HasWeight>
-class rms_norm_kernel<scalar_t, NUM_DIMS, 0, HasWeight> {
+template <typename scalar_t, int NUM_DIMS, bool HasWeight, bool IS_GEMMA>
+class rms_norm_kernel<scalar_t, NUM_DIMS, 0, HasWeight, IS_GEMMA> {
  public:
   rms_norm_kernel(
       scalar_t* out_,
@@ -218,7 +228,12 @@ class rms_norm_kernel<scalar_t, NUM_DIMS, 0, HasWeight> {
       float x = (float)input_row[idx];
       scalar_t normalized = static_cast<scalar_t>(x * (*s_variance_ptr));
       if constexpr (HasWeight) {
-        out_row[idx] = normalized * weight[idx];
+        if constexpr (IS_GEMMA) {
+          out_row[idx] = static_cast<scalar_t>(
+              x * (*s_variance_ptr) * (static_cast<float>(weight[idx]) + 1.0f));
+        } else {
+          out_row[idx] = normalized * weight[idx];
+        }
       } else {
         out_row[idx] = normalized;
       }
@@ -249,7 +264,8 @@ template <
     int NUM_DIMS,
     int VEC_SIZE,
     int ROWS_PER_WG,
-    bool HasWeight>
+    bool HasWeight,
+    bool IS_GEMMA = false>
 class rms_norm_multi_row_kernel {
  public:
   rms_norm_multi_row_kernel(
@@ -365,7 +381,12 @@ class rms_norm_multi_row_kernel {
         float x = static_cast<float>(src1.val[j]);
         scalar_t normalized = static_cast<scalar_t>(x * s_var);
         if constexpr (HasWeight) {
-          dst.val[j] = normalized * src2.val[j];
+          if constexpr (IS_GEMMA) {
+            dst.val[j] = static_cast<scalar_t>(
+                x * s_var * (static_cast<float>(src2.val[j]) + 1.0f));
+          } else {
+            dst.val[j] = normalized * src2.val[j];
+          }
         } else {
           dst.val[j] = normalized;
         }
@@ -389,7 +410,7 @@ class rms_norm_multi_row_kernel {
   sycl::local_accessor<float, 1> s_variance;
 };
 
-template <typename scalar_t, bool HasWeight>
+template <typename scalar_t, bool HasWeight, bool IS_GEMMA = false>
 void call_rms_norm_kernel(
     torch::Tensor& out,
     torch::Tensor& input,
@@ -460,7 +481,8 @@ void call_rms_norm_kernel(
                   tensor_rank,
                   vec_size,
                   ROWS_PER_WG,
-                  HasWeight>(
+                  HasWeight,
+                  IS_GEMMA>(
                   (sycl_t*)out_ptr,
                   (const sycl_t*)input_ptr,
                   input_stride_d2,
@@ -485,7 +507,7 @@ void call_rms_norm_kernel(
         sycl::local_accessor<float, 1> s_variance(sycl::range<1>(1), cgh);
         cgh.parallel_for(
             sycl::nd_range<3>(grid * block, block),
-            rms_norm_kernel<sycl_t, tensor_rank, vec_size, HasWeight>(
+            rms_norm_kernel<sycl_t, tensor_rank, vec_size, HasWeight, IS_GEMMA>(
                 (sycl_t*)out_ptr,
                 (const sycl_t*)input_ptr,
                 input_stride_d2,
@@ -508,7 +530,7 @@ void call_rms_norm_kernel(
         sycl::local_accessor<float, 1> s_variance(sycl::range<1>(1), cgh);
         cgh.parallel_for(
             sycl::nd_range<3>(grid * block, block),
-            rms_norm_kernel<sycl_t, tensor_rank, 0, HasWeight>(
+            rms_norm_kernel<sycl_t, tensor_rank, 0, HasWeight, IS_GEMMA>(
                 (sycl_t*)out_ptr,
                 (const sycl_t*)input_ptr,
                 input_stride_d2,
@@ -526,7 +548,7 @@ void call_rms_norm_kernel(
   }
 }
 
-template <typename scalar_t, int width, bool HasWeight>
+template <typename scalar_t, int width, bool HasWeight, bool IS_GEMMA = false>
 class fused_add_rms_norm_kernel {
  public:
   fused_add_rms_norm_kernel(
@@ -604,7 +626,12 @@ class fused_add_rms_norm_kernel {
         float x = static_cast<float>(res.val[i]);
         scalar_t normalized = static_cast<scalar_t>(x * s_var);
         if constexpr (HasWeight) {
-          out.val[i] = normalized * w.val[i];
+          if constexpr (IS_GEMMA) {
+            out.val[i] = static_cast<scalar_t>(
+                x * s_var * (static_cast<float>(w.val[i]) + 1.0f));
+          } else {
+            out.val[i] = normalized * w.val[i];
+          }
         } else {
           out.val[i] = normalized;
         }
@@ -624,8 +651,8 @@ class fused_add_rms_norm_kernel {
   sycl::local_accessor<float, 1> s_variance;  // local memory for variance
 };
 
-template <typename scalar_t, bool HasWeight>
-class fused_add_rms_norm_kernel<scalar_t, 0, HasWeight> {
+template <typename scalar_t, bool HasWeight, bool IS_GEMMA>
+class fused_add_rms_norm_kernel<scalar_t, 0, HasWeight, IS_GEMMA> {
  public:
   fused_add_rms_norm_kernel(
       scalar_t* __restrict__ input_,     // [..., hidden_size]
@@ -675,8 +702,15 @@ class fused_add_rms_norm_kernel<scalar_t, 0, HasWeight> {
       float x = (float)residual[item_ct1.get_group(2) * hidden_size + idx];
       scalar_t normalized = static_cast<scalar_t>(x * (*s_variance_ptr));
       if constexpr (HasWeight) {
-        input[item_ct1.get_group(2) * input_stride + idx] =
-            normalized * weight[idx];
+        if constexpr (IS_GEMMA) {
+          input[item_ct1.get_group(2) * input_stride + idx] =
+              static_cast<scalar_t>(
+                  x * (*s_variance_ptr) *
+                  (static_cast<float>(weight[idx]) + 1.0f));
+        } else {
+          input[item_ct1.get_group(2) * input_stride + idx] =
+              normalized * weight[idx];
+        }
       } else {
         input[item_ct1.get_group(2) * input_stride + idx] = normalized;
       }
@@ -694,7 +728,7 @@ class fused_add_rms_norm_kernel<scalar_t, 0, HasWeight> {
   sycl::local_accessor<float, 1> s_variance;  // local memory for variance
 };
 
-template <typename scalar_t, bool HasWeight>
+template <typename scalar_t, bool HasWeight, bool IS_GEMMA = false>
 void call_fused_add_rms_norm_kernel(
     torch::Tensor& input,
     torch::Tensor& residual,
@@ -731,7 +765,7 @@ void call_fused_add_rms_norm_kernel(
       sycl::local_accessor<float, 1> s_variance(sycl::range<1>(1), cgh);
       cgh.parallel_for(
           sycl::nd_range<3>(grid * block, block),
-          fused_add_rms_norm_kernel<sycl_t, vector_width, HasWeight>(
+          fused_add_rms_norm_kernel<sycl_t, vector_width, HasWeight, IS_GEMMA>(
               (sycl_t*)input_ptr,
               (sycl_t*)residual_ptr,
               input_stride,
@@ -747,7 +781,7 @@ void call_fused_add_rms_norm_kernel(
       sycl::local_accessor<float, 1> s_variance(sycl::range<1>(1), cgh);
       cgh.parallel_for(
           sycl::nd_range<3>(grid * block, block),
-          fused_add_rms_norm_kernel<sycl_t, 0, HasWeight>(
+          fused_add_rms_norm_kernel<sycl_t, 0, HasWeight, IS_GEMMA>(
               (sycl_t*)input_ptr,
               (sycl_t*)residual_ptr,
               input_stride,
@@ -813,5 +847,50 @@ void fused_add_rms_norm(
           vllm::call_fused_add_rms_norm_kernel<scalar_t, false>(
               input, residual, weight_ptr, epsilon);
         }
+      });
+}
+
+void gemma_rms_norm(
+    torch::Tensor& out,
+    torch::Tensor& input,
+    torch::Tensor& weight,
+    double epsilon) {
+  const at::DeviceGuard device_guard(input.device());
+  TORCH_CHECK(out.is_contiguous());
+  if (input.stride(-1) != 1) {
+    input = input.contiguous();
+  }
+  TORCH_CHECK(input.stride(-1) == 1);
+  TORCH_CHECK(weight.is_contiguous());
+  TORCH_CHECK(
+      weight.scalar_type() == input.scalar_type(),
+      "gemma_rms_norm expects weight dtype to match input dtype");
+  VLLM_DISPATCH_FLOATING_TYPES(
+      input.scalar_type(), "call_gemma_rms_norm_kernel", [&] {
+        const scalar_t* weight_ptr = weight.data_ptr<scalar_t>();
+        vllm::call_rms_norm_kernel<
+            scalar_t,
+            /*HasWeight=*/true,
+            /*IS_GEMMA=*/true>(out, input, weight_ptr, epsilon);
+      });
+}
+
+void fused_add_gemma_rms_norm(
+    torch::Tensor& input,
+    torch::Tensor& residual,
+    torch::Tensor& weight,
+    double epsilon) {
+  const at::DeviceGuard device_guard(input.device());
+  TORCH_CHECK(weight.is_contiguous());
+  TORCH_CHECK(
+      weight.scalar_type() == input.scalar_type(),
+      "fused_add_gemma_rms_norm expects weight dtype to match input dtype");
+  VLLM_DISPATCH_FLOATING_TYPES(
+      input.scalar_type(), "call_fused_add_gemma_rms_norm_kernel", [&] {
+        const scalar_t* weight_ptr = weight.data_ptr<scalar_t>();
+        vllm::call_fused_add_rms_norm_kernel<
+            scalar_t,
+            /*HasWeight=*/true,
+            /*IS_GEMMA=*/true>(input, residual, weight_ptr, epsilon);
       });
 }

--- a/csrc/ops.h
+++ b/csrc/ops.h
@@ -17,6 +17,18 @@ void fused_add_rms_norm(
     std::optional<torch::Tensor> weight,
     double epsilon);
 
+void gemma_rms_norm(
+    torch::Tensor& out,
+    torch::Tensor& input,
+    torch::Tensor& weight,
+    double epsilon);
+
+void fused_add_gemma_rms_norm(
+    torch::Tensor& input,
+    torch::Tensor& residual,
+    torch::Tensor& weight,
+    double epsilon);
+
 // Fused RMSNorm + dynamic per-token quantization (FP8 or INT8 output).
 void rms_norm_dynamic_per_token_quant(
     torch::Tensor& out,

--- a/csrc/torch_bindings.cpp
+++ b/csrc/torch_bindings.cpp
@@ -35,6 +35,19 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
       "float epsilon) -> ()");
   ops.impl("fused_add_rms_norm", torch::kXPU, &fused_add_rms_norm);
 
+  // Gemma RMS Normalization: out = (x / rms(x)) * (1 + weight), folding the
+  // Gemma unit-offset and fp32 weighted multiply into the kernel.
+  ops.def(
+      "gemma_rms_norm(Tensor! result, Tensor! input, Tensor! weight, "
+      "float epsilon) -> ()");
+  ops.impl("gemma_rms_norm", torch::kXPU, &gemma_rms_norm);
+
+  // In-place fused Add and Gemma RMS Normalization.
+  ops.def(
+      "fused_add_gemma_rms_norm(Tensor! input, Tensor! residual, "
+      "Tensor! weight, float epsilon) -> ()");
+  ops.impl("fused_add_gemma_rms_norm", torch::kXPU, &fused_add_gemma_rms_norm);
+
   // Fused RMSNorm + dynamic per-token quantization (FP8 or INT8).
   ops.def(
       "rms_norm_dynamic_per_token_quant(Tensor! result, Tensor input, "

--- a/tests/ops/layernorm_op.py
+++ b/tests/ops/layernorm_op.py
@@ -42,6 +42,109 @@ def dispatch_cuda_rmsnorm_func(add_residual: bool):
     return rms_norm
 
 
+def gemma_rms_norm(x: torch.Tensor, weight: torch.Tensor,
+                   variance_epsilon: float) -> torch.Tensor:
+    import tests.register_ops as ops
+    out = torch.empty_like(x)
+    ops.gemma_rms_norm(
+        out,
+        x,
+        weight,
+        variance_epsilon,
+    )
+    return out
+
+
+def fused_add_gemma_rms_norm(
+        x: torch.Tensor, residual: torch.Tensor, weight: torch.Tensor,
+        variance_epsilon: float) -> tuple[torch.Tensor, torch.Tensor]:
+    import tests.register_ops as ops
+    ops.fused_add_gemma_rms_norm(
+        x,
+        residual,
+        weight,
+        variance_epsilon,
+    )
+    return x, residual
+
+
+def dispatch_cuda_gemma_rmsnorm_func(add_residual: bool):
+    if add_residual:
+        return fused_add_gemma_rms_norm
+    return gemma_rms_norm
+
+
+class GemmaRMSNorm(CustomOp):
+    """RMS normalization for Gemma.
+
+    Two differences from RMSNorm:
+        1. x * (1 + w) instead of x * w.
+        2. (x * (1 + w)) is computed in fp32 then downcast.
+    """
+
+    def __init__(
+        self,
+        hidden_size: int,
+        eps: float = 1e-6,
+        dtype: Optional[torch.dtype] = None,
+    ) -> None:
+        super().__init__()
+        self.hidden_size = hidden_size
+        self.variance_epsilon = eps
+        if dtype is not None:
+            self.weight = nn.Parameter(torch.zeros(hidden_size, dtype=dtype))
+        else:
+            self.weight = nn.Parameter(torch.zeros(hidden_size))
+
+    @staticmethod
+    def forward_static(
+        weight: torch.Tensor,
+        variance_epsilon: float,
+        x: torch.Tensor,
+        residual: Optional[torch.Tensor],
+    ) -> Union[torch.Tensor, tuple[torch.Tensor, torch.Tensor]]:
+        orig_dtype = x.dtype
+        if residual is not None:
+            x = x + residual.to(torch.float32)
+            residual = x.to(orig_dtype)
+
+        x = x.to(torch.float32)
+        variance = x.pow(2).mean(dim=-1, keepdim=True)
+        x = x * torch.rsqrt(variance + variance_epsilon)
+        # Llama does x.to(float16) * w whilst Gemma is (x * w).to(float16)
+        # See https://github.com/huggingface/transformers/pull/29402
+        x = x * (1.0 + weight.float())
+        x = x.to(orig_dtype)
+        return x if residual is None else (x, residual)
+
+    def forward_native(
+        self,
+        x: torch.Tensor,
+        residual: Optional[torch.Tensor] = None,
+    ) -> Union[torch.Tensor, tuple[torch.Tensor, torch.Tensor]]:
+        return self.forward_static(self.weight.data, self.variance_epsilon, x,
+                                   residual)
+
+    def forward_cuda(
+        self,
+        x: torch.Tensor,
+        residual: Optional[torch.Tensor] = None,
+    ) -> Union[torch.Tensor, tuple[torch.Tensor, torch.Tensor]]:
+        add_residual = residual is not None
+        norm_func = dispatch_cuda_gemma_rmsnorm_func(add_residual)
+        weight = self.weight.data
+        if add_residual:
+            return norm_func(x, residual, weight, self.variance_epsilon)
+        return norm_func(x, weight, self.variance_epsilon)
+
+    def forward_xpu(
+        self,
+        x: torch.Tensor,
+        residual: Optional[torch.Tensor] = None,
+    ) -> Union[torch.Tensor, tuple[torch.Tensor, torch.Tensor]]:
+        return self.forward_cuda(x, residual)
+
+
 class RMSNorm(CustomOp):
     """Root mean square normalization.
 

--- a/tests/register_ops.py
+++ b/tests/register_ops.py
@@ -23,6 +23,17 @@ def fused_add_rms_norm(input: torch.Tensor, residual: torch.Tensor,
     torch.ops._C.fused_add_rms_norm(input, residual, weight, epsilon)
 
 
+def gemma_rms_norm(out: torch.Tensor, input: torch.Tensor,
+                   weight: torch.Tensor, epsilon: float) -> None:
+    input_contiguous = input.contiguous()
+    torch.ops._C.gemma_rms_norm(out, input_contiguous, weight, epsilon)
+
+
+def fused_add_gemma_rms_norm(input: torch.Tensor, residual: torch.Tensor,
+                             weight: torch.Tensor, epsilon: float) -> None:
+    torch.ops._C.fused_add_gemma_rms_norm(input, residual, weight, epsilon)
+
+
 def silu_and_mul(out: torch.Tensor, input: torch.Tensor) -> None:
     torch.ops._C.silu_and_mul(out, input)
 

--- a/tests/register_ops.py
+++ b/tests/register_ops.py
@@ -25,8 +25,7 @@ def fused_add_rms_norm(input: torch.Tensor, residual: torch.Tensor,
 
 def gemma_rms_norm(out: torch.Tensor, input: torch.Tensor,
                    weight: torch.Tensor, epsilon: float) -> None:
-    input_contiguous = input.contiguous()
-    torch.ops._C.gemma_rms_norm(out, input_contiguous, weight, epsilon)
+    torch.ops._C.gemma_rms_norm(out, input, weight, epsilon)
 
 
 def fused_add_gemma_rms_norm(input: torch.Tensor, residual: torch.Tensor,

--- a/tests/test_layernorm.py
+++ b/tests/test_layernorm.py
@@ -4,7 +4,7 @@
 import pytest
 import torch
 
-from tests.ops.layernorm_op import RMSNorm
+from tests.ops.layernorm_op import GemmaRMSNorm, RMSNorm
 from tests.utils import opcheck
 
 DTYPES = [torch.half, torch.bfloat16]
@@ -125,3 +125,53 @@ def test_rms_norm_uncontigous(
         torch.ops._C.rms_norm,
         (out, q_by_head, layer.weight.data, layer.variance_epsilon),
     )
+
+
+@pytest.mark.parametrize("num_tokens", NUM_TOKENS)
+@pytest.mark.parametrize("hidden_size", HIDDEN_SIZES)
+@pytest.mark.parametrize("add_residual", ADD_RESIDUAL)
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("seed", SEEDS)
+@pytest.mark.parametrize("device", XPU_DEVICES)
+@pytest.mark.parametrize("strided_input", [False, True])
+@torch.inference_mode()
+def test_gemma_rms_norm(
+    num_tokens: int,
+    hidden_size: int,
+    add_residual: bool,
+    dtype: torch.dtype,
+    seed: int,
+    device: str,
+    strided_input: bool,
+) -> None:
+    torch.manual_seed(seed)
+    torch.set_default_device("xpu")
+    torch.xpu.set_device(device)
+    layer = GemmaRMSNorm(hidden_size).to(dtype=dtype)
+    # Gemma weight is zero-centered; use a small spread around 0.
+    layer.weight.data.normal_(mean=0.0, std=0.1)
+    scale = 1 / (2 * hidden_size)
+    last_dim = 2 * hidden_size if strided_input else hidden_size
+    x = torch.randn(num_tokens, last_dim, dtype=dtype)
+    x = x[..., :hidden_size]
+    if num_tokens > 1:
+        assert x.is_contiguous() != strided_input
+    x *= scale
+    residual = torch.randn_like(x) * scale if add_residual else None
+
+    # NOTE: reference runs first because the fused kernel is in-place.
+    ref_out = layer.forward_native(x, residual)
+    out = layer(x, residual)
+    if add_residual:
+        torch.testing.assert_close(out[0], ref_out[0], atol=1e-2, rtol=1e-2)
+        torch.testing.assert_close(out[1], ref_out[1], atol=1e-2, rtol=1e-2)
+    else:
+        torch.testing.assert_close(out, ref_out, atol=1e-2, rtol=1e-2)
+
+    weight = layer.weight.data
+    if residual is not None:
+        opcheck(torch.ops._C.fused_add_gemma_rms_norm,
+                (x, residual, weight, layer.variance_epsilon))
+    else:
+        opcheck(torch.ops._C.gemma_rms_norm,
+                (out, x, weight, layer.variance_epsilon))


### PR DESCRIPTION
# [Kernel] Add fused XPU GemmaRMSNorm kernels  for the eager path

## Summary
Adds fused XPU ops for GemmaRMSNorm so the enforce-eager path gets a single fused kernel instead of falling back to separated element-wise ops — closing the enforce-eager vs  torch.compile  prefill gap for  GemmaRMSNorm  models (e.g. Qwen3.5).

Two new ops:  gemma_rms_norm(...)  and  fused_add_gemma_rms_norm(...) . The only functional difference from the existing kernels is the Gemma unit offset: weight applied as  (1 + weight)  instead of  weight .

out = round(x * inv_rms(x) * (weight + weight_bias))

• Generic ops:  weight_bias = 0.0f  (default) — byte-identical to master.
• Gemma ops:  weight_bias = 1.0f  — Gemma's  (1 + weight) .

## Performance (enforce-eager prefill)

| Model            | TP | eager (native fallback) | eager (fused) | torch.compile |
|------------------|----|-------------------------|---------------|---------------|
| Qwen3.5-9B       | 1  | 1.256 s                 | **1.023 s**   | 1.013 s       |
| Qwen3.5-35B-A3B  | 4  | 0.580 s                 | **0.419 s**   | 0.421 s       |

## Accuracy (GSM8K, lm-eval-harness, max_gen_toks=4096)

| Model            | TP | exact_match (strict) | exact_match (flexible) |
|------------------|----|----------------------|------------------------|
| Qwen3.5-9B       | 1  | 0.8923               | 0.8901                 |
| Qwen3.6-27B      | 4  | 0.6748               | 0.6755                 |
| Qwen3.5-35B-A3B  | 4  | 0.9462               | 0.9538                 |

## Testing

•  tests/test_layernorm.py : 2304 passed (704 Gemma cases), on current  main  (post-#534). pre-commit clean.