### PR TITLE
Fix GDN conv state length for strided caches

### DIFF
--- a/benchmark/benchmark_causal_conv1d.py
+++ b/benchmark/benchmark_causal_conv1d.py
@@ -75,6 +75,7 @@ def estimate_bytes_moved(kwargs):
     ba_per_tok = nk * (2 * nv // nk)
     qkv_per_tok = nk * (2 * hk + hv * nv // nk)
     z_per_tok = nv * hv
+    conv_state_len = kwargs["conv_state"].shape[1]
     # {q,k,v} (=qkv_per_tok) plus b, a (2*nv) intermediates written out.
     inter_per_tok = qkv_per_tok + 2 * nv
 
@@ -85,7 +86,7 @@ def estimate_bytes_moved(kwargs):
     bytes_in = n_tok * (qkvz_per_tok + ba_per_tok) * bpe_in
     bytes_z = n_tok * z_per_tok * bpe_out
     bytes_inter = n_tok * inter_per_tok * bpe_out
-    bytes_conv_state = batch * (width - 1) * qkv_per_tok * bpe_in * 2  # RW
+    bytes_conv_state = batch * conv_state_len * qkv_per_tok * bpe_in * 2
     bytes_weights = qkv_per_tok * width * bpe_in
     # Bias is only read when conv_bias is provided.
     bytes_bias = qkv_per_tok * bpe_in if kwargs["conv_bias"] is not None else 0

--- a/benchmark/benchmark_gdn_attn.py
+++ b/benchmark/benchmark_gdn_attn.py
@@ -261,7 +261,9 @@ def _make_spec_inputs(shape: GdnShape, workload: Workload, dtype):
     projected_states_ba = torch.randn(
         (num_actual_tokens, mixed_ba_size), dtype=dtype, device=DEVICE)
     conv_state = torch.randn(
-        (cache_batch_size, width - 1, mixed_qkv_size),
+        (cache_batch_size,
+         width - 1 + num_spec_tokens,
+         mixed_qkv_size),
         dtype=dtype, device=DEVICE)
     ssm_state = torch.randn(
         (cache_batch_size, num_v_heads // tp_size, head_v_dim, head_k_dim),
@@ -356,6 +358,7 @@ def estimate_bytes_moved(kwargs):
     ba_per_tok = nk * (2 * nv // nk)
     qkv_per_tok = nk * (2 * hk + hv * nv // nk)
     out_per_tok = nv * hv
+    conv_state_len = kwargs["conv_state"].shape[1]
 
     batch = max(1,
                 kwargs["num_prefills"] + kwargs["num_decodes"]
@@ -363,7 +366,7 @@ def estimate_bytes_moved(kwargs):
 
     bytes_in = n_tok * (qkvz_per_tok + ba_per_tok) * bpe_in
     bytes_out = n_tok * (out_per_tok * 2) * bpe_out     # core_attn_out + z
-    bytes_conv_state = batch * (width - 1) * qkv_per_tok * bpe_in * 2  # RW
+    bytes_conv_state = batch * conv_state_len * qkv_per_tok * bpe_in * 2
     bytes_ssm_state = batch * nv * hk * hv * bpe_ssm * 2              # RW
     bytes_weights = qkv_per_tok * width * bpe_in + qkv_per_tok * bpe_in
 

--- a/csrc/xpu/gdn_attn/causal_conv1d.hpp
+++ b/csrc/xpu/gdn_attn/causal_conv1d.hpp
@@ -674,7 +674,10 @@ struct causal_conv1d_spec_kernel {
     // Single cache line (column 0); accepted window starts at row init_row.
     int init_row = num_accepted_tokens[batch_id] - 1;
     if (init_row < 0) init_row = 0;
-    const int state_len = conv_states_stride_0 / conv_elems;
+    // Match the effective state length used by the CUDA/Triton path.  The
+    // leading stride may span interleaved states from multiple layers, so it
+    // cannot be used to recover this dimension.
+    const int state_len = Width - 1 + (num_spec_tokens - 1);
     const int state_id = cache_indices[batch_id * cache_indices_stride_0 + 0];
     const bool has_conv_state = (state_id != pad_slot_id);
     T* state_line_ptr = has_conv_state

--- a/csrc/xpu/gdn_attn/gdn_attn_interface.cpp
+++ b/csrc/xpu/gdn_attn/gdn_attn_interface.cpp
@@ -94,6 +94,14 @@ std::vector<torch::Tensor> causal_conv1d_spec(
       "spec_state_indices_tensor must have size [num_spec_decodes, "
       "num_speculative_tokens + 1]");
   const int num_speculative_tokens = spec_state_indices_tensor.size(1) - 1;
+  const int64_t required_conv_state_len =
+      conv_weights.size(1) - 1 + num_speculative_tokens;
+  TORCH_CHECK(
+      conv_state.size(1) >= required_conv_state_len,
+      "conv_state must have at least ",
+      required_conv_state_len,
+      " rows for speculative decoding, but got ",
+      conv_state.size(1));
 
   TORCH_CHECK(
       num_accepted_tokens.is_contiguous(),

--- a/tests/gdn_attn/test_causal_conv1d.py
+++ b/tests/gdn_attn/test_causal_conv1d.py
@@ -554,11 +554,20 @@ def test_causal_conv1d_mtp(num_spec_decodes, num_spec_tokens, num_k_heads,
                                       device=device)
     # Sliding-window layout: state_len = (width-1) + num_spec rows per line.
     state_len = (width - 1) + num_spec
-    conv_state = torch.randn(cache_batch_size,
-                             state_len,
-                             mixed_qkv_size,
-                             dtype=dtype,
-                             device=device)
+    # vLLM stores every layer in one allocation and passes a per-layer view.
+    # Keep one extra cache line so a stride-derived state length corrupts only
+    # the guard storage instead of writing past the allocation.
+    num_layers = 3
+    layer_idx = 1
+    conv_state_storage = torch.randn(cache_batch_size + 1,
+                                     num_layers,
+                                     state_len,
+                                     mixed_qkv_size,
+                                     dtype=dtype,
+                                     device=device)
+    conv_state = conv_state_storage[:cache_batch_size, layer_idx]
+    assert conv_state.stride(0) != state_len * mixed_qkv_size
+    neighbor_states = conv_state_storage[:, (0, 2)].clone()
     ref_conv_state = conv_state.clone()
     conv_weights = torch.randn(mixed_qkv_size,
                                width,
@@ -642,6 +651,12 @@ def test_causal_conv1d_mtp(num_spec_decodes, num_spec_tokens, num_k_heads,
     rtol = 5e-2
 
     torch.testing.assert_close(z, ref_z, atol=atol, rtol=rtol)
+
+    # The kernel must not overwrite adjacent layers in the shared allocation.
+    torch.testing.assert_close(conv_state_storage[:, (0, 2)],
+                               neighbor_states,
+                               atol=0,
+                               rtol=0)
 
     # Conv writes back to column 0; assert that slot.
     for n in range(num_spec_decodes):

--- a/tests/gdn_attn/test_gated_delta_rule.py
+++ b/tests/gdn_attn/test_gated_delta_rule.py
@@ -534,6 +534,7 @@ def test_gated_delta_rule_mtp(num_spec_decodes, num_spec_tokens, num_k_heads,
 
     assert head_k_dim == head_v_dim
     K = num_spec_tokens
+    num_spec = K - 1  # num_speculative_tokens
     num_actual_tokens = num_spec_decodes * K
     cache_batch_size = 200
 
@@ -551,8 +552,9 @@ def test_gated_delta_rule_mtp(num_spec_decodes, num_spec_tokens, num_k_heads,
                                       mixed_ba_size,
                                       dtype=dtype,
                                       device=device)
+    # Sliding-window layout: state_len = (width-1) + num_spec rows per line.
     conv_state = torch.randn(cache_batch_size,
-                             width - 1,
+                             (width - 1) + num_spec,
                              mixed_qkv_size,
                              dtype=dtype,
                              device=device)
@@ -574,7 +576,7 @@ def test_gated_delta_rule_mtp(num_spec_decodes, num_spec_tokens, num_k_heads,
                         device=device)
     dt_bias = torch.randn(num_v_heads // tp_size, dtype=dtype, device=device)
 
-    # Each spec seq owns K consecutive cache slots (cols 0..K-1).
+    # K slots per seq: conv uses only column 0, ssm uses all K columns.
     state_slots = random.sample(range(cache_batch_size), num_spec_decodes * K)
     spec_state_indices_tensor = torch.tensor(state_slots,
                                              dtype=torch.int32,


### PR DESCRIPTION
# Essential Elements of an Effective PR Description Checklist

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.

## Purpose

PR #544 changes the XPU GDN speculative-decoding conv state to the
sliding-window convention used by vLLM and the CUDA/Triton implementation.
The updated kernel currently derives the effective state length from the
leading stride:

```cpp
const int state_len = conv_states_stride_0 / conv_elems;
```

This is correct for the contiguous cache tensors used by the kernel tests, but
not for the per-layer views used by vLLM. In an end-to-end Qwen3.5-0.8B run,
the conv cache passed to the kernel had:

```text
shape  = (3067, 6, 6144)
stride = (589824, 6144, 1)
```

The stride-based expression therefore produced a state length of 96 instead
of 6. The kernel then read and wrote beyond the selected layer's state and
corrupted adjacent layers in the shared cache allocation, causing MTP output
to diverge immediately.

This follow-up derives the effective state length from the convolution width
and speculative-token count, matching the CUDA/Triton path:

```cpp
const int state_len = Width - 1 + (num_spec_tokens - 1);
```

It also changes the existing MTP conv test to use a per-layer view into a
shared allocation and verifies that neighboring layers remain unchanged. The
public op now rejects speculative conv states shorter than the effective
sliding window, and the remaining direct spec-decode test and benchmark
callers allocate the enlarged state. The benchmark byte models use the actual
state length as well.

## Test Plan

Run the focused XPU GDN conv test:

```bash
python -m pytest -q -ra -p no:cacheprovider \
  tests/gdn_attn/test_causal_conv1d.py \
  -k test_causal_conv1d_mtp
```

Run the direct conv-to-delta speculative-decoding test:

```bash
python -m pytest -q -ra -p no:cacheprovider \
  tests/gdn_attn/test_gated_delta_rule.py \
  -k test_gated_delta_rule_mtp
```

Run the repository pre-commit suite:

```bash
pre-commit run --all-files
```

After this follow-up is merged into `fix/gdn`, PR #544's main-target CI will
run again and build an updated wheel. Use that artifact to repeat the
Qwen3.5-0.8B vLLM end-to-end comparison with MTP enabled and verify that its
output matches the no-boundary control.

## Test Result

The new strided-cache test was first run against the unmodified PR #544 wheel.
It failed on the first case by detecting writes into adjacent layers:

```text
Running 32 items in this shard
FAILED test_causal_conv1d_mtp[float16-True-silu-True-1-4-128-32-128-16-2-1]
Mismatched elements: 65528 / 13172736 (0.5%)
1 failed, 96 deselected in 2.78s
```

The applicable local source checks passed, including ruff, codespell, isort,
clang-format, SPDX-header checks, filename checks, and import-regex checks.

The fixed-kernel local XPU build and focused tests are in progress. Their
results will be added here when they complete. This PR targets `fix/gdn`, while
the GPU test workflow only runs for pull requests targeting `main`; after this
commit is incorporated, PR #544's main-target CI will also rebuild and test the
updated wheel.

## (Optional) Documentation Update

N/A. This fixes the internal state-length calculation without changing the
public API or documented behavior.

## AI assistance

Codex CLI (gpt-5.6-sol xhigh) helped inspect the runtime cache layout, identify
the stride-derived state-length error, and prepare the focused fix and
regression test. During my review, I pointed out an inconsistency in one
revision of the patch before settling on the final version. I reviewed the
resulting diff and ran the reported local checks.

**BEFORE SUBMITTING, PLEASE READ <https://docs.vllm.ai/en/latest/contributing>** (anything written below this line will be removed by GitHub Actions)