### PR TITLE
[Bugfix] Guard moe_align_block_size against negative expert_id (padding sentinel)

### DIFF
--- a/csrc/moe/moe_align_sum_kernels.cpp
+++ b/csrc/moe/moe_align_sum_kernels.cpp
@@ -195,7 +195,7 @@ void _moe_align_block_size(
 
   for (size_t i = tid; i < numel; i += stride) {
     int expert_id = static_cast<int>(topk_ids[i]);
-    if (expert_id >= num_experts) {
+    if (expert_id >= num_experts || expert_id < 0) {
       continue;
     }
     if (has_expert_map) {
@@ -329,6 +329,9 @@ void _moe_align_block_size_small_batch_expert(
   if (local_id_x >= fill_threads) {
     for (size_t i = tid; i < numel; i += stride) {
       int32_t expert_id = static_cast<int32_t>(topk_ids[i]);
+      if (expert_id >= num_experts || expert_id < 0) {
+        continue;
+      }
       if (has_expert_map) {
         expert_id = expert_map[expert_id];
         // filter invalid expert
@@ -384,6 +387,9 @@ void _moe_align_block_size_small_batch_expert(
 
     for (size_t i = tid; i < numel; i += stride) {
       int32_t expert_id = static_cast<int32_t>(topk_ids[i]);
+      if (expert_id >= num_experts || expert_id < 0) {
+        continue;
+      }
       if (has_expert_map) {
         expert_id = expert_map[expert_id];
         // filter invalid expert
@@ -425,7 +431,7 @@ void _count_and_sort_expert_tokens(
 
   for (size_t i = tid; i < numel; i += stride) {
     int32_t expert_id = static_cast<int32_t>(topk_ids[i]);
-    if (expert_id >= num_experts) {
+    if (expert_id >= num_experts || expert_id < 0) {
       continue;
     }
 

--- a/tests/test_moe_align_block_size.py
+++ b/tests/test_moe_align_block_size.py
@@ -250,15 +250,17 @@ def test_moe_align_block_size(m: int, topk: int, num_experts: int,
 @pytest.mark.parametrize("topk", [2, 4])
 @pytest.mark.parametrize("num_experts", [8])
 @pytest.mark.parametrize("block_size", [64])
+@pytest.mark.parametrize("mask_inactive_experts", [False, True])
 def test_moe_align_block_size_with_expert_map(m: int, topk: int,
                                               num_experts: int,
-                                              block_size: int):
-    """Test moe_align_block_size with expert mapping (EP scenario)"""
-    topk_ids = torch.zeros((m, topk), device="xpu", dtype=torch.int32)
-    for i in range(m):
-        experts = torch.randperm(num_experts, device="xpu")[:topk]
-        topk_ids[i] = experts
+                                              block_size: int,
+                                              mask_inactive_experts: bool):
+    """Test moe_align_block_size with expert mapping (EP scenario).
 
+    mask_inactive_experts=True feeds topk_ids=-1 for experts not owned by
+    this rank's expert_map (the padding-sentinel case), exercising the
+    expert_id < 0 guard on the OOB-read side of moe_align_block_size.
+    """
     expert_map = torch.full((num_experts, ),
                             -1,
                             device="xpu",
@@ -266,6 +268,14 @@ def test_moe_align_block_size_with_expert_map(m: int, topk: int,
     local_experts = list(range(0, num_experts, 2))
     for i, expert_id in enumerate(local_experts):
         expert_map[expert_id] = i
+
+    topk_ids = torch.empty((m, topk), device="xpu", dtype=torch.int32)
+    for i in range(m):
+        experts = torch.randperm(num_experts, device="xpu")[:topk]
+        for k in range(topk):
+            topk_ids[i, k] = (experts[k] if (
+                experts[k].item() in local_experts) or not mask_inactive_experts
+                              else -1)
 
     actual_sorted_ids, actual_expert_ids, actual_num_tokens = (
         moe_align_block_size(
@@ -299,6 +309,69 @@ def test_moe_align_block_size_with_expert_map(m: int, topk: int,
         actual_num_tokens.item(),
         m * topk,
     )
+
+
+@pytest.mark.parametrize("m", [16, 32])
+@pytest.mark.parametrize("topk", [2, 4])
+@pytest.mark.parametrize("num_experts", [8])
+@pytest.mark.parametrize("block_size", [64])
+def test_moe_align_block_size_negative_topk_ids_no_expert_map(
+        m: int, topk: int, num_experts: int, block_size: int):
+    """Test moe_align_block_size with topk_ids=-1 padding sentinels and
+    expert_map=None.
+
+    This is the DP/cudagraph padding path (VLLM_MOE_SKIP_PADDING), distinct
+    from test_moe_align_block_size_with_expert_map's EP path above: with no
+    expert_map, a missing `expert_id < 0` guard corrupts the small-batch
+    counting/sorting loops directly instead of going through the expert_map
+    lookup. Golden-compare below proves the valid (non-negative) tokens are
+    still routed correctly; it does not by itself prove the absence of an
+    out-of-bounds write for the padding rows on real hardware — that needs a
+    build with a memory sanitizer or validation layer, which this environment
+    cannot run.
+    """
+    topk_ids = torch.empty((m, topk), device="xpu", dtype=torch.int32)
+    num_valid_rows = m // 2
+    for i in range(m):
+        if i < num_valid_rows:
+            experts = torch.randperm(num_experts, device="xpu")[:topk]
+            topk_ids[i] = experts
+        else:
+            topk_ids[i] = -1
+
+    actual_sorted_ids, actual_expert_ids, actual_num_tokens = (
+        moe_align_block_size(
+            topk_ids=topk_ids,
+            block_size=block_size,
+            num_experts=num_experts,
+            ignore_invalid_experts=True,
+        ))
+    golden_sorted_ids, golden_expert_ids, golden_num_tokens = (
+        torch_moe_align_block_size(
+            topk_ids=topk_ids,
+            block_size=block_size,
+            num_experts=num_experts,
+        ))
+
+    torch.testing.assert_close(actual_num_tokens,
+                               golden_num_tokens,
+                               atol=0,
+                               rtol=0)
+    torch.testing.assert_close(actual_expert_ids,
+                               golden_expert_ids,
+                               atol=0,
+                               rtol=0)
+    _verify_expert_level_sorting(
+        actual_sorted_ids,
+        golden_sorted_ids,
+        actual_expert_ids,
+        block_size,
+        actual_num_tokens.item(),
+        m * topk,
+    )
+    assert (actual_expert_ids
+            >= 0).all() and (actual_expert_ids < num_experts).all(), (
+                "expert_ids should contain valid expert indices")
 
 
 @pytest.mark.parametrize("m", [128])


### PR DESCRIPTION
## Purpose

Fixes vllm-project/vllm-xpu-kernels#571.

`moe_align_block_size` (SYCL) guards `expert_id >= num_experts` but never `expert_id < 0`, at 4 sites (2 have no bound check at all). `-1` is a legitimate input: vLLM's padding-sentinel mechanism (`VLLM_MOE_SKIP_PADDING`, default on) emits it on essentially every XPU MoE forward (see `csrc/moe/topk.cpp:236-239`), and used as a raw index it causes an out-of-bounds write past `sorted_token_ids` — corrupting a neighboring tensor or segfaulting depending on size.

Fixed: `_moe_align_block_size` (L197) and `_count_and_sort_expert_tokens` (L433) — added the missing lower bound. `_moe_align_block_size_small_batch_expert` (L331/L386) — had no bound check at all. Same pattern already existed at L598 (`moe_sum_slot_active`); this applies it consistently. LoRA kernels call into these same functions, so they're fixed too.

Distinct from #453 (closed): that was valid, all-zero `topk_ids`; this is out-of-bounds access from an invalid (`-1`) input, still present on `origin/main`.

Out of scope: `csrc/moe/remap_hidden_states.cpp:61,104,224` has the same unguarded pattern — flagged in the issue, not fixed here.

Root cause verified by code reading. Hardware repro of the resulting corruption/segfault is in the companion vLLM-side PR vllm-project/vllm#55231 — that PR is a temporary stopgap (gates padding-sentinel emission on XPU) meant to be removed once this kernel fix ships in a released wheel; the repro there is evidence for vLLM's dispatch code, not offered here as evidence for this kernel diff.

## Test Plan

```
.venv/bin/python -m pytest tests/test_moe_align_block_size.py -k "expert_map or negative_topk_ids" -v
```

Extended `test_moe_align_block_size_with_expert_map` with a `mask_inactive_experts` case (ported from vLLM CUDA's `f378f79b7c`) and added `test_moe_align_block_size_negative_topk_ids_no_expert_map` for the previously-unguarded `expert_map=None` path.

## Test Result

Not build/run-verified — no SYCL/oneAPI environment available here. Golden-compare confirms valid tokens still route correctly with `-1` sentinels present; it doesn't by itself prove absence of an out-of-bounds write on hardware (needs a sanitizer build). Please run before merging.

## (Optional) Documentation Update

None.

