### PR TITLE
[Attn] Fix Gemma4-26B default kernel coverage

### DIFF
--- a/csrc/xpu/attn/kernel_configs/paged_decode_default.conf
+++ b/csrc/xpu/attn/kernel_configs/paged_decode_default.conf
@@ -97,7 +97,7 @@
 16,128,16,false,true,false
 # spec-decode uniform qlen (qgroup=16, head=128, page=16, non-causal)
 16,128,16,false,false,false
-# google/gemma-3-12b-it, google/gemma-4-26B-A4B-it
+# google/gemma-3-12b-it, google/gemma-4-26b-a4b-it
 8,256,32,false,true,false
 8,256,64,false,true,false
 8,512,32,false,false,false

--- a/csrc/xpu/attn/kernel_configs/paged_decode_default.conf
+++ b/csrc/xpu/attn/kernel_configs/paged_decode_default.conf
@@ -98,7 +98,10 @@
 # spec-decode uniform qlen (qgroup=16, head=128, page=16, non-causal)
 16,128,16,false,false,false
 # google/gemma-3-12b-it, google/gemma-4-26B-A4B-it
+8,256,32,false,true,false
 8,256,64,false,true,false
+8,512,32,false,false,false
+8,512,64,false,false,false
 # google/gemma-3-27b-it
 
 # --- Qwen3-Next decode heads -------------------------------------------------

--- a/csrc/xpu/attn/kernel_configs/paged_decode_default.conf
+++ b/csrc/xpu/attn/kernel_configs/paged_decode_default.conf
@@ -97,12 +97,18 @@
 16,128,16,false,true,false
 # spec-decode uniform qlen (qgroup=16, head=128, page=16, non-causal)
 16,128,16,false,false,false
-# google/gemma-3-12b-it, google/gemma-4-26b-a4b-it
+
+# --- Gemma decode heads ----------------------------------------------------
+# Single-query decode uses causal=false: valid KV lengths exclude future tokens.
+# Sliding-window layers: head_size=256, local=true, sink=false.
+# google/gemma-3-12b-it, google/gemma-4-26B-A4B-it
 8,256,32,false,true,false
 8,256,64,false,true,false
+
+# Full-attention layers: global_head_dim=512, local=false, sink=false.
+# google/gemma-4-26B-A4B-it
 8,512,32,false,false,false
 8,512,64,false,false,false
-# google/gemma-3-27b-it
 
 # --- Qwen3-Next decode heads -------------------------------------------------
 # Qwen/Qwen3-Next-80B-A3B-Instruct, Qwen/Qwen3-Next-80B-A3B-Thinking


### PR DESCRIPTION
This PR adds missing default kernel config entries in response to https://github.com/vllm-project/vllm-xpu-kernels/issues/364#issuecomment-5537531185
