### PR TITLE
Add mini scope for test_kernels_mixed_precision

### DIFF
--- a/tests/test_punica_ops.py
+++ b/tests/test_punica_ops.py
@@ -41,6 +41,17 @@ MINI_PYTEST_PARAMS = {
         "seed": [0],
         "op_type": ["shrink", "expand"],
     },
+    "test_kernels_mixed_precision": {
+        "batches": [1],
+        "num_loras": [1],
+        "rank": [1],
+        "hidden_size": [128],
+        "nslices": [1],
+        "weight_dtype": [torch.float16],
+        "device": ["xpu:0"],
+        "seed": [0],
+        "op_type": ["shrink", "expand"],
+    },
 }
 
 


### PR DESCRIPTION
This PR adds a mini-scope test configuration for test_kernels_mixed_precision in tests/test_punica_ops.py. It covers mixed‑precision (float16) LoRA Punica kernels on XPU devices with a minimal parameter set (batches=1, num_loras=1, rank=1, hidden_size=128, nslices=1) for both shrink and expand ops.