### PR TITLE
Fix SYCL 2020(oneapi 2026) barrier warinings

### DIFF
--- a/.claude/skills/new-sycl-kernel.md
+++ b/.claude/skills/new-sycl-kernel.md
@@ -258,7 +258,7 @@ XPU_KERNEL_PYTEST_PROFILER=MINI .venv/bin/python -m pytest tests/test_your_kerne
 | `blockDim.x` | `item_ct1.get_local_range(2)` |
 | `gridDim.x` | `item_ct1.get_group_range(2)` |
 | `__shared__` | `sycl::local_accessor<T, 1>` |
-| `__syncthreads()` | `item_ct1.barrier(sycl::access::fence_space::local_space)` |
+| `__syncthreads()` | `sycl::group_barrier(item_ct1.get_group())` |
 | `warpReduceSum` | `sycl::reduce_over_group` |
 | `__half` | `sycl::half` |
 | `__nv_bfloat16` | `sycl::ext::oneapi::bfloat16` |

--- a/csrc/cache.cpp
+++ b/csrc/cache.cpp
@@ -687,7 +687,7 @@ class cp_gather_indexer_k_quant_cache_kernel {
     }
 
     // Synchronise SLM writes before any thread reads batch_idx_acc_
-    item.barrier(sycl::access::fence_space::local_space);
+    sycl::group_barrier(item.get_group());
 
     // Exit threads after barrier to make sure nothing to write.
     if (head_idx >= static_cast<int>(head_dim_) || token_idx >= num_tokens_) {

--- a/csrc/layernorm.cpp
+++ b/csrc/layernorm.cpp
@@ -91,7 +91,7 @@ class rms_norm_kernel {
       *s_variance_ptr = sycl::rsqrt(variance / hidden_size + epsilon);
     }
 
-    item_ct1.barrier(sycl::access::fence_space::local_space);
+    sycl::group_barrier(item_ct1.get_group());
 
     scalar_t* out_row = out + item_ct1.get_group(2) * hidden_size;
     auto* v_in =
@@ -215,7 +215,7 @@ class rms_norm_kernel<scalar_t, NUM_DIMS, 0, HasWeight> {
       *s_variance_ptr = sycl::rsqrt(variance / hidden_size + epsilon);
     }
 
-    item_ct1.barrier(sycl::access::fence_space::local_space);
+    sycl::group_barrier(item_ct1.get_group());
 
     scalar_t* out_row = out + item_ct1.get_group(2) * hidden_size;
 #pragma unroll
@@ -353,7 +353,7 @@ class rms_norm_multi_row_kernel {
       s_variance_ptr[row_in_wg] = sycl::rsqrt(variance / hidden_size + epsilon);
     }
 
-    item_ct1.barrier(sycl::access::fence_space::local_space);
+    sycl::group_barrier(item_ct1.get_group());
 
     // Phase 2: normalize
     scalar_t* out_row = out + global_row * hidden_size;
@@ -603,7 +603,7 @@ class fused_add_rms_norm_kernel {
       *s_variance_ptr = sycl::rsqrt(variance / hidden_size + epsilon);
     }
 
-    item_ct1.barrier(sycl::access::fence_space::local_space);
+    sycl::group_barrier(item_ct1.get_group());
 
     float s_var = *s_variance_ptr;
     for (int idx = item_ct1.get_local_id(2); idx < vec_hidden_size;
@@ -688,7 +688,7 @@ class fused_add_rms_norm_kernel<scalar_t, 0, HasWeight> {
       *s_variance_ptr = sycl::rsqrt(variance / hidden_size + epsilon);
     }
 
-    item_ct1.barrier(sycl::access::fence_space::local_space);
+    sycl::group_barrier(item_ct1.get_group());
 
     for (int idx = item_ct1.get_local_id(2); idx < hidden_size;
          idx += item_ct1.get_local_range(2)) {

--- a/csrc/moe/grouped_topk.cpp
+++ b/csrc/moe/grouped_topk.cpp
@@ -575,7 +575,7 @@ class grouped_topk_fused_kernel_impl {
         lane_id,
         num_experts_per_group);
 
-    item.barrier(sycl::access::fence_space::local_space);
+    sycl::group_barrier(item.get_group());
 
     // --- Phase 2: sub_group 0 selects groups and experts ---
     if (warp_id != 0) {

--- a/csrc/moe/moe_align_sum_kernels.cpp
+++ b/csrc/moe/moe_align_sum_kernels.cpp
@@ -95,7 +95,7 @@ class batched_moe_align_block_size_kernel {
 
     // Compute prefix sum over token counts per expert
     temp_storage[local_id_x] = ceil_b_num_tokens;
-    item.barrier(sycl::access::fence_space::local_space);
+    sycl::group_barrier(item.get_group());
 
     int cumsum_val;
     sycl::joint_exclusive_scan(
@@ -188,7 +188,7 @@ void _moe_align_block_size(
     }
   }
 
-  item.barrier(sycl::access::fence_space::local_space);
+  sycl::group_barrier(item.get_group());
 
   const size_t tid = local_id_x;
   const size_t stride = local_range_x;
@@ -217,7 +217,7 @@ void _moe_align_block_size(
     atomic_count.fetch_add(mask);
   }
 
-  item.barrier(sycl::access::fence_space::local_space);
+  sycl::group_barrier(item.get_group());
 
   // Compute prefix sum over token counts per expert
   int expert_count = 0;
@@ -230,7 +230,7 @@ void _moe_align_block_size(
   }
 
   temp_storage[local_id_x] = expert_count;
-  item.barrier(sycl::access::fence_space::local_space);
+  sycl::group_barrier(item.get_group());
 
   int cumsum_val;
   sycl::joint_exclusive_scan(
@@ -253,7 +253,7 @@ void _moe_align_block_size(
     total_tokens_post_pad[model_offset] = cumsum_val;
   }
 
-  item.barrier(sycl::access::fence_space::local_space);
+  sycl::group_barrier(item.get_group());
 
   if (local_id_x < num_experts) {
     for (int i = cumsum[cumsum_offset + local_id_x];
@@ -310,7 +310,7 @@ void _moe_align_block_size_small_batch_expert(
           static_cast<int32_t>(numel);
     }
   }
-  item.barrier(sycl::access::fence_space::local_space);
+  sycl::group_barrier(item.get_group());
   const size_t tid = local_id_x - fill_threads;
   const size_t stride = local_range_x - fill_threads;
 
@@ -325,7 +325,7 @@ void _moe_align_block_size_small_batch_expert(
     }
   }
 
-  item.barrier(sycl::access::fence_space::local_space);
+  sycl::group_barrier(item.get_group());
   if (local_id_x >= fill_threads) {
     for (size_t i = tid; i < numel; i += stride) {
       int32_t expert_id = static_cast<int32_t>(topk_ids[i]);
@@ -339,7 +339,7 @@ void _moe_align_block_size_small_batch_expert(
     }
   }
 
-  item.barrier(sycl::access::fence_space::local_space);
+  sycl::group_barrier(item.get_group());
 
   if (local_id_x >= fill_threads) {
     if (tid < num_experts) {
@@ -351,7 +351,7 @@ void _moe_align_block_size_small_batch_expert(
     }
   }
 
-  item.barrier(sycl::access::fence_space::local_space);
+  sycl::group_barrier(item.get_group());
 
   if (local_id_x >= fill_threads) {
     if (tid == 0) {
@@ -367,7 +367,7 @@ void _moe_align_block_size_small_batch_expert(
     }
   }
 
-  item.barrier(sycl::access::fence_space::local_space);
+  sycl::group_barrier(item.get_group());
   if (local_id_x >= fill_threads) {
     if (tid < num_experts) {
       for (int i = cumsum[tid]; i < cumsum[tid + 1]; i += block_size) {
@@ -820,7 +820,7 @@ class moe_lora_align_block_size_kernel {
       }
     }
 
-    item.barrier(sycl::access::fence_space::local_space);
+    sycl::group_barrier(item.get_group());
 
     _moe_align_block_size(
         topk_ids,
@@ -1003,7 +1003,7 @@ class moe_lora_align_block_size_small_batch_expert_kernel {
       }
     }
 
-    item.barrier(sycl::access::fence_space::local_space);
+    sycl::group_barrier(item.get_group());
 
     _moe_align_block_size_small_batch_expert<scalar_t, fill_threads>(
         topk_ids,

--- a/csrc/moe/remap_hidden_states.cpp
+++ b/csrc/moe/remap_hidden_states.cpp
@@ -49,7 +49,7 @@ class RowsPerExpertCount {
     for (int i = local_id; i < local_experts_num; i += local_range) {
       local_counts[i] = 0;
     }
-    item.barrier(sycl::access::fence_space::local_space);
+    sycl::group_barrier(item.get_group());
 
     // ===== Phase 2: local atomic =====
     if (global_id < num_rows * TopK) {
@@ -76,7 +76,7 @@ class RowsPerExpertCount {
       }
     }
 
-    item.barrier(sycl::access::fence_space::local_space);
+    sycl::group_barrier(item.get_group());
 
     // ===== Phase 3: global atomic =====
     for (int i = local_id; i < local_experts_num; i += local_range) {
@@ -92,7 +92,7 @@ class RowsPerExpertCount {
       }
     }
 
-    item.barrier(sycl::access::fence_space::local_space);
+    sycl::group_barrier(item.get_group());
 
     // ===== Phase 4: fix unpermuted_row_to_permuted_row =====
     if (global_id < num_rows * TopK) {
@@ -191,7 +191,7 @@ class RemapHiddenStates {
       expert_cumsum_ptr[i + 1] = rows_per_expert[i];
     }
 
-    item.barrier(sycl::access::fence_space::local_space);
+    sycl::group_barrier(item.get_group());
 
     sycl::joint_inclusive_scan(
         item.get_group(),
@@ -243,7 +243,7 @@ class RemapHiddenStates {
       }
     }
 
-    item.barrier(sycl::access::fence_space::local_space);
+    sycl::group_barrier(item.get_group());
 
     auto hidden_states_base = hidden_states +
                               row * static_cast<int64_t>(hidden_size) +

--- a/csrc/moe/topk.cpp
+++ b/csrc/moe/topk.cpp
@@ -71,7 +71,7 @@ class MoeSoftmax {
     if (local_id_x == 0) {
       *float_max = maxElem;
     }
-    item.barrier(sycl::access::fence_space::local_space);
+    sycl::group_barrier(item.get_group());
 
     threadData = 0;
 
@@ -85,7 +85,7 @@ class MoeSoftmax {
     if (local_id_x == 0) {
       *normalizing_factor = 1.f / Z;
     }
-    item.barrier(sycl::access::fence_space::local_space);
+    sycl::group_barrier(item.get_group());
 
     for (int ii = local_id_x; ii < num_cols; ii += TPB) {
       const int idx = thread_row_offset + ii;
@@ -239,7 +239,7 @@ class MoeTopK {
         assert(is_pad_row || indices[idx] >= 0);
         source_rows[idx] = k_idx * num_rows + block_row;
       }
-      item.barrier(sycl::access::fence_space::local_space);
+      sycl::group_barrier(item.get_group());
     }
 
     if (local_id_x == 0) {

--- a/csrc/xpu/gdn_attn/xe_2/chunk_gated_delta_rule_kernels_xe2.hpp
+++ b/csrc/xpu/gdn_attn/xe_2/chunk_gated_delta_rule_kernels_xe2.hpp
@@ -206,14 +206,14 @@ CUTE_DEVICE void chunk_compute_A_kernel(
         // iteration may still be reading g_slm_ptr in the exp()
         // epilogue; all must arrive before any sub-group refills the
         // SLM (g_slm_ptr) for this iteration.
-        item.barrier(sycl::access::fence_space::local_space);
+        sycl::group_barrier(item.get_group());
         CUTE_UNROLL
         for (int e = local_id; e < chunk_size; e += local_range) {
           g_slm_ptr[e] =
               a[(chunk_start_offset + e) + v_head_id * total_virtual_seqlen];
         }
 
-        item.barrier(sycl::access::fence_space::local_space);
+        sycl::group_barrier(item.get_group());
 
         auto k_ptr = k +
                      static_cast<int64_t>(chunk_start_offset) * num_k_heads *
@@ -350,7 +350,7 @@ CUTE_DEVICE void chunk_inverse_kernel(
         for (int idx = local_id; idx < chunk_size; idx += local_range) {
           A_ptr_save[idx * chunk_size + idx] = 1.0f;
         }
-        item.barrier(sycl::access::fence_space::local_space);
+        sycl::group_barrier(item.get_group());
 
         // inverse
         CUTE_UNROLL
@@ -370,7 +370,7 @@ CUTE_DEVICE void chunk_inverse_kernel(
           }
         }
 
-        item.barrier(sycl::access::fence_space::local_space);
+        sycl::group_barrier(item.get_group());
 
         CUTE_UNROLL
         for (int m_idx = sg_id; m_idx < chunk_size; m_idx += sg_range) {
@@ -780,7 +780,7 @@ CUTE_DEVICE void chunk_compute_wu_kernel(
         // WAR fence: previous iteration's sub-groups may still be
         // reading beta_slm_ptr/g_slm_ptr; all must arrive before any
         // sub-group refills the SLM for this iteration.
-        item.barrier(sycl::access::fence_space::local_space);
+        sycl::group_barrier(item.get_group());
         CUTE_UNROLL
         for (int e = local_id; e < chunk_size; e += local_range) {
           float beta_value =
@@ -791,7 +791,7 @@ CUTE_DEVICE void chunk_compute_wu_kernel(
           g_slm_ptr[e] = sycl::exp(a_value) * beta_value;
         }
 
-        item.barrier(sycl::access::fence_space::local_space);
+        sycl::group_barrier(item.get_group());
 
         auto A_ptr = A +
                      static_cast<int64_t>(v_head_id) * total_virtual_seqlen *
@@ -982,7 +982,7 @@ CUTE_DEVICE void chunk_fwd_o_kernel(
       // still be reading g_slm_ptr/g_multi_slm_ptr/g_exp_slm_ptr in
       // their output/state GEMM epilogues; all must arrive before any
       // sub-group refills these SLM buffers for this chunk.
-      item.barrier(sycl::access::fence_space::local_space);
+      sycl::group_barrier(item.get_group());
       CUTE_UNROLL
       for (int e = local_id; e < current_chunk_size; e += local_range) {
         float g_cumsum_value =
@@ -999,7 +999,7 @@ CUTE_DEVICE void chunk_fwd_o_kernel(
         g_multi_slm_ptr[e] = 0.0f;
         g_exp_slm_ptr[e] = 0.0f;
       }
-      item.barrier(sycl::access::fence_space::local_space);
+      sycl::group_barrier(item.get_group());
 
       auto W_ptr = w + v_head_id * total_virtual_seqlen * head_k_dim +
                    chunk_offset * head_k_dim;
@@ -1157,7 +1157,7 @@ CUTE_DEVICE void chunk_fwd_o_kernel(
 
           // Barrier: ensure U_new[dv] is visible across all subgroups
           // before O2U reads it via U_tensor_T.
-          item.barrier(sycl::access::fence_space::local_space);
+          sycl::group_barrier(item.get_group());
 
           // --- O2U MMA: O[dv] += O1[dv] + O2 × U_T[dv] ---
           gemm_TTS(O2_tensor, U_tensor_T, tSrO_c, 0, dv, mma);

--- a/csrc/xpu/grouped_gemm/xe_2/grouped_gemm_xe2.hpp
+++ b/csrc/xpu/grouped_gemm/xe_2/grouped_gemm_xe2.hpp
@@ -228,7 +228,7 @@ CUTE_DEVICE void MoEGEMM(
       if (local_id == 0) {
         slm_mem[0] = cutlass::atomicAdd(atomic_buffer, 1);
       }
-      item.barrier(sycl::access::fence_space::local_space);
+      sycl::group_barrier(item.get_group());
       group_id = group_range + slm_mem[0];
       group_m_id = (group_id * wg_tile_n) / gemm_n_pad;
     }


### PR DESCRIPTION
SYCL 2020 (oneAPI 2026 headers) deprecated the nd_item::barrier(sycl::access::fence_space) member function in favor of the free function sycl::group_barrier()