### PR TITLE
[KV offload] Replace Tensor pointer parameters with int64_t to reduce overhead

### DIFF
--- a/csrc/ops.h
+++ b/csrc/ops.h
@@ -291,14 +291,9 @@ void xpu_memcpy_sync(
     int64_t kind,
     int64_t device = -1);
 
-// ptr is a single-element uint64 tensor holding the raw address. A scalar
-// int64 op argument cannot losslessly carry every 64-bit pointer bit
-// pattern (addresses with bit 63 set overflow the signed range and fail to
-// cast from Python), so the address is passed via a uint64 Tensor instead,
-// matching the pattern used by swap_blocks_batch.
-bool xpu_host_register(const torch::Tensor& ptr, int64_t n_bytes);
+bool xpu_host_register(int64_t ptr, int64_t n_bytes);
 
-bool xpu_host_unregister(const torch::Tensor& ptr);
+bool xpu_host_unregister(int64_t ptr);
 
 void merge_attn_states(
     torch::Tensor& output,

--- a/csrc/torch_bindings.cpp
+++ b/csrc/torch_bindings.cpp
@@ -250,9 +250,9 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
   // memory outside the caching host allocator (e.g. a shared mmap region) has
   // no other way to become pinned. Returns false if registration is
   // unsupported, in which case transfers remain correct but slower.
-  ops.def("xpu_host_register(Tensor ptr, int n_bytes) -> bool");
+  ops.def("xpu_host_register(int ptr, int n_bytes) -> bool");
   ops.impl("xpu_host_register", &xpu_host_register);
-  ops.def("xpu_host_unregister(Tensor ptr) -> bool");
+  ops.def("xpu_host_unregister(int ptr) -> bool");
   ops.impl("xpu_host_unregister", &xpu_host_unregister);
 
   // Merge attn states

--- a/csrc/utils/host_register.cpp
+++ b/csrc/utils/host_register.cpp
@@ -54,42 +54,16 @@ bool hostUnregister(void* ptr) {
 }  // namespace xpu
 }  // namespace vllm
 
-namespace {
-
-// Extracts the raw address from a single-element uint64 tensor. Addresses
-// are passed this way (rather than as a scalar int64) because a pointer's
-// full 64-bit bit pattern (e.g. bit 63 set) can exceed the signed int64
-// range and would otherwise fail to cast from Python.
-uint64_t ptrFromTensor(const torch::Tensor& ptr) {
-  // Must live on the CPU: the address is dereferenced with data_ptr<uint64_t>
-  // on the host, so a device-resident tensor here would be undefined
-  // behavior rather than a clean error.
-  TORCH_CHECK(ptr.device().is_cpu(), "ptr must be on CPU");
-  TORCH_CHECK(
-      ptr.numel() == 1,
-      "ptr must be a single-element tensor, got ",
-      ptr.numel());
-  TORCH_CHECK(
-      ptr.scalar_type() == torch::kUInt64,
-      "ptr must be a uint64 tensor, got ",
-      ptr.scalar_type());
-  return *ptr.data_ptr<uint64_t>();
-}
-
-}  // namespace
-
-bool xpu_host_register(const torch::Tensor& ptr, int64_t n_bytes) {
+bool xpu_host_register(int64_t ptr, int64_t n_bytes) {
   TORCH_CHECK(n_bytes >= 0, "n_bytes must be non-negative");
-  uint64_t addr = ptrFromTensor(ptr);
-  if (addr == 0 || n_bytes == 0) return false;
+  if (ptr == 0 || n_bytes == 0) return false;
   return vllm::xpu::hostRegister(
-      reinterpret_cast<void*>(static_cast<uintptr_t>(addr)),
+      reinterpret_cast<void*>(static_cast<uintptr_t>(ptr)),
       static_cast<size_t>(n_bytes));
 }
 
-bool xpu_host_unregister(const torch::Tensor& ptr) {
-  uint64_t addr = ptrFromTensor(ptr);
-  if (addr == 0) return false;
+bool xpu_host_unregister(int64_t ptr) {
+  if (ptr == 0) return false;
   return vllm::xpu::hostUnregister(
-      reinterpret_cast<void*>(static_cast<uintptr_t>(addr)));
+      reinterpret_cast<void*>(static_cast<uintptr_t>(ptr)));
 }

--- a/tests/register_ops.py
+++ b/tests/register_ops.py
@@ -612,7 +612,7 @@ def swap_blocks_batch(
     torch.ops._C_cache_ops.swap_blocks_batch(src_ptrs, dst_ptrs, sizes)
 
 
-def xpu_host_register(ptr: torch.Tensor, n_bytes: int) -> bool:
+def xpu_host_register(ptr: int, n_bytes: int) -> bool:
     """Page-lock a host range and import it into the device context so
     transfers use direct DMA. Intended for host memory that cannot come from
     the caching host allocator, such as a shared mmap region. Returns False if
@@ -627,7 +627,7 @@ def xpu_host_register(ptr: torch.Tensor, n_bytes: int) -> bool:
     return torch.ops._C.xpu_host_register(ptr, n_bytes)
 
 
-def xpu_host_unregister(ptr: torch.Tensor) -> bool:
+def xpu_host_unregister(ptr: int) -> bool:
     """Release a host range previously passed to xpu_host_register.
 
     ptr is a single-element uint64 tensor holding the raw address; see

--- a/tests/test_host_register.py
+++ b/tests/test_host_register.py
@@ -33,22 +33,6 @@ def _force_cpu_default_device():
     yield
     torch.set_default_device(original)
 
-
-def _ptr_tensor(ptr: int) -> torch.Tensor:
-    """Wrap a raw address in a single-element uint64 tensor.
-
-    xpu_host_register/xpu_host_unregister take the address this way because a
-    scalar int64 op argument cannot losslessly carry every 64-bit pointer bit
-    pattern (addresses with bit 63 set, as seen with USM-mapped host
-    allocations on XPU, overflow the signed range and fail to cast from
-    Python). The mask normalizes Tensor.data_ptr()'s Python int into the exact
-    bit pattern torch.uint64 expects.
-    """
-    return torch.tensor([ptr & 0xFFFFFFFFFFFFFFFF],
-                        dtype=torch.uint64,
-                        device="cpu")
-
-
 @pytest.mark.parametrize("device", ["xpu:0"])
 def test_host_register_mmap_roundtrip(device: str) -> None:
     """Registered mmap memory must still transfer correct bytes.
@@ -66,7 +50,7 @@ def test_host_register_mmap_roundtrip(device: str) -> None:
         host = torch.frombuffer(memoryview(region), dtype=torch.uint8)
         host_ptr = host.data_ptr()
 
-        assert ops.xpu_host_register(_ptr_tensor(host_ptr), total)
+        assert ops.xpu_host_register(host_ptr, total)
         try:
             expected = torch.randint(0, 256, (total, ), dtype=torch.uint8)
             dev = expected.to(device)
@@ -90,7 +74,7 @@ def test_host_register_mmap_roundtrip(device: str) -> None:
             torch.xpu.synchronize()
             torch.testing.assert_close(out.cpu(), expected)
         finally:
-            assert ops.xpu_host_unregister(_ptr_tensor(host_ptr))
+            assert ops.xpu_host_unregister(host_ptr)
             del host
 
 
@@ -100,7 +84,6 @@ def test_host_register_rejects_empty(device: str) -> None:
     torch.xpu.set_device(device)
     buf = torch.zeros(4096, dtype=torch.uint8)
 
-    assert not ops.xpu_host_register(_ptr_tensor(0), 4096)
-    assert not ops.xpu_host_register(_ptr_tensor(buf.data_ptr()), 0)
-    assert not ops.xpu_host_unregister(_ptr_tensor(0))
-
+    assert not ops.xpu_host_register(0, 4096)
+    assert not ops.xpu_host_register(buf.data_ptr(), 0)
+    assert not ops.xpu_host_unregister(0)


### PR DESCRIPTION
## Summary

This PR replaces the `Tensor` parameters in `xpu_host_register` and `xpu_host_unregister` with `int64_t` (pointer address), eliminating unnecessary tensor creation and parsing overhead.

## Motivation

Previously, the functions accepted a `Tensor` containing a single `uint64_t` value that stored the pointer address. This required:

1. Creating a `torch.tensor([ptr], dtype=torch.uint64, device="cpu")` on the Python side
2. Parsing the tensor and extracting the address via `data_ptr<uint64_t>()` on the C++ side

This overhead is unnecessary for a simple address value and adds latency on the hot path.

## Changes

### C++ functions

**Before:**
```cpp
bool xpu_host_register(const at::Tensor& ptr, int64_t n_bytes);
bool xpu_host_unregister(const at::Tensor& ptr);
```

**After:**
```cpp
bool xpu_host_register(int64_t ptr, int64_t n_bytes);
bool xpu_host_unregister(int64_t ptr);
```