### PR TITLE
optimize top p only sampler

### DIFF
--- a/csrc/xpu/sampler/topk_topp_sampler_kernels.hpp
+++ b/csrc/xpu/sampler/topk_topp_sampler_kernels.hpp
@@ -892,11 +892,30 @@ struct top_p_only_kernel {
     // topp
     if (top_p_value != 1.0f) {
       float low_count = 1.0f;
+      // Approximate count(high); replaced with the exact value once
+      // `high` actually moves.
+      float high_count = static_cast<float>(high);
+      // Illinois side tracker: +1 if `low` moved last, -1 if `high` did.
+      int last_side = 0;
       int iter = 0;
       do {
         float pivot_count_local = 0.0f;
 
-        pivot = (low + high) / 2;
+        // Regula falsi: interpolate the next pivot from the endpoints'
+        // measured counts instead of a plain midpoint; falls back to
+        // bisection if degenerate. Margin only guards zero-progress.
+        double denom =
+            static_cast<double>(low_count) - static_cast<double>(high_count);
+        double margin = (high - low) * 0.01;
+        if (denom > 1e-12 && margin > 0.0) {
+          pivot = low + (high - low) *
+                            (static_cast<double>(low_count) - top_p_value) /
+                            denom;
+          if (pivot < low + margin) pivot = low + margin;
+          if (pivot > high - margin) pivot = high - margin;
+        } else {
+          pivot = (low + high) / 2;
+        }
 
         for (int l = 0; l < loop_times; ++l) {
 #pragma unroll
@@ -938,10 +957,20 @@ struct top_p_only_kernel {
         if (pivot_count == top_p_value) {
           break;
         } else if (pivot_count < top_p_value) {
+          // Illinois: halve the stale side's count to avoid stalling.
+          if (last_side == -1) {
+            low_count = top_p_value + (low_count - top_p_value) * 0.5f;
+          }
           high = pivot;
+          high_count = pivot_count;
+          last_side = -1;
         } else {
+          if (last_side == 1) {
+            high_count = top_p_value + (high_count - top_p_value) * 0.5f;
+          }
           low = pivot;
           low_count = pivot_count;
+          last_side = 1;
         }
         ++iter;
       } while (((high - low) > eps) && iter < kMaxBisectIters);


### PR DESCRIPTION
Change the point selection method in binary search from the fixed midpoint `(low + high) / 2` to linear interpolation (using the regula falsi method with the Illinois modification).

Benchmark results:
Base:
<img width="965" height="224" alt="image" src="https://github.com/user-attachments/assets/b85ecae7-3f9e-44f5-b93e-c54a39fc6543" />
Optimized:
<img width="965" height="218" alt="image" src="https://github.com/user-attachments/assets/7089c57c-e551-4416-83fe-27e3f65edd94" />
 
As the pictures show, topp_whole and topp_partial 1.9x improvement.