### PR TITLE
[kernel] [Config] Add missing DeepSeek-V2 non-causal chunk-prefill kernel configs

### DIFF
--- a/csrc/xpu/attn/kernel_configs/chunk_prefill_default.conf
+++ b/csrc/xpu/attn/kernel_configs/chunk_prefill_default.conf
@@ -30,6 +30,7 @@
 192,true,true,false,false,false
 192,false,true,false,false,false
 192,false,true,false,false,true
+192,false,false,false,false,true
 
 # --- Falcon-7B (MQA, head_size=64); GQA ratio handled by per-head grid -------
 # paged (chunked decode/prefill with page table) + non-paged (initial prompt)


### PR DESCRIPTION
## Problem

When running **DeepSeek-V2-Lite-Instruct-FP8** (and other DeepSeek-V2/V3 models) with chunked prefill, the engine falls back to the PyTorch reference attention path with this error:

```
XPU kernel not compiled for this config, falling back to PyTorch reference attention.
Chunk prefill kernel tuple not compiled for this configuration.

Add this line to your chunk_prefill config file (csrc/xpu/attn/kernel_configs/chunk_prefill_default.conf):
  192,false,false,false,false,true
```

## Root Cause

DeepSeek-V2's MLA attention uses `is_causal=False` (non-causal) mode during chunked prefill batches. The LSE output variant (`lse=true`) is required for chunked prefill state  
