### PR TITLE
Fix RMSNorm fp32/bf16 precision mismatch vs CUDA

### DIFF
--- a/csrc/layernorm.cpp
+++ b/csrc/layernorm.cpp
@@ -109,11 +109,11 @@ class rms_norm_kernel {
 #pragma unroll
       for (int j = 0; j < VEC_SIZE; j++) {
         float x = static_cast<float>(src1.val[j]);
-        scalar_t normalized = static_cast<scalar_t>(x * s_variance_val);
         if constexpr (HasWeight) {
-          dst.val[j] = normalized * src2.val[j];
+          float w = static_cast<float>(src2.val[j]);
+          dst.val[j] = static_cast<scalar_t>(x * s_variance_val * w);
         } else {
-          dst.val[j] = normalized;
+          dst.val[j] = static_cast<scalar_t>(x * s_variance_val);
         }
       }
       v_out[idx] = dst;
@@ -216,11 +216,11 @@ class rms_norm_kernel<scalar_t, NUM_DIMS, 0, HasWeight> {
     for (int idx = item_ct1.get_local_id(2); idx < hidden_size;
          idx += item_ct1.get_local_range(2)) {
       float x = (float)input_row[idx];
-      scalar_t normalized = static_cast<scalar_t>(x * (*s_variance_ptr));
       if constexpr (HasWeight) {
-        out_row[idx] = normalized * weight[idx];
+        float w = static_cast<float>(weight[idx]);
+        out_row[idx] = static_cast<scalar_t>(x * (*s_variance_ptr) * w);
       } else {
-        out_row[idx] = normalized;
+        out_row[idx] = static_cast<scalar_t>(x * (*s_variance_ptr));
       }
     }
   }
@@ -363,11 +363,11 @@ class rms_norm_multi_row_kernel {
 #pragma unroll
       for (int j = 0; j < VEC_SIZE; j++) {
         float x = static_cast<float>(src1.val[j]);
-        scalar_t normalized = static_cast<scalar_t>(x * s_var);
         if constexpr (HasWeight) {
-          dst.val[j] = normalized * src2.val[j];
+          float w = static_cast<float>(src2.val[j]);
+          dst.val[j] = static_cast<scalar_t>(x * s_var * w);
         } else {
-          dst.val[j] = normalized;
+          dst.val[j] = static_cast<scalar_t>(x * s_var);
         }
       }
       v_out[idx] = dst;
@@ -602,11 +602,11 @@ class fused_add_rms_norm_kernel {
 #pragma unroll
       for (int i = 0; i < width; i++) {
         float x = static_cast<float>(res.val[i]);
-        scalar_t normalized = static_cast<scalar_t>(x * s_var);
         if constexpr (HasWeight) {
-          out.val[i] = normalized * w.val[i];
+          float wf = static_cast<float>(w.val[i]);
+          out.val[i] = static_cast<scalar_t>(x * s_var * wf);
         } else {
-          out.val[i] = normalized;
+          out.val[i] = static_cast<scalar_t>(x * s_var);
         }
       }
       input_v[strided_id] = out;
@@ -673,12 +673,13 @@ class fused_add_rms_norm_kernel<scalar_t, 0, HasWeight> {
     for (int idx = item_ct1.get_local_id(2); idx < hidden_size;
          idx += item_ct1.get_local_range(2)) {
       float x = (float)residual[item_ct1.get_group(2) * hidden_size + idx];
-      scalar_t normalized = static_cast<scalar_t>(x * (*s_variance_ptr));
       if constexpr (HasWeight) {
+        float w = static_cast<float>(weight[idx]);
         input[item_ct1.get_group(2) * input_stride + idx] =
-            normalized * weight[idx];
+            static_cast<scalar_t>(x * (*s_variance_ptr) * w);
       } else {
-        input[item_ct1.get_group(2) * input_stride + idx] = normalized;
+        input[item_ct1.get_group(2) * input_stride + idx] =
+            static_cast<scalar_t>(x * (*s_variance_ptr));
       }
     }
   }

--- a/csrc/layernorm_quant.cpp
+++ b/csrc/layernorm_quant.cpp
@@ -561,9 +561,12 @@ class rms_norm_static_fp8_quant_kernel {
 #pragma unroll
       for (int j = 0; j < VEC_SIZE; j++) {
         float x = static_cast<float>(src[j]);
-        // Weight multiply in scalar_t precision to match unfused path
+        // Full multiply in fp32, then round through scalar_t once to match
+        // the precision of the unfused RMSNorm path (CUDA reference
+        // behavior).
+        float w = static_cast<float>(wgt[j]);
         float norm_x =
-            static_cast<float>(static_cast<scalar_t>(x * inv_rms) * wgt[j]);
+            static_cast<float>(static_cast<scalar_t>(x * inv_rms * w));
         float q = norm_x * scale_inv;
         token_output[i * VEC_SIZE + j] =
             static_cast<out_t>(sycl::max(sycl::min(q, fp8_max), -fp8_max));
@@ -655,9 +658,12 @@ class fused_add_rms_norm_static_fp8_quant_kernel {
 #pragma unroll
       for (int j = 0; j < VEC_SIZE; j++) {
         float x = static_cast<float>(res[j]);
-        // Weight multiply in scalar_t precision to match unfused path
+        // Full multiply in fp32, then round through scalar_t once to match
+        // the precision of the unfused RMSNorm path (CUDA reference
+        // behavior).
+        float w = static_cast<float>(wgt[j]);
         float norm_x =
-            static_cast<float>(static_cast<scalar_t>(x * inv_rms) * wgt[j]);
+            static_cast<float>(static_cast<scalar_t>(x * inv_rms * w));
         float q = norm_x * scale_inv;
         token_output[i * VEC_SIZE + j] =
             static_cast<out_t>(sycl::max(sycl::min(q, fp8_max), -fp8_max));


### PR DESCRIPTION
**Purpose**

Fix a numerical precision discrepancy between the CUDA and XPU RMSNorm kernels. CUDA's RMSNorm computes  x * variance * weight  fully in fp32 and casts to  scalar_t  (bf16/fp16) exactly once, at the end. Several XPU SYCL kernels instead cast  x * variance  to  scalar_t  before multiplying by the weight, introducing an extra premature rounding step and a lower-precision (bf16×bf16) multiply, causing XPU outputs to diverge from CUDA for the same inputs.

Fixes 7 call sites across 2 files to match the CUDA reference pattern (single cast at the end, full multiply in fp32):

•  csrc/layernorm.cpp :  rms_norm_kernel  (vectorized + scalar specialization),  rms_norm_multi_row_kernel ,  fused_add_rms_norm_kernel  (vectorized + scalar specialization)
•  csrc/layernorm_quant.cpp : fused RMSNorm + static-scale FP8 quant kernel (no-residual and residual variants) — one had a comment explicitly noting it mirrored this same bug "to match unfused path"; updated the comment to reflect the corrected fp32 semantics.

**Test Plan**

python -m pytest tests/test_layernorm.py -q
python -m pytest tests/test_fused_norm_quant.py -q
python -m pytest tests/test_fused_qk_norm_rope.py tests/test_deepseek_qnorm_rope_kv_insert.py -q
python benchmark/benchmark_layernorm.py --num-tokens 4096 --hidden-size 8192 --dtype bfloat16
python benchmark/benchmark_rmsnorm.py --batch-size 16 --seq-len 512 --hidden-size 4096

Test Result

•  tests/test_layernorm.py : 1600 passed
•  tests/test_fused_norm_quant.py : 1152 passed
•  tests/test_fused_qk_norm_rope.py  +  tests/test_deepseek_qnorm_rope_kv_insert.py  (regression, untouched code): 406 passed
•  benchmark_rmsnorm.py  correctness check: ✅ All implementations match (HuggingFace-native, vLLM kernel,  torch.compile )
• Perf sweeps show no regression — vLLM's kernel remains consistently faster than HuggingFace-native/ torch.compile  baselines; the fix only reorders a cast, without altering vectorization or memory access patterns.
