### PR TITLE
[ATTN][BUILD] Make the chunk-prefill _b16 tile policy explicit in .conf files

### DIFF
--- a/KERNEL_CONFIGURATION.md
+++ b/KERNEL_CONFIGURATION.md
@@ -115,16 +115,14 @@ Config files are located in `csrc/xpu/attn/kernel_configs/`.
 # Lines starting with # are comments. Empty lines are ignored.
 # Use 'all' to build everything (same as chunk_prefill_full.conf).
 
-# Format: headsize,paged,causal,local,sink,lse[,b16]
-128,true,true,false,false,false
-128,true,true,false,false,true    # paged LSE
-128,false,true,false,false,false
-128,false,true,false,false,true   # non-paged LSE
-192,true,true,false,false,false
-
-# Explicit tile policy (7th field):
-128,true,true,false,false,false,false   # standard policy only
-128,true,true,false,false,false,true    # _b16 policy only (page size 16)
+# Format: headsize,paged,causal,local,sink,lse,b16
+# All seven fields are required. Each line maps to exactly one kernel.
+128,true,true,false,false,false,false    # standard policy
+128,true,true,false,false,false,true     # _b16 policy (KV page size 16)
+128,true,true,false,false,true,false     # paged LSE
+128,false,true,false,false,false,false
+128,false,true,false,false,true,false    # non-paged LSE
+192,true,true,false,false,false,false
 ```
 
 **Parameters:**
@@ -135,19 +133,18 @@ Config files are located in `csrc/xpu/attn/kernel_configs/`.
 - `sink` — whether StreamingLLM attention sinks are used
 - `lse` — whether log-sum-exp is output. Paged and non-paged kernels require
   `local=false`, `sink=false`.
-- `b16` — *optional*. Selects the tile policy for the head size:
-  `false` builds `chunk_policy_head<N>` (`TileShapeQK` K-dim 32) and `true`
-  builds `chunk_policy_head<N>_b16` (K-dim 16). When omitted, **both** are
-  built. The `_b16` policy exists so that `tiles_per_page` stays 1 for a KV
-  cache page size of 16, and the dispatcher selects it only when the request
-  is paged and the page size is 16 — so `b16=true` requires `paged=true`.
-  Entries with `b16=true, paged=false` are unreachable and are skipped with a
-  warning.
+- `b16` — selects the tile policy for the head size: `false` builds
+  `chunk_policy_head<N>` (`TileShapeQK` K-dim 32), `true` builds
+  `chunk_policy_head<N>_b16` (K-dim 16). The `_b16` policy exists so that
+  `tiles_per_page` stays 1 for a KV cache page size of 16, and the dispatcher
+  selects it only when the request is paged and the page size is 16 — so
+  `b16=true` requires `paged=true`. Entries with `b16=true, paged=false` are
+  unreachable and are skipped with a warning.
 
-If boolean flags are omitted, all 20 valid combinations are generated for
-that headsize (each in both tile policies). A line must therefore have
-exactly 1, 6, or 7 comma-separated fields; any other count is rejected with
-a warning rather than silently truncated or expanded.
+Every line must have exactly 7 comma-separated fields. Any other count is
+rejected with a warning rather than silently truncated or expanded, so a
+typo cannot quietly change the generated kernel set. Use `all` on its own
+line to build every combination.
 
 ### Paged Decode
 

--- a/KERNEL_CONFIGURATION.md
+++ b/KERNEL_CONFIGURATION.md
@@ -145,7 +145,9 @@ Config files are located in `csrc/xpu/attn/kernel_configs/`.
   warning.
 
 If boolean flags are omitted, all 20 valid combinations are generated for
-that headsize (each in both tile policies).
+that headsize (each in both tile policies). A line must therefore have
+exactly 1, 6, or 7 comma-separated fields; any other count is rejected with
+a warning rather than silently truncated or expanded.
 
 ### Paged Decode
 

--- a/KERNEL_CONFIGURATION.md
+++ b/KERNEL_CONFIGURATION.md
@@ -85,7 +85,7 @@ Config files are located in `csrc/xpu/attn/kernel_configs/`.
 | File | Kernels | Use Case |
 |------|---------|----------|
 | `chunk_prefill_full.conf` | 240 | All combinations — supports every model |
-| `chunk_prefill_default.conf` | 70 | Llama, Qwen, DeepSeek MLA, Falcon, Gemma, Phi, GLM (default build) |
+| `chunk_prefill_default.conf` | 49 | Llama, Qwen, DeepSeek MLA, Falcon, Gemma, Phi, GLM (default build) |
 
 ### Paged Decode
 
@@ -115,12 +115,16 @@ Config files are located in `csrc/xpu/attn/kernel_configs/`.
 # Lines starting with # are comments. Empty lines are ignored.
 # Use 'all' to build everything (same as chunk_prefill_full.conf).
 
-# Format: headsize,paged,causal,local,sink,lse
+# Format: headsize,paged,causal,local,sink,lse[,b16]
 128,true,true,false,false,false
 128,true,true,false,false,true    # paged LSE
 128,false,true,false,false,false
 128,false,true,false,false,true   # non-paged LSE
 192,true,true,false,false,false
+
+# Explicit tile policy (7th field):
+128,true,true,false,false,false,false   # standard policy only
+128,true,true,false,false,false,true    # _b16 policy only (page size 16)
 ```
 
 **Parameters:**
@@ -131,9 +135,17 @@ Config files are located in `csrc/xpu/attn/kernel_configs/`.
 - `sink` — whether StreamingLLM attention sinks are used
 - `lse` — whether log-sum-exp is output. Paged and non-paged kernels require
   `local=false`, `sink=false`.
+- `b16` — *optional*. Selects the tile policy for the head size:
+  `false` builds `chunk_policy_head<N>` (`TileShapeQK` K-dim 32) and `true`
+  builds `chunk_policy_head<N>_b16` (K-dim 16). When omitted, **both** are
+  built. The `_b16` policy exists so that `tiles_per_page` stays 1 for a KV
+  cache page size of 16, and the dispatcher selects it only when the request
+  is paged and the page size is 16 — so `b16=true` requires `paged=true`.
+  Entries with `b16=true, paged=false` are unreachable and are skipped with a
+  warning.
 
 If boolean flags are omitted, all 20 valid combinations are generated for
-that headsize.
+that headsize (each in both tile policies).
 
 ### Paged Decode
 
@@ -396,7 +408,7 @@ cat build/temp_template/csrc/xpu/attn/xe_2/paged_decode_enabled_policies_gen.hpp
 
 | Config | Build Time | Chunk Prefill Kernels | Paged Decode Kernels | Flexibility |
 |--------|------------|----------------------|----------------------|-------------|
-| `default` | ~2 min | ~31 | ~17 | Llama, Qwen, DeepSeek MLA, Falcon |
+| `default` | ~2 min | 49 | 32 | Llama, Qwen, DeepSeek MLA, Falcon |
 | `full` | ~60 min | 240 | 384 | All models |
 
 ### Binary Size Impact

--- a/KERNEL_CONFIGURATION.md
+++ b/KERNEL_CONFIGURATION.md
@@ -84,7 +84,7 @@ Config files are located in `csrc/xpu/attn/kernel_configs/`.
 
 | File | Kernels | Use Case |
 |------|---------|----------|
-| `chunk_prefill_full.conf` | 240 | All combinations — supports every model |
+| `chunk_prefill_full.conf` | 180 | All combinations — supports every model |
 | `chunk_prefill_default.conf` | 49 | Llama, Qwen, DeepSeek MLA, Falcon, Gemma, Phi, GLM (default build) |
 
 ### Paged Decode
@@ -144,7 +144,9 @@ Config files are located in `csrc/xpu/attn/kernel_configs/`.
 Every line must have exactly 7 comma-separated fields. Any other count is
 rejected with a warning rather than silently truncated or expanded, so a
 typo cannot quietly change the generated kernel set. Use `all` on its own
-line to build every combination.
+line to build every reachable combination; `all` applies the same
+`b16=true` requires `paged=true` rule, so it never emits the unreachable
+`b16=true, paged=false` kernels.
 
 ### Paged Decode
 
@@ -408,7 +410,7 @@ cat build/temp_template/csrc/xpu/attn/xe_2/paged_decode_enabled_policies_gen.hpp
 | Config | Build Time | Chunk Prefill Kernels | Paged Decode Kernels | Flexibility |
 |--------|------------|----------------------|----------------------|-------------|
 | `default` | ~2 min | 49 | 32 | Llama, Qwen, DeepSeek MLA, Falcon |
-| `full` | ~60 min | 240 | 384 | All models |
+| `full` | ~45 min | 180 | 384 | All models |
 
 ### Binary Size Impact
 

--- a/csrc/xpu/attn/kernel_configs/README.md
+++ b/csrc/xpu/attn/kernel_configs/README.md
@@ -6,7 +6,7 @@ variants are compiled.
 | File | Kernels | Use Case |
 |------|---------|----------|
 | `chunk_prefill_full.conf` | 240 | Chunk prefill — all combinations |
-| `chunk_prefill_default.conf` | 70 | Chunk prefill — Llama, Qwen, DeepSeek MLA, Falcon, Gemma, Phi, GLM |
+| `chunk_prefill_default.conf` | 49 | Chunk prefill — Llama, Qwen, DeepSeek MLA, Falcon, Gemma, Phi, GLM |
 | `paged_decode_full.conf` | 384 | Paged decode — all combinations |
 | `paged_decode_default.conf` | 32 | Paged decode — Llama, Qwen, DeepSeek MLA, Falcon, Starcoder2, Phi, VLM2Vec |
 
@@ -14,7 +14,8 @@ For config file format, usage examples, model-specific guidance, and
 troubleshooting, see **[KERNEL_CONFIGURATION.md](../../../../KERNEL_CONFIGURATION.md)**
 at the repository root.
 
-Note: each chunk prefill config line expands to two kernels (the standard and
-`_b16` policy for that head size), so the 35 lines in
-`chunk_prefill_default.conf` produce 70 kernels. Paged decode config lines map
-one-to-one to kernels.
+Note: a chunk prefill config line that omits the trailing `b16` field expands
+to two kernels (the standard and `_b16` policy for that head size). Adding an
+explicit `b16` value selects a single policy, so each such line produces one
+kernel. `chunk_prefill_default.conf` is fully explicit and its 49 lines produce
+49 kernels. Paged decode config lines map one-to-one to kernels.

--- a/csrc/xpu/attn/kernel_configs/README.md
+++ b/csrc/xpu/attn/kernel_configs/README.md
@@ -14,8 +14,8 @@ For config file format, usage examples, model-specific guidance, and
 troubleshooting, see **[KERNEL_CONFIGURATION.md](../../../../KERNEL_CONFIGURATION.md)**
 at the repository root.
 
-Note: a chunk prefill config line that omits the trailing `b16` field expands
-to two kernels (the standard and `_b16` policy for that head size). Adding an
-explicit `b16` value selects a single policy, so each such line produces one
-kernel. `chunk_prefill_default.conf` is fully explicit and its 49 lines produce
-49 kernels. Paged decode config lines map one-to-one to kernels.
+Note: every chunk prefill config line has seven required fields and maps to
+exactly one kernel, so the 49 lines in `chunk_prefill_default.conf` produce 49
+kernels. The trailing `b16` field picks the tile policy (`chunk_policy_head<N>`
+or `chunk_policy_head<N>_b16`). Paged decode config lines map one-to-one to
+kernels.

--- a/csrc/xpu/attn/kernel_configs/README.md
+++ b/csrc/xpu/attn/kernel_configs/README.md
@@ -5,7 +5,7 @@ variants are compiled.
 
 | File | Kernels | Use Case |
 |------|---------|----------|
-| `chunk_prefill_full.conf` | 240 | Chunk prefill — all combinations |
+| `chunk_prefill_full.conf` | 180 | Chunk prefill — all combinations |
 | `chunk_prefill_default.conf` | 49 | Chunk prefill — Llama, Qwen, DeepSeek MLA, Falcon, Gemma, Phi, GLM |
 | `paged_decode_full.conf` | 384 | Paged decode — all combinations |
 | `paged_decode_default.conf` | 32 | Paged decode — Llama, Qwen, DeepSeek MLA, Falcon, Starcoder2, Phi, VLM2Vec |
@@ -19,3 +19,8 @@ exactly one kernel, so the 49 lines in `chunk_prefill_default.conf` produce 49
 kernels. The trailing `b16` field picks the tile policy (`chunk_policy_head<N>`
 or `chunk_policy_head<N>_b16`). Paged decode config lines map one-to-one to
 kernels.
+
+The `all` keyword in `chunk_prefill_full.conf` expands to every valid
+combination except `b16` with `paged=false`: `fmha_xe2.cpp` only selects a
+`_b16` policy when the attention is paged with block size 16, so those kernels
+could never be dispatched.

--- a/csrc/xpu/attn/kernel_configs/chunk_prefill_default.conf
+++ b/csrc/xpu/attn/kernel_configs/chunk_prefill_default.conf
@@ -7,75 +7,101 @@
 #   Llama-2/3 / Qwen2/2.5/3 -> head_size=128, causal=true
 #   DeepSeek-V2/V3/R1 (MLA) -> head_size=192, causal=true
 #
-# Format: headsize,paged,causal,local,sink,lse
+# Format: headsize,paged,causal,local,sink,lse,b16
 #
-# This config generates a small subset of kernels (vs 240 full)
+# The trailing b16 field selects the tile policy explicitly:
+#   b16=false -> chunk_policy_head<N>      (TileShapeQK K-dim 32)
+#   b16=true  -> chunk_policy_head<N>_b16  (TileShapeQK K-dim 16)
+# The _b16 policy is dispatched by fmha_xe2.cpp only when the request is paged
+# AND the KV cache page size is 16, so b16=true requires paged=true.
+#
+# Every line below is explicit, so each line generates exactly one kernel.
+# Shapes that need both page sizes list two lines. The b16 entries kept here
+# are the ones exercised by tests/flash_attn/test_flash_attn_varlen_func.py;
+# other shapes ship the standard policy only and fall back to the reference
+# path if they are ever run paged with page size 16.
+#
+# This config generates 49 kernels (vs 240 full).
 # To enable sliding-window, uncomment the local=true lines below.
 
 # --- Llama / Qwen family (head_size=128) ------------------------------------
 # paged KV cache (chunked decode/prefill with page table)
-128,true,true,false,false,false
-128,true,true,false,false,true
+128,true,true,false,false,false,false
+128,true,true,false,false,false,true
+128,true,true,false,false,true,false
+128,true,true,false,false,true,true
 # paged KV cache, non-causal (mixed prefill/decode batches with is_causal=False)
-128,true,false,false,false,false
-128,true,false,false,false,true
+128,true,false,false,false,false,false
+128,true,false,false,false,false,true
+128,true,false,false,false,true,false
+128,true,false,false,false,true,true
 # non-paged (initial prompt processing)
-128,false,true,false,false,false
+128,false,true,false,false,false,false
 # BMG BME campaign (non-paged, non-causal)
-128,false,false,false,false,false
+128,false,false,false,false,false,false
 # non-paged with LSE output (chunked prefill state merging)
-128,false,true,false,false,true
+128,false,true,false,false,true,false
 
 # Sliding window -- uncomment if needed:
-# 128,true,true,true,false,false
-# 128,false,true,true,false,false
+# 128,true,true,true,false,false,false
+# 128,false,true,true,false,false,false
 
 # --- DeepSeek MLA latent heads (head_size=192) ------------------------------
-192,true,true,false,false,false
-192,true,true,false,false,true
-192,false,true,false,false,false
-192,false,true,false,false,true
-192,false,false,false,false,true
+192,true,true,false,false,false,false
+192,true,true,false,false,true,false
+192,false,true,false,false,false,false
+192,false,true,false,false,true,false
+192,false,false,false,false,true,false
 
 # --- Falcon-7B (MQA, head_size=64); GQA ratio handled by per-head grid -------
 # paged (chunked decode/prefill with page table) + non-paged (initial prompt)
-64,true,true,false,false,false
-64,true,true,false,false,true
-64,true,false,false,false,false
-64,true,false,false,false,true
-64,false,true,false,false,false
-64,false,false,false,false,false
+64,true,true,false,false,false,false
+64,true,true,false,false,false,true
+64,true,true,false,false,true,false
+64,true,true,false,false,true,true
+64,true,false,false,false,false,false
+64,true,false,false,false,false,true
+64,true,false,false,false,true,false
+64,true,false,false,false,true,true
+64,false,true,false,false,false,false
+64,false,false,false,false,false,false
 # BMG BME campaign (non-paged, local/sliding-window (head_size=64))
-64,false,false,true,false,false
+64,false,false,true,false,false,false
 
 # openai/gpt-oss-20b
-64,true,false,true,true,false
-64,true,true,false,true,false
+64,true,false,true,true,false,false
+64,true,false,true,true,false,true
+64,true,true,false,true,false,false
+64,true,true,false,true,false,true
 
 # --- Qwen3.5 non-causal heads ----------------------------------------------
 # Qwen/Qwen3.5-35B-A3B, Qwen/Qwen3.5-9B
-96,false,false,false,false,false
+96,false,false,false,false,false,false
 # BMG BME campaign (paged, causal (head_size=96))
-96,true,true,false,false,false
-96,true,true,false,false,true
+96,true,true,false,false,false,false
+96,true,true,false,false,true,false
 
 # --- Sliding-window/local model coverage ------------------------------------
 # google/gemma-3-12b-it, google/gemma-4-26B-A4B-it
-256,true,false,true,false,false
-512,true,true,false,false,false
-512,true,true,false,false,true
+256,true,false,true,false,false,false
+256,true,false,true,false,false,true
+512,true,true,false,false,false,false
+512,true,true,false,false,false,true
+512,true,true,false,false,true,false
 # google/gemma-3-27b-it
-128,true,false,true,false,false
+128,true,false,true,false,false,false
+128,true,false,true,false,false,true
 # Microsoft/Phi-3.5-mini-instruct
-96,true,false,true,false,false
+96,true,false,true,false,false,false
 
 # --- Qwen3-Next causal heads -------------------------------------------------
 # Qwen/Qwen3-Next-80B-A3B-Instruct, Qwen/Qwen3-Next-80B-A3B-Thinking
-256,true,true,false,false,false
-256,true,true,false,false,true
+256,true,true,false,false,false,false
+256,true,true,false,false,false,true
+256,true,true,false,false,true,false
 
 # --- zai-org/GLM-4.7-Flash ---------------------------------------------------
-256,false,true,false,false,false
-256,false,true,false,false,true
-256,false,false,false,false,true
-256,false,false,false,false,false
+256,false,true,false,false,false,false
+256,false,true,false,false,true,false
+256,false,false,false,false,true,false
+256,false,false,false,false,false,false

--- a/csrc/xpu/attn/kernel_configs/chunk_prefill_default.conf
+++ b/csrc/xpu/attn/kernel_configs/chunk_prefill_default.conf
@@ -9,13 +9,13 @@
 #
 # Format: headsize,paged,causal,local,sink,lse,b16
 #
-# The trailing b16 field selects the tile policy explicitly:
+# All seven fields are required, so each line generates exactly one kernel.
+# The b16 field selects the tile policy:
 #   b16=false -> chunk_policy_head<N>      (TileShapeQK K-dim 32)
 #   b16=true  -> chunk_policy_head<N>_b16  (TileShapeQK K-dim 16)
 # The _b16 policy is dispatched by fmha_xe2.cpp only when the request is paged
 # AND the KV cache page size is 16, so b16=true requires paged=true.
 #
-# Every line below is explicit, so each line generates exactly one kernel.
 # Shapes that need both page sizes list two lines. The b16 entries kept here
 # are the ones exercised by tests/flash_attn/test_flash_attn_varlen_func.py;
 # other shapes ship the standard policy only and fall back to the reference

--- a/csrc/xpu/attn/kernel_configs/chunk_prefill_full.conf
+++ b/csrc/xpu/attn/kernel_configs/chunk_prefill_full.conf
@@ -1,21 +1,25 @@
 # =============================================================================
 # Full chunk prefill kernel configuration (default - builds ALL combinations)
 # =============================================================================
-# This produces the maximum number of kernels (240 instantiations).
+# This produces the maximum number of kernels (180 instantiations).
 # Use model-specific configs to reduce compile time and binary size.
 #
-# Format: headsize[,paged,causal,local,sink,lse]
+# Format: headsize,paged,causal,local,sink,lse,b16
 #   - headsize: 64, 96, 128, 192, 256, or 512
 #   - paged: true or false (whether paged KV cache is used)
 #   - causal: true or false
 #   - local: true or false (sliding window)
 #   - sink: true or false (StreamingLLM)
 #   - lse: true or false (paged and non-paged require local=false,sink=false)
+#   - b16: false selects chunk_policy_head<N>, true selects
+#     chunk_policy_head<N>_b16 (requires paged=true)
 #
-# If boolean flags are omitted, all valid combinations are generated (20 per policy).
-# Both standard and b16 policies are generated for each headsize.
+# All seven fields are required and each line maps to exactly one kernel.
 #
 # Lines starting with # are comments. Empty lines are ignored.
-# Use 'all' as a special keyword to build everything.
+# Use 'all' as a special keyword to build every reachable combination. It
+# expands to 180 kernels rather than 240 because the dispatcher in
+# fmha_xe2.cpp only selects a _b16 policy when the attention is paged with a
+# KV page size of 16, so the 60 b16 + paged=false kernels can never run.
 
 all

--- a/csrc/xpu/attn/xe_2/chunk_prefill_configure.cmake
+++ b/csrc/xpu/attn/xe_2/chunk_prefill_configure.cmake
@@ -7,11 +7,11 @@
 #
 # CMake Options: VLLM_CHUNK_PREFILL_CONFIG - Path to kernel config file
 # (default: chunk_prefill_full.conf) Config files located in:
-# csrc/xpu/attn/kernel_configs/ chunk_prefill_full.conf    - All 240
+# csrc/xpu/attn/kernel_configs/ chunk_prefill_full.conf    - All 180 reachable
 # combinations chunk_prefill_default.conf - Default model configs
 #
 # Config file format: - Lines starting with # are comments - Empty lines are
-# ignored - 'all' keyword builds everything - Each line:
+# ignored - 'all' keyword builds every reachable combination - Each line:
 # headsize,paged,causal,local,sink,lse,b16 - All seven fields are required, and
 # each line maps to exactly one kernel. Paged and non-paged LSE require
 # local=false,sink=false.
@@ -20,6 +20,7 @@
 # chunk_policy_head<N>_b16 (TileShapeQK[1] = 16, required for block_size = 16),
 # b16=false builds chunk_policy_head<N>. b16=true requires paged=true, since
 # fmha_xe2.cpp selects the _b16 policies only when is_paged && block_size == 16.
+# This applies to the 'all' keyword too, so it emits 180 kernels and not 240.
 # =============================================================================
 
 # Default config path
@@ -116,9 +117,18 @@ function(fmha_forward_configure FILENAME_SUFFIX)
   set(BUILD_TUPLES)
 
   if(CONFIG_IS_FULL)
-    # Full mode: generate all valid combinations (original behavior)
+    # Full mode: generate every reachable combination
     foreach(IMPL_POLICY ${policy_list})
+      set(_policy_is_b16 FALSE)
+      if(IMPL_POLICY MATCHES "_b16$")
+        set(_policy_is_b16 TRUE)
+      endif()
       foreach(IMPL_KISPAGED ${L_BOOLS})
+        # The _b16 policies are selected by fmha_xe2.cpp only when is_paged &&
+        # block_size == 16, so a non-paged _b16 kernel can never be dispatched.
+        if(_policy_is_b16 AND IMPL_KISPAGED STREQUAL "false")
+          continue()
+        endif()
         foreach(IMPL_KISCAUSAL ${L_BOOLS})
           foreach(IMPL_KISLOCAL ${L_BOOLS})
             foreach(IMPL_KISSINK ${L_BOOLS})

--- a/csrc/xpu/attn/xe_2/chunk_prefill_configure.cmake
+++ b/csrc/xpu/attn/xe_2/chunk_prefill_configure.cmake
@@ -161,6 +161,20 @@ function(fmha_forward_configure FILENAME_SUFFIX)
         continue()
       endif()
 
+      # A config entry is either a bare head size (all 20 valid combinations
+      # are generated) or a head size plus the five boolean flags, optionally
+      # followed by the b16 tile policy selector. Any other field count is a
+      # typo. Accepting it would silently drop the extra fields, or silently
+      # expand a partially specified entry into all 20 combinations, either of
+      # which yields an unexpected kernel set.
+      if(NOT (_nparts EQUAL 1 OR _nparts EQUAL 6 OR _nparts EQUAL 7))
+        message(
+          WARNING
+            "Skipping invalid config: expected 1, 6 or 7 comma-separated fields, got ${_nparts}: ${_entry}"
+        )
+        continue()
+      endif()
+
       if(_nparts GREATER_EQUAL 6)
         # Explicit boolean values provided
         list(GET _parts 1 _paged)
@@ -172,17 +186,19 @@ function(fmha_forward_configure FILENAME_SUFFIX)
         # Optional 7th field selects the tile policy explicitly. When omitted,
         # both the standard and the _b16 policy are generated.
         set(_b16 "")
-        if(_nparts GREATER_EQUAL 7)
+        if(_nparts EQUAL 7)
           list(GET _parts 6 _b16)
         endif()
 
-        # Validate boolean values
-        set(_bools ${_paged} ${_causal} ${_local} ${_sink} ${_lse})
-        if(NOT "${_b16}" STREQUAL "")
-          list(APPEND _bools ${_b16})
+        # Validate boolean values. Quote the values and iterate with IN LISTS
+        # so that empty fields (for example from a trailing or doubled comma)
+        # are actually seen rather than dropped by list expansion.
+        set(_bools "${_paged}" "${_causal}" "${_local}" "${_sink}" "${_lse}")
+        if(_nparts EQUAL 7)
+          list(APPEND _bools "${_b16}")
         endif()
         set(_invalid_bool FALSE)
-        foreach(_v ${_bools})
+        foreach(_v IN LISTS _bools)
           if(NOT (_v STREQUAL "true" OR _v STREQUAL "false"))
             message(WARNING "Skipping invalid config boolean entry: ${_entry}")
             set(_invalid_bool TRUE)
@@ -230,7 +246,7 @@ function(fmha_forward_configure FILENAME_SUFFIX)
           )
         endif()
       else()
-        # No booleans specified: generate all 20 valid combinations.
+        # Bare head size (_nparts == 1): generate all 20 valid combinations.
         foreach(IMPL_KISPAGED ${L_BOOLS})
           foreach(IMPL_KISCAUSAL ${L_BOOLS})
             foreach(IMPL_KISLOCAL ${L_BOOLS})

--- a/csrc/xpu/attn/xe_2/chunk_prefill_configure.cmake
+++ b/csrc/xpu/attn/xe_2/chunk_prefill_configure.cmake
@@ -146,9 +146,9 @@ function(fmha_forward_configure FILENAME_SUFFIX)
       string(REPLACE "|" ";" _parts "${_entry}")
       list(LENGTH _parts _nparts)
 
-      # Every entry is fully explicit: headsize plus the six boolean flags.
-      # Any other field count is a typo, and accepting it would silently drop
-      # or invent flags and yield an unexpected kernel set.
+      # Every entry is fully explicit: headsize plus the six boolean flags. Any
+      # other field count is a typo, and accepting it would silently drop or
+      # invent flags and yield an unexpected kernel set.
       if(NOT _nparts EQUAL 7)
         message(
           WARNING
@@ -175,9 +175,9 @@ function(fmha_forward_configure FILENAME_SUFFIX)
         continue()
       endif()
 
-      # Validate boolean values. Quote the values and iterate with IN LISTS
-      # so that empty fields (for example from a doubled comma) are actually
-      # seen rather than dropped by list expansion.
+      # Validate boolean values. Quote the values and iterate with IN LISTS so
+      # that empty fields (for example from a doubled comma) are actually seen
+      # rather than dropped by list expansion.
       set(_bools "${_paged}" "${_causal}" "${_local}" "${_sink}" "${_lse}"
                  "${_b16}")
       set(_invalid_bool FALSE)
@@ -202,9 +202,8 @@ function(fmha_forward_configure FILENAME_SUFFIX)
         continue()
       endif()
 
-      # The _b16 policies are selected by fmha_xe2.cpp only when
-      # is_paged && block_size == 16, so a non-paged _b16 kernel can never be
-      # dispatched.
+      # The _b16 policies are selected by fmha_xe2.cpp only when is_paged &&
+      # block_size == 16, so a non-paged _b16 kernel can never be dispatched.
       if(_b16 STREQUAL "true" AND _paged STREQUAL "false")
         message(
           WARNING

--- a/csrc/xpu/attn/xe_2/chunk_prefill_configure.cmake
+++ b/csrc/xpu/attn/xe_2/chunk_prefill_configure.cmake
@@ -2,8 +2,8 @@
 # Chunk Prefill Kernel Configuration
 # =============================================================================
 # This function generates kernel source files based on a configuration file that
-# specifies which (headsize, paged, causal, local, sink, lse) combinations to
-# build.
+# specifies which (headsize, paged, causal, local, sink, lse, b16) combinations
+# to build.
 #
 # CMake Options: VLLM_CHUNK_PREFILL_CONFIG - Path to kernel config file
 # (default: chunk_prefill_full.conf) Config files located in:
@@ -12,15 +12,14 @@
 #
 # Config file format: - Lines starting with # are comments - Empty lines are
 # ignored - 'all' keyword builds everything - Each line:
-# headsize[,paged,causal,local,sink,lse[,b16]] - If boolean flags are omitted,
-# all 20 valid combinations are generated. Paged and non-paged LSE require
+# headsize,paged,causal,local,sink,lse,b16 - All seven fields are required, and
+# each line maps to exactly one kernel. Paged and non-paged LSE require
 # local=false,sink=false.
 #
-# The optional 7th field selects the tile policy: b16=true builds only
+# The b16 field selects the tile policy: b16=true builds
 # chunk_policy_head<N>_b16 (TileShapeQK[1] = 16, required for block_size = 16),
-# b16=false builds only chunk_policy_head<N>. Omit it to build both. b16=true
-# requires paged=true, since fmha_xe2.cpp selects the _b16 policies only when
-# is_paged && block_size == 16.
+# b16=false builds chunk_policy_head<N>. b16=true requires paged=true, since
+# fmha_xe2.cpp selects the _b16 policies only when is_paged && block_size == 16.
 # =============================================================================
 
 # Default config path
@@ -146,11 +145,26 @@ function(fmha_forward_configure FILENAME_SUFFIX)
     foreach(_entry ${CONFIG_TUPLES})
       string(REPLACE "|" ";" _parts "${_entry}")
       list(LENGTH _parts _nparts)
-      if(_nparts LESS 1)
-        message(WARNING "Skipping invalid config entry: ${_entry}")
+
+      # Every entry is fully explicit: headsize plus the six boolean flags.
+      # Any other field count is a typo, and accepting it would silently drop
+      # or invent flags and yield an unexpected kernel set.
+      if(NOT _nparts EQUAL 7)
+        message(
+          WARNING
+            "Skipping invalid config: expected 7 comma-separated fields "
+            "(headsize,paged,causal,local,sink,lse,b16), got ${_nparts}: ${_entry}"
+        )
         continue()
       endif()
+
       list(GET _parts 0 _headsize)
+      list(GET _parts 1 _paged)
+      list(GET _parts 2 _causal)
+      list(GET _parts 3 _local)
+      list(GET _parts 4 _sink)
+      list(GET _parts 5 _lse)
+      list(GET _parts 6 _b16)
 
       # Guard against malformed entries (for example, BOM-prefixed comment
       # lines) that would otherwise expand to an empty policy name.
@@ -161,118 +175,52 @@ function(fmha_forward_configure FILENAME_SUFFIX)
         continue()
       endif()
 
-      # A config entry is either a bare head size (all 20 valid combinations
-      # are generated) or a head size plus the five boolean flags, optionally
-      # followed by the b16 tile policy selector. Any other field count is a
-      # typo. Accepting it would silently drop the extra fields, or silently
-      # expand a partially specified entry into all 20 combinations, either of
-      # which yields an unexpected kernel set.
-      if(NOT (_nparts EQUAL 1 OR _nparts EQUAL 6 OR _nparts EQUAL 7))
+      # Validate boolean values. Quote the values and iterate with IN LISTS
+      # so that empty fields (for example from a doubled comma) are actually
+      # seen rather than dropped by list expansion.
+      set(_bools "${_paged}" "${_causal}" "${_local}" "${_sink}" "${_lse}"
+                 "${_b16}")
+      set(_invalid_bool FALSE)
+      foreach(_v IN LISTS _bools)
+        if(NOT (_v STREQUAL "true" OR _v STREQUAL "false"))
+          message(WARNING "Skipping invalid config boolean entry: ${_entry}")
+          set(_invalid_bool TRUE)
+          break()
+        endif()
+      endforeach()
+      if(_invalid_bool)
+        continue()
+      endif()
+
+      # Local/Sink LSE tuples remain unsupported.
+      if(_lse STREQUAL "true" AND (_local STREQUAL "true" OR _sink STREQUAL
+                                                             "true"))
         message(
           WARNING
-            "Skipping invalid config: expected 1, 6 or 7 comma-separated fields, got ${_nparts}: ${_entry}"
+            "Skipping invalid config: lse=true requires local=false,sink=false: ${_entry}"
         )
         continue()
       endif()
 
-      if(_nparts GREATER_EQUAL 6)
-        # Explicit boolean values provided
-        list(GET _parts 1 _paged)
-        list(GET _parts 2 _causal)
-        list(GET _parts 3 _local)
-        list(GET _parts 4 _sink)
-        list(GET _parts 5 _lse)
-
-        # Optional 7th field selects the tile policy explicitly. When omitted,
-        # both the standard and the _b16 policy are generated.
-        set(_b16 "")
-        if(_nparts EQUAL 7)
-          list(GET _parts 6 _b16)
-        endif()
-
-        # Validate boolean values. Quote the values and iterate with IN LISTS
-        # so that empty fields (for example from a trailing or doubled comma)
-        # are actually seen rather than dropped by list expansion.
-        set(_bools "${_paged}" "${_causal}" "${_local}" "${_sink}" "${_lse}")
-        if(_nparts EQUAL 7)
-          list(APPEND _bools "${_b16}")
-        endif()
-        set(_invalid_bool FALSE)
-        foreach(_v IN LISTS _bools)
-          if(NOT (_v STREQUAL "true" OR _v STREQUAL "false"))
-            message(WARNING "Skipping invalid config boolean entry: ${_entry}")
-            set(_invalid_bool TRUE)
-            break()
-          endif()
-        endforeach()
-        if(_invalid_bool)
-          continue()
-        endif()
-
-        # Local/Sink LSE tuples remain unsupported.
-        if(_lse STREQUAL "true" AND (_local STREQUAL "true" OR _sink STREQUAL
-                                                               "true"))
-          message(
-            WARNING
-              "Skipping invalid config: lse=true requires local=false,sink=false: ${_entry}"
-          )
-          continue()
-        endif()
-
-        # The _b16 policies are selected by fmha_xe2.cpp only when
-        # is_paged && block_size == 16, so a non-paged _b16 kernel can never be
-        # dispatched.
-        if(_b16 STREQUAL "true" AND _paged STREQUAL "false")
-          message(
-            WARNING
-              "Skipping unreachable config: b16=true requires paged=true: ${_entry}"
-          )
-          continue()
-        endif()
-
-        # Generate the requested policies for this head size.
-        if("${_b16}" STREQUAL "" OR _b16 STREQUAL "false")
-          list(
-            APPEND
-            BUILD_TUPLES
-            "${std_policy_${_headsize}}|${_paged}|${_causal}|${_local}|${_sink}|${_lse}"
-          )
-        endif()
-        if("${_b16}" STREQUAL "" OR _b16 STREQUAL "true")
-          list(
-            APPEND
-            BUILD_TUPLES
-            "${b16_policy_${_headsize}}|${_paged}|${_causal}|${_local}|${_sink}|${_lse}"
-          )
-        endif()
-      else()
-        # Bare head size (_nparts == 1): generate all 20 valid combinations.
-        foreach(IMPL_KISPAGED ${L_BOOLS})
-          foreach(IMPL_KISCAUSAL ${L_BOOLS})
-            foreach(IMPL_KISLOCAL ${L_BOOLS})
-              foreach(IMPL_KISSINK ${L_BOOLS})
-                set(LSE_BOOLS "false")
-                if(IMPL_KISLOCAL STREQUAL "false" AND IMPL_KISSINK STREQUAL
-                                                      "false")
-                  set(LSE_BOOLS ${L_BOOLS})
-                endif()
-                foreach(IMPL_KISLSE ${LSE_BOOLS})
-                  list(
-                    APPEND
-                    BUILD_TUPLES
-                    "${std_policy_${_headsize}}|${IMPL_KISPAGED}|${IMPL_KISCAUSAL}|${IMPL_KISLOCAL}|${IMPL_KISSINK}|${IMPL_KISLSE}"
-                  )
-                  list(
-                    APPEND
-                    BUILD_TUPLES
-                    "${b16_policy_${_headsize}}|${IMPL_KISPAGED}|${IMPL_KISCAUSAL}|${IMPL_KISLOCAL}|${IMPL_KISSINK}|${IMPL_KISLSE}"
-                  )
-                endforeach()
-              endforeach()
-            endforeach()
-          endforeach()
-        endforeach()
+      # The _b16 policies are selected by fmha_xe2.cpp only when
+      # is_paged && block_size == 16, so a non-paged _b16 kernel can never be
+      # dispatched.
+      if(_b16 STREQUAL "true" AND _paged STREQUAL "false")
+        message(
+          WARNING
+            "Skipping unreachable config: b16=true requires paged=true: ${_entry}"
+        )
+        continue()
       endif()
+
+      # Emit the single policy selected by the b16 flag.
+      if(_b16 STREQUAL "true")
+        set(_policy "${b16_policy_${_headsize}}")
+      else()
+        set(_policy "${std_policy_${_headsize}}")
+      endif()
+      list(APPEND BUILD_TUPLES
+           "${_policy}|${_paged}|${_causal}|${_local}|${_sink}|${_lse}")
     endforeach()
   endif()
 

--- a/csrc/xpu/attn/xe_2/chunk_prefill_configure.cmake
+++ b/csrc/xpu/attn/xe_2/chunk_prefill_configure.cmake
@@ -12,11 +12,15 @@
 #
 # Config file format: - Lines starting with # are comments - Empty lines are
 # ignored - 'all' keyword builds everything - Each line:
-# headsize[,paged,causal,local,sink,lse] - If boolean flags are omitted, all 20
-# valid combinations are generated. Paged and non-paged LSE require
+# headsize[,paged,causal,local,sink,lse[,b16]] - If boolean flags are omitted,
+# all 20 valid combinations are generated. Paged and non-paged LSE require
 # local=false,sink=false.
 #
-# Both standard and b16 policies are generated for each headsize.
+# The optional 7th field selects the tile policy: b16=true builds only
+# chunk_policy_head<N>_b16 (TileShapeQK[1] = 16, required for block_size = 16),
+# b16=false builds only chunk_policy_head<N>. Omit it to build both. b16=true
+# requires paged=true, since fmha_xe2.cpp selects the _b16 policies only when
+# is_paged && block_size == 16.
 # =============================================================================
 
 # Default config path
@@ -165,9 +169,20 @@ function(fmha_forward_configure FILENAME_SUFFIX)
         list(GET _parts 4 _sink)
         list(GET _parts 5 _lse)
 
+        # Optional 7th field selects the tile policy explicitly. When omitted,
+        # both the standard and the _b16 policy are generated.
+        set(_b16 "")
+        if(_nparts GREATER_EQUAL 7)
+          list(GET _parts 6 _b16)
+        endif()
+
         # Validate boolean values
+        set(_bools ${_paged} ${_causal} ${_local} ${_sink} ${_lse})
+        if(NOT "${_b16}" STREQUAL "")
+          list(APPEND _bools ${_b16})
+        endif()
         set(_invalid_bool FALSE)
-        foreach(_v ${_paged} ${_causal} ${_local} ${_sink} ${_lse})
+        foreach(_v ${_bools})
           if(NOT (_v STREQUAL "true" OR _v STREQUAL "false"))
             message(WARNING "Skipping invalid config boolean entry: ${_entry}")
             set(_invalid_bool TRUE)
@@ -188,17 +203,32 @@ function(fmha_forward_configure FILENAME_SUFFIX)
           continue()
         endif()
 
-        # Generate for both standard and b16 policies
-        list(
-          APPEND
-          BUILD_TUPLES
-          "${std_policy_${_headsize}}|${_paged}|${_causal}|${_local}|${_sink}|${_lse}"
-        )
-        list(
-          APPEND
-          BUILD_TUPLES
-          "${b16_policy_${_headsize}}|${_paged}|${_causal}|${_local}|${_sink}|${_lse}"
-        )
+        # The _b16 policies are selected by fmha_xe2.cpp only when
+        # is_paged && block_size == 16, so a non-paged _b16 kernel can never be
+        # dispatched.
+        if(_b16 STREQUAL "true" AND _paged STREQUAL "false")
+          message(
+            WARNING
+              "Skipping unreachable config: b16=true requires paged=true: ${_entry}"
+          )
+          continue()
+        endif()
+
+        # Generate the requested policies for this head size.
+        if("${_b16}" STREQUAL "" OR _b16 STREQUAL "false")
+          list(
+            APPEND
+            BUILD_TUPLES
+            "${std_policy_${_headsize}}|${_paged}|${_causal}|${_local}|${_sink}|${_lse}"
+          )
+        endif()
+        if("${_b16}" STREQUAL "" OR _b16 STREQUAL "true")
+          list(
+            APPEND
+            BUILD_TUPLES
+            "${b16_policy_${_headsize}}|${_paged}|${_causal}|${_local}|${_sink}|${_lse}"
+          )
+        endif()
       else()
         # No booleans specified: generate all 20 valid combinations.
         foreach(IMPL_KISPAGED ${L_BOOLS})


### PR DESCRIPTION
## Purpose

Every chunk-prefill config line silently expanded to **two** translation units: `chunk_policy_head<N>` and its `_b16` variant (same thing with `TileShapeQK[1]` 32 -> 16, so `tiles_per_page` stays 1 at page size 16). But the dispatcher only selects `_b16` in one case (`fmha_xe2.cpp:269`):

```cpp
const bool use_b16_policy = is_paged && (block_size == 16);
```

So every `_b16` kernel with `paged=false` was dead code: 14 of the 70 in `chunk_prefill_default.conf`, 60 of the 240 in `chunk_prefill_full.conf`, each paying full AOT cost across 4 devices. The tile policy was also invisible in the config, so a 35-line `.conf` producing 70 kernels was not apparent to a reader.

This makes `b16` a regular required field:

```
headsize,paged,causal,local,sink,lse,b16
```

All seven fields are mandatory and **each line maps to exactly one kernel**. `b16=false` builds the standard policy, `b16=true` builds `_b16`, and `b16=true` with `paged=false` is rejected as undispatchable. The parser requires exactly 7 fields and warns plus skips otherwise, which removes the old implicit expansions that made the kernel set hard to predict from reading a `.conf`: a bare head size produced 40 kernels from one line, and a 6-field line produced 2.

The same `b16 => paged` rule is applied to the `all` keyword, so `chunk_prefill_full.conf` drops the 60 undispatchable tuples too. This is the config the CI `build-wheel` job uses, and that job gates `run-unit-tests-pvc` / `run-unit-tests-bmg`.

`chunk_prefill_default.conf` is rewritten fully explicit. Paged decode already treats this dimension as a first-class `pagesize` field, so this brings chunk prefill to the same footing.

## Test Plan

No unit test exists for the CMake parser and this box has no XPU hardware, so the parser was executed directly via a `cmake -P` harness that stubs `configure_file()` and prints the generated TU list. Verified the accepted and rejected forms, and diffed the emitted kernel sets old vs new.

## Test Result

| Config | Before | After |
| --- | --- | --- |
| `chunk_prefill_default.conf` | 70 | **49** |
| `chunk_prefill_full.conf` | 240 | **180** |

- All **35 standard-policy TUs are byte-identical** to before, so the non-`_b16` dispatch surface is unchanged.
- For `full.conf`, the emitted set was diffed old vs new: **60 removed, 0 added**, and all 60 are `_b16` with `paged=false`. Zero undispatchable kernels remain in either preset.
- 7 more `_b16` TUs removed from `default.conf` that no test exercises: head 96 paged (x3), head 192 paged (x2), head 256 paged+LSE, head 512 paged+LSE.
- The 14 retained `_b16` TUs in `default.conf` are all backed by `test_flash_attn_varlen_func.py`.
- Both presets parse with 0 warnings; files are ASCII-only (`file(STRINGS)` splits on non-ASCII bytes).

Malformed entries that used to be accepted silently are now rejected:

```
128                                       -> expected 7 fields, got 1
128,true,true,false,false,false           -> expected 7 fields, got 6
64,true,true,false,false,false,true,extra -> expected 7 fields, got 8
128,true,true,false,false,false,          -> invalid config boolean entry
128,true,,false,false,false,true          -> invalid config boolean entry
192,false,true,false,false,false,true     -> b16=true requires paged=true
```

Both shipped presets are unaffected by the stricter parser: `chunk_prefill_default.conf` is already fully explicit and `chunk_prefill_full.conf` uses the `all` keyword.

### Please review carefully

**This is a breaking change to the chunk-prefill config format.** Any out-of-tree `.conf` using a bare head size or the 6-field form will now warn and skip rather than build. Both in-tree presets are fine, but downstream configs need the `b16` field added.

**The 7 untested `_b16` removals from `default.conf` are a real, if narrow, coverage reduction**, and `flash_attn_varlen_func` swallows `"not compiled"` errors into a PyTorch fallback, so a missing kernel is a slowdown rather than a failure. Page-16 coverage in the two default configs now disagrees:

- `paged_decode_default.conf` has `pagesize=16` for heads 64, 96, 128, 192, 256
- `chunk_prefill_default.conf` has `b16=true` for heads 64, 128, 256, 512

Heads **96 and 192** (Phi / Qwen3.5, DeepSeek MLA) would decode with a real kernel but prefill through the fallback at page size 16. Realigning costs 5 TUs (49 -> 54). Happy to add them back if you prefer symmetry over the smaller build.

The `full.conf` reduction carries **no** coverage risk, since the removed kernels are unreachable by construction.

Unrelated finding, for visibility: the UTs exercise 108 distinct chunk-prefill tuples but only 38 exist in `chunk_prefill_default.conf`. CI never notices because the unit-test jobs install the **full-config** wheel, while `build-wheel-with-default-config` is built but never tested. That job is also 100% ccache hits today (measured: 761 cacheable calls, 761 hits, 0 misses), so the `default.conf` reduction is a cold-build and binary-size win rather than a CI-time win. The `full.conf` change is the one that shortens the critical path. All of this predates the PR and is otherwise left alone.

## (Optional) Documentation Update

- `KERNEL_CONFIGURATION.md`: documented `b16` as a required field with the `paged=true` rule and the strict field count; corrected the stale default-preset counts (claimed `~31`/`~17`, actual 49/32); updated the full-preset counts to 180.
- `csrc/xpu/attn/kernel_configs/README.md`: updated counts, replaced the now-wrong "each line expands to two kernels" note, documented what `all` expands to.
- `chunk_prefill_configure.cmake` header and both `.conf` headers describe the seven-field format; `chunk_prefill_full.conf` had a stale optional-field description that is now corrected.