### PR TITLE
[Kernel] Add NVFP4 (E2M1 + E4M3 group-16) B-dtype to the Xe2 grouped MoE GEMM

### DIFF
--- a/csrc/xpu/grouped_gemm/xe_2/gemm_xe2.hpp
+++ b/csrc/xpu/grouped_gemm/xe_2/gemm_xe2.hpp
@@ -63,6 +63,17 @@ enum class B_DTYPE {
   PER_TENSOR_FP8,
   MXFP8,
   BLOCK_FP8,
+  // NVFP4: packed E2M1 weights with E4M3 block scales over 16 elements, as
+  // shipped by NVIDIA-ecosystem checkpoints (ModelOpt, compressed-tensors).
+  // It cannot reuse the MXFP4 path because both axes differ: MXFP4 scales are
+  // E8M0 (exponent-only) over 32 elements, decoded by shifting the byte into
+  // the float exponent field, which produces garbage for E4M3 bits.
+  //
+  // The per-expert FP32 global scale that NVFP4 checkpoints also carry is not
+  // handled here. It is constant per expert, so it factors out of the dot
+  // product and is cheaper for the caller to apply to that expert's output
+  // rows than to apply per weight.
+  NVFP4,
 };
 
 template <typename TB>
@@ -282,6 +293,16 @@ CUTE_DEVICE void xe_gemm_4bits(
   auto wg_tile = mma.tile_mnk();
   auto wg_coord = make_coord(wg_m, wg_n, 0);
 
+  // A block-scaled tile must not span more than one scale group. The scale
+  // reload below is gated on `k_tile * tile_k % group_size == 0`, so a tile
+  // whose K extent exceeds group_size would load only the first group's scale
+  // and apply it across the whole tile -- wrong results, no error. Fail the
+  // build instead.
+  static_assert(
+      cute::size<2>(decltype(wg_tile){}) <= group_size,
+      "tile_k must not exceed the block-scale group size; pair a group_size "
+      "of 16 with a tile_k=16 policy (see w4a16_policy_*_k16)");
+
   Tensor gA = local_tile(
       cA, select<0, 2>(wg_tile), make_coord(wg_m, _));  // (BLK_M,BLK_K,k)
   Tensor gB = local_tile(
@@ -422,6 +443,21 @@ CUTE_DEVICE void xe_gemm_4bits(
               int k_block = group_idx;
               scale = static_cast<scaleStoreType>(
                   Scales[k_block * n_blocks + n_block]);
+            } else if constexpr (TENSOR_B_DTYPE == B_DTYPE::NVFP4) {
+              // NVFP4: uint8 E4M3 bits -> float. E4M3 carries a mantissa, so
+              // the E8M0 `bits << 23` shift does not apply; go through
+              // cutlass's float_e4m3_t conversion, which is table-free bit
+              // manipulation and lands in the same registers.
+              //
+              // Scale indexing is identical to the MX path -- [N,
+              // K/group_size] per expert, row-major -- so no rearrangement is
+              // needed for checkpoints that already store scales that way.
+              uint8_t bits =
+                  Scales
+                      [(n_tile_start + n_sg_start + sg_local_n) * group_num +
+                       group_idx];
+              scale = static_cast<scaleStoreType>(static_cast<float>(
+                  reinterpret_cast<cutlass::float_e4m3_t const&>(bits)));
             } else {
               // MXFP4 / MXFP8: uint8 E8M0 bits -> float via (bits << 23).
               uint32_t scale_u32 =

--- a/csrc/xpu/grouped_gemm/xe_2/gemm_xe2_policy.hpp
+++ b/csrc/xpu/grouped_gemm/xe_2/gemm_xe2_policy.hpp
@@ -104,4 +104,37 @@ class w4a16_policy_m_32 : public xe_gemm_policy_base {
   using SGLayout = Layout<Shape<_1, _4, _1>, Stride<_4, _1, _0>>;
 };
 
+// NVFP4 ladder. These mirror the w4a16 policies above with the K tile halved
+// to 16 so that tile_k == group_size for NVFP4's 16-element block scales.
+// One tile then covers exactly one scale group, which keeps the existing
+// scale-reload gate in xe_gemm_4bits (`k_tile * tile_k % group_size == 0`)
+// correct without touching the mainloop. Halving tile_k also halves the work
+// per K iteration, so these are not interchangeable with the tile_k=32
+// variants on performance grounds.
+class w4a16_policy_k16 : public xe_gemm_policy_base {
+ public:
+  using WGTile = Shape<_128, _256, _16>;
+  using SGLayout = Layout<Shape<_4, _8, _1>, Stride<_8, _1, _0>>;
+
+  using GmemTiledCopyD = XE_STORE_2D<16, 8, 32>;
+};
+
+class w4a16_policy_m_8_k16 : public xe_gemm_policy_base {
+ public:
+  using WGTile = Shape<_8, _64, _16>;
+  using SGLayout = Layout<Shape<_1, _4, _1>, Stride<_4, _1, _0>>;
+};
+
+class w4a16_policy_m_16_k16 : public xe_gemm_policy_base {
+ public:
+  using WGTile = Shape<_16, _64, _16>;
+  using SGLayout = Layout<Shape<_1, _4, _1>, Stride<_4, _1, _0>>;
+};
+
+class w4a16_policy_m_32_k16 : public xe_gemm_policy_base {
+ public:
+  using WGTile = Shape<_32, _64, _16>;
+  using SGLayout = Layout<Shape<_1, _4, _1>, Stride<_4, _1, _0>>;
+};
+
 }  // namespace MoE

--- a/csrc/xpu/grouped_gemm/xe_2/grouped_gemm_xe2.hpp
+++ b/csrc/xpu/grouped_gemm/xe_2/grouped_gemm_xe2.hpp
@@ -88,8 +88,12 @@ CUTE_DEVICE void MoEGEMM(
     int32_t* atomic_buffer,
     const sycl::local_accessor<int32_t, 1>& slm_mem_const) {
   constexpr char actual_layout_of_B = LayoutKindB ^ ('R' ^ 'C');
+  // NVFP4 joins the 4-bit family here. This gate drives the /2 on the weight
+  // offset (two values per byte) and the [E, N, K/group_size] scale offset, so
+  // omitting it would address weights and scales as though they were 16-bit.
   static constexpr bool is_B_4bits =
-      (TENSOR_B_DTYPE == B_DTYPE::INT4 || TENSOR_B_DTYPE == B_DTYPE::MXFP4);
+      (TENSOR_B_DTYPE == B_DTYPE::INT4 || TENSOR_B_DTYPE == B_DTYPE::MXFP4 ||
+       TENSOR_B_DTYPE == B_DTYPE::NVFP4);
 
   auto item = sycl::ext::oneapi::this_work_item::get_nd_item<3>();
   auto wg_tile = mma.tile_mnk();
@@ -168,7 +172,10 @@ CUTE_DEVICE void MoEGEMM(
       if constexpr (TENSOR_B_DTYPE == B_DTYPE::INT4) {
         return make_moe_tensor<int4_t, actual_layout_of_B>(
             reinterpret_cast<int4_t*>(ptr_B_curr_batch), gemm_n, gemm_k);
-      } else if constexpr (TENSOR_B_DTYPE == B_DTYPE::MXFP4) {
+      } else if constexpr (
+          TENSOR_B_DTYPE == B_DTYPE::MXFP4 ||
+          TENSOR_B_DTYPE == B_DTYPE::NVFP4) {
+        // Identical packed E2M1 payload for both; only the scales differ.
         return make_moe_tensor<float_e2m1_t, actual_layout_of_B>(
             reinterpret_cast<float_e2m1_t*>(ptr_B_curr_batch), gemm_n, gemm_k);
       } else {
@@ -204,7 +211,15 @@ CUTE_DEVICE void MoEGEMM(
       D_tensor,                         \
       tile_coord,                       \
       mma);
-        if (group_size == 32) {
+        if constexpr (TENSOR_B_DTYPE == B_DTYPE::NVFP4) {
+          // NVFP4 block scales are defined at group 16, and the host entry
+          // pairs this dtype exclusively with a tile_k=16 policy so that one
+          // tile covers exactly one scale group. Dispatching at compile time
+          // keeps the other group sizes out of this instantiation, and keeps
+          // group_size 16 out of the tile_k=32 instantiations, which
+          // xe_gemm_4bits static_asserts against.
+          XE_GEMM_4BITS_CALLER(16)
+        } else if (group_size == 32) {
           XE_GEMM_4BITS_CALLER(32)
         } else if (group_size == 64) {
           XE_GEMM_4BITS_CALLER(64)

--- a/csrc/xpu/grouped_gemm/xe_2/grouped_gemm_xe2_interface.hpp
+++ b/csrc/xpu/grouped_gemm/xe_2/grouped_gemm_xe2_interface.hpp
@@ -191,8 +191,14 @@ at::Tensor cutlass_grouped_gemm_xe2_impl(
   bool is_weight_fp8 =
       ((B_dtype == at::kFloat8_e4m3fn) || (B_dtype == at::kFloat8_e5m2));
   bool is_B_int4 = (B_dtype == at::kChar) && ptr_scales.has_value();
-  bool is_B_mxfp4 =
-      (B_dtype == at::kFloat4_e2m1fn_x2) && ptr_scales.has_value();
+  // NVFP4 and MXFP4 share the packed E2M1 weight dtype and are told apart by
+  // the scale dtype: NVFP4 carries E4M3 block scales (group 16), MXFP4 carries
+  // E8M0 (group 32). Checking this keeps E4M3 scales from being decoded as
+  // E8M0, which silently produces wrong results.
+  bool is_B_nvfp4 = (B_dtype == at::kFloat4_e2m1fn_x2) &&
+      ptr_scales.has_value() && (ptr_scales->dtype() == at::kFloat8_e4m3fn);
+  bool is_B_mxfp4 = (B_dtype == at::kFloat4_e2m1fn_x2) &&
+      ptr_scales.has_value() && !is_B_nvfp4;
   // MXFP8: FP8 weights + E8M0 (uint8 / float8_e8m0fnu) block scales, gs=32.
   bool is_B_mxfp8 = false;
   if (is_weight_fp8 && ptr_scales.has_value() && ptr_scales->dim() == 3) {
@@ -228,7 +234,7 @@ at::Tensor cutlass_grouped_gemm_xe2_impl(
   int B_E = ptr_B.size(0);
   int B_K = ptr_B.size(1);
   int B_N = ptr_B.size(2);
-  if (is_B_int4 || is_B_mxfp4) {
+  if (is_B_int4 || is_B_mxfp4 || is_B_nvfp4) {
     B_K = ptr_B.size(2) * 2;
     B_N = ptr_B.size(1);
   }
@@ -278,7 +284,7 @@ at::Tensor cutlass_grouped_gemm_xe2_impl(
       group_size,                                                              \
       static_cast<int*>(atomic_buffer.data_ptr()));
 
-  if (is_B_int4 || is_B_mxfp4) {
+  if (is_B_int4 || is_B_mxfp4 || is_B_nvfp4) {
     TORCH_CHECK(ptr_scales.has_value(), "w8a16 grouped gemm must have scales");
     TORCH_CHECK(ptr_scales->is_contiguous(), "ptr_scales must be contiguous");
     TORCH_CHECK(
@@ -295,10 +301,18 @@ at::Tensor cutlass_grouped_gemm_xe2_impl(
     int group_num = ptr_scales->size(2);
     group_size = K / group_num;
 
-    TORCH_CHECK(
-        group_size == 32 || group_size == 64 || group_size == 128 ||
-            group_size == 256,
-        "group_size must be 32, 64, 128 or 256");
+    if (is_B_nvfp4) {
+      TORCH_CHECK(
+          group_size == 16,
+          "nvfp4 group_size must be 16 (E4M3 block scales are defined over 16 "
+          "elements); got ",
+          group_size);
+    } else {
+      TORCH_CHECK(
+          group_size == 32 || group_size == 64 || group_size == 128 ||
+              group_size == 256,
+          "group_size must be 32, 64, 128 or 256");
+    }
 
 #define W4A16LauncherCallER(policy)    \
   if (is_B_int4) {                     \
@@ -351,7 +365,9 @@ at::Tensor cutlass_grouped_gemm_xe2_impl(
     }                                  \
   }
 
-    if (A_avg_M <= 4) {
+    if (is_B_nvfp4) {
+      // handled by the NVFP4 ladder below
+    } else if (A_avg_M <= 4) {
       using policy = w4a16_policy_m_8;
       W4A16LauncherCallER(policy);
     } else if (A_avg_M <= 8) {
@@ -365,6 +381,52 @@ at::Tensor cutlass_grouped_gemm_xe2_impl(
       W4A16LauncherCallER(policy);
     }
 #undef W4A16LauncherCallER
+
+    // NVFP4 needs its own ladder because correctness requires tile_k == 16,
+    // so it cannot share the tile_k=32 policies above. Tiers mirror the w4a16
+    // ladder. Guarded so the tile_k=16 templates are only instantiated for
+    // this dtype.
+    if (is_B_nvfp4) {
+#define NVFP4LauncherCallER(policy)    \
+  if (A_dtype == at::kBFloat16) {      \
+    using scalar_t = bfloat16_t;       \
+    MoEGEMMLauncherCallER(             \
+        'R',                           \
+        'C',                           \
+        policy,                        \
+        A_DTYPE::BITS16,               \
+        B_DTYPE::NVFP4,                \
+        scalar_t,                      \
+        uint8_t,                       \
+        uint8_t);                      \
+  } else if (A_dtype == at::kHalf) {   \
+    using scalar_t = half_t;           \
+    MoEGEMMLauncherCallER(             \
+        'R',                           \
+        'C',                           \
+        policy,                        \
+        A_DTYPE::BITS16,               \
+        B_DTYPE::NVFP4,                \
+        scalar_t,                      \
+        uint8_t,                       \
+        uint8_t);                      \
+  }
+
+    if (A_avg_M <= 4) {
+      using policy = w4a16_policy_m_8_k16;
+      NVFP4LauncherCallER(policy);
+    } else if (A_avg_M <= 8) {
+      using policy = w4a16_policy_m_16_k16;
+      NVFP4LauncherCallER(policy);
+    } else if (A_avg_M <= 128) {
+      using policy = w4a16_policy_m_32_k16;
+      NVFP4LauncherCallER(policy);
+    } else {
+      using policy = w4a16_policy_k16;
+      NVFP4LauncherCallER(policy);
+    }
+#undef NVFP4LauncherCallER
+    }
   } else if (is_B_mxfp8) {
     TORCH_CHECK(ptr_scales.has_value(), "mxfp8 grouped gemm must have scales");
     TORCH_CHECK(ptr_scales->is_contiguous(), "ptr_scales must be contiguous");

--- a/tests/fused_moe/test_grouped_gemm.py
+++ b/tests/fused_moe/test_grouped_gemm.py
@@ -444,6 +444,123 @@ def test_xe_grouped_gemm_mxfp4(m, n, k, e, topk, dtype, has_bias):
     torch.testing.assert_close(output, ref, rtol=1e-2, atol=1e-2)
 
 
+def dequantize_nvfp4(qweight, scales, group_size, dtype):
+    """Dequant packed E2M1 weight [N, K/2] with E4M3 scales [N, K/group]."""
+    import numpy as np
+    k = qweight.shape[1] * 2
+    n = qweight.shape[0]
+    unpack_idx = np.array([0, 1])
+    data = qweight[:, [i // 2 for i in range(k)]]
+    shift = (torch.tensor(unpack_idx[[i % 2 for i in range(k)]],
+                          dtype=torch.int32,
+                          device="xpu")[None, :].expand([n, -1]) * 4)
+    dst_data = (data >> shift) & 0xF
+
+    table = torch.tensor([
+        +0.0,
+        0.5,
+        1.0,
+        1.5,
+        2.0,
+        3.0,
+        4.0,
+        6.0,
+        -0.0,
+        -0.5,
+        -1.0,
+        -1.5,
+        -2.0,
+        -3.0,
+        -4.0,
+        -6.0,
+    ],
+                         dtype=dtype,
+                         device="xpu")
+    dst_data = table[dst_data]
+    # E4M3 block scales carry a mantissa, so unlike MXFP4's E8M0 they are
+    # ordinary small floats rather than a value reconstructed from an exponent
+    # field.
+    expand_scales = scales[:, [i // group_size for i in range(k)]]
+    dst_scale = expand_scales.to(torch.float32).to(dtype)
+
+    return (dst_data * dst_scale).to(dtype)
+
+
+# Upstream grouped-GEMM coverage runs at 16 experts. 85 is included here
+# because a routed MoE layer commonly shards far more experts than that onto
+# one device, and at these token counts it also exercises empty experts.
+NVFP4_NUM_EXPERTS = [16, 85]
+
+
+@pytest.mark.parametrize("m,n,k", FUSED_MOE_MNK_FACTORS)
+@pytest.mark.parametrize("e", NVFP4_NUM_EXPERTS)
+@pytest.mark.parametrize("topk", TOP_KS)
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16],
+                         ids=format_tc)
+@pytest.mark.parametrize("has_bias", [False, True])
+def test_xe_grouped_gemm_nvfp4(m, n, k, e, topk, dtype, has_bias):
+    """Native NVFP4 (E2M1 + E4M3 group-16) grouped GEMM vs dequant gold."""
+    seed_everything(7)
+    num_experts = e
+    group_size = 16
+    group_num = k // group_size
+    total_m = m * topk
+    # input
+    input_A = torch.randn((total_m, k), dtype=dtype,
+                          device=DEVICE).contiguous()
+    ref_A = input_A
+    # weight
+    input_B_nvfp4 = (torch.randint(0,
+                                   0xff, [num_experts, n, k // 2],
+                                   device=DEVICE)).to(torch.uint8)
+    # scale: E4M3 in [0.5, 1.0), which keeps the dequantised weights in range
+    # for both bf16 and fp16 while still exercising the mantissa bits that
+    # distinguish E4M3 from E8M0.
+    scale_B = (torch.rand((num_experts, n, group_num), device=DEVICE) * 0.5 +
+               0.5).to(torch.float8_e4m3fn)
+
+    if has_bias:
+        bias = torch.randn((num_experts, n), dtype=dtype, device=DEVICE) * 100
+    else:
+        bias = None
+
+    input_B_16 = torch.empty(num_experts, n, k, dtype=dtype, device=DEVICE)
+    for i in range(num_experts):
+        input_B_16[i] = dequantize_nvfp4(input_B_nvfp4[i], scale_B[i],
+                                         group_size, dtype)
+
+    # output offset
+    num_rows_per_expert = torch.zeros(num_experts,
+                                      device=DEVICE,
+                                      dtype=torch.int32)
+    init_rows_for_experts(m, topk, num_rows_per_expert)
+
+    output = torch.empty((total_m, n), dtype=dtype, device=DEVICE)
+    input_B_nvfp4 = input_B_nvfp4.view(torch.float4_e2m1fn_x2)
+    cutlass_grouped_gemm_xe2(input_A, input_B_nvfp4, scale_B, bias, output,
+                             num_rows_per_expert, n, k, num_experts)
+    # ref gg
+    ref = []
+    pre_token_sum = 0
+    for i in range(num_experts):
+        cur_token_num = num_rows_per_expert[i]
+        if cur_token_num == 0:
+            continue
+        # mma uses fp32 as calculate dtype
+        # so here use fp32 to avoid accuracy error
+        input = ref_A[pre_token_sum:pre_token_sum + cur_token_num, :].to(
+            torch.float32)
+        weight = input_B_16[i, :, :].to(torch.float32)
+        expert_output_fp32 = input @ weight.T
+        if has_bias:
+            expert_output_fp32 += bias[i]
+        ref.append(expert_output_fp32.to(dtype))
+        pre_token_sum += cur_token_num
+    ref = torch.cat(ref, dim=0)
+
+    torch.testing.assert_close(output, ref, rtol=1e-2, atol=1e-2)
+
+
 def dequantize_mxfp8_wei_kn(wei, wei_scale, group_size=32):
     """Dequant MXFP8 weight [K, N] with scales [K/group, N] (E8M0 bits)."""
     scale_f = wei_scale.view(torch.float8_e8m0fnu).to(torch.float32)


### PR DESCRIPTION
## Purpose

The Xe2 grouped MoE GEMM supports MXFP4 (E2M1 weights, E8M0 scales at group 32)
but not NVFP4 (E2M1 weights, **E4M3** scales at group **16**), which is the
4-bit format NVIDIA-ecosystem checkpoints actually ship — ModelOpt and
compressed-tensors both emit it. Today running such a checkpoint on Xe2 requires
requantizing to MXFP4, and e8m0/block-32 is a lossier scale representation than
e4m3/block-16, so that conversion costs accuracy.

This adds NVFP4 as a B-dtype so those checkpoints run as-is.

NVFP4 cannot reuse the MXFP4 path, because it differs on both axes:

- **Scale decode.** MXFP4's E8M0 is exponent-only and is decoded by shifting the
  byte into the float exponent field (`bits << 23`). E4M3 carries a mantissa, so
  that shift produces garbage. This goes through `cutlass::float_e4m3_t`.
- **Group size.** 16 rather than 32. The scale reload in `xe_gemm_4bits` is gated
  on `k_tile * tile_k % group_size == 0`, so a `tile_k` of 32 would span two
  16-element scale groups and apply only the first group's scale to all 32
  values — wrong results, no error.

What is in the change:

- `B_DTYPE::NVFP4`, appended so existing enumerator values are unchanged, plus
  the E4M3 decode branch. Scale indexing is identical to the MX path
  (`[N, K/group_size]` per expert, row-major), so no layout change is required.
- A `tile_k=16` policy ladder (`w4a16_policy_*_k16`) mirroring the existing
  w4a16 tiers, so `tile_k == group_size` and the existing reload gate stays
  correct without touching the mainloop.
- NVFP4 is told apart from MXFP4 by the **scale dtype**. As a side effect this
  stops an E4M3 scale tensor from being silently decoded as E8M0, which is what
  happens today.
- A `static_assert` that `tile_k` does not exceed the block-scale group size, so
  pairing a group size with too large a K tile is a build error rather than
  wrong numbers.

The per-expert FP32 global scale that NVFP4 checkpoints also carry is
deliberately left to the caller. It is constant per expert, so it factors out of
the dot product and is cheaper to apply to that expert's output rows than per
weight.

## Test Plan

Added `test_xe_grouped_gemm_nvfp4` to `tests/fused_moe/test_grouped_gemm.py`,
mirroring `test_xe_grouped_gemm_mxfp4` — same `FUSED_MOE_MNK_FACTORS`, both
activation dtypes, bias on and off — against an fp32 dequant reference.

Two deliberate additions to coverage:

- **E=85 as well as E=16.** Existing grouped-GEMM coverage runs at 16 experts. A
  routed MoE layer commonly shards more than that onto one device, and at these
  token counts E=85 also exercises **empty experts** (`init_rows_for_experts`
  leaves most experts with zero rows at `m=1`/`m=4`), which is the case the
  persistent scheduler has to walk past.
- A negative test of the new `static_assert`, done by hand (below).

```
# correctness
pytest tests/fused_moe/test_grouped_gemm.py -k nvfp4
# regression on the paths this touches
pytest tests/fused_moe/test_grouped_gemm.py -k mxfp4
pytest tests/fused_moe/test_grouped_gemm.py -k "int4 or mxfp8 or block_fp8"
```

Hardware: Intel Arc Pro B70 (Battlemage G31), driver `1.15.39122+12`, NEO
`26.27.39122.12`, oneAPI 2026.1, torch 2.13.0+xpu, JIT spir64,
`SYCL_UR_USE_LEVEL_ZERO_V2=0`.

## Test Result

Build: `make -C build/temp grouped_gemm_xe_2` succeeds for `bmg-g31-a0`, no new
warnings attributable to this change.

```
NVFP4   (new)                          32 passed, 112 deselected in 52.10s
MXFP4   (pre-existing, regression)     16 passed, 128 deselected in 10.52s
int4 / mxfp8 / block_fp8 (regression)  32 passed, 112 deselected in 18.82s
```

The `static_assert` was verified to fire, by temporarily pointing the NVFP4
ladder at `w4a16_policy` (`tile_k=32`) and rebuilding:

```
csrc/xpu/grouped_gemm/xe_2/gemm_xe2.hpp:302:7: error: static assertion failed due to
requirement 'cute::size(cute::tuple<cute::C<128>, cute::C<256>, cute::C<32>>{}) <= group_size':
tile_k must not exceed the block-scale group size; pair a group_size of 16 with a
tile_k=16 policy (see w4a16_policy_*_k16)
```

### Performance, and a caveat I want to be upfront about

Timed through the same `cutlass_grouped_gemm_xe2` entry, same device, same
M/N/K/E, `E=85`, `n=2048`, `k=3072`, fp16 activations, uniform fill, best of
3 x 20 iterations:

| variant | rows/expert | total_m | ms | TFLOP/s |
|---|---|---|---|---|
| nvfp4 | 30 | 2550 | 1.1986 | 26.8 |
| mxfp4 | 30 | 2550 | 0.6267 | 51.2 |
| bits16 | 30 | 2550 | 2.2931 | 14.0 |
| nvfp4 | 120 | 10200 | 4.8562 | 26.4 |
| mxfp4 | 120 | 10200 | 2.0949 | 61.3 |
| bits16 | 120 | 10200 | 2.2234 | 57.7 |

**NVFP4 is 1.9x-2.3x slower than MXFP4 here, and at 120 rows/expert it is slower
than 16-bit.** That is not a measurement artifact and I do not want to bury it.
The cause is structural: correctness forces `tile_k == 16`, which halves the K
work per mainloop iteration relative to the `tile_k=32` policies every other
4-bit variant uses. The policy comment says the same thing.

So the value of this PR is capability, not throughput: it lets an NVFP4
checkpoint run without a lossy requantization step. It is not a faster 4-bit
path, and anyone who can requantize to MXFP4 without caring about the accuracy
delta should keep using MXFP4.

The obvious follow-up, which I have deliberately kept out of this PR to keep it
single-purpose, is to let one `tile_k=32` tile carry two scale groups so NVFP4
can use the wider tiles. That means touching the mainloop's scale handling
rather than just adding a dtype, and it should be its own change with its own
measurements. Happy to take direction on whether you want that, and whether
you would rather land it as one change instead — in which case I will close this
and come back with both.

## (Optional) Documentation Update

None. If you would like the group-size constraint written up somewhere more
discoverable than the `static_assert` message and the policy comment, point me at
the right file and I will add it.
