### PR TITLE
[XPU] Fix VEC_SIZE decaying to 1 for act-and-mul kernels at d <= 1024

### DIFF
--- a/csrc/activation.cpp
+++ b/csrc/activation.cpp
@@ -432,6 +432,34 @@ class situ_and_mul_kernel {
 
 }  // namespace vllm
 
+namespace {
+
+// Below this many columns per vector lane, VEC_SIZE>1 has a per-call
+// device-time floor that regresses small-batch decode (see PR description).
+constexpr int kActAndMulMinVecCols = 256;
+// Below this total element count, the decode-regime floor above applies;
+// above it, larger batches amortize the floor enough that wider vector
+// loads still win.
+constexpr int64_t kActAndMulMinElemsForNarrowVec = int64_t(1) << 19;
+
+// Shrinks `max_vec_size` until `d` divides evenly by it and either the
+// resulting per-lane column count clears the small-batch decode floor, or
+// the input is large enough to amortize that floor anyway.
+inline int
+ComputeActAndMulVecSize(int d, int64_t num_tokens, int max_vec_size) {
+  const int64_t elems =
+      static_cast<int64_t>(num_tokens) * static_cast<int64_t>(d);
+  int vec_size = max_vec_size;
+  while (vec_size > 1 &&
+         (d % vec_size != 0 || (d / vec_size < kActAndMulMinVecCols &&
+                                elems < kActAndMulMinElemsForNarrowVec))) {
+    vec_size >>= 1;
+  }
+  return vec_size;
+}
+
+}  // namespace
+
 // Launch activation and gating kernel.
 // Use ACT_FIRST (bool) indicating whether to apply the activation function
 // first.
@@ -478,69 +506,55 @@ class situ_and_mul_kernel {
     break;                                                            \
   }
 
-#define LAUNCH_ACTIVATION_GATE_KERNEL_VEC(KERNEL, ACT_FIRST)             \
-  using sycl_t = vllm::xpu::SyclTypeTrait<scalar_t>::Type;               \
-  int d = input.size(-1) / 2;                                            \
-  int64_t num_tokens = input.numel() / input.size(-1);                   \
-  if (num_tokens == 0) {                                                 \
-    return;                                                              \
-  }                                                                      \
-  auto out_ptr = out.data_ptr<scalar_t>();                               \
-  auto input_ptr = input.data_ptr<scalar_t>();                           \
-  at::DeviceGuard device_guard(input.device());                          \
-  auto& queue = vllm::xpu::vllmGetQueue();                               \
-  int vec_size = static_cast<int>(sizeof(float) * 4 / sizeof(scalar_t)); \
-  {                                                                      \
-    const int64_t elems = num_tokens * static_cast<int64_t>(d);          \
-    while (vec_size > 1 &&                                               \
-           (d % vec_size != 0 ||                                         \
-            (d / vec_size < 256 && elems < (int64_t(1) << 19)))) {       \
-      vec_size = vec_size >> 1;                                          \
-    }                                                                    \
-  }                                                                      \
-  int64_t wg_size = std::min(                                            \
-      static_cast<int64_t>(d / vec_size), static_cast<int64_t>(1024));   \
-  switch (vec_size) {                                                    \
-    VEC_LAUNCH_ACT_AND_MUL(KERNEL, ACT_FIRST, 1);                        \
-    VEC_LAUNCH_ACT_AND_MUL(KERNEL, ACT_FIRST, 2);                        \
-    VEC_LAUNCH_ACT_AND_MUL(KERNEL, ACT_FIRST, 4);                        \
-    VEC_LAUNCH_ACT_AND_MUL(KERNEL, ACT_FIRST, 8);                        \
-    VEC_LAUNCH_ACT_AND_MUL(KERNEL, ACT_FIRST, 16);                       \
-    default:                                                             \
-      TORCH_CHECK(false, "Unsupported vector size: ", vec_size);         \
+#define LAUNCH_ACTIVATION_GATE_KERNEL_VEC(KERNEL, ACT_FIRST)                  \
+  using sycl_t = vllm::xpu::SyclTypeTrait<scalar_t>::Type;                    \
+  int d = input.size(-1) / 2;                                                 \
+  int64_t num_tokens = input.numel() / input.size(-1);                        \
+  if (num_tokens == 0) {                                                      \
+    return;                                                                   \
+  }                                                                           \
+  auto out_ptr = out.data_ptr<scalar_t>();                                    \
+  auto input_ptr = input.data_ptr<scalar_t>();                                \
+  at::DeviceGuard device_guard(input.device());                               \
+  auto& queue = vllm::xpu::vllmGetQueue();                                    \
+  int vec_size = ComputeActAndMulVecSize(                                     \
+      d, num_tokens, static_cast<int>(sizeof(float) * 4 / sizeof(scalar_t))); \
+  int64_t wg_size = std::min(                                                 \
+      static_cast<int64_t>(d / vec_size), static_cast<int64_t>(1024));        \
+  switch (vec_size) {                                                         \
+    VEC_LAUNCH_ACT_AND_MUL(KERNEL, ACT_FIRST, 1);                             \
+    VEC_LAUNCH_ACT_AND_MUL(KERNEL, ACT_FIRST, 2);                             \
+    VEC_LAUNCH_ACT_AND_MUL(KERNEL, ACT_FIRST, 4);                             \
+    VEC_LAUNCH_ACT_AND_MUL(KERNEL, ACT_FIRST, 8);                             \
+    VEC_LAUNCH_ACT_AND_MUL(KERNEL, ACT_FIRST, 16);                            \
+    default:                                                                  \
+      TORCH_CHECK(false, "Unsupported vector size: ", vec_size);              \
   }
 
-#define LAUNCH_ACTIVATION_GATE_KERNEL_WITH_PARAM_VEC(KERNEL, PARAM)      \
-  using sycl_t = vllm::xpu::SyclTypeTrait<scalar_t>::Type;               \
-  int d = input.size(-1) / 2;                                            \
-  int64_t num_tokens = input.numel() / input.size(-1);                   \
-  if (num_tokens == 0) {                                                 \
-    return;                                                              \
-  }                                                                      \
-  auto out_ptr = out.data_ptr<scalar_t>();                               \
-  auto input_ptr = input.data_ptr<scalar_t>();                           \
-  const float param = static_cast<float>(PARAM);                         \
-  at::DeviceGuard device_guard(input.device());                          \
-  auto& queue = vllm::xpu::vllmGetQueue();                               \
-  int vec_size = static_cast<int>(sizeof(float) * 4 / sizeof(scalar_t)); \
-  {                                                                      \
-    const int64_t elems = num_tokens * static_cast<int64_t>(d);          \
-    while (vec_size > 1 &&                                               \
-           (d % vec_size != 0 ||                                         \
-            (d / vec_size < 256 && elems < (int64_t(1) << 19)))) {       \
-      vec_size = vec_size >> 1;                                          \
-    }                                                                    \
-  }                                                                      \
-  int64_t wg_size = std::min(                                            \
-      static_cast<int64_t>(d / vec_size), static_cast<int64_t>(1024));   \
-  switch (vec_size) {                                                    \
-    VEC_LAUNCH_ACT_AND_MUL_WITH_PARAM(KERNEL, 1);                        \
-    VEC_LAUNCH_ACT_AND_MUL_WITH_PARAM(KERNEL, 2);                        \
-    VEC_LAUNCH_ACT_AND_MUL_WITH_PARAM(KERNEL, 4);                        \
-    VEC_LAUNCH_ACT_AND_MUL_WITH_PARAM(KERNEL, 8);                        \
-    VEC_LAUNCH_ACT_AND_MUL_WITH_PARAM(KERNEL, 16);                       \
-    default:                                                             \
-      TORCH_CHECK(false, "Unsupported vector size: ", vec_size);         \
+#define LAUNCH_ACTIVATION_GATE_KERNEL_WITH_PARAM_VEC(KERNEL, PARAM)           \
+  using sycl_t = vllm::xpu::SyclTypeTrait<scalar_t>::Type;                    \
+  int d = input.size(-1) / 2;                                                 \
+  int64_t num_tokens = input.numel() / input.size(-1);                        \
+  if (num_tokens == 0) {                                                      \
+    return;                                                                   \
+  }                                                                           \
+  auto out_ptr = out.data_ptr<scalar_t>();                                    \
+  auto input_ptr = input.data_ptr<scalar_t>();                                \
+  const float param = static_cast<float>(PARAM);                              \
+  at::DeviceGuard device_guard(input.device());                               \
+  auto& queue = vllm::xpu::vllmGetQueue();                                    \
+  int vec_size = ComputeActAndMulVecSize(                                     \
+      d, num_tokens, static_cast<int>(sizeof(float) * 4 / sizeof(scalar_t))); \
+  int64_t wg_size = std::min(                                                 \
+      static_cast<int64_t>(d / vec_size), static_cast<int64_t>(1024));        \
+  switch (vec_size) {                                                         \
+    VEC_LAUNCH_ACT_AND_MUL_WITH_PARAM(KERNEL, 1);                             \
+    VEC_LAUNCH_ACT_AND_MUL_WITH_PARAM(KERNEL, 2);                             \
+    VEC_LAUNCH_ACT_AND_MUL_WITH_PARAM(KERNEL, 4);                             \
+    VEC_LAUNCH_ACT_AND_MUL_WITH_PARAM(KERNEL, 8);                             \
+    VEC_LAUNCH_ACT_AND_MUL_WITH_PARAM(KERNEL, 16);                            \
+    default:                                                                  \
+      TORCH_CHECK(false, "Unsupported vector size: ", vec_size);              \
   }
 
 void silu_and_mul(
@@ -572,35 +586,29 @@ void silu_and_mul(
     break;                                                                    \
   }
 
-#define LAUNCH_ACTIVATION_GATE_QUANT_KERNEL(KERNEL)                          \
-  using sycl_t = vllm::xpu::SyclTypeTrait<scalar_t>::Type;                   \
-  int d = input.size(-1) / 2;                                                \
-  int64_t num_tokens = input.numel() / input.size(-1);                       \
-  if (num_tokens == 0) {                                                     \
-    return;                                                                  \
-  }                                                                          \
-  auto input_ptr = input.data_ptr<scalar_t>();                               \
-  auto scale_ptr = scale.data_ptr<float>();                                  \
-  at::DeviceGuard device_guard(input.device());                              \
-  auto& queue = vllm::xpu::vllmGetQueue();                                   \
-  /* Compute vec_size like non-quant path: gcd(4*sizeof(float)/sizeof, d) */ \
-  int vec_size = static_cast<int>(sizeof(float) * 4 / sizeof(sycl_t));       \
-  {                                                                          \
-    const int64_t elems = num_tokens * static_cast<int64_t>(d);              \
-    while (vec_size > 1 &&                                                   \
-           (d % vec_size != 0 ||                                             \
-            (d / vec_size < 256 && elems < (int64_t(1) << 19)))) {           \
-      vec_size = vec_size >> 1;                                              \
-    }                                                                        \
-  }                                                                          \
-  switch (vec_size) {                                                        \
-    LAUNCH_ACT_AND_MUL_QUANT_VEC(KERNEL, 1);                                 \
-    LAUNCH_ACT_AND_MUL_QUANT_VEC(KERNEL, 2);                                 \
-    LAUNCH_ACT_AND_MUL_QUANT_VEC(KERNEL, 4);                                 \
-    LAUNCH_ACT_AND_MUL_QUANT_VEC(KERNEL, 8);                                 \
-    LAUNCH_ACT_AND_MUL_QUANT_VEC(KERNEL, 16);                                \
-    default:                                                                 \
-      TORCH_CHECK(false, "Unsupported vector size: ", vec_size);             \
+#define LAUNCH_ACTIVATION_GATE_QUANT_KERNEL(KERNEL)                         \
+  using sycl_t = vllm::xpu::SyclTypeTrait<scalar_t>::Type;                  \
+  int d = input.size(-1) / 2;                                               \
+  int64_t num_tokens = input.numel() / input.size(-1);                      \
+  if (num_tokens == 0) {                                                    \
+    return;                                                                 \
+  }                                                                         \
+  auto input_ptr = input.data_ptr<scalar_t>();                              \
+  auto scale_ptr = scale.data_ptr<float>();                                 \
+  at::DeviceGuard device_guard(input.device());                             \
+  auto& queue = vllm::xpu::vllmGetQueue();                                  \
+  /* Same vec_size heuristic as the non-quant path, see */                  \
+  /* ComputeActAndMulVecSize above.                     */                  \
+  int vec_size = ComputeActAndMulVecSize(                                   \
+      d, num_tokens, static_cast<int>(sizeof(float) * 4 / sizeof(sycl_t))); \
+  switch (vec_size) {                                                       \
+    LAUNCH_ACT_AND_MUL_QUANT_VEC(KERNEL, 1);                                \
+    LAUNCH_ACT_AND_MUL_QUANT_VEC(KERNEL, 2);                                \
+    LAUNCH_ACT_AND_MUL_QUANT_VEC(KERNEL, 4);                                \
+    LAUNCH_ACT_AND_MUL_QUANT_VEC(KERNEL, 8);                                \
+    LAUNCH_ACT_AND_MUL_QUANT_VEC(KERNEL, 16);                               \
+    default:                                                                \
+      TORCH_CHECK(false, "Unsupported vector size: ", vec_size);            \
   }
 
 void silu_and_mul_quant(
@@ -811,13 +819,8 @@ void situ_and_mul(
   auto& queue = vllm::xpu::vllmGetQueue();
   VLLM_DISPATCH_FLOATING_TYPES(input.scalar_type(), "situ_and_mul", [&] {
     using sycl_t = vllm::xpu::SyclTypeTrait<scalar_t>::Type;
-    int vec_size = static_cast<int>(sizeof(float) * 4 / sizeof(sycl_t));
-    const int64_t elems = num_tokens * static_cast<int64_t>(d);
-    while (vec_size > 1 &&
-           (d % vec_size != 0 ||
-            (d / vec_size < 256 && elems < (int64_t(1) << 19)))) {
-      vec_size >>= 1;
-    }
+    const int vec_size = ComputeActAndMulVecSize(
+        d, num_tokens, static_cast<int>(sizeof(float) * 4 / sizeof(sycl_t)));
     const int64_t wg_size = std::min(
         static_cast<int64_t>(d / vec_size), static_cast<int64_t>(1024));
 

--- a/csrc/activation.cpp
+++ b/csrc/activation.cpp
@@ -491,13 +491,13 @@ class situ_and_mul_kernel {
   auto& queue = vllm::xpu::vllmGetQueue();                               \
   int vec_size = static_cast<int>(sizeof(float) * 4 / sizeof(scalar_t)); \
   {                                                                      \
-    int64_t tmp_wg =                                                     \
-        std::min(static_cast<int64_t>(d), static_cast<int64_t>(1024));   \
-    while (vec_size > 1 && (vec_size >> 1) * tmp_wg >= d) {              \
+    const int64_t elems = num_tokens * static_cast<int64_t>(d);          \
+    while (vec_size > 1 &&                                               \
+           (d % vec_size != 0 ||                                         \
+            (d / vec_size < 256 && elems < (int64_t(1) << 19)))) {       \
       vec_size = vec_size >> 1;                                          \
     }                                                                    \
   }                                                                      \
-  if (d % vec_size != 0) vec_size = 1;                                   \
   int64_t wg_size = std::min(                                            \
       static_cast<int64_t>(d / vec_size), static_cast<int64_t>(1024));   \
   switch (vec_size) {                                                    \
@@ -524,13 +524,13 @@ class situ_and_mul_kernel {
   auto& queue = vllm::xpu::vllmGetQueue();                               \
   int vec_size = static_cast<int>(sizeof(float) * 4 / sizeof(scalar_t)); \
   {                                                                      \
-    int64_t tmp_wg =                                                     \
-        std::min(static_cast<int64_t>(d), static_cast<int64_t>(1024));   \
-    while (vec_size > 1 && (vec_size >> 1) * tmp_wg >= d) {              \
+    const int64_t elems = num_tokens * static_cast<int64_t>(d);          \
+    while (vec_size > 1 &&                                               \
+           (d % vec_size != 0 ||                                         \
+            (d / vec_size < 256 && elems < (int64_t(1) << 19)))) {       \
       vec_size = vec_size >> 1;                                          \
     }                                                                    \
   }                                                                      \
-  if (d % vec_size != 0) vec_size = 1;                                   \
   int64_t wg_size = std::min(                                            \
       static_cast<int64_t>(d / vec_size), static_cast<int64_t>(1024));   \
   switch (vec_size) {                                                    \
@@ -586,13 +586,13 @@ void silu_and_mul(
   /* Compute vec_size like non-quant path: gcd(4*sizeof(float)/sizeof, d) */ \
   int vec_size = static_cast<int>(sizeof(float) * 4 / sizeof(sycl_t));       \
   {                                                                          \
-    int64_t tmp_wg =                                                         \
-        std::min(static_cast<int64_t>(d), static_cast<int64_t>(1024));       \
-    while (vec_size > 1 && (vec_size >> 1) * tmp_wg >= d) {                  \
+    const int64_t elems = num_tokens * static_cast<int64_t>(d);              \
+    while (vec_size > 1 &&                                                   \
+           (d % vec_size != 0 ||                                             \
+            (d / vec_size < 256 && elems < (int64_t(1) << 19)))) {           \
       vec_size = vec_size >> 1;                                              \
     }                                                                        \
   }                                                                          \
-  if (d % vec_size != 0) vec_size = 1;                                       \
   switch (vec_size) {                                                        \
     LAUNCH_ACT_AND_MUL_QUANT_VEC(KERNEL, 1);                                 \
     LAUNCH_ACT_AND_MUL_QUANT_VEC(KERNEL, 2);                                 \
@@ -812,13 +812,11 @@ void situ_and_mul(
   VLLM_DISPATCH_FLOATING_TYPES(input.scalar_type(), "situ_and_mul", [&] {
     using sycl_t = vllm::xpu::SyclTypeTrait<scalar_t>::Type;
     int vec_size = static_cast<int>(sizeof(float) * 4 / sizeof(sycl_t));
-    int64_t tmp_wg =
-        std::min(static_cast<int64_t>(d), static_cast<int64_t>(1024));
-    while (vec_size > 1 && (vec_size >> 1) * tmp_wg >= d) {
+    const int64_t elems = num_tokens * static_cast<int64_t>(d);
+    while (vec_size > 1 &&
+           (d % vec_size != 0 ||
+            (d / vec_size < 256 && elems < (int64_t(1) << 19)))) {
       vec_size >>= 1;
-    }
-    if (d % vec_size != 0) {
-      vec_size = 1;
     }
     const int64_t wg_size = std::min(
         static_cast<int64_t>(d / vec_size), static_cast<int64_t>(1024));


### PR DESCRIPTION
# Essential Elements of an Effective PR Description Checklist

  - [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
  - [x] The test plan, such as providing test command.
  - [x] The test results, such as pasting the results comparison before and after, or e2e results
  - [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.

  ## Purpose

  The `VEC_SIZE` heuristic in the act-and-mul kernels (`silu_and_mul`, `gelu_and_mul`, `mul_and_silu`, the FP8 quant variant, `fatrelu_and_mul`, `situ_and_mul`) compares the candidate vector width against
  `tmp_wg = min(d, 1024)`. For `d <= 1024`, `tmp_wg == d`, so the guard is trivially true and `vec_size` always decays to 1 — scalar loads instead of vectorized ones. `d <= 1024` is exactly the per-expert
  intermediate size several real MoE models use, so this silently de-optimizes MoE activation on Intel XPU.

  Fix: also weigh total element count (`num_tokens * d`), not just `d`:

  ```cpp
  const int64_t elems = num_tokens * static_cast<int64_t>(d);
  while (vec_size > 1 &&
         (d % vec_size != 0 ||
          (d / vec_size < 256 && elems < (int64_t(1) << 19)))) {
    vec_size >>= 1;
  }
```
  Applied at all four call sites sharing this heuristic (a fourth site, fatrelu_and_mul, had the identical bug but was missed originally).

  Note: a d-only version of this fix regresses small-batch decode — VEC_SIZE=8 has a real per-call device-time floor once d / vec_size <= 128, invisible to wall-clock but visible in profiler device time.
  The elems term exists specifically to avoid that.

  ## Test Plan

  - tests/test_activation.py unit tests, all four kernels, all dtypes.
  - Correctness vs. a torch reference across the affected d range and several num_tokens.
  - Bandwidth vs. a byte-identical control kernel, to confirm vectorized loads are actually used at d <= 1024.
  - Small-batch sweep across d × num_tokens targeting the decode regime a naive fix would regress.
  - Real MoE model (expert intermediate size in the affected range) end-to-end, prefill/balanced/decode regimes, checking dispatch path and device time.

  ## Test Result

  - Unit tests: 108/108 passed.
  - Correctness: max absolute error 0 at every d/num_tokens.
  - Bandwidth: 1.3–1.75x faster at d<=1024, now matching the control kernel; unchanged at d>=1536.
  - Decode sweep: no regression anywhere (within 1–2% of baseline), including where a naive d-only fix previously regressed 1.30x.
  - Real-model e2e: native CUTLASS MoE dispatch confirmed; fixed kernel measured at 1.8–7.9% of device time depending on regime, coherent output in all cases.
