### PR TITLE
[Attn]  Fix Gemma4-26B default kernel coverage and chunk prefill diagnostics

### DIFF
--- a/csrc/xpu/attn/kernel_configs/chunk_prefill_default.conf
+++ b/csrc/xpu/attn/kernel_configs/chunk_prefill_default.conf
@@ -57,3 +57,4 @@
 # --- Qwen3-Next causal heads -------------------------------------------------
 # Qwen/Qwen3-Next-80B-A3B-Instruct, Qwen/Qwen3-Next-80B-A3B-Thinking
 256,true,true,false,false,false
+512,true,true,false,false,false

--- a/csrc/xpu/attn/kernel_configs/chunk_prefill_default.conf
+++ b/csrc/xpu/attn/kernel_configs/chunk_prefill_default.conf
@@ -49,6 +49,7 @@
 # --- Sliding-window/local model coverage ------------------------------------
 # google/gemma-3-12b-it, google/gemma-4-26B-A4B-it
 256,true,false,true,false,false
+512,true,true,false,false,false
 # google/gemma-3-27b-it
 128,true,false,true,false,false
 # Microsoft/Phi-3.5-mini-instruct
@@ -57,4 +58,3 @@
 # --- Qwen3-Next causal heads -------------------------------------------------
 # Qwen/Qwen3-Next-80B-A3B-Instruct, Qwen/Qwen3-Next-80B-A3B-Thinking
 256,true,true,false,false,false
-512,true,true,false,false,false

--- a/csrc/xpu/attn/kernel_configs/paged_decode_default.conf
+++ b/csrc/xpu/attn/kernel_configs/paged_decode_default.conf
@@ -80,6 +80,7 @@
 # --- Qwen3-Next decode heads -------------------------------------------------
 # Qwen/Qwen3-Next-80B-A3B-Instruct, Qwen/Qwen3-Next-80B-A3B-Thinking
 8,256,64,false,false,false
+8,512,64,false,false,false
 
 # --- google/gemma-3-1b-it-512 decode heads ----------------------------------
 8,256,16,false,true,false

--- a/csrc/xpu/attn/kernel_configs/paged_decode_default.conf
+++ b/csrc/xpu/attn/kernel_configs/paged_decode_default.conf
@@ -74,13 +74,13 @@
 16,128,16,false,true,false
 # google/gemma-3-12b-it, google/gemma-4-26B-A4B-it
 8,256,64,false,true,false
+8,512,64,false,false,false
 # google/gemma-3-27b-it
 8,128,64,false,true,false
 
 # --- Qwen3-Next decode heads -------------------------------------------------
 # Qwen/Qwen3-Next-80B-A3B-Instruct, Qwen/Qwen3-Next-80B-A3B-Thinking
 8,256,64,false,false,false
-8,512,64,false,false,false
 
 # --- google/gemma-3-1b-it-512 decode heads ----------------------------------
 8,256,16,false,true,false

--- a/csrc/xpu/attn/xe_2/chunk_prefill_utils.hpp
+++ b/csrc/xpu/attn/xe_2/chunk_prefill_utils.hpp
@@ -21,6 +21,21 @@ struct is_chunk_policy_tuple_enabled : std::true_type {};
 
 using namespace cute;
 
+template <typename Policy>
+struct chunk_policy_reported_head_size {
+  static constexpr int value = cute::size<1>(typename Policy::ShapeOut{});
+};
+
+// Some policy reuses a 256-wide output tile due to register pressure.
+// Keep diagnostics aligned with the logical model head_size.
+template <>
+struct chunk_policy_reported_head_size<chunk_policy_head512>
+    : std::integral_constant<int, 512> {};
+
+template <>
+struct chunk_policy_reported_head_size<chunk_policy_head512_b16>
+    : std::integral_constant<int, 512> {};
+
 template <typename chunk_policy, bool... Bs>
 void policy_dispatch_func(
     sycl::queue& queue,
@@ -40,8 +55,8 @@ void policy_dispatch_func(
   constexpr bool Local = flags[2];
   constexpr bool Sink = flags[3];
   constexpr bool SoftmaxLSE = flags[4];
-  // Extract head_size from policy at compile time.
-  constexpr int _head_sz = cute::size<1>(typename chunk_policy::ShapeOut{});
+  // Report the logical head_size in diagnostics instead of ShapeOut width.
+  constexpr int _head_sz = chunk_policy_reported_head_size<chunk_policy>::value;
 
   if constexpr (SoftmaxLSE && (Paged || Local || Sink)) {
     TORCH_CHECK(


### PR DESCRIPTION
Summary:

```text
This PR addresses Gemma4-26B XPU fallback and misleading diagnostics with two patches:

1) Add missing default kernel config entries:
	 - paged_decode_default.conf: 8,512,64,false,false,false
	 - chunk_prefill_default.conf: 512,true,true,false,false,false
	 - This would prevent runtime fallback to PyTorch reference attention for these combination.


2) Fix chunk prefill diagnostic head_size reporting for head_size=512 policies.
	 - Gemma-4 has a unique head_size of 512. This change would avoid head_size=512 being repported as 256 in error log.
```