### PR TITLE
Fix rmsnorm benchmark 

### DIFF
--- a/benchmark/benchmark_rmsnorm.py
+++ b/benchmark/benchmark_rmsnorm.py
@@ -231,40 +231,37 @@ def get_benchmark(use_residual, dtype):
 
         quantiles = [0.5, 0.2, 0.8]
 
+        # Clone once, outside the timed region. Some providers (e.g. vLLM's
+        # fused_add_rms_norm) mutate their input/residual buffers in place,
+        # so do_bench's repeated calls will keep operating on the same
+        # buffers across iterations -- that's fine, since this op's runtime
+        # is data-independent (determined by shape/dtype, not values), and
+        # it matches how the kernel is actually used in production (no
+        # per-call clone). Cloning *inside* the do_bench lambda would add a
+        # full extra memory-bound copy to every timed iteration, roughly
+        # doubling the measured latency of in-place ops and understating
+        # their true achieved memory bandwidth.
+        x_bench = x.clone()
+        residual_bench = residual.clone() if residual is not None else None
+
         if provider == "huggingface":
             ms, min_ms, max_ms = triton.testing.do_bench(
-                lambda: rmsnorm_naive(
-                    x.clone(),
-                    weight,
-                    residual.clone() if residual is not None else None,
-                ),
+                lambda: rmsnorm_naive(x_bench, weight, residual_bench),
                 quantiles=quantiles,
             )
         elif provider == "t.compile":
             ms, min_ms, max_ms = triton.testing.do_bench(
-                lambda: rmsnorm_compile(
-                    x.clone(),
-                    weight,
-                    residual.clone() if residual is not None else None,
-                ),
+                lambda: rmsnorm_compile(x_bench, weight, residual_bench),
                 quantiles=quantiles,
             )
         elif provider == "ipex" and HAS_IPEX:
             ms, min_ms, max_ms = triton.testing.do_bench(
-                lambda: rmsnorm_ipex(
-                    x.clone(),
-                    weight,
-                    residual.clone() if residual is not None else None,
-                ),
+                lambda: rmsnorm_ipex(x_bench, weight, residual_bench),
                 quantiles=quantiles,
             )
         else:
             ms, min_ms, max_ms = triton.testing.do_bench(
-                lambda: rmsnorm_vllm(
-                    x.clone(),
-                    weight,
-                    residual.clone() if residual is not None else None,
-                ),
+                lambda: rmsnorm_vllm(x_bench, weight, residual_bench),
                 quantiles=quantiles,
             )
         return 1000 * ms, 1000 * max_ms, 1000 * min_ms


### PR DESCRIPTION
rmsnorm benchmark timing is wrong. This PR is to fix it. benchmark_rmsnorm.py  timed  x.clone() / residual.clone()  inside the do_bench()  lambda for every provider. Each clone is a full memory-bound copy, which roughly doubles measured latency for in-place ops like vLLM's  fused_add_rms_norm  (production usage doesn't clone per call).

vLLM ( fused_add_rms_norm ) latency — before vs. after fix (us)


head_num | batch | seq | Before (with clone) | After (clone hoisted out) | Reduction
-- | -- | -- | -- | -- | --
16 | 1 | 64 | 7.45 | 4.64 | −38%
16 | 1 | 128 | 8.80 | 5.57 | −37%
16 | 1 | 256 | 11.98 | 7.66 | −36%
16 | 1 | 512 | 18.54 | 12.08 | −35%
16 | 4 | 64 | 11.98 | 7.71 | −36%
16 | 4 | 128 | 18.44 | 12.08 | −34%
16 | 4 | 256 | 32.08 | 19.32 | −40%
16 | 4 | 512 | 55.47 | 34.22 | −38%
16 | 16 | 64 | 32.14 | 19.43 | −40%
16 | 16 | 128 | 55.42 | 34.12 | −38%
16 | 16 | 256 | 180.31 | 82.14 | −54%
16 | 16 | 512 | 458.96 | 206.46 | −55%
16 | 64 | 64 | 180.26 | 82.14 | −54%
16 | 64 | 128 | 459.06 | 206.41 | −55%
16 | 64 | 256 | 959.11 | 457.55 | −52%
16 | 64 | 512 | 1986.56 | 968.05 | −51%


Change: hoist  .clone()  calls to once per benchmark config, before  do_bench() , for all four providers.  calculate_diff()  (correctness check) is unchanged.

Testing: correctness check still passes ( ✅ All implementations match ); before/after sweep shows consistent 34–55% latency reduction for vLLM across all configs;  pre-commit  passes.