### PR TITLE
[GDN] Fix token-indexed conv-state layout in causal_conv1d spec-decode kernel

### DIFF
--- a/benchmark/benchmark_causal_conv1d.py
+++ b/benchmark/benchmark_causal_conv1d.py
@@ -75,6 +75,7 @@ def estimate_bytes_moved(kwargs):
     ba_per_tok = nk * (2 * nv // nk)
     qkv_per_tok = nk * (2 * hk + hv * nv // nk)
     z_per_tok = nv * hv
+    conv_state_len = kwargs["conv_state"].shape[1]
     # {q,k,v} (=qkv_per_tok) plus b, a (2*nv) intermediates written out.
     inter_per_tok = qkv_per_tok + 2 * nv
 
@@ -85,7 +86,7 @@ def estimate_bytes_moved(kwargs):
     bytes_in = n_tok * (qkvz_per_tok + ba_per_tok) * bpe_in
     bytes_z = n_tok * z_per_tok * bpe_out
     bytes_inter = n_tok * inter_per_tok * bpe_out
-    bytes_conv_state = batch * (width - 1) * qkv_per_tok * bpe_in * 2  # RW
+    bytes_conv_state = batch * conv_state_len * qkv_per_tok * bpe_in * 2
     bytes_weights = qkv_per_tok * width * bpe_in
     # Bias is only read when conv_bias is provided.
     bytes_bias = qkv_per_tok * bpe_in if kwargs["conv_bias"] is not None else 0

--- a/benchmark/benchmark_gdn_attn.py
+++ b/benchmark/benchmark_gdn_attn.py
@@ -261,7 +261,9 @@ def _make_spec_inputs(shape: GdnShape, workload: Workload, dtype):
     projected_states_ba = torch.randn(
         (num_actual_tokens, mixed_ba_size), dtype=dtype, device=DEVICE)
     conv_state = torch.randn(
-        (cache_batch_size, width - 1, mixed_qkv_size),
+        (cache_batch_size,
+         width - 1 + num_spec_tokens,
+         mixed_qkv_size),
         dtype=dtype, device=DEVICE)
     ssm_state = torch.randn(
         (cache_batch_size, num_v_heads // tp_size, head_v_dim, head_k_dim),
@@ -356,6 +358,7 @@ def estimate_bytes_moved(kwargs):
     ba_per_tok = nk * (2 * nv // nk)
     qkv_per_tok = nk * (2 * hk + hv * nv // nk)
     out_per_tok = nv * hv
+    conv_state_len = kwargs["conv_state"].shape[1]
 
     batch = max(1,
                 kwargs["num_prefills"] + kwargs["num_decodes"]
@@ -363,7 +366,7 @@ def estimate_bytes_moved(kwargs):
 
     bytes_in = n_tok * (qkvz_per_tok + ba_per_tok) * bpe_in
     bytes_out = n_tok * (out_per_tok * 2) * bpe_out     # core_attn_out + z
-    bytes_conv_state = batch * (width - 1) * qkv_per_tok * bpe_in * 2  # RW
+    bytes_conv_state = batch * conv_state_len * qkv_per_tok * bpe_in * 2
     bytes_ssm_state = batch * nv * hk * hv * bpe_ssm * 2              # RW
     bytes_weights = qkv_per_tok * width * bpe_in + qkv_per_tok * bpe_in
 

--- a/csrc/xpu/gdn_attn/causal_conv1d.hpp
+++ b/csrc/xpu/gdn_attn/causal_conv1d.hpp
@@ -674,7 +674,10 @@ struct causal_conv1d_spec_kernel {
     // Single cache line (column 0); accepted window starts at row init_row.
     int init_row = num_accepted_tokens[batch_id] - 1;
     if (init_row < 0) init_row = 0;
-    const int state_len = conv_states_stride_0 / conv_elems;
+    // Match the effective state length used by the CUDA/Triton path.  The
+    // leading stride may span interleaved states from multiple layers, so it
+    // cannot be used to recover this dimension.
+    const int state_len = Width - 1 + (num_spec_tokens - 1);
     const int state_id = cache_indices[batch_id * cache_indices_stride_0 + 0];
     const bool has_conv_state = (state_id != pad_slot_id);
     T* state_line_ptr = has_conv_state

--- a/csrc/xpu/gdn_attn/causal_conv1d.hpp
+++ b/csrc/xpu/gdn_attn/causal_conv1d.hpp
@@ -477,25 +477,11 @@ struct update_states_kernel {
 // -----------------------------------------------------------------------------
 // Spec-decoding kernel for causal_conv1d.
 //
-// Each spec sequence contributes exactly num_spec_tokens (== num_spec + 1)
-// contiguous tokens in the LOCAL q/k/v/b/a buffers, ordered by
-// spec_query_start_loc; their corresponding GLOBAL positions in
-// mixed_qkvz / mixed_ba / z_out are given by token_indx.
-//
-// Grid: (num_spec_decodes, groups_per_token). Each thread owns a feature
-// chunk of `elems_per_item` lanes and walks all num_spec_tokens tokens of
-// one sequence in a sliding window:
-//   - q/k/v lanes: load Width-1 prior values from
-//     conv_states[cache_indices[batch, num_accepted_tokens[batch] - 1]],
-//     then for every t_local in [0, num_spec_tokens) shift the window left
-//     by one, load the new input from mixed_qkvz[token_indx[...]], apply the
-//     conv (+bias +activation) and store to local q/k/v outputs.
-//   - z lanes: pure reorder, no conv.
-//   - b/a lanes: pure reorder.
-// After processing all tokens we write the trailing Width-1 input values to
-// ONLY the last cache slot: conv_states[cache_indices[batch, num_spec]],
-// matching the Triton fused_recurrent path which keeps a single rollback
-// reference for the next forward.
+// Sliding-window conv state (single cache line, matches CUDA/Triton and vLLM
+// get_conv_copy_spec): the conv state lives in column 0 of the cache_indices
+// row, with state_len = (Width-1) + num_spec rows. The accepted window starts
+// at row num_accepted_tokens-1; after processing, the rolled state (shifted
+// history + the K draft inputs) is written back to that same line.
 // -----------------------------------------------------------------------------
 template <typename T, int Width, bool ReorderInput>
 struct causal_conv1d_spec_kernel {
@@ -685,14 +671,15 @@ struct causal_conv1d_spec_kernel {
     }
 
     // -- conv1d on q/k/v lanes ----------------------------------------------
-    // Pick the initial conv-state slot using num_accepted_tokens. The slot
-    // at column num_accepted_tokens[batch_id] - 1 was written by the previous
-    // step's last accepted token; we fall back to col 0 defensively when
-    // num_accepted_tokens == 0.
-    int init_col = num_accepted_tokens[batch_id] - 1;
-    if (init_col < 0) init_col = 0;
-    const int init_state_id =
-        cache_indices[batch_id * cache_indices_stride_0 + init_col];
+    // Single cache line (column 0); accepted window starts at row init_row.
+    int init_row = num_accepted_tokens[batch_id] - 1;
+    if (init_row < 0) init_row = 0;
+    const int state_len = conv_states_stride_0 / conv_elems;
+    const int state_id = cache_indices[batch_id * cache_indices_stride_0 + 0];
+    const bool has_conv_state = (state_id != pad_slot_id);
+    T* state_line_ptr = has_conv_state
+                            ? conv_states + state_id * conv_states_stride_0
+                            : nullptr;
 
     // Load weights
     T local_weights[Width * elems_per_item];
@@ -705,23 +692,20 @@ struct causal_conv1d_spec_kernel {
       }
     }
 
-    // Sliding window of size Width. Positions [0, Width-1) start with the
-    // prior conv_state; position Width-1 is filled per-iter with the new
-    // input. When the cache slot is the pad slot the prior is zeroed.
+    // Prime the window from rows [init_row, init_row + Width - 1); the trailing
+    // slot is filled per-iter. Pad slot => zeroed prior.
     T local_input[Width * elems_per_item];
 #pragma unroll
     for (int i = 0; i < Width * elems_per_item; ++i) {
       local_input[i] = static_cast<T>(0);
     }
-    if (Width > 1 && init_state_id != pad_slot_id) {
-      const T* init_state_ptr =
-          conv_states + init_state_id * conv_states_stride_0;
+    if (Width > 1 && has_conv_state) {
 #pragma unroll
       for (int i = 0; i < Width - 1; ++i) {
 #pragma unroll
         for (int e = 0; e < elems_per_item; ++e) {
-          local_input[Width * e + i] =
-              init_state_ptr[i * conv_elems + reordered_elems_id + e];
+          local_input[Width * e + i] = state_line_ptr
+              [(init_row + i) * conv_elems + reordered_elems_id + e];
         }
       }
     }
@@ -801,25 +785,29 @@ struct causal_conv1d_spec_kernel {
                qkvz_dim_id - (q_dim + k_dim) + e] = res[e];
         }
       }
+    }
 
-      // Checkpoint the rolling conv state at every step into the cache slot
-      // that the next decoding round will read when `num_accepted_tokens ==
-      // t_local + 1`. Writing each column (not only the last one) keeps the
-      // scheduler's per-acceptance rollback consistent: column `t_local`
-      // holds the conv state right after consuming spec token `t_local`.
-      if (Width > 1) {
-        const int save_state_id =
-            cache_indices[batch_id * cache_indices_stride_0 + t_local];
-        if (save_state_id != pad_slot_id) {
-          T* save_state_ptr =
-              conv_states + save_state_id * conv_states_stride_0;
+    // Roll the line back to column 0: rows [0, hist_rows) = shifted history
+    // from row init_row+1, rows [hist_rows, state_len) = the K draft inputs.
+    // In-place left shift is safe since src row (init_row+1+j) >= dst row j.
+    if (Width > 1 && has_conv_state) {
+      const int hist_rows = state_len - num_spec_tokens;
+      for (int j = 0; j < state_len; ++j) {
+        if (j < hist_rows) {
+          const int src_row = init_row + 1 + j;
 #pragma unroll
-          for (int i = 0; i < Width - 1; ++i) {
+          for (int e = 0; e < elems_per_item; ++e) {
+            state_line_ptr[j * conv_elems + reordered_elems_id + e] =
+                state_line_ptr[src_row * conv_elems + reordered_elems_id + e];
+          }
+        } else {
+          const int draft_t = j - hist_rows;
+          const int token_id_local = batch_id * num_spec_tokens + draft_t;
+          const int global_t = token_indx[token_id_local];
 #pragma unroll
-            for (int e = 0; e < elems_per_item; ++e) {
-              save_state_ptr[i * conv_elems + reordered_elems_id + e] =
-                  local_input[Width * e + i + 1];
-            }
+          for (int e = 0; e < elems_per_item; ++e) {
+            state_line_ptr[j * conv_elems + reordered_elems_id + e] =
+                mixed_qkvz[global_t * qkvz_elems + mixed_qkvz_id + e];
           }
         }
       }

--- a/csrc/xpu/gdn_attn/gdn_attn_interface.cpp
+++ b/csrc/xpu/gdn_attn/gdn_attn_interface.cpp
@@ -94,6 +94,14 @@ std::vector<torch::Tensor> causal_conv1d_spec(
       "spec_state_indices_tensor must have size [num_spec_decodes, "
       "num_speculative_tokens + 1]");
   const int num_speculative_tokens = spec_state_indices_tensor.size(1) - 1;
+  const int64_t required_conv_state_len =
+      conv_weights.size(1) - 1 + num_speculative_tokens;
+  TORCH_CHECK(
+      conv_state.size(1) >= required_conv_state_len,
+      "conv_state must have at least ",
+      required_conv_state_len,
+      " rows for speculative decoding, but got ",
+      conv_state.size(1));
 
   TORCH_CHECK(
       num_accepted_tokens.is_contiguous(),

--- a/tests/gdn_attn/test_causal_conv1d.py
+++ b/tests/gdn_attn/test_causal_conv1d.py
@@ -554,11 +554,20 @@ def test_causal_conv1d_mtp(num_spec_decodes, num_spec_tokens, num_k_heads,
                                       device=device)
     # Sliding-window layout: state_len = (width-1) + num_spec rows per line.
     state_len = (width - 1) + num_spec
-    conv_state = torch.randn(cache_batch_size,
-                             state_len,
-                             mixed_qkv_size,
-                             dtype=dtype,
-                             device=device)
+    # vLLM stores every layer in one allocation and passes a per-layer view.
+    # Keep one extra cache line so a stride-derived state length corrupts only
+    # the guard storage instead of writing past the allocation.
+    num_layers = 3
+    layer_idx = 1
+    conv_state_storage = torch.randn(cache_batch_size + 1,
+                                     num_layers,
+                                     state_len,
+                                     mixed_qkv_size,
+                                     dtype=dtype,
+                                     device=device)
+    conv_state = conv_state_storage[:cache_batch_size, layer_idx]
+    assert conv_state.stride(0) != state_len * mixed_qkv_size
+    neighbor_states = conv_state_storage[:, (0, 2)].clone()
     ref_conv_state = conv_state.clone()
     conv_weights = torch.randn(mixed_qkv_size,
                                width,
@@ -642,6 +651,12 @@ def test_causal_conv1d_mtp(num_spec_decodes, num_spec_tokens, num_k_heads,
     rtol = 5e-2
 
     torch.testing.assert_close(z, ref_z, atol=atol, rtol=rtol)
+
+    # The kernel must not overwrite adjacent layers in the shared allocation.
+    torch.testing.assert_close(conv_state_storage[:, (0, 2)],
+                               neighbor_states,
+                               atol=0,
+                               rtol=0)
 
     # Conv writes back to column 0; assert that slot.
     for n in range(num_spec_decodes):

--- a/tests/gdn_attn/test_causal_conv1d.py
+++ b/tests/gdn_attn/test_causal_conv1d.py
@@ -185,18 +185,16 @@ def ref_causal_conv1d_spec(
     tp_size,
     reorder_input,
 ):
-    """Standalone reference for the causal_conv1d conv stage (spec-decode path).
+    """Reference for the causal_conv1d conv stage (spec-decode path).
 
-    Mirrors :func:`ref_causal_conv1d` but routes the gather/scatter through
-    ``spec_token_indx`` and writes the final conv cache into the last slot of
-    each speculative sequence (``spec_state_indices_tensor[n, K - 1]``).
-    ``z`` and ``conv_state`` are weight-independent; the returned
-    ``{q, k, v, b, a}`` intermediates use the spec native layout, indexed by
-    the LOCAL token position ``n * K + t`` (not the scattered global position).
+    Sliding-window convention: the conv state lives in a single cache line
+    (column 0), accepted window at row num_accepted-1, rolled state written
+    back to the same line.
     """
     dtype = projected_states_qkvz.dtype
     width = conv_weights.shape[-1]
     K = spec_state_indices_tensor.shape[1]
+    state_len = conv_state.shape[1]
     qkv, b, a, z_global = _extract_qkv_b_a_z(
         projected_states_qkvz, projected_states_ba, num_actual_tokens,
         num_k_heads, num_v_heads, head_k_dim, head_v_dim, tp_size,
@@ -234,15 +232,23 @@ def ref_causal_conv1d_spec(
         globals_ = spec_token_indx[start:end].to(torch.long)
 
         naccepted = int(num_accepted_tokens[n].item())
-        init_col = max(naccepted - 1, 0)
-        init_slot = int(spec_state_indices_tensor[n, init_col].item())
-        final_conv_slot = int(spec_state_indices_tensor[n, K - 1].item())
+        init_row = max(naccepted - 1, 0)
+        slot = int(spec_state_indices_tensor[n, 0].item())  # column 0
 
-        conv_state_batch = conv_state[init_slot].clone()
+        # Prior window = rows [init_row, init_row + width - 1).
+        line = conv_state[slot]
+        prior = line[init_row:init_row + (width - 1)].clone()
         qkv_batch = qkv[globals_]
-        qkv_conv_input = torch.cat([conv_state_batch, qkv_batch], dim=0)
-        # Final conv state goes ONLY to the last cache slot.
-        conv_state[final_conv_slot] = qkv_conv_input[-(width - 1):]
+        qkv_conv_input = torch.cat([prior, qkv_batch], dim=0)
+
+        # Roll the line: rows [0, hist_rows) = shifted history from init_row+1,
+        # rows [hist_rows, state_len) = the K draft inputs.
+        new_line = torch.empty_like(line)
+        hist_rows = state_len - K
+        if hist_rows > 0:
+            new_line[:hist_rows] = line[init_row + 1:init_row + 1 + hist_rows]
+        new_line[hist_rows:] = qkv_batch
+        conv_state[slot] = new_line
 
         # Grouped causal conv1d + activation over the [history, qkv] window.
         conv_in = qkv_conv_input.transpose(0, 1).unsqueeze(0)
@@ -516,8 +522,8 @@ def test_causal_conv1d_mtp(num_spec_decodes, num_spec_tokens, num_k_heads,
                            head_k_dim, num_v_heads, head_v_dim, width,
                            tp_size, has_bias, activation, reorder_input,
                            dtype):
-    """Pure spec-decode batch conv stage. Asserts z (scattered) and the final
-    per-seq conv-state slot match a standalone conv-stage reference."""
+    """Pure spec-decode conv stage, single-cache-line sliding-window layout.
+    Asserts z and the column-0 conv-state slot match the reference."""
     if (os.getenv("SKIP_ACC_ERROR_KERNEL") is not None
             and os.getenv("SKIP_ACC_ERROR_KERNEL") == "1"):
         pytest.skip("skip gdn attention kernels testing on PVC.")
@@ -528,6 +534,7 @@ def test_causal_conv1d_mtp(num_spec_decodes, num_spec_tokens, num_k_heads,
 
     assert head_k_dim == head_v_dim
     K = num_spec_tokens
+    num_spec = K - 1  # num_speculative_tokens
     num_actual_tokens = num_spec_decodes * K
     cache_batch_size = 200
 
@@ -545,8 +552,10 @@ def test_causal_conv1d_mtp(num_spec_decodes, num_spec_tokens, num_k_heads,
                                       mixed_ba_size,
                                       dtype=dtype,
                                       device=device)
+    # Sliding-window layout: state_len = (width-1) + num_spec rows per line.
+    state_len = (width - 1) + num_spec
     conv_state = torch.randn(cache_batch_size,
-                             width - 1,
+                             state_len,
                              mixed_qkv_size,
                              dtype=dtype,
                              device=device)
@@ -558,15 +567,15 @@ def test_causal_conv1d_mtp(num_spec_decodes, num_spec_tokens, num_k_heads,
     conv_bias = (torch.randn(mixed_qkv_size, dtype=dtype, device=device)
                  if has_bias else None)
 
-    # Each spec seq owns K consecutive cache slots (cols 0..K-1).
+    # K slots per seq: conv uses only column 0, ssm uses all K columns.
     state_slots = random.sample(range(cache_batch_size), num_spec_decodes * K)
     spec_state_indices_tensor = torch.tensor(state_slots,
                                              dtype=torch.int32,
                                              device=device).reshape(
                                                  num_spec_decodes, K)
-    # Mix of acceptance counts including the 0 edge case.
+    # Cover acceptance 0..K (0 edge case and num_accepted > 1).
     num_accepted_tokens = torch.tensor(
-        [random.randint(0, K) for _ in range(num_spec_decodes)],
+        [n % (K + 1) for n in range(num_spec_decodes)],
         dtype=torch.int32,
         device=device)
 
@@ -634,11 +643,11 @@ def test_causal_conv1d_mtp(num_spec_decodes, num_spec_tokens, num_k_heads,
 
     torch.testing.assert_close(z, ref_z, atol=atol, rtol=rtol)
 
-    # Final conv-state slot per seq (col K-1) must match the reference.
+    # Conv writes back to column 0; assert that slot.
     for n in range(num_spec_decodes):
-        final_slot = int(spec_state_indices_tensor[n, K - 1].item())
-        torch.testing.assert_close(conv_state[final_slot],
-                                   ref_conv_state[final_slot],
+        slot = int(spec_state_indices_tensor[n, 0].item())
+        torch.testing.assert_close(conv_state[slot],
+                                   ref_conv_state[slot],
                                    atol=atol,
                                    rtol=rtol)
 

--- a/tests/gdn_attn/test_gated_delta_rule.py
+++ b/tests/gdn_attn/test_gated_delta_rule.py
@@ -534,6 +534,7 @@ def test_gated_delta_rule_mtp(num_spec_decodes, num_spec_tokens, num_k_heads,
 
     assert head_k_dim == head_v_dim
     K = num_spec_tokens
+    num_spec = K - 1  # num_speculative_tokens
     num_actual_tokens = num_spec_decodes * K
     cache_batch_size = 200
 
@@ -551,8 +552,9 @@ def test_gated_delta_rule_mtp(num_spec_decodes, num_spec_tokens, num_k_heads,
                                       mixed_ba_size,
                                       dtype=dtype,
                                       device=device)
+    # Sliding-window layout: state_len = (width-1) + num_spec rows per line.
     conv_state = torch.randn(cache_batch_size,
-                             width - 1,
+                             (width - 1) + num_spec,
                              mixed_qkv_size,
                              dtype=dtype,
                              device=device)
@@ -574,7 +576,7 @@ def test_gated_delta_rule_mtp(num_spec_decodes, num_spec_tokens, num_k_heads,
                         device=device)
     dt_bias = torch.randn(num_v_heads // tp_size, dtype=dtype, device=device)
 
-    # Each spec seq owns K consecutive cache slots (cols 0..K-1).
+    # K slots per seq: conv uses only column 0, ssm uses all K columns.
     state_slots = random.sample(range(cache_batch_size), num_spec_decodes * K)
     spec_state_indices_tensor = torch.tensor(state_slots,
                                              dtype=torch.int32,

--- a/tests/gdn_attn/test_gdn_attn.py
+++ b/tests/gdn_attn/test_gdn_attn.py
@@ -91,11 +91,16 @@ def ref_gdn_attention(
     if conv_bias is not None:
         conv_bias = conv_bias.to(torch.float)
 
+    # Cache lines may reserve extra spec-decode rows; non-spec uses only the
+    # leading (width - 1) history rows.
+    width = conv_weights.shape[-1]
+
     for batch in range(batch_size):
         if has_initial_state[batch]:
-            conv_state_batch = conv_state[non_spec_state_indices_tensor[batch]]
+            conv_state_batch = conv_state[
+                non_spec_state_indices_tensor[batch]][:width - 1]
         else:
-            conv_state_batch = torch.zeros_like(conv_state[0])
+            conv_state_batch = torch.zeros_like(conv_state[0][:width - 1])
 
         batch_start_id = non_spec_query_start_loc[batch]
         batch_end_id = non_spec_query_start_loc[batch + 1]
@@ -103,8 +108,8 @@ def ref_gdn_attention(
 
         qkv_batch = qkv[batch_start_id:batch_end_id]
         qkv_conv_input = torch.cat([conv_state_batch, qkv_batch], dim=0)
-        conv_state[non_spec_state_indices_tensor[batch]] = qkv_conv_input[
-            batch_num_tokens:]
+        conv_state[non_spec_state_indices_tensor[batch]][:width - 1] = (
+            qkv_conv_input[batch_num_tokens:])
 
         qkv_conv_input = qkv_conv_input.transpose(0, 1).unsqueeze(0)
 
@@ -701,9 +706,9 @@ def ref_gdn_attention_spec(
     tp_size,
     reorder_input,
 ):
-    """Spec-decode reference. Mirrors the non-spec ref but routes gather/
-    scatter through spec_token_indx and writes per-step ssm-state + final
-    conv-state into spec_state_indices_tensor."""
+    """Spec-decode reference. Conv uses the single-cache-line sliding-window
+    convention (column 0 + row offset); ssm keeps the token-indexed
+    convention (per-step writeback to every column)."""
     eps = 0.000001
     scale = 1.0 / math.sqrt(head_k_dim)
     dtype = projected_states_qkvz.dtype
@@ -741,15 +746,24 @@ def ref_gdn_attention_spec(
 
         naccepted = int(num_accepted_tokens[n].item())
         init_col = max(naccepted - 1, 0)
-        init_slot = int(spec_state_indices_tensor[n, init_col].item())
-        final_conv_slot = int(spec_state_indices_tensor[n, K - 1].item())
+        init_slot = int(spec_state_indices_tensor[n, init_col].item())  # ssm
+        conv_slot = int(spec_state_indices_tensor[n, 0].item())  # conv, col 0
+        conv_state_len = conv_state.shape[1]
+        conv_init_row = init_col
 
-        # ---- conv1d on the K gathered tokens (with Width-1 history) ----
-        conv_state_batch = conv_state[init_slot].clone()
+        # conv1d: window = rows [init_row, init_row + width - 1), col 0
+        conv_line = conv_state[conv_slot]
+        prior = conv_line[conv_init_row:conv_init_row + (width - 1)].clone()
         qkv_batch = qkv[globals_]  # [K, qkv_elems]
-        qkv_conv_input = torch.cat([conv_state_batch, qkv_batch], dim=0)
-        # Final conv state goes ONLY to the last cache slot.
-        conv_state[final_conv_slot] = qkv_conv_input[-(width - 1):]
+        qkv_conv_input = torch.cat([prior, qkv_batch], dim=0)
+        # Roll the line: history from init_row+1, then the K draft inputs.
+        new_conv_line = torch.empty_like(conv_line)
+        hist_rows = conv_state_len - K
+        if hist_rows > 0:
+            new_conv_line[:hist_rows] = conv_line[
+                conv_init_row + 1:conv_init_row + 1 + hist_rows]
+        new_conv_line[hist_rows:] = qkv_batch
+        conv_state[conv_slot] = new_conv_line
 
         qkv_conv_in = qkv_conv_input.transpose(0, 1).unsqueeze(0).to(
             torch.float32)
@@ -839,6 +853,7 @@ def test_gdn_attention_mtp(num_spec_decodes, num_spec_tokens, num_k_heads,
 
     assert head_k_dim == head_v_dim
     K = num_spec_tokens
+    num_spec = K - 1  # num_speculative_tokens
     num_actual_tokens = num_spec_decodes * K
     cache_batch_size = 200
 
@@ -856,8 +871,9 @@ def test_gdn_attention_mtp(num_spec_decodes, num_spec_tokens, num_k_heads,
                                       mixed_ba_size,
                                       dtype=dtype,
                                       device=device)
+    # Sliding-window layout: state_len = (width-1) + num_spec rows per line.
     conv_state = torch.randn(cache_batch_size,
-                             width - 1,
+                             (width - 1) + num_spec,
                              mixed_qkv_size,
                              dtype=dtype,
                              device=device)
@@ -880,15 +896,15 @@ def test_gdn_attention_mtp(num_spec_decodes, num_spec_tokens, num_k_heads,
                         device=device)
     dt_bias = torch.randn(num_v_heads // tp_size, dtype=dtype, device=device)
 
-    # Each spec seq owns K consecutive cache slots (cols 0..K-1).
+    # K slots per seq: conv uses only column 0, ssm uses all K columns.
     state_slots = random.sample(range(cache_batch_size), num_spec_decodes * K)
     spec_state_indices_tensor = torch.tensor(state_slots,
                                              dtype=torch.int32,
                                              device=device).reshape(
                                                  num_spec_decodes, K)
-    # Mix of acceptance counts including the 0 edge case.
+    # Cover acceptance 0..K (0 edge case and num_accepted > 1).
     num_accepted_tokens = torch.tensor(
-        [random.randint(0, K) for _ in range(num_spec_decodes)],
+        [n % (K + 1) for n in range(num_spec_decodes)],
         dtype=torch.int32,
         device=device)
 
@@ -984,11 +1000,11 @@ def test_gdn_attention_mtp(num_spec_decodes, num_spec_tokens, num_k_heads,
                                rtol=rtol,
                                equal_nan=True)
 
-    # Final conv-state slot per seq (col K-1) must match the reference.
+    # Conv state uses a single cache line (column 0); assert that slot.
     for n in range(num_spec_decodes):
-        final_slot = int(spec_state_indices_tensor[n, K - 1].item())
-        torch.testing.assert_close(conv_state[final_slot],
-                                   ref_conv_state[final_slot],
+        conv_slot = int(spec_state_indices_tensor[n, 0].item())
+        torch.testing.assert_close(conv_state[conv_slot],
+                                   ref_conv_state[conv_slot],
                                    atol=atol,
                                    rtol=rtol)
         # All K ssm-state slots are written per-step.
@@ -1084,9 +1100,13 @@ def test_gdn_attention_mixed_spec_non_spec(num_spec_decodes, num_spec_tokens,
                                       dtype=dtype,
                                       device=device)
 
-    conv_state = torch.randn((cache_batch_size, width - 1, mixed_qkv_size),
-                             dtype=dtype,
-                             device=device)
+    # Shared conv cache: state_len=(width-1)+num_spec. non-spec uses only the
+    # leading width-1 rows; spec uses the full sliding window in column 0.
+    num_spec = K - 1
+    conv_state = torch.randn(
+        (cache_batch_size, (width - 1) + num_spec, mixed_qkv_size),
+        dtype=dtype,
+        device=device)
     ref_conv_state = conv_state.clone()
     ssm_state = torch.randn(
         (cache_batch_size, num_v_heads // tp_size, head_v_dim, head_k_dim),
@@ -1139,7 +1159,7 @@ def test_gdn_attention_mixed_spec_non_spec(num_spec_decodes, num_spec_tokens,
                                              device=device).reshape(
                                                  num_spec_decodes, K)
     num_accepted_tokens = torch.tensor(
-        [random.randint(0, K) for _ in range(num_spec_decodes)],
+        [n % (K + 1) for n in range(num_spec_decodes)],
         dtype=torch.int32,
         device=device)
     # Shuffle spec token positions WITHIN the trailing segment.
@@ -1268,11 +1288,11 @@ def test_gdn_attention_mixed_spec_non_spec(num_spec_decodes, num_spec_tokens,
                                    atol=atol,
                                    rtol=rtol)
 
-    # spec conv (final slot) / ssm (all K per-step slots) cache checks.
+    # spec conv (single cache line, column 0) / ssm (all K per-step slots).
     for n in range(num_spec_decodes):
-        final_slot = int(spec_state_indices_tensor[n, K - 1].item())
-        torch.testing.assert_close(conv_state[final_slot],
-                                   ref_conv_state[final_slot],
+        conv_slot = int(spec_state_indices_tensor[n, 0].item())
+        torch.testing.assert_close(conv_state[conv_slot],
+                                   ref_conv_state[conv_slot],
                                    atol=atol,
                                    rtol=rtol)
         for t in range(K):
@@ -1519,7 +1539,6 @@ def test_causal_conv1d_conv_elems_oob_guard(dtype):
                                         dtype=dtype, device=device)
     projected_states_ba = torch.randn((num_actual_tokens, mixed_ba_size),
                                       dtype=dtype, device=device)
-                                      
     conv_state = torch.randn((cache_batch_size, width - 1, mixed_qkv_size),
                              dtype=dtype, device=device)
     ref_conv_state = conv_state.clone()


### PR DESCRIPTION
## Problem
XPU GDN spec-decode conv1d kernel writes conv state token-indexed (a full
snapshot per speculative token, one per block-table column), but vLLM's
generic Mamba copy (get_conv_copy_spec) expects a single sliding-window cache
line read by row offset. When num_accepted_tokens > 1 at a cache-block
boundary, the wrong conv state migrates into the next block and corrupts
recurrent updates.

## Impact
Qwen3-Next / Qwen3.5 (GDN) on XPU with MTP: long-context generation collapses
into a narrow token/semantic loop, no runtime error. Larger block size only
delays it.

## Fix
Rewrite conv-state read/write in causal_conv1d_spec_kernel to the
single-cache-line sliding-window convention (column 0 + row offset
num_accepted-1), matching the CUDA/Triton reference and get_conv_copy_spec.
No vLLM change: kernel still takes the 2D cache_indices, conv uses column 0,
ssm keeps all columns (matches get_temporal_copy_spec). SSM and non-spec paths
unchanged.

## Test
Updated GDN spec UTs (tests/gdn_attn/test_causal_conv1d.py, test_gdn_attn.py).
Verify on XPU: pytest tests/gdn_attn/. E2E: Qwen3-Next/Qwen3.5 + MTP no longer
collapses, matches no-boundary control.

## Credit
Root cause was identified and reported by @recutita in vllm-project/vllm#53229
(vLLM-side workaround, not merged). This PR implements that kernel-side fix. Token-indexed
layout was introduced by vllm-xpu-kernels#368 (80372569).

## Model-level verification (XPU, real MTP serving)

Reproducer: recutita's harness (request.sh + compare.py) from #53229 —
3 deterministic recurrence prompts, greedy, seed-fixed, ignore_eos,
3800 generated tokens. Compared block 3200 (crosses the cache-block
boundary) vs block 4000->4032 (no-boundary control), same vLLM / model
/ params; only the xpu-kernels build differs.

Config: Qwen3.5-0.8B, MTP num_speculative_tokens=3, bf16, fp8 KV,
max-model-len 4096, max-num-seqs 1, enforce-eager.

Before fix (unpatched kernel):
  variant 1/2/3: DIFF at seq position ~3201-3203
  => output diverges right at the 3200 boundary (bug reproduced).

After fix (patched kernel, incl. #545 strided state_len fix):
  variant 1/2/3: MATCH, 3800 tokens each, coherent output
  => boundary-crossing output is token-for-token identical to the
     no-boundary control. Fix verified.

