### PR TITLE
[GDN] Write spec conv-state from registers instead of epilogue roll

### DIFF
--- a/csrc/xpu/gdn_attn/causal_conv1d.hpp
+++ b/csrc/xpu/gdn_attn/causal_conv1d.hpp
@@ -674,10 +674,9 @@ struct causal_conv1d_spec_kernel {
     // Single cache line (column 0); accepted window starts at row init_row.
     int init_row = num_accepted_tokens[batch_id] - 1;
     if (init_row < 0) init_row = 0;
-    // Match the effective state length used by the CUDA/Triton path.  The
-    // leading stride may span interleaved states from multiple layers, so it
-    // cannot be used to recover this dimension.
-    const int state_len = Width - 1 + (num_spec_tokens - 1);
+    // Effective state length (CUDA/Triton convention) is
+    // Width - 1 + (num_spec_tokens - 1); rows are written from registers
+    // below, so it is not materialized here.
     const int state_id = cache_indices[batch_id * cache_indices_stride_0 + 0];
     const bool has_conv_state = (state_id != pad_slot_id);
     T* state_line_ptr = has_conv_state
@@ -711,6 +710,18 @@ struct causal_conv1d_spec_kernel {
               [(init_row + i) * conv_elems + reordered_elems_id + e];
         }
       }
+      // Rolled-state history rows [0, Width-2) equal window slots
+      // [1, Width-1); write them back now from registers (the priming reads
+      // above are complete, lanes are disjoint across items) instead of an
+      // aliased in-place shift after the loop.
+#pragma unroll
+      for (int i = 1; i < Width - 1; ++i) {
+#pragma unroll
+        for (int e = 0; e < elems_per_item; ++e) {
+          state_line_ptr[(i - 1) * conv_elems + reordered_elems_id + e] =
+              local_input[Width * e + i];
+        }
+      }
     }
 
     for (int t_local = 0; t_local < num_spec_tokens; ++t_local) {
@@ -727,11 +738,20 @@ struct causal_conv1d_spec_kernel {
           }
         }
       }
-      // Load new input at the trailing slot.
+      // Load new input at the trailing slot; it is also rolled-state row
+      // (Width-2 + t_local), so store it from the register while it is hot.
 #pragma unroll
       for (int e = 0; e < elems_per_item; ++e) {
         local_input[Width * e + Width - 1] =
             mixed_qkvz[global_t * qkvz_elems + mixed_qkvz_id + e];
+      }
+      if (Width > 1 && has_conv_state) {
+#pragma unroll
+        for (int e = 0; e < elems_per_item; ++e) {
+          state_line_ptr
+              [(Width - 2 + t_local) * conv_elems + reordered_elems_id + e] =
+                  local_input[Width * e + Width - 1];
+        }
       }
 
       float res[elems_per_item];
@@ -790,31 +810,8 @@ struct causal_conv1d_spec_kernel {
       }
     }
 
-    // Roll the line back to column 0: rows [0, hist_rows) = shifted history
-    // from row init_row+1, rows [hist_rows, state_len) = the K draft inputs.
-    // In-place left shift is safe since src row (init_row+1+j) >= dst row j.
-    if (Width > 1 && has_conv_state) {
-      const int hist_rows = state_len - num_spec_tokens;
-      for (int j = 0; j < state_len; ++j) {
-        if (j < hist_rows) {
-          const int src_row = init_row + 1 + j;
-#pragma unroll
-          for (int e = 0; e < elems_per_item; ++e) {
-            state_line_ptr[j * conv_elems + reordered_elems_id + e] =
-                state_line_ptr[src_row * conv_elems + reordered_elems_id + e];
-          }
-        } else {
-          const int draft_t = j - hist_rows;
-          const int token_id_local = batch_id * num_spec_tokens + draft_t;
-          const int global_t = token_indx[token_id_local];
-#pragma unroll
-          for (int e = 0; e < elems_per_item; ++e) {
-            state_line_ptr[j * conv_elems + reordered_elems_id + e] =
-                mixed_qkvz[global_t * qkvz_elems + mixed_qkvz_id + e];
-          }
-        }
-      }
-    }
+    // Rolled state (rows [0, state_len)) was already written from registers:
+    // history rows during priming, draft rows as each input was loaded.
   }
 
  private:


### PR DESCRIPTION
## Purpose

#544 introduced the sliding-window conv-state convention for the spec-decode causal_conv1d kernel. Its epilogue rebuilds the state line in place after the main loop: an aliased same-pointer shift (which blocks vectorization), a runtime-bounded loop with a per-iteration branch, and K redundant global re-reads of `mixed_qkvz`.

This PR removes the epilogue entirely. The rolled state's history rows equal the priming window's register slots [1, Width-1), so they are written back immediately after priming (compile-time unrolled, write-only, no aliasing); each draft input is stored to its rolled-state row from the register at load time. State content is bit-identical by construction: history rows are the same values read at priming, and draft rows use the identical `mixed_qkvz` indexing expression the epilogue read. Edge cases preserved: Width==1 skip, pad-slot skip, num_spec_tokens==1, num_accepted clamp.

## Test Plan

- `pytest tests/gdn_attn` on BMG hardware (2x Arc B70, oneAPI 2026.0), full scope.
- `benchmark/benchmark_causal_conv1d.py` spec workloads, before/after.
- End-to-end MTP serving (Qwen3.5-class GDN model, TP=2, num_speculative_tokens=1).

## Test Result

- tests/gdn_attn: **1303 passed / 0 failed / 128 skipped** — identical to pre-change baseline, including the #544 boundary-crossing conv-state tests, the mixed spec/non-spec batch tests, and a bitwise mixed-batch differential. (Run with this change applied atop a fork of current main; the diff is confined to causal_conv1d_spec_kernel.)
- Microbench spec workloads (bf16, 30 iters): **-1% to -4%** latency on Qwen3-Next-80B shapes, up to -11% on synthetic shapes; no regression outside noise on any shape.
- End-to-end MTP serving TPOT: neutral — the kernel is ~64-72 us/call, so this is a codegen/traffic cleanup at kernel level, not an end-to-end win.

## Related work

Open PR #476 also optimizes this file (load/store vectorization, batch-id binary search) but targets the pre-#544 version of this function and does not address the epilogue roll. The changes are complementary; happy to coordinate rebase order.

---
AI-assisted change (Claude Code); reviewed, tested, and submitted by a human.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016G7BGjSYFhwRoAFxY7N76a