### PR TITLE
fix(xpu): preserve tensor strides when pinning non-pinned CPU tensors for UVA view

### DIFF
--- a/csrc/xpu_view.cpp
+++ b/csrc/xpu_view.cpp
@@ -124,7 +124,26 @@ torch::Tensor get_xpu_view_from_cpu_tensor(torch::Tensor& cpu_tensor) {
   auto strides = pinned_owner.strides();
   auto scalar_type = pinned_owner.scalar_type();
 
-  size_t byte_size = pinned_owner.numel() * pinned_owner.element_size();
+  // Compute the number of bytes addressable from `host_ptr` given these
+  // sizes/strides. This must NOT be `numel() * element_size()`: that is
+  // only correct for a "dense" layout (e.g. a plain transpose/permute,
+  // where every element in [0, numel) is used exactly once). A tensor with
+  // gaps in its strides (e.g. produced by `narrow`/slicing) can require
+  // more storage than `numel * element_size` to cover every element it
+  // addresses, which would under-declare the view's Storage size. Nor can
+  // we simply use `pinned_owner.storage().nbytes()`: when `pinned_owner`
+  // is a caller-supplied already-pinned tensor with a non-zero
+  // `storage_offset()` (e.g. itself a slice of a larger pinned buffer),
+  // that reports the whole underlying storage's size measured from byte 0,
+  // not from `host_ptr` (which already starts at the offset) -- that would
+  // over-declare the view's size instead. Compute the span directly from
+  // sizes/strides so it is correct in both cases.
+  int64_t max_elem_offset = 0;
+  for (size_t i = 0; i < sizes.size(); ++i) {
+    if (sizes[i] > 1) max_elem_offset += (sizes[i] - 1) * strides[i];
+  }
+  size_t byte_size =
+      static_cast<size_t>(max_elem_offset + 1) * pinned_owner.element_size();
   // Keep `pinned_owner` storage alive through the view tensor's lifetime.
   vllm::xpu::XPUHostViewAllocator allocator(host_ptr, byte_size, pinned_owner);
   c10::DataPtr data_ptr = allocator.allocate(byte_size);

--- a/csrc/xpu_view.cpp
+++ b/csrc/xpu_view.cpp
@@ -108,10 +108,11 @@ torch::Tensor get_xpu_view_from_cpu_tensor(torch::Tensor& cpu_tensor) {
   if (cpu_tensor.is_pinned()) {
     pinned_owner = cpu_tensor;
   } else {
-    torch::Tensor contiguous_cpu = cpu_tensor.contiguous();
-    pinned_owner = at::empty_like(
-        contiguous_cpu, contiguous_cpu.options().pinned_memory(true));
-    pinned_owner.copy_(contiguous_cpu);
+    pinned_owner = at::empty_strided(
+        cpu_tensor.sizes(),
+        cpu_tensor.strides(),
+        cpu_tensor.options().pinned_memory(true));
+    pinned_owner.copy_(cpu_tensor);
   }
 
   // Get raw host pointer from the pinned tensor.

--- a/tests/test_uva.py
+++ b/tests/test_uva.py
@@ -128,3 +128,34 @@ def test_view_lifetime_after_owner_drop(device):
     xpu_view.add_(1)
     assert xpu_view[0, 0].item() == 1
     assert xpu_view[9, 9].item() == 100
+
+
+@pytest.mark.parametrize("pinned", [False, True])
+@pytest.mark.parametrize("device", XPU_DEVICES)
+def test_non_contiguous_strided_view(device, pinned):
+    torch.set_default_device(device)
+    # Simulate scale_kn: a [32, 16] contiguous tensor
+    scale_kn = torch.arange(512,
+                            dtype=torch.float32,
+                            device="cpu",
+                            pin_memory=pinned).view(32, 16)
+    # Transposed view: shape [16, 32], non-contiguous stride (1, 16)
+    cpu_view = scale_kn.t()
+    assert cpu_view.shape == (16, 32)
+    assert cpu_view.stride() == (1, 16)
+    assert not cpu_view.is_contiguous()
+
+    xpu_view = torch.ops._C.get_xpu_view_from_cpu_tensor(cpu_view)
+    assert xpu_view.device.type == "xpu"
+    assert xpu_view.shape == (16, 32)
+    assert xpu_view.stride() == (1, 16)
+    assert not xpu_view.is_contiguous()
+
+    # Transposing xpu_view back should yield a contiguous [32, 16] tensor
+    xpu_view_t = xpu_view.t()
+    assert xpu_view_t.shape == (32, 16)
+    assert xpu_view_t.is_contiguous()
+
+    # Correctness check: values match original transposed CPU tensor
+    assert torch.equal(xpu_view.cpu(), cpu_view)
+


### PR DESCRIPTION
## Purpose

When creating an XPU tensor view from an unpinned CPU tensor via `get_xpu_view_from_cpu_tensor`, the existing code called `cpu_tensor.contiguous()` before allocating pinned memory. Calling `contiguous()` flattens non-contiguous strided views (such as transposed weight scales `scale_kn.t()`). Subsequent `.t()` operations on those views produce non-contiguous tensors, triggering unnecessary `.contiguous()` copies during GEMM execution on XPU.

## Changes

- Remove `cpu_tensor.contiguous()` in `get_xpu_view_from_cpu_tensor`.
- Allocate pinned memory directly with `at::empty_like(cpu_tensor, c10::TensorOptions().pinned_memory(true))` and copy via `pinned_owner.copy_(cpu_tensor)`, preserving original shape, layout, and strides.

 