### PR TITLE
Improve BlockFP8 Xe2 perf by scaling in accumulator

### DIFF
--- a/csrc/xpu/grouped_gemm/xe_2/gemm_xe2.hpp
+++ b/csrc/xpu/grouped_gemm/xe_2/gemm_xe2.hpp
@@ -321,8 +321,6 @@ CUTE_DEVICE void xe_gemm_4bits(
   auto pAgA = thr_prefetch_A.partition_S(gA);
   auto pBgB = thr_prefetch_B.partition_S(gB);
 
-  const int prefetch_dist = 6;
-
   constexpr SPIRVScope barrier_scope = ScopeWorkgroup;
 
   int k_tile_count = ceil_div(shape<1>(A), get<2>(wg_tile));
@@ -343,6 +341,11 @@ CUTE_DEVICE void xe_gemm_4bits(
   static constexpr auto SG_N = tile_n / ATOM_N;  // BLK_N / ATOM_N;
   static constexpr auto SG_K = tile_k / ATOM_K;  // BLK_K / ATOM_K;
 
+  // 6 k-tiles in flight hide the packed-weight decode; block-fp8 has none to
+  // hide and measured best at 1 for the 16-row tile, 3 for the others.
+  static constexpr int prefetch_dist =
+      TENSOR_B_DTYPE != B_DTYPE::BLOCK_FP8 ? 6 : (tile_m <= 16 ? 1 : 3);
+
   static constexpr auto thr_N = get<1>(tCrB.shape());
   static constexpr auto channel_num = get<0>(get<0>(tCrB.shape()));
   auto n_tile_start = wg_n * tile_n;
@@ -355,6 +358,13 @@ CUTE_DEVICE void xe_gemm_4bits(
 
   using scaleStoreType = conditional_t<is_same_v<TA, half_t>, half_t, float>;
   scaleStoreType scales[thr_N * channel_num];
+
+  // A workgroup tile never straddles a 128-wide N block (tile_n is 64 or 128
+  // and n_tile_start is a multiple of tile_n), so for block-fp8 the scale is a
+  // single scalar per K block. The accumulator is kept in units of that scale.
+  float blk_scale_cur = 1.0f;
+  const int blk_n_blocks = static_cast<int>(get<0>(B.shape())) / group_size;
+  const int blk_n_block = n_tile_start / group_size;
 
   clear(tCrC);
 
@@ -399,30 +409,36 @@ CUTE_DEVICE void xe_gemm_4bits(
     if (k_tile * tile_k % group_size == 0) {
       int group_idx = (k_tile * tile_k) / group_size;
 
-      CUTLASS_PRAGMA_UNROLL
-      for (int n = 0; n < thr_N; ++n) {
+      if constexpr (TENSOR_B_DTYPE == B_DTYPE::BLOCK_FP8) {
+        // Re-express the running sum in the new block's units. One multiply
+        // per accumulator element per K block replaces scaling every B
+        // element on every k-tile, and needs no second accumulator.
+        float s_new =
+            static_cast<float>(Scales[group_idx * blk_n_blocks + blk_n_block]);
+        if (group_idx > 0) {
+          float ratio = blk_scale_cur / s_new;
+          CUTLASS_PRAGMA_UNROLL
+          for (int i = 0; i < tCrC.size(); ++i) {
+            tCrC(i) *= ratio;
+          }
+        }
+        blk_scale_cur = s_new;
+      } else {
         CUTLASS_PRAGMA_UNROLL
-        for (int c = 0; c < channel_num; ++c) {
-          int real_idx = x_idx + c * (sg_local_range / channel_num);
-          int sg_local_n = n * sg_local_range + real_idx;
-          scaleStoreType scale;
-          if constexpr (std::is_same_v<TB, int4_t>) {
-            scale = Scales
-                [(n_tile_start + n_sg_start + sg_local_n) * group_num +
-                 group_idx];
-          } else if constexpr (
-              std::is_same_v<TB, float_e2m1_t> ||
-              std::is_same_v<TB, float_e4m3_t> ||
-              std::is_same_v<TB, float_e5m2_t>) {
-            if constexpr (TENSOR_B_DTYPE == B_DTYPE::BLOCK_FP8) {
-              // Block-FP8: float32 scales [K/128, N/128] (B is (N,K)).
-              int n_global = n_tile_start + n_sg_start + sg_local_n;
-              int n_blocks = static_cast<int>(get<0>(B.shape())) / group_size;
-              int n_block = n_global / group_size;
-              int k_block = group_idx;
-              scale = static_cast<scaleStoreType>(
-                  Scales[k_block * n_blocks + n_block]);
-            } else {
+        for (int n = 0; n < thr_N; ++n) {
+          CUTLASS_PRAGMA_UNROLL
+          for (int c = 0; c < channel_num; ++c) {
+            int real_idx = x_idx + c * (sg_local_range / channel_num);
+            int sg_local_n = n * sg_local_range + real_idx;
+            scaleStoreType scale;
+            if constexpr (std::is_same_v<TB, int4_t>) {
+              scale = Scales
+                  [(n_tile_start + n_sg_start + sg_local_n) * group_num +
+                   group_idx];
+            } else if constexpr (
+                std::is_same_v<TB, float_e2m1_t> ||
+                std::is_same_v<TB, float_e4m3_t> ||
+                std::is_same_v<TB, float_e5m2_t>) {
               // MXFP4 / MXFP8: uint8 E8M0 bits -> float via (bits << 23).
               uint32_t scale_u32 =
                   Scales
@@ -432,9 +448,9 @@ CUTE_DEVICE void xe_gemm_4bits(
               scale = static_cast<scaleStoreType>(
                   reinterpret_cast<float&>(scale_u32));
             }
-          }
 
-          scales[n * channel_num + c] = scale;
+            scales[n * channel_num + c] = scale;
+          }
         }
       }
 
@@ -466,17 +482,20 @@ CUTE_DEVICE void xe_gemm_4bits(
     reorder(tArA, tCrA);
     reorder(tBrB, tCrB);
 
-    CUTLASS_PRAGMA_UNROLL
-    for (int n = 0; n < thr_N; ++n) {
+    if constexpr (TENSOR_B_DTYPE != B_DTYPE::BLOCK_FP8) {
       CUTLASS_PRAGMA_UNROLL
-      for (int c = 0; c < channel_num; ++c) {
+      for (int n = 0; n < thr_N; ++n) {
         CUTLASS_PRAGMA_UNROLL
-        for (int i = 0; i < tCrB.size() / thr_N / channel_num; ++i) {
-          if constexpr (std::is_same_v<TA, half_t>) {
-            tCrB(cute::tuple(c, _), n, _)[i] *= scales[n * channel_num + c];
-          } else {
-            tCrB(cute::tuple(c, _), n, _)[i] = apply_scale(
-                tCrB(cute::tuple(c, _), n, _)[i], scales[n * channel_num + c]);
+        for (int c = 0; c < channel_num; ++c) {
+          CUTLASS_PRAGMA_UNROLL
+          for (int i = 0; i < tCrB.size() / thr_N / channel_num; ++i) {
+            if constexpr (std::is_same_v<TA, half_t>) {
+              tCrB(cute::tuple(c, _), n, _)[i] *= scales[n * channel_num + c];
+            } else {
+              tCrB(cute::tuple(c, _), n, _)[i] = apply_scale(
+                  tCrB(cute::tuple(c, _), n, _)[i],
+                  scales[n * channel_num + c]);
+            }
           }
         }
       }
@@ -485,6 +504,13 @@ CUTE_DEVICE void xe_gemm_4bits(
     cute::gemm(mma, tCrA, tCrB, tCrC);
 
     barrier_wait(barrier_scope);
+  }
+
+  if constexpr (TENSOR_B_DTYPE == B_DTYPE::BLOCK_FP8) {
+    CUTLASS_PRAGMA_UNROLL
+    for (int i = 0; i < tCrC.size(); ++i) {
+      tCrC(i) *= blk_scale_cur;
+    }
   }
 
   if (Bias != nullptr) {

--- a/tests/fused_moe/test_grouped_gemm.py
+++ b/tests/fused_moe/test_grouped_gemm.py
@@ -521,13 +521,26 @@ def test_xe_grouped_gemm_mxfp8(m, n, k, e, topk, dtype, has_bias):
     torch.testing.assert_close(output, ref, rtol=2e-2, atol=2e-2)
 
 
-@pytest.mark.parametrize("m,n,k", [(1, 256, 256), (4, 256, 256)])
+# A_avg_M = m * topk / e picks the tile policy, so with e=2 these m values
+# straddle both dispatch thresholds (<=8, <=32, else).
+BLOCK_FP8_MNK_FACTORS = [
+    (1, 256, 256),
+    (4, 256, 256),
+    (64, 256, 256),
+    (128, 256, 256),
+]
+
+
+@pytest.mark.parametrize("m,n,k", BLOCK_FP8_MNK_FACTORS)
 @pytest.mark.parametrize("e", [2])
 @pytest.mark.parametrize("topk", [1])
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16],
                          ids=format_tc)
+@pytest.mark.parametrize("fp8_dtype", [torch.float8_e5m2, torch.float8_e4m3fn],
+                         ids=format_tc)
 @pytest.mark.parametrize("has_bias", [False, True])
-def test_xe_grouped_gemm_block_fp8(m, n, k, e, topk, dtype, has_bias):
+def test_xe_grouped_gemm_block_fp8(m, n, k, e, topk, dtype, fp8_dtype,
+                                   has_bias):
     """Native block-FP8 W8A16 grouped GEMM vs dequant+matmul gold.
 
     Keeps FP8 weights + float32 2D scales [E, K/128, N/128] in memory.
@@ -544,7 +557,7 @@ def test_xe_grouped_gemm_block_fp8(m, n, k, e, topk, dtype, has_bias):
 
     input_A = torch.randn((total_m, k), dtype=dtype,
                           device=DEVICE).contiguous() / 10
-    input_B = torch.empty(num_experts, k, n, dtype=torch.float8_e4m3fn,
+    input_B = torch.empty(num_experts, k, n, dtype=fp8_dtype,
                           device=DEVICE)
     scale_B = (torch.randn(num_experts,
                            k // group_size,
@@ -554,7 +567,7 @@ def test_xe_grouped_gemm_block_fp8(m, n, k, e, topk, dtype, has_bias):
 
     for i in range(num_experts):
         hp = torch.randn(k, n, dtype=torch.float32, device=DEVICE) / 10
-        input_B[i] = hp.to(torch.float8_e4m3fn)
+        input_B[i] = hp.to(fp8_dtype)
 
     if has_bias:
         bias = torch.randn((num_experts, n), dtype=dtype, device=DEVICE) / 10
@@ -587,3 +600,62 @@ def test_xe_grouped_gemm_block_fp8(m, n, k, e, topk, dtype, has_bias):
     ref = torch.cat(ref, dim=0)
 
     torch.testing.assert_close(output, ref, rtol=2e-2, atol=2e-2)
+
+
+@pytest.mark.parametrize("m,n,k", [(4, 256, 512), (128, 256, 512)])
+@pytest.mark.parametrize("dtype", [torch.bfloat16], ids=format_tc)
+def test_xe_grouped_gemm_block_fp8_wide_scales(m, n, k, dtype):
+    """Block scales spanning 2^-10..2^10 across consecutive K blocks.
+
+    The mainloop carries the accumulator in units of the current block's
+    scale, so it is the ratio between adjacent K blocks -- not the scale
+    magnitude -- that has to stay representable.
+    """
+    if not torch.xpu.is_available():
+        pytest.skip("XPU required")
+    seed_everything(7)
+    from vllm_xpu_kernels.moe_utils import dequant_fp8_block_wei
+
+    num_experts, topk, group_size = 2, 1, 128
+    total_m = m * topk
+
+    input_A = torch.randn((total_m, k), dtype=dtype,
+                          device=DEVICE).contiguous() / 10
+    input_B = torch.empty(num_experts, k, n, dtype=torch.float8_e4m3fn,
+                          device=DEVICE)
+    for i in range(num_experts):
+        hp = torch.randn(k, n, dtype=torch.float32, device=DEVICE) / 10
+        input_B[i] = hp.to(torch.float8_e4m3fn)
+
+    # Exact powers of two so the reference dequant introduces no rounding of
+    # its own and any mismatch is attributable to the kernel.
+    exponents = torch.randint(-10,
+                              11, (num_experts, k // group_size,
+                                   n // group_size),
+                              device=DEVICE)
+    scale_B = torch.pow(2.0, exponents.float()).contiguous()
+
+    num_rows_per_expert = torch.zeros(num_experts,
+                                      device=DEVICE,
+                                      dtype=torch.int32)
+    init_rows_for_experts(m, topk, num_rows_per_expert)
+
+    output = torch.empty((total_m, n), dtype=dtype, device=DEVICE)
+    cutlass_grouped_gemm_xe2(input_A, input_B, scale_B, None, output,
+                             num_rows_per_expert, n, k, num_experts)
+
+    ref = []
+    pre_token_sum = 0
+    for i in range(num_experts):
+        cur_token_num = int(num_rows_per_expert[i].item())
+        if cur_token_num == 0:
+            continue
+        inp = input_A[pre_token_sum:pre_token_sum + cur_token_num].to(
+            torch.float32)
+        wei = dequant_fp8_block_wei(input_B[i], scale_B[i])
+        ref.append((inp @ wei).to(dtype))
+        pre_token_sum += cur_token_num
+    ref = torch.cat(ref, dim=0)
+
+    # Outputs span many orders of magnitude here, so lean on rtol.
+    torch.testing.assert_close(output, ref, rtol=3e-2, atol=0.0)

--- a/tests/fused_moe/test_grouped_gemm.py
+++ b/tests/fused_moe/test_grouped_gemm.py
@@ -602,14 +602,24 @@ def test_xe_grouped_gemm_block_fp8(m, n, k, e, topk, dtype, fp8_dtype,
     torch.testing.assert_close(output, ref, rtol=2e-2, atol=2e-2)
 
 
-@pytest.mark.parametrize("m,n,k", [(4, 256, 512), (128, 256, 512)])
+# Exponent extremes for the wide-scale test: adjacent K blocks differ by
+# 2^(2*BLOCK_FP8_MAX_EXP), and the full range spans 2^-20 .. 2^20 ratios.
+BLOCK_FP8_MAX_EXP = 10
+
+
+@pytest.mark.parametrize("m,n,k", [(4, 256, 1024), (128, 256, 1024)])
+@pytest.mark.parametrize("pattern", ["alternating", "descending", "ascending"])
 @pytest.mark.parametrize("dtype", [torch.bfloat16], ids=format_tc)
-def test_xe_grouped_gemm_block_fp8_wide_scales(m, n, k, dtype):
-    """Block scales spanning 2^-10..2^10 across consecutive K blocks.
+def test_xe_grouped_gemm_block_fp8_wide_scales(m, n, k, pattern, dtype):
+    """Block scales laid out to force the worst case for the K-block rescale.
 
     The mainloop carries the accumulator in units of the current block's
-    scale, so it is the ratio between adjacent K blocks -- not the scale
-    magnitude -- that has to stay representable.
+    scale, so what matters is the ratio between adjacent K blocks, not the
+    magnitude. Random exponents would not reliably produce large ratios, so
+    each pattern is constructed:
+      alternating -- every adjacent pair swings the full 2^(2*MAX_EXP)
+      descending  -- scales shrink, so the carried accumulator grows monotonically
+      ascending   -- scales grow, so the carried accumulator shrinks monotonically
     """
     if not torch.xpu.is_available():
         pytest.skip("XPU required")
@@ -618,6 +628,8 @@ def test_xe_grouped_gemm_block_fp8_wide_scales(m, n, k, dtype):
 
     num_experts, topk, group_size = 2, 1, 128
     total_m = m * topk
+    num_k_blocks = k // group_size
+    num_n_blocks = n // group_size
 
     input_A = torch.randn((total_m, k), dtype=dtype,
                           device=DEVICE).contiguous() / 10
@@ -627,13 +639,23 @@ def test_xe_grouped_gemm_block_fp8_wide_scales(m, n, k, dtype):
         hp = torch.randn(k, n, dtype=torch.float32, device=DEVICE) / 10
         input_B[i] = hp.to(torch.float8_e4m3fn)
 
+    hi = float(BLOCK_FP8_MAX_EXP)
+    if pattern == "alternating":
+        per_k = torch.tensor([hi if i % 2 == 0 else -hi
+                              for i in range(num_k_blocks)])
+    elif pattern == "descending":
+        per_k = torch.linspace(hi, -hi, num_k_blocks)
+    else:
+        per_k = torch.linspace(-hi, hi, num_k_blocks)
+
     # Exact powers of two so the reference dequant introduces no rounding of
     # its own and any mismatch is attributable to the kernel.
-    exponents = torch.randint(-10,
-                              11, (num_experts, k // group_size,
-                                   n // group_size),
-                              device=DEVICE)
-    scale_B = torch.pow(2.0, exponents.float()).contiguous()
+    exponents = per_k.to(DEVICE).view(1, num_k_blocks, 1).expand(
+        num_experts, num_k_blocks, num_n_blocks)
+    scale_B = torch.pow(2.0, exponents).contiguous()
+
+    # Fail loudly if a shape change ever makes this test stop being "wide".
+    assert scale_B.max() / scale_B.min() >= 2.0**(2 * BLOCK_FP8_MAX_EXP - 1)
 
     num_rows_per_expert = torch.zeros(num_experts,
                                       device=DEVICE,
@@ -657,5 +679,10 @@ def test_xe_grouped_gemm_block_fp8_wide_scales(m, n, k, dtype):
         pre_token_sum += cur_token_num
     ref = torch.cat(ref, dim=0)
 
-    # Outputs span many orders of magnitude here, so lean on rtol.
-    torch.testing.assert_close(output, ref, rtol=3e-2, atol=0.0)
+    # Scales spanning 2^20 make the dominant K block ~1e6 larger than the
+    # smallest results, and a near-cancelled element cannot be resolved more
+    # finely than one bf16 ULP of the terms that formed it. Measured error is
+    # flat in the block ratio (~1e-3 of max) rather than growing with it, so
+    # the floor is set from the output magnitude instead of using atol=0.
+    atol = float(ref.abs().max()) * 2**-8
+    torch.testing.assert_close(output, ref, rtol=3e-2, atol=atol)

--- a/tests/fused_moe/test_grouped_gemm.py
+++ b/tests/fused_moe/test_grouped_gemm.py
@@ -618,8 +618,8 @@ def test_xe_grouped_gemm_block_fp8_wide_scales(m, n, k, pattern, dtype):
     magnitude. Random exponents would not reliably produce large ratios, so
     each pattern is constructed:
       alternating -- every adjacent pair swings the full 2^(2*MAX_EXP)
-      descending  -- scales shrink, so the carried accumulator grows monotonically
-      ascending   -- scales grow, so the carried accumulator shrinks monotonically
+      descending  -- scales shrink, so the accumulator grows monotonically
+      ascending   -- scales grow, so the accumulator shrinks monotonically
     """
     if not torch.xpu.is_available():
         pytest.skip("XPU required")


### PR DESCRIPTION
## Purpose

Improves block-FP8 performance by up to 1.5x.

`xe_gemm_4bits` handles block-FP8 by scaling every element of the B fragment on every k-tile. That is inherited from the packed-4-bit path, where each element genuinely needs its own scale. But Block-FP8 doesn't. The scale is one scalar for the whole tile, varying only with the K block, so the existing code broadcasts a constant and multiplies elementwise, doing $O(\text{tile}\times K)$ work for something that is mathematically $O(\text{accumulator}\times K/128)$.

### Change
I keep the accumulator in units of the current block scale. At each K-block boundary correct it and apply the scale once at the end. That's one multiply per accumulator element per 128-K block.

I also tune `prefetch_dist` for block-FP8: the 4-bit path uses 6 to hide packed-weight decode, which block-FP8 doesn't have. Measured best at 1 for the 16-row tile and 3 for the others (worth ~20% at the 32-row tile). Non-block-FP8 paths keep the literal 6 and are unchanged.

The effect is that the block-FP8 2D scale-indexing branch becomes dead and is removed, so the diff is +62/-36 in one file.

## Test Plan
Correctness tests in `test_grouped_gemm.py` pass. New policy cases have been covered.

Current benchmark files don't explore BlockFP8 MoE/grouped_gemm, and I didn't want to expand the scope of current benchmarks unexpectedly. I used a custom benchmark file:

<details><summary>benchmark_grouped_gemm_block_fp8.py</summary>
<p>

```python
"""Benchmark the XE2 cutlass grouped GEMM kernel across quantization recipes.

Compares three weight recipes for a single grouped GEMM (one expert-batched
matmul, the same op used by gemm1/gemm2 inside the fused MoE):

* ``bf16``       - 16-bit weights, no scales (``cutlass_grouped_gemm_xe2``).
* ``fp8``        - per-tensor / per-expert fp8 weights (W8A16, 1D scales).
* ``block_fp8``  - block-wise fp8 weights (W8A16, 128x128 fp32 block scales).

Latency is reported in microseconds along with achieved TFLOP/s so the recipes
can be compared at matched problem sizes.

Example:
    python benchmark/benchmark_grouped_gemm_block_fp8.py
    python benchmark/benchmark_grouped_gemm_block_fp8.py --check
    python benchmark/benchmark_grouped_gemm_block_fp8.py \
        --save-path ./grouped_gemm_bench
"""

# isort: off
import argparse
import csv
import gc

import torch

try:
    import triton
    import triton.testing
    HAS_TRITON = True
except ImportError:
    triton = None
    HAS_TRITON = False

from utils import bootstrap_benchmark_env, ensure_save_path_exists

bootstrap_benchmark_env(__file__)
from tests.ops.fp8_quant_op import scaled_fp8_quant
from tests.utils import seed_everything
from vllm_xpu_kernels.fused_moe_interface import cutlass_grouped_gemm_xe2
# isort: on

DEVICE = "xpu"
BLOCK_SIZE = 128

# (m, n, k) - shapes for Llama-4-scout style MoE grouped GEMMs.
MNK_FACTORS = [
    (1, 5120, 8192),
    (4, 5120, 8192),
    (16, 5120, 8192),
    (64, 5120, 8192),
    (256, 5120, 8192),
    (1024, 5120, 8192),
    (8192, 5120, 8192),
]
NUM_EXPERTS = 16
TOPK = 1

# DeepSeek-V3: hidden 7168, moe_intermediate 2048, 256 routed experts, top-8,
# 128x128 block scales. gate_up fuses gate+up, so its N is 2 * 2048.
# Expert count is per rank = 256 / EP; 64 matches the TP=4 + EP runs.
DSV3_M = [1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192]
PRESETS = {
    "llama4": (MNK_FACTORS, 16, 1),
    "dsv3-gateup": ([(m, 4096, 7168) for m in DSV3_M], 64, 8),
    "dsv3-down": ([(m, 7168, 2048) for m in DSV3_M], 64, 8),
}

RECIPES = ["bf16", "fp8", "block_fp8"]
RECIPE_STYLES = {
    "bf16": ("blue", "-"),
    "fp8": ("green", "-"),
    "block_fp8": ("red", "-"),
}


def clear_xpu_cache():
    torch.xpu.empty_cache()
    torch.xpu.synchronize()
    gc.collect()


def init_rows_for_experts(tokens, topk, num_rows_per_expert):
    """Uniform-random routing of tokens*topk rows across experts.

    Mirrors tests/fused_moe/test_grouped_gemm.py; inlined so the benchmark does
    not import the test module (which requires pytest).
    """
    if num_rows_per_expert.shape[0] == 1:
        num_rows_per_expert[0] = tokens * topk
        return
    n_experts = num_rows_per_expert.numel()
    rand = torch.rand(tokens, n_experts, device=num_rows_per_expert.device)
    topk_idx = torch.topk(rand, topk, dim=1).indices
    num_rows_per_expert += torch.bincount(topk_idx.flatten(),
                                          minlength=n_experts)


def calculate_tflops(m, n, k, latency_us):
    # The kernel processes m * TOPK rows: each token is routed to TOPK experts.
    flops = 2.0 * m * TOPK * n * k
    return flops / (latency_us * 1e-6) / 1e12


def make_grouped_gemm_input(m, n, k, recipe, x_dtype, fp8_dtype, has_bias):
    """Build inputs for ``cutlass_grouped_gemm_xe2`` for the given recipe.

    Returns a kwargs dict ready to splat into ``cutlass_grouped_gemm_xe2``.
    """
    num_experts = NUM_EXPERTS
    total_m = m * TOPK

    input_A = torch.randn((total_m, k), dtype=x_dtype,
                          device=DEVICE).contiguous()
    # Weights are stored row-major [num_experts, K, N] for the W8A16 paths.
    input_B = torch.randn((num_experts, k, n), dtype=x_dtype, device=DEVICE)

    if has_bias:
        bias = torch.randn((num_experts, n), dtype=x_dtype, device=DEVICE)
    else:
        bias = None

    num_rows_per_expert = torch.zeros(num_experts,
                                      device=DEVICE,
                                      dtype=torch.int32)
    init_rows_for_experts(m, TOPK, num_rows_per_expert)
    output = torch.empty((total_m, n), dtype=x_dtype, device=DEVICE)

    if recipe == "bf16":
        scales = None
        is_B_fp8block = False
    elif recipe == "fp8":
        # per-expert (per-tensor) fp8 quantization, 1D scales [num_experts].
        random_exponents = torch.randint(-3, 4, (num_experts, ),
                                         device=DEVICE)
        scales = torch.pow(2.0, random_exponents.float())
        input_B_fp8 = torch.empty_like(input_B, dtype=fp8_dtype)
        for i in range(num_experts):
            input_B_fp8[i], _ = scaled_fp8_quant(input_B[i],
                                                 scales[i].to(torch.float32),
                                                 False,
                                                 False,
                                                 fp8_dtype=fp8_dtype)
        input_B = input_B_fp8
        is_B_fp8block = False
    elif recipe == "block_fp8":
        assert n % BLOCK_SIZE == 0 and k % BLOCK_SIZE == 0, (
            "block_fp8 requires N and K divisible by 128")
        # block-wise fp8 weights, 128x128 fp32 block scales
        # [num_experts, K // 128, N // 128].
        num_k_blocks = k // BLOCK_SIZE
        num_n_blocks = n // BLOCK_SIZE
        random_exponents = torch.randint(
            -3, 4, (num_experts, num_k_blocks, num_n_blocks), device=DEVICE)
        scales = torch.pow(2.0, random_exponents.float()).contiguous()
        input_B = input_B.to(fp8_dtype)
        is_B_fp8block = True
    else:
        raise ValueError(f"Unknown recipe: {recipe}")

    return dict(
        input_A=input_A,
        input_B=input_B,
        scales=scales,
        bias=bias,
        output=output,
        num_rows_per_expert=num_rows_per_expert,
        n=n,
        k=k,
        num_experts=num_experts,
        is_B_int4=False,
        is_B_mxfp4=False,
        is_B_fp8block=is_B_fp8block,
    )


def run_grouped_gemm(kwargs):
    # The recipe is inferred from the dtype/shape of input_B and scales.
    cutlass_grouped_gemm_xe2(
        kwargs["input_A"],
        kwargs["input_B"],
        kwargs["scales"],
        kwargs["bias"],
        kwargs["output"],
        kwargs["num_rows_per_expert"],
        kwargs["n"],
        kwargs["k"],
        kwargs["num_experts"],
    )


def time_ms(fn, warmup=25, rep=100):
    """Median latency in milliseconds using XPU events (triton-free)."""
    for _ in range(warmup):
        fn()
    torch.xpu.synchronize()

    times = []
    for _ in range(rep):
        start = torch.xpu.Event(enable_timing=True)
        end = torch.xpu.Event(enable_timing=True)
        start.record()
        fn()
        end.record()
        torch.xpu.synchronize()
        times.append(start.elapsed_time(end))
    times.sort()
    return times[len(times) // 2]


def get_benchmark(x_dtype, fp8_dtype, has_bias):
    line_vals = []
    line_names = []
    styles = []
    for recipe in RECIPES:
        line_vals.append(recipe)
        line_names.append(f"{recipe}(us)")
        styles.append(RECIPE_STYLES[recipe])
    for recipe in RECIPES:
        line_vals.append(f"{recipe}_tflops")
        line_names.append(f"{recipe}(TFLOP/s)")
        color, _ = RECIPE_STYLES[recipe]
        styles.append((color, "--"))

    @triton.testing.perf_report(
        triton.testing.Benchmark(
            x_names=["m", "n", "k"],
            x_vals=MNK_FACTORS,
            line_arg="provider",
            line_vals=line_vals,
            line_names=line_names,
            styles=styles,
            ylabel="Latency (us)",
            plot_name=f"grouped-gemm-block-fp8-{x_dtype}".replace(
                "torch.", ""),
            args={},
        ))
    def benchmark(m, n, k, provider):
        clear_xpu_cache()
        recipe = provider.replace("_tflops", "")
        report_tflops = provider.endswith("_tflops")

        kwargs = make_grouped_gemm_input(m, n, k, recipe, x_dtype, fp8_dtype,
                                         has_bias)

        quantiles = [0.5, 0.2, 0.8]
        ms, min_ms, max_ms = triton.testing.do_bench(
            lambda: run_grouped_gemm(kwargs),
            quantiles=quantiles,
            warmup=200,
            rep=1000,
        )

        if report_tflops:
            return (
                calculate_tflops(m, n, k, ms * 1000),
                calculate_tflops(m, n, k, max_ms * 1000),
                calculate_tflops(m, n, k, min_ms * 1000),
            )
        # do_bench returns milliseconds; report microseconds.
        return ms * 1000, min_ms * 1000, max_ms * 1000

    return benchmark


def bench_us(kwargs):
    """Median latency in microseconds, preferring triton's do_bench."""
    def fn():
        run_grouped_gemm(kwargs)

    if HAS_TRITON:
        return triton.testing.do_bench(fn, warmup=200, rep=1000) * 1000
    return time_ms(fn) * 1000


def run_plain(x_dtype, fp8_dtype, has_bias, csv_path=None):
    """Print a latency/TFLOP-s table per problem size, optionally saving CSV."""
    header = f"{'m':>6} {'n':>6} {'k':>6}"
    for recipe in RECIPES:
        header += f" | {recipe + ' us':>14} {recipe + ' TFLOP/s':>16}"
    print(header)
    print("-" * len(header))

    rows = []
    for m, n, k in MNK_FACTORS:
        line = f"{m:>6} {n:>6} {k:>6}"
        for recipe in RECIPES:
            clear_xpu_cache()
            kwargs = make_grouped_gemm_input(m, n, k, recipe, x_dtype,
                                             fp8_dtype, has_bias)
            us = bench_us(kwargs)
            tflops = calculate_tflops(m, n, k, us)
            line += f" | {us:>14.2f} {tflops:>16.2f}"
            rows.append((m, n, k, NUM_EXPERTS, TOPK, recipe, us, tflops))
        print(line, flush=True)

    if csv_path:
        with open(csv_path, "w", newline="") as f:
            w = csv.writer(f)
            w.writerow(["m", "n", "k", "experts", "topk", "recipe",
                        "latency_us", "tflops"])
            for r in rows:
                w.writerow([*r[:6], f"{r[6]:.2f}", f"{r[7]:.3f}"])
        print(f"\nwrote {csv_path}")


def check_correctness(x_dtype, fp8_dtype, has_bias):
    """Sanity check each recipe against an fp32 reference grouped GEMM."""
    seed_everything(7)
    n, k = 5120, 8192
    # Dispatch keys on A_avg_M = m*TOPK/NUM_EXPERTS, so sweep m to cover all
    # three policies; the large-M one folds scales into A instead of using a
    # second accumulator and is otherwise never exercised here.
    for avg_target in (4, 16, 64):
        m = max(1, round(avg_target * NUM_EXPERTS / TOPK))
        for recipe in RECIPES:
            check_one(m, n, k, recipe, x_dtype, fp8_dtype, has_bias)


def check_one(m, n, k, recipe, x_dtype, fp8_dtype, has_bias):
        avg_m = m * TOPK / NUM_EXPERTS
        kwargs = make_grouped_gemm_input(m, n, k, recipe, x_dtype, fp8_dtype,
                                         has_bias)
        run_grouped_gemm(kwargs)
        output = kwargs["output"]

        # Build an fp32 dequantized reference.
        input_A = kwargs["input_A"]
        input_B = kwargs["input_B"]
        scales = kwargs["scales"]
        bias = kwargs["bias"]
        num_rows_per_expert = kwargs["num_rows_per_expert"]

        ref = []
        pre = 0
        for i in range(NUM_EXPERTS):
            cur = int(num_rows_per_expert[i])
            if cur == 0:
                continue
            a = input_A[pre:pre + cur, :].to(torch.float32)
            if recipe == "bf16":
                w = input_B[i].to(torch.float32)
            elif recipe == "fp8":
                w = input_B[i].to(torch.float32) * scales[i]
            else:  # block_fp8
                scale_full = scales[i].repeat_interleave(
                    BLOCK_SIZE, dim=0).repeat_interleave(BLOCK_SIZE, dim=1)
                w = input_B[i].to(torch.float32) * scale_full
            out = a @ w
            if has_bias:
                out += bias[i]
            ref.append(out.to(x_dtype))
            pre += cur
        ref = torch.cat(ref, dim=0)

        try:
            torch.testing.assert_close(output, ref, rtol=1e-2, atol=1e-1)
            print(f"✅ {recipe:10s} m={m:<5d} avg_M={avg_m:<6.1f} matches reference")
        except AssertionError as err:
            print(f"❌ {recipe:10s} m={m:<5d} avg_M={avg_m:<6.1f} DIFFERS -> {err}")


def parse_args():
    parser = argparse.ArgumentParser(
        description="Benchmark XE2 grouped GEMM across fp8 recipes.")
    parser.add_argument(
        "--check",
        action="store_true",
        help="Verify each recipe against an fp32 reference before timing.")
    parser.add_argument(
        "--save-path",
        type=str,
        default=None,
        help="Directory to save benchmark CSV/plots. Defaults to no save.")
    parser.add_argument(
        "--dtype",
        type=str,
        choices=["bfloat16", "float16"],
        default="bfloat16",
        help="Activation/output dtype.")
    parser.add_argument(
        "--fp8-dtype",
        type=str,
        choices=["e4m3", "e5m2"],
        default="e4m3",
        help="FP8 weight dtype for the fp8 / block_fp8 recipes.")
    parser.add_argument(
        "--bias",
        action="store_true",
        help="Include a per-expert bias.")
    parser.add_argument(
        "--preset",
        choices=sorted(PRESETS),
        default="llama4",
        help="Problem-size preset: shapes, expert count and topk.")
    parser.add_argument(
        "--experts",
        type=int,
        default=None,
        help="Override expert count (per rank, i.e. 256/EP for DeepSeek-V3).")
    parser.add_argument(
        "--topk",
        type=int,
        default=None,
        help="Override experts-per-token.")
    parser.add_argument(
        "--m-values",
        type=str,
        default=None,
        help="Comma-separated token counts to sweep, overriding the preset.")
    parser.add_argument(
        "--recipes",
        type=str,
        default=None,
        help="Comma-separated subset of bf16,fp8,block_fp8.")
    parser.add_argument(
        "--plain",
        action="store_true",
        help="Print a table instead of triton's perf_report (no matplotlib).")
    parser.add_argument(
        "--csv",
        type=str,
        default=None,
        help="Write results to this CSV path (implies --plain).")
    return parser.parse_args()


def main():
    args = parse_args()
    seed_everything(7)

    global MNK_FACTORS, NUM_EXPERTS, TOPK, RECIPES
    MNK_FACTORS, NUM_EXPERTS, TOPK = PRESETS[args.preset]
    if args.experts is not None:
        NUM_EXPERTS = args.experts
    if args.topk is not None:
        TOPK = args.topk
    if args.m_values:
        _, n, k = MNK_FACTORS[0]
        MNK_FACTORS = [(int(m), n, k) for m in args.m_values.split(",")]
    if args.recipes:
        RECIPES = [r.strip() for r in args.recipes.split(",")]
    print(f"[config] preset={args.preset} experts={NUM_EXPERTS} topk={TOPK} "
          f"recipes={RECIPES} shapes={len(MNK_FACTORS)}")

    x_dtype = {
        "bfloat16": torch.bfloat16,
        "float16": torch.float16,
    }[args.dtype]
    fp8_dtype = {
        "e4m3": torch.float8_e4m3fn,
        "e5m2": torch.float8_e5m2,
    }[args.fp8_dtype]
    has_bias = args.bias

    if args.check:
        check_correctness(x_dtype, fp8_dtype, has_bias)

    if not HAS_TRITON:
        print("[info] triton not available; using XPU-event timing fallback.")
    if args.plain or args.csv or not HAS_TRITON:
        run_plain(x_dtype, fp8_dtype, has_bias, args.csv)
        return

    benchmark = get_benchmark(x_dtype, fp8_dtype, has_bias)
    if args.save_path:
        ensure_save_path_exists(args.save_path)
        benchmark.run(print_data=True,
                      show_plots=False,
                      save_path=args.save_path)
    else:
        benchmark.run(print_data=True, show_plots=False)


if __name__ == "__main__":
    main()
```

</p>
</details> 

## Test Result
I tested DeepSeek-V3 MoE shapes, 64 experts per rank (EP=4), top-8, 128x128 block scales, bf16 activations / e4m3 weights. `m` is tokens before top-k expansion.


### Max 1550 (PVC), single tile

#### gate_up — N=4096, K=7168

| m | main (us) | this PR (us) | speedup | main TF/s | PR TF/s |
|---|---|---|---|---|---|
| 1 | 577.8 | ~595 | — [1] | 0.8 | 0.8 |
| 8 | 1868.0 | 1779.5 | **1.05x** | 2.0 | 2.1 |
| 64 | 2788.7 | 2463.0 | **1.13x** | 10.8 | 12.2 |
| 256 | 4766.5 | 3169.2 | **1.50x** | 25.2 | 37.9 |
| 512 | 6881.9 | 5169.5 | **1.33x** | 34.9 | 46.5 |
| 1024 | 9966.7 | 7654.7 | **1.30x** | 48.3 | 62.8 |
| 2048 | 16739.0 | 12913.9 | **1.30x** | 57.5 | 74.5 |
| 8192 | 57596.3 | 44740.3 | **1.29x** | 66.8 | **86.0** |

#### down_proj — N=7168, K=2048

| m | main (us) | this PR (us) | speedup | main TF/s | PR TF/s |
|---|---|---|---|---|---|
| 1 | 302.3 | 274.7 | — [1] | 0.8 | 0.9 |
| 8 | 970.8 | 932.1 | **1.04x** | 1.9 | 2.0 |
| 64 | 1541.4 | 1377.2 | **1.12x** | 9.8 | 10.9 |
| 256 | 2439.6 | 1647.3 | **1.48x** | 24.6 | 36.5 |
| 512 | 3305.4 | 2485.8 | **1.33x** | 36.4 | 48.4 |
| 1024 | 4946.5 | 3675.2 | **1.35x** | 48.6 | 65.4 |
| 2048 | 8604.4 | 6507.4 | **1.32x** | 55.9 | 73.9 |
| 8192 | 29258.1 | 22353.6 | **1.31x** | 65.8 | **86.1** |

[1] m=1 is launch-dominated (0.8 TF/s) and run-to-run spread is ~3.7% for both versions, so no reliable difference. All other points reproduce within 0.1-0.3%.

Peak throughput improves from 66.8 to 86.0 TF/s. The largest gain (~1.5x) is at m=256, which is the decode regime where block-FP8 is preferred over bf16.

### B60 (BMG)
#### gate_up N=4096 K=7168

| m | baseline (us) | this PR (us) | speedup | base TF/s | PR TF/s |
|---|---|---|---|---|---|
| 1 | 634.9 | 634.2 | **1.00x** | 0.7 | 0.7 |
| 8 | 3085.7 | 3067.9 | **1.01x** | 1.2 | 1.2 |
| 64 | 4318.0 | 4299.5 | **1.00x** | 7.0 | 7.0 |
| 256 | 6077.0 | 6030.2 | **1.01x** | 19.8 | 19.9 |
| 512 | 10579.2 | 7512.2 | **1.41x** | 22.7 | 32.0 |
| 1024 | 15058.4 | 10691.7 | **1.41x** | 31.9 | 45.0 |
| 2048 | 26499.5 | 18932.1 | **1.40x** | 36.3 | 50.8 |

#### down_proj N=7168 K=2048

| m | baseline (us) | this PR (us) | speedup | base TF/s | PR TF/s |
|---|---|---|---|---|---|
| 1 | 336.9 | 335.4 | **1.00x** | 0.7 | 0.7 |
| 8 | 1448.0 | 1449.9 | **1.00x** | 1.3 | 1.3 |
| 64 | 2233.3 | 2238.8 | **1.00x** | 6.7 | 6.7 |
| 256 | 2923.1 | 2843.2 | **1.03x** | 20.6 | 21.1 |
| 512 | 5316.3 | 3786.2 | **1.40x** | 22.6 | 31.8 |
| 1024 | 8025.8 | 5728.7 | **1.40x** | 30.0 | 42.0 |
| 2048 | 13225.4 | 9438.1 | **1.40x** | 36.4 | 51.0 |

### Why it's faster

VTune `gpu-hotspots`, per computing task, m=8192 gate_up:

| metric | main | this PR |
|---|---|---|
| avg kernel time | 57.380 ms | 44.165 ms |
| XVE Array Stalled | 18.5% | **14.6%** |
| ALU2 active | 26.5% | **38.8%** |
| XVE Threads Occupancy | 49.7% | 49.7% |
| Threads started | 98,560 | 98,560 |

