### PR TITLE
add compact_sampling_mask_kernel

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -681,6 +681,7 @@ if(XPU_SPECIFIC_KERNELS_ENABLED)
       "csrc/xpu/lora/lora_expand.cpp"
       "csrc/xpu/lora/lora_ops.cpp"
       "csrc/xpu/sampler/topk_topp_sampler.cpp"
+      "csrc/xpu/sampler/compact_sampling_mask.cpp"
       "csrc/xpu/sycl/deepseek_scaling_rope.cpp"
       "csrc/xpu/sycl/deepseek_qnorm_rope_kv_insert.cpp"
       "csrc/xpu/sycl/deepseek_inv_rope_bf16.cpp"

--- a/benchmark/benchmark_compact_sampling_mask.py
+++ b/benchmark/benchmark_compact_sampling_mask.py
@@ -1,0 +1,435 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# ruff: noqa: E402
+"""
+Benchmark comparing Sycl vs PyTorch implementations of compact_sampling_mask.
+
+Compares:
+- compact_sampling_mask_xpu (Sycl kernel)
+- compact_sampling_mask_torch (pure-PyTorch reference)
+- compact_sampling_mask_triton (vllm's Triton kernel), only when
+  USE_TRITON_COMPACT_SAMPLING_MASK=1 and vllm (with Triton) is importable.
+
+Scenarios (per batch/vocab size):
+- dense: (almost) all logits finite
+- sparse: only a small fraction of logits finite (post top_k/top_p filtering)
+- half_inactive: half the rows have no sampled token (num_sampled_tokens == 0)
+"""
+
+import argparse
+import gc
+from dataclasses import dataclass
+
+import torch
+from utils import bootstrap_benchmark_env
+
+bootstrap_benchmark_env(__file__)
+
+from tests.ops.compact_sampling_mask_op import (TRITON_AVAILABLE,
+                                                compact_sampling_mask_torch,
+                                                compact_sampling_mask_triton,
+                                                compact_sampling_mask_xpu)
+
+MAX_NUM_KEPT = 64
+
+
+@dataclass
+class BenchmarkConfig:
+    """Configuration for a benchmark run."""
+
+    name: str
+    batch_size: int
+    vocab_size: int
+    max_num_kept: int
+    finite_fraction: float
+    inactive_fraction: float
+    description: str
+
+
+def create_logits(
+    batch_size: int,
+    vocab_size: int,
+    finite_fraction: float,
+    device: str = "xpu",
+) -> torch.Tensor:
+    """Create random logits with a controllable fraction of finite entries,
+    mimicking rows that already went through top_k/top_p filtering."""
+    logits = torch.randn(batch_size, vocab_size, dtype=torch.float32,
+                         device=device)
+    if finite_fraction < 1.0:
+        drop_mask = torch.rand(batch_size, vocab_size,
+                               device=device) >= finite_fraction
+        logits = logits.masked_fill(drop_mask, float("-inf"))
+    return logits
+
+
+def create_num_sampled_tokens(
+    batch_size: int,
+    inactive_fraction: float,
+    device: str = "xpu",
+) -> torch.Tensor:
+    num_sampled_tokens = torch.ones(batch_size, dtype=torch.int32,
+                                    device=device)
+    num_inactive = int(round(batch_size * inactive_fraction))
+    if num_inactive > 0:
+        num_sampled_tokens[:num_inactive] = 0
+    return num_sampled_tokens
+
+
+def measure_memory() -> tuple[int, int]:
+    """Return (allocated, reserved) memory in bytes."""
+    torch.xpu.synchronize()
+    return torch.xpu.memory_allocated(), torch.xpu.max_memory_allocated()
+
+
+def reset_memory_stats():
+    """Reset peak memory statistics."""
+    torch.xpu.reset_peak_memory_stats()
+    torch.xpu.empty_cache()
+    gc.collect()
+
+
+def benchmark_function(
+    func: str,
+    logits: torch.Tensor,
+    num_sampled_tokens: torch.Tensor,
+    max_num_kept: int,
+    warmup_iters: int = 5,
+    benchmark_iters: int = 20,
+) -> tuple[float, int]:
+    """
+    Benchmark a function and return (avg_time_ms, peak_memory_bytes).
+    """
+    # Warmup
+    for _ in range(warmup_iters):
+        if func == "sycl":
+            compact_sampling_mask_xpu(logits, num_sampled_tokens,
+                                      max_num_kept)
+        elif func == "pytorch":
+            compact_sampling_mask_torch(logits, num_sampled_tokens,
+                                        max_num_kept)
+        elif func == "triton":
+            compact_sampling_mask_triton(logits, num_sampled_tokens,
+                                         max_num_kept)
+    torch.xpu.synchronize()
+
+    # Reset memory stats before benchmark
+    reset_memory_stats()
+
+    # Benchmark
+    start_events = [
+        torch.xpu.Event(enable_timing=True) for _ in range(benchmark_iters)
+    ]
+    end_events = [
+        torch.xpu.Event(enable_timing=True) for _ in range(benchmark_iters)
+    ]
+
+    for i in range(benchmark_iters):
+        start_events[i].record()
+        if func == "sycl":
+            compact_sampling_mask_xpu(logits, num_sampled_tokens,
+                                      max_num_kept)
+        elif func == "pytorch":
+            compact_sampling_mask_torch(logits, num_sampled_tokens,
+                                        max_num_kept)
+        elif func == "triton":
+            compact_sampling_mask_triton(logits, num_sampled_tokens,
+                                         max_num_kept)
+        end_events[i].record()
+
+    torch.xpu.synchronize()
+
+    # Calculate timing
+    times = [
+        start_events[i].elapsed_time(end_events[i])
+        for i in range(benchmark_iters)
+    ]
+    avg_time = sum(times) / len(times)
+
+    # Get peak memory
+    _, peak_memory = measure_memory()
+
+    return avg_time, peak_memory
+
+
+def create_benchmark_configs(
+    batch_sizes: list[int],
+    vocab_sizes: list[int],
+) -> list[BenchmarkConfig]:
+    """Create all benchmark configurations."""
+    configs = []
+
+    for vocab_size in vocab_sizes:
+        for batch_size in batch_sizes:
+            configs.append(
+                BenchmarkConfig(
+                    name=f"dense_b{batch_size}_v{vocab_size // 1000}k",
+                    batch_size=batch_size,
+                    vocab_size=vocab_size,
+                    max_num_kept=MAX_NUM_KEPT,
+                    finite_fraction=1.0,
+                    inactive_fraction=0.0,
+                    description=f"Dense (all finite), "
+                    f"batch={batch_size}, vocab={vocab_size}",
+                ))
+
+            configs.append(
+                BenchmarkConfig(
+                    name=f"sparse_b{batch_size}_v{vocab_size // 1000}k",
+                    batch_size=batch_size,
+                    vocab_size=vocab_size,
+                    max_num_kept=MAX_NUM_KEPT,
+                    finite_fraction=0.05,
+                    inactive_fraction=0.0,
+                    description=
+                    f"Sparse (5% finite, post top_k/top_p filtering), "
+                    f"batch={batch_size}, vocab={vocab_size}",
+                ))
+
+            configs.append(
+                BenchmarkConfig(
+                    name=f"half_inactive_b{batch_size}_v{vocab_size // 1000}k",
+                    batch_size=batch_size,
+                    vocab_size=vocab_size,
+                    max_num_kept=MAX_NUM_KEPT,
+                    finite_fraction=1.0,
+                    inactive_fraction=0.5,
+                    description=f"Half inactive (no sampled token), "
+                    f"batch={batch_size}, vocab={vocab_size}",
+                ))
+
+    return configs
+
+
+def format_memory(bytes_val: int) -> str:
+    """Format memory in human-readable form."""
+    if bytes_val >= 1024**3:
+        return f"{bytes_val / (1024**3):.2f} GB"
+    elif bytes_val >= 1024**2:
+        return f"{bytes_val / (1024**2):.2f} MB"
+    elif bytes_val >= 1024:
+        return f"{bytes_val / 1024:.2f} KB"
+    return f"{bytes_val} B"
+
+
+def run_benchmark(
+    configs: list[BenchmarkConfig],
+    warmup_iters: int = 5,
+    benchmark_iters: int = 20,
+    verbose: bool = True,
+):
+    """Run all benchmarks and print results."""
+    results = []
+
+    print("=" * 100)
+    label = "compact_sampling_mask Benchmark: Sycl vs PyTorch"
+    if TRITON_AVAILABLE:
+        label += " vs Triton"
+    print(label)
+    print("=" * 100)
+    print()
+
+    for config in configs:
+        if verbose:
+            print(f"Running: {config.description}")
+
+        logits = create_logits(config.batch_size, config.vocab_size,
+                               config.finite_fraction)
+        num_sampled_tokens = create_num_sampled_tokens(
+            config.batch_size, config.inactive_fraction)
+
+        # Benchmark Sycl
+        reset_memory_stats()
+        sycl_time, sycl_mem = benchmark_function(
+            "sycl",
+            logits,
+            num_sampled_tokens,
+            config.max_num_kept,
+            warmup_iters,
+            benchmark_iters,
+        )
+
+        # Benchmark PyTorch
+        reset_memory_stats()
+        pytorch_time, pytorch_mem = benchmark_function(
+            "pytorch",
+            logits,
+            num_sampled_tokens,
+            config.max_num_kept,
+            warmup_iters,
+            benchmark_iters,
+        )
+
+        speedup = pytorch_time / sycl_time if sycl_time > 0 else float("inf")
+        mem_ratio = pytorch_mem / sycl_mem if sycl_mem > 0 else float("inf")
+
+        result = {
+            "config": config,
+            "sycl_time_ms": sycl_time,
+            "pytorch_time_ms": pytorch_time,
+            "sycl_mem": sycl_mem,
+            "pytorch_mem": pytorch_mem,
+            "speedup": speedup,
+            "mem_ratio": mem_ratio,
+        }
+
+        # Optional: benchmark vllm's own Triton kernel too.
+        if TRITON_AVAILABLE:
+            reset_memory_stats()
+            triton_time, triton_mem = benchmark_function(
+                "triton",
+                logits,
+                num_sampled_tokens,
+                config.max_num_kept,
+                warmup_iters,
+                benchmark_iters,
+            )
+            result["triton_time_ms"] = triton_time
+            result["triton_mem"] = triton_mem
+            result["triton_speedup"] = (
+                triton_time / sycl_time if sycl_time > 0 else float("inf"))
+
+        results.append(result)
+
+        if verbose:
+            print(f"  Sycl:  {sycl_time:.3f} ms, {format_memory(sycl_mem)}")
+            print(
+                f"  PyT: {pytorch_time:.3f} ms, {format_memory(pytorch_mem)}")
+            print(f"  Speedup: {speedup:.2f}x, Memory ratio: {mem_ratio:.2f}x")
+            if TRITON_AVAILABLE:
+                print(f"  Triton: {result['triton_time_ms']:.3f} ms, "
+                      f"{format_memory(result['triton_mem'])} "
+                      f"(Sycl speedup: {result['triton_speedup']:.2f}x)")
+            print()
+
+        # Clean up
+        del logits, num_sampled_tokens
+        reset_memory_stats()
+
+    return results
+
+
+def print_summary_table(results: list[dict]):
+    """Print a summary table of results."""
+    print()
+    print("=" * 130)
+    print("SUMMARY TABLE")
+    print("=" * 130)
+    print()
+
+    has_triton = bool(results) and "triton_time_ms" in results[0]
+
+    # Header
+    header = (f"{'Scenario':<40} {'Batch':>6} {'Vocab':>7} "
+              f"{'Sycl (ms)':>12} {'PyTorch (ms)':>13} {'Speedup':>8} "
+              f"{'Sycl Mem':>10} {'Pyt Mem':>10}")
+    if has_triton:
+        header += f" {'Triton (ms)':>12} {'SyclVsTr':>9}"
+    print(header)
+    print("-" * 130)
+
+    # Group by scenario type
+    current_vocab = None
+    for result in results:
+        config = result["config"]
+
+        # Add separator between vocab sizes
+        if current_vocab != config.vocab_size:
+            if current_vocab is not None:
+                print("-" * 130)
+            current_vocab = config.vocab_size
+
+        scenario = config.name.split("_b")[0]  # Extract scenario name
+        row = (f"{scenario:<40} {config.batch_size:>6} {config.vocab_size:>7} "
+              f"{result['sycl_time_ms']:>12.3f} "
+              f"{result['pytorch_time_ms']:>13.3f} "
+              f"{result['speedup']:>7.2f}x "
+              f"{format_memory(result['sycl_mem']):>10} "
+              f"{format_memory(result['pytorch_mem']):>10}")
+        if has_triton:
+            row += (f" {result['triton_time_ms']:>12.3f} "
+                    f"{result['triton_speedup']:>8.2f}x")
+        print(row)
+
+    print("=" * 130)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Benchmark Sycl vs PyTorch compact_sampling_mask")
+    parser.add_argument(
+        "--batch-sizes",
+        type=int,
+        nargs="+",
+        default=[1, 4, 16, 64, 128, 512, 1024, 2048],
+        help="Batch sizes to test (default: 1 4 16 64 128 512 1024 2048)",
+    )
+    parser.add_argument(
+        "--vocab-sizes",
+        type=int,
+        nargs="+",
+        default=[32768, 131072],  # 32k, 128k
+        help="Vocabulary sizes to test (default: 32768 131072)",
+    )
+    parser.add_argument(
+        "--warmup-iters",
+        type=int,
+        default=5,
+        help="Number of warmup iterations (default: 5)",
+    )
+    parser.add_argument(
+        "--benchmark-iters",
+        type=int,
+        default=20,
+        help="Number of benchmark iterations (default: 20)",
+    )
+    parser.add_argument(
+        "--quiet",
+        action="store_true",
+        help="Only print summary table",
+    )
+
+    args = parser.parse_args()
+
+    # Print configuration
+    print(f"Batch sizes: {args.batch_sizes}")
+    print(f"Vocab sizes: {args.vocab_sizes}")
+    print(f"Warmup iterations: {args.warmup_iters}")
+    print(f"Benchmark iterations: {args.benchmark_iters}")
+    if TRITON_AVAILABLE:
+        print("Triton comparison: enabled (USE_TRITON_COMPACT_SAMPLING_MASK)")
+    else:
+        print("Triton comparison: disabled (set "
+              "USE_TRITON_COMPACT_SAMPLING_MASK=1 to enable, requires vllm "
+              "with Triton)")
+    print()
+
+    if not torch.xpu.is_available():
+        print("ERROR: XPU is not available. This benchmark requires a GPU.")
+        return
+
+    device_name = torch.xpu.get_device_name(0)
+    print(f"GPU: {device_name}")
+    print()
+
+    # Create configs
+    configs = create_benchmark_configs(
+        args.batch_sizes,
+        args.vocab_sizes,
+    )
+
+    # Run benchmarks
+    results = run_benchmark(
+        configs,
+        warmup_iters=args.warmup_iters,
+        benchmark_iters=args.benchmark_iters,
+        verbose=not args.quiet,
+    )
+
+    # Print summary
+    print_summary_table(results)
+
+
+if __name__ == "__main__":
+    main()

--- a/csrc/xpu/ops.h
+++ b/csrc/xpu/ops.h
@@ -402,3 +402,9 @@ void fused_input_norm(
     torch::Tensor& input,
     torch::Tensor& weight,
     torch::Tensor& bias);
+
+std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> compact_sampling_mask(
+    torch::Tensor& logits,
+    torch::Tensor& num_sampled_tokens,
+    int64_t max_num_kept,
+    int64_t MAX_COMPACT_SUPPORT);

--- a/csrc/xpu/ops.h
+++ b/csrc/xpu/ops.h
@@ -407,4 +407,4 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> compact_sampling_mask(
     const torch::Tensor& logits,
     const torch::Tensor& num_sampled_tokens,
     int64_t max_num_kept,
-    int64_t MAX_COMPACT_SUPPORT);
+    int64_t max_compact_support);

--- a/csrc/xpu/ops.h
+++ b/csrc/xpu/ops.h
@@ -404,7 +404,7 @@ void fused_input_norm(
     torch::Tensor& bias);
 
 std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> compact_sampling_mask(
-    torch::Tensor& logits,
-    torch::Tensor& num_sampled_tokens,
+    const torch::Tensor& logits,
+    const torch::Tensor& num_sampled_tokens,
     int64_t max_num_kept,
     int64_t MAX_COMPACT_SUPPORT);

--- a/csrc/xpu/sampler/compact_sampling_mask.cpp
+++ b/csrc/xpu/sampler/compact_sampling_mask.cpp
@@ -9,7 +9,7 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> compact_sampling_mask(
     const torch::Tensor& logits,
     const torch::Tensor& num_sampled_tokens,
     int64_t max_num_kept,
-    int64_t MAX_COMPACT_SUPPORT) {
+    int64_t max_compact_support) {
   CHECK_DEVICE(logits);
   CHECK_CONTIGUOUS(logits);
   TORCH_CHECK(
@@ -50,7 +50,7 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> compact_sampling_mask(
   int real_max_num_kept = std::min(
       {static_cast<int64_t>(max_num_kept),
        static_cast<int64_t>(vocab_size),
-       MAX_COMPACT_SUPPORT});
+       max_compact_support});
   int aligned_vocab_size = (vocab_size + 7) / 8;
 
   auto device = logits.device();

--- a/csrc/xpu/sampler/compact_sampling_mask.cpp
+++ b/csrc/xpu/sampler/compact_sampling_mask.cpp
@@ -6,8 +6,8 @@
 #include "compact_sampling_mask_kernels.hpp"
 
 std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> compact_sampling_mask(
-    torch::Tensor& logits,
-    torch::Tensor& num_sampled_tokens,
+    const torch::Tensor& logits,
+    const torch::Tensor& num_sampled_tokens,
     int64_t max_num_kept,
     int64_t MAX_COMPACT_SUPPORT) {
   CHECK_DEVICE(logits);

--- a/csrc/xpu/sampler/compact_sampling_mask.cpp
+++ b/csrc/xpu/sampler/compact_sampling_mask.cpp
@@ -47,8 +47,10 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> compact_sampling_mask(
 
   int num_reqs = logits.size(0);
   int vocab_size = logits.size(1);
-  int real_max_num_kept =
-      std::min({max_num_kept, vocab_size, MAX_COMPACT_SUPPORT});
+  int real_max_num_kept = std::min(
+      {static_cast<int64_t>(max_num_kept),
+       static_cast<int64_t>(vocab_size),
+       MAX_COMPACT_SUPPORT});
   int aligned_vocab_size = (vocab_size + 7) / 8;
 
   auto device = logits.device();

--- a/csrc/xpu/sampler/compact_sampling_mask.cpp
+++ b/csrc/xpu/sampler/compact_sampling_mask.cpp
@@ -1,0 +1,80 @@
+#include <torch/all.h>
+
+#include "utils.h"
+#include "dispatch_utils.h"
+
+#include "compact_sampling_mask_kernels.hpp"
+
+std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> compact_sampling_mask(
+    torch::Tensor& logits,
+    torch::Tensor& num_sampled_tokens,
+    int64_t max_num_kept,
+    int64_t MAX_COMPACT_SUPPORT) {
+  CHECK_DEVICE(logits);
+  CHECK_CONTIGUOUS(logits);
+  TORCH_CHECK(
+      logits.dim() == 2,
+      "logits tensor must be 2D [num_reqs, vocab_size], but got dim ",
+      logits.dim());
+  TORCH_CHECK(
+      logits.dtype() == torch::kFloat32,
+      "logits tensor must be float32, but got ",
+      logits.dtype());
+
+  CHECK_DEVICE(num_sampled_tokens);
+  CHECK_CONTIGUOUS(num_sampled_tokens);
+  TORCH_CHECK(
+      num_sampled_tokens.dim() == 1,
+      "num_sampled_tokens tensor must be 1D [num_reqs], but got dim ",
+      num_sampled_tokens.dim());
+  TORCH_CHECK(
+      num_sampled_tokens.dtype() == torch::kInt32,
+      "num_sampled_tokens tensor must be int32, but got ",
+      num_sampled_tokens.dtype());
+  TORCH_CHECK(
+      num_sampled_tokens.size(0) == logits.size(0),
+      "num_sampled_tokens size(0) (",
+      num_sampled_tokens.size(0),
+      ") must match logits size(0) (",
+      logits.size(0),
+      ")");
+  TORCH_CHECK(
+      num_sampled_tokens.device() == logits.device(),
+      "num_sampled_tokens and logits must be on the same device, got ",
+      num_sampled_tokens.device(),
+      " and ",
+      logits.device());
+
+  int num_reqs = logits.size(0);
+  int vocab_size = logits.size(1);
+  int real_max_num_kept =
+      std::min({max_num_kept, vocab_size, MAX_COMPACT_SUPPORT});
+  int aligned_vocab_size = (vocab_size + 7) / 8;
+
+  auto device = logits.device();
+
+  torch::Tensor token_ids = torch::empty(
+      {num_reqs, real_max_num_kept},
+      torch::dtype(torch::kInt32).device(device).requires_grad(false));
+  torch::Tensor packed_mask = torch::empty(
+      {num_reqs, aligned_vocab_size},
+      torch::dtype(torch::kUInt8).device(device).requires_grad(false));
+  torch::Tensor counts = torch::empty(
+      {num_reqs},
+      torch::dtype(torch::kInt32).device(device).requires_grad(false));
+
+  auto& queue = vllm::xpu::vllmGetQueue();
+
+  CompactSamplingMaskImpl::compact_sampling_mask_kernel_launcher(
+      queue,
+      logits.data_ptr<float>(),
+      num_sampled_tokens.data_ptr<int>(),
+      token_ids.data_ptr<int>(),
+      packed_mask.data_ptr<uint8_t>(),
+      counts.data_ptr<int>(),
+      num_reqs,
+      real_max_num_kept,
+      vocab_size);
+
+  return {token_ids, packed_mask, counts};
+}

--- a/csrc/xpu/sampler/compact_sampling_mask_kernels.hpp
+++ b/csrc/xpu/sampler/compact_sampling_mask_kernels.hpp
@@ -48,7 +48,7 @@ struct compact_sampling_mask_kernel {
 
     const int aligned_vocab_size = (vocab_size + 7) / 8;
 
-    float* logits_ptr = logits + batch_id * vocab_size;
+    const float* logits_ptr = logits + batch_id * vocab_size;
     int* token_ids_ptr = token_ids + batch_id * max_num_kept;
     uint8_t* packed_mask_ptr = packed_mask + batch_id * aligned_vocab_size;
 
@@ -166,7 +166,8 @@ struct compact_sampling_mask_kernel {
       const int nibble_shift = (chunk_index % 2) * VEC_SIZE;
       const int shifted_nibble = static_cast<int>(nibble) << nibble_shift;
 
-      const int partner_nibble = sub_group.shuffle_xor(shifted_nibble, 1);
+      const int partner_nibble =
+          sycl::permute_group_by_xor(sub_group, shifted_nibble, 1);
       const uint8_t byte_val =
           static_cast<uint8_t>(shifted_nibble | partner_nibble);
 

--- a/csrc/xpu/sampler/compact_sampling_mask_kernels.hpp
+++ b/csrc/xpu/sampler/compact_sampling_mask_kernels.hpp
@@ -1,0 +1,221 @@
+#pragma once
+#include <sycl/sycl.hpp>
+
+#include <limits>
+
+namespace CompactSamplingMaskImpl {
+struct compact_sampling_mask_kernel {
+ public:
+  static constexpr int sub_group_size = 16;
+  static constexpr int group_size = 512;
+  static constexpr int VEC_SIZE = 4;
+
+  compact_sampling_mask_kernel(
+      const float* logits,
+      const int* num_sampled_tokens,
+      int* token_ids,
+      uint8_t* packed_mask,
+      int* counts,
+      const int num_reqs,
+      const int max_num_kept,
+      const int vocab_size)
+      : logits(logits),
+        num_sampled_tokens(num_sampled_tokens),
+        token_ids(token_ids),
+        packed_mask(packed_mask),
+        counts(counts),
+        num_reqs(num_reqs),
+        max_num_kept(max_num_kept),
+        vocab_size(vocab_size) {}
+
+  static inline sycl::nd_range<1>
+  get_nd_range(const int num_reqs, const int vocab_size) {
+    int local_size = group_size;
+    if (vocab_size < group_size) {
+      local_size =
+          (vocab_size + sub_group_size - 1) / sub_group_size * sub_group_size;
+    }
+    sycl::range<1> local(local_size);
+    sycl::range<1> global(num_reqs);
+    return sycl::nd_range<1>(global * local, local);
+  }
+
+  [[sycl::reqd_sub_group_size(sub_group_size)]] void
+  operator()(sycl::nd_item<1> item) const {
+    const int batch_id = item.get_group(0);
+    const int local_id = item.get_local_linear_id();
+    const int local_range = item.get_local_range(0);
+
+    const int aligned_vocab_size = (vocab_size + 7) / 8;
+
+    float* logits_ptr = logits + batch_id * vocab_size;
+    int* token_ids_ptr = token_ids + batch_id * max_num_kept;
+    uint8_t* packed_mask_ptr = packed_mask + batch_id * aligned_vocab_size;
+
+    int num_sampled_tokens_ = num_sampled_tokens[batch_id];
+    bool is_active = num_sampled_tokens_ > 0;
+
+    if (!is_active) {
+      counts[batch_id] = 0;
+
+      using VecT = sycl::vec<int, VEC_SIZE>;
+      constexpr int bytes_per_vec = static_cast<int>(sizeof(int) * VEC_SIZE);
+      VecT* packed_mask_vec_ptr = reinterpret_cast<VecT*>(packed_mask_ptr);
+      const int aligned_vocab_vecs = aligned_vocab_size / bytes_per_vec;
+
+      VecT zero_vec(0);
+      for (int i = local_id; i < aligned_vocab_vecs; i += local_range) {
+        packed_mask_vec_ptr[i] = zero_vec;
+      }
+
+      // Tail bytes that don't fill a full 4-int (16-byte) pack.
+      for (int i = aligned_vocab_vecs * bytes_per_vec + local_id;
+           i < aligned_vocab_size;
+           i += local_range) {
+        packed_mask_ptr[i] = 0;
+      }
+
+      return;
+    }
+
+    // Same-sized "wave" (local_range * VEC_SIZE contiguous tokens) per
+    // iteration for every work-item, so the group-wide scan/reduce calls
+    // below stay convergent (every work-item calls them the same number
+    // of times) and the compact token ids come out in increasing order,
+    // matching the Triton kernel's per-block cumsum semantics.
+    using LogitsVecT = sycl::vec<float, VEC_SIZE>;
+    using TokenIdVecT = sycl::vec<int, VEC_SIZE>;
+    const int wave_size = local_range * VEC_SIZE;
+    const int num_waves = (vocab_size + wave_size - 1) / wave_size;
+    auto sub_group = item.get_sub_group();
+
+    int running_count = 0;
+
+    for (int w = 0; w < num_waves; ++w) {
+      const int base = w * wave_size + local_id * VEC_SIZE;
+      const bool full_load = base + VEC_SIZE <= vocab_size;
+
+      // Load: one vec read for a full in-bounds chunk, scalar fallback
+      // (padded with -inf, like Triton's `other=-inf`) for the tail.
+      float local_logits[VEC_SIZE];
+      if (full_load) {
+        *reinterpret_cast<LogitsVecT*>(local_logits) =
+            *reinterpret_cast<const LogitsVecT*>(logits_ptr + base);
+      } else {
+#pragma unroll
+        for (int j = 0; j < VEC_SIZE; ++j) {
+          const int idx = base + j;
+          local_logits[j] = idx < vocab_size
+                                ? logits_ptr[idx]
+                                : -std::numeric_limits<float>::infinity();
+        }
+      }
+
+      // Process element-by-element on the local copy.
+      bool keep[VEC_SIZE];
+      int local_keep = 0;
+      int local_token_ids[VEC_SIZE];
+#pragma unroll
+      for (int j = 0; j < VEC_SIZE; ++j) {
+        keep[j] = sycl::isfinite(local_logits[j]);
+        if (keep[j]) {
+          local_token_ids[local_keep++] = base + j;
+        }
+      }
+
+      const int exclusive_prefix = sycl::exclusive_scan_over_group(
+          item.get_group(), local_keep, sycl::plus<int>());
+      const int wave_total = sycl::reduce_over_group(
+          item.get_group(), local_keep, sycl::plus<int>());
+
+      // Store: results are buffered in `local_token_ids` above; flush
+      // with a single vec store when this chunk is fully kept and fits,
+      // otherwise fall back to per-element stores.
+      const int write_pos = running_count + exclusive_prefix;
+      if (local_keep == VEC_SIZE && write_pos + VEC_SIZE <= max_num_kept) {
+        *reinterpret_cast<TokenIdVecT*>(token_ids_ptr + write_pos) =
+            *reinterpret_cast<TokenIdVecT*>(local_token_ids);
+      } else {
+#pragma unroll
+        for (int j = 0; j < VEC_SIZE; ++j) {
+          if (j < local_keep && write_pos + j < max_num_kept) {
+            token_ids_ptr[write_pos + j] = local_token_ids[j];
+          }
+        }
+      }
+
+      // packed_mask: pack `keep` into bits, 8 tokens per byte (little
+      // bit order, matching np.packbits(bitorder="little")). VEC_SIZE
+      // (4) keep flags only fill half a byte, so this work-item's
+      // nibble is combined with the adjacent chunk-index's nibble
+      // (even/odd pair, i.e. neighboring lanes) via a sub-group
+      // shuffle to form the full byte before the (single) store.
+      static_assert(
+          VEC_SIZE == 4,
+          "packed_mask packing assumes 4 keep bits (a nibble) per "
+          "work-item, two of which combine into one byte");
+      uint8_t nibble = 0;
+#pragma unroll
+      for (int j = 0; j < VEC_SIZE; ++j) {
+        if (keep[j]) {
+          nibble |= static_cast<uint8_t>(1u << j);
+        }
+      }
+      const int chunk_index = w * local_range + local_id;
+      const int byte_index = chunk_index / 2;
+      const int nibble_shift = (chunk_index % 2) * VEC_SIZE;
+      const int shifted_nibble = static_cast<int>(nibble) << nibble_shift;
+
+      const int partner_nibble = sub_group.shuffle_xor(shifted_nibble, 1);
+      const uint8_t byte_val =
+          static_cast<uint8_t>(shifted_nibble | partner_nibble);
+
+      if ((chunk_index % 2) == 0 && byte_index < aligned_vocab_size) {
+        packed_mask_ptr[byte_index] = byte_val;
+      }
+
+      running_count += wave_total;
+    }
+
+    if (0 == local_id) {
+      counts[batch_id] = running_count;
+    }
+  }
+
+ private:
+  const float* logits;
+  const int* num_sampled_tokens;
+  int* token_ids;
+  uint8_t* packed_mask;
+  int* counts;
+  const int num_reqs;
+  const int max_num_kept;
+  const int vocab_size;
+};
+
+void compact_sampling_mask_kernel_launcher(
+    sycl::queue& queue,
+    const float* logits,
+    const int* num_sampled_tokens,
+    int* token_ids,
+    uint8_t* packed_mask,
+    int* counts,
+    const int num_reqs,
+    const int max_num_kept,
+    const int vocab_size) {
+  using KERNEL = compact_sampling_mask_kernel;
+  auto range = KERNEL::get_nd_range(num_reqs, vocab_size);
+  queue.submit([&](sycl::handler& cgh) {
+    KERNEL task(
+        logits,
+        num_sampled_tokens,
+        token_ids,
+        packed_mask,
+        counts,
+        num_reqs,
+        max_num_kept,
+        vocab_size);
+    cgh.parallel_for(range, task);
+  });
+}
+}  // namespace CompactSamplingMaskImpl

--- a/csrc/xpu/torch_bindings.cpp
+++ b/csrc/xpu/torch_bindings.cpp
@@ -330,7 +330,7 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, xpu_ops) {
   xpu_ops.impl("fused_input_norm", torch::kXPU, &fused_input_norm);
 
   xpu_ops.def(
-      "compact_sampling_mask(Tensor! logits, Tensor! num_sampled_tokens,"
+      "compact_sampling_mask(Tensor logits, Tensor num_sampled_tokens,"
       "int max_num_kept, int MAX_COMPACT_SUPPORT) -> (Tensor, Tensor, Tensor)");
   xpu_ops.impl("compact_sampling_mask", torch::kXPU, &compact_sampling_mask);
 }

--- a/csrc/xpu/torch_bindings.cpp
+++ b/csrc/xpu/torch_bindings.cpp
@@ -328,6 +328,11 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, xpu_ops) {
       "fused_input_norm(Tensor! out, Tensor input, Tensor weight, "
       "Tensor bias) -> ()");
   xpu_ops.impl("fused_input_norm", torch::kXPU, &fused_input_norm);
+
+  xpu_ops.def(
+      "compact_sampling_mask(Tensor! logits, Tensor! num_sampled_tokens,"
+      "int max_num_kept, int MAX_COMPACT_SUPPORT) -> (Tensor, Tensor, Tensor)");
+  xpu_ops.impl("compact_sampling_mask", torch::kXPU, &compact_sampling_mask);
 }
 
 REGISTER_EXTENSION(TORCH_EXTENSION_NAME)

--- a/csrc/xpu/torch_bindings.cpp
+++ b/csrc/xpu/torch_bindings.cpp
@@ -331,7 +331,7 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, xpu_ops) {
 
   xpu_ops.def(
       "compact_sampling_mask(Tensor logits, Tensor num_sampled_tokens,"
-      "int max_num_kept, int MAX_COMPACT_SUPPORT) -> (Tensor, Tensor, Tensor)");
+      "int max_num_kept, int max_compact_support) -> (Tensor, Tensor, Tensor)");
   xpu_ops.impl("compact_sampling_mask", torch::kXPU, &compact_sampling_mask);
 }
 

--- a/tests/ops/compact_sampling_mask_op.py
+++ b/tests/ops/compact_sampling_mask_op.py
@@ -1,0 +1,145 @@
+# SPDX-License-Identifier: Apache-2.0
+import os
+
+import numpy as np
+import torch
+
+import vllm_xpu_kernels._xpu_C  # noqa: F401
+
+# Mirrors vllm.v1.worker.gpu.sample.output.MAX_COMPACT_SUPPORT: bounds the
+# [num_reqs, width] int32 buffer; wider rows fall back to the bitmask.
+MAX_COMPACT_SUPPORT = 2048
+
+# Set USE_TRITON_COMPACT_SAMPLING_MASK=1 to enable
+# compact_sampling_mask_triton(), which runs vllm's own Triton kernel
+# (_compact_sampling_mask_kernel) instead of the SYCL/PyTorch paths here.
+# Requires vllm (with Triton) to be importable.
+HAS_TRITON = False
+USE_TRITON_COMPACT_SAMPLING_MASK = os.getenv(
+    "USE_TRITON_COMPACT_SAMPLING_MASK", "False").lower() in ("1", "true")
+if USE_TRITON_COMPACT_SAMPLING_MASK:
+    try:
+        from vllm.triton_utils import HAS_TRITON  # noqa: F401
+        from vllm.v1.worker.gpu.sample.output import (  # noqa: F401
+            _compact_sampling_mask_kernel)
+    except ImportError:
+        print("Triton is not available. compact_sampling_mask_triton() "
+              "will raise if called.")
+
+TRITON_AVAILABLE = USE_TRITON_COMPACT_SAMPLING_MASK and HAS_TRITON
+
+
+def compact_sampling_mask_torch(
+    logits: torch.Tensor,
+    num_sampled_tokens: torch.Tensor,
+    max_num_kept: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Pure-PyTorch reference implementation.
+
+    Mirrors vllm's ``_compact_sampling_mask_torch``: for every row with a
+    sampled token (``num_sampled_tokens > 0``), computes the finite-logit
+    count, the first ``max_num_kept`` finite-logit token ids (increasing
+    order), and the full finite-logit bitmask (little bit order, 1 byte per
+    8 tokens).
+    """
+    num_reqs, vocab_size = logits.shape
+    is_active = num_sampled_tokens > 0
+    finite = torch.isfinite(logits) & is_active.unsqueeze(1)
+
+    counts = finite.sum(dim=1).to(torch.int32)
+
+    token_ids = torch.zeros(
+        (num_reqs, max_num_kept), dtype=torch.int32, device=logits.device)
+    for row in range(num_reqs):
+        idx = finite[row].nonzero(as_tuple=True)[0]
+        n = min(idx.numel(), max_num_kept)
+        if n:
+            token_ids[row, :n] = idx[:n].to(torch.int32)
+
+    finite_np = finite.to("cpu", dtype=torch.uint8).numpy()
+    packed_np = np.packbits(finite_np, axis=1, bitorder="little")
+    packed_mask = torch.from_numpy(packed_np).to(
+        device=logits.device, dtype=torch.uint8)
+
+    return token_ids, packed_mask, counts
+
+
+def compact_sampling_mask_xpu(
+    logits: torch.Tensor,
+    num_sampled_tokens: torch.Tensor,
+    max_num_kept: int,
+    max_compact_support: int = MAX_COMPACT_SUPPORT,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """XPU (SYCL) implementation."""
+    return torch.ops._xpu_C.compact_sampling_mask(
+        logits, num_sampled_tokens, max_num_kept, max_compact_support)
+
+
+def compact_sampling_mask_triton(
+    logits: torch.Tensor,
+    num_sampled_tokens: torch.Tensor,
+    max_num_kept: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """vllm's own Triton kernel (``_compact_sampling_mask_kernel``).
+
+    Only usable when USE_TRITON_COMPACT_SAMPLING_MASK=1 and vllm/Triton are
+    importable (see TRITON_AVAILABLE above); raises otherwise.
+    """
+    if not TRITON_AVAILABLE:
+        raise RuntimeError(
+            "compact_sampling_mask_triton() requires "
+            "USE_TRITON_COMPACT_SAMPLING_MASK=1 and vllm (with Triton) to "
+            "be importable.")
+
+    num_reqs, vocab_size = logits.shape
+    device = logits.device
+
+    token_ids = torch.empty((num_reqs, max_num_kept),
+                            dtype=torch.int32,
+                            device=device)
+    packed_mask = torch.empty((num_reqs, (vocab_size + 7) // 8),
+                              dtype=torch.uint8,
+                              device=device)
+    counts = torch.empty(num_reqs, dtype=torch.int32, device=device)
+
+    _compact_sampling_mask_kernel[(num_reqs, )](
+        logits,
+        logits.stride(0),
+        logits.stride(1),
+        num_sampled_tokens,
+        token_ids,
+        token_ids.stride(0),
+        packed_mask,
+        packed_mask.stride(0),
+        counts,
+        vocab_size,
+        max_num_kept,
+        BLOCK_SIZE=8192,
+    )
+    return token_ids, packed_mask, counts
+
+
+def unpack_support(
+    token_ids: torch.Tensor,
+    packed_mask: torch.Tensor,
+    counts: torch.Tensor,
+    vocab_size: int,
+) -> list[np.ndarray]:
+    """CPU-side helper mirroring ``SamplingMaskTensors.tolists()``: use the
+    compact token ids when they fit within ``max_num_kept``, otherwise fall
+    back to unpacking the bitmask.
+    """
+    counts_np = counts.cpu().numpy()
+    token_ids_np = token_ids.cpu().numpy()
+    packed_mask_np = packed_mask.cpu().numpy()
+    width = token_ids_np.shape[1]
+
+    supports = []
+    for row in range(len(counts_np)):
+        if counts_np[row] <= width:
+            supports.append(token_ids_np[row, :counts_np[row]])
+        else:
+            bits = np.unpackbits(
+                packed_mask_np[row], count=vocab_size, bitorder="little")
+            supports.append(np.flatnonzero(bits).astype(np.int32))
+    return supports

--- a/tests/test_compact_sampling_mask.py
+++ b/tests/test_compact_sampling_mask.py
@@ -1,0 +1,173 @@
+# SPDX-License-Identifier: Apache-2.0
+import numpy as np
+import pytest
+import torch
+
+from tests.ops.compact_sampling_mask_op import (compact_sampling_mask_torch,
+                                                compact_sampling_mask_xpu,
+                                                unpack_support)
+from tests.utils import seed_everything
+
+DEVICE = "xpu"
+
+BATCH_SIZE = [1, 4, 32]
+VOCAB_SIZE = [128, 1024, 4096]
+MAX_NUM_KEPT = [8, 64, 512]
+INACTIVE_FRACTION = [0.0, 0.5, 1.0]
+FINITE_FRACTION = [0.0, 0.2, 0.5, 1.0]
+
+# CI/mini scope parameter overrides
+MINI_PYTEST_PARAMS = {
+    "default": {
+        "batch_size": [1, 4],
+        "vocab_size": [128, 1024],
+        "max_num_kept": [8, 64],
+        "inactive_fraction": [0.0, 0.5],
+        "finite_fraction": [0.2, 1.0],
+    },
+}
+
+
+def _make_logits(batch_size, vocab_size, finite_fraction, device):
+    logits = torch.randn(batch_size,
+                         vocab_size,
+                         dtype=torch.float32,
+                         device=device)
+    if finite_fraction < 1.0:
+        # Mask out (1 - finite_fraction) of the entries with -inf, mimicking
+        # rows where only a subset of the vocab survived upstream filtering
+        # (e.g. top_k/top_p).
+        drop_mask = torch.rand(batch_size, vocab_size,
+                               device=device) >= finite_fraction
+        logits = logits.masked_fill(drop_mask, float("-inf"))
+    return logits
+
+
+def _make_num_sampled_tokens(batch_size, inactive_fraction, device):
+    num_sampled_tokens = torch.ones(batch_size,
+                                    dtype=torch.int32,
+                                    device=device)
+    num_inactive = int(round(batch_size * inactive_fraction))
+    if num_inactive > 0:
+        num_sampled_tokens[:num_inactive] = 0
+    return num_sampled_tokens
+
+
+def _check_against_reference(logits, num_sampled_tokens, max_num_kept):
+    vocab_size = logits.shape[1]
+    batch_size = logits.shape[0]
+
+    token_ids, packed_mask, counts = compact_sampling_mask_xpu(
+        logits, num_sampled_tokens, max_num_kept)
+
+    ref_token_ids, ref_packed_mask, ref_counts = compact_sampling_mask_torch(
+        logits, num_sampled_tokens, max_num_kept)
+
+    torch.testing.assert_close(counts, ref_counts, rtol=0, atol=0)
+    torch.testing.assert_close(packed_mask, ref_packed_mask, rtol=0, atol=0)
+
+    # token_ids beyond a row's count are unspecified (never read downstream),
+    # so only compare the valid compact prefix for rows that fit.
+    counts_np = counts.cpu().numpy()
+    width = token_ids.shape[1]
+    for row in range(batch_size):
+        n = int(counts_np[row])
+        if n <= width:
+            torch.testing.assert_close(token_ids[row, :n],
+                                       ref_token_ids[row, :n],
+                                       rtol=0,
+                                       atol=0)
+
+    # Cross-check against the downstream consumer's fallback logic
+    # (compact token_ids vs. unpacked bitmask) for full self-consistency.
+    supports = unpack_support(token_ids, packed_mask, counts, vocab_size)
+    ref_supports = unpack_support(ref_token_ids, ref_packed_mask, ref_counts,
+                                  vocab_size)
+    for row in range(batch_size):
+        np.testing.assert_array_equal(supports[row], ref_supports[row])
+
+
+@pytest.mark.parametrize("batch_size", BATCH_SIZE)
+@pytest.mark.parametrize("vocab_size", VOCAB_SIZE)
+@pytest.mark.parametrize("max_num_kept", MAX_NUM_KEPT)
+@pytest.mark.parametrize("inactive_fraction", INACTIVE_FRACTION)
+@pytest.mark.parametrize("finite_fraction", FINITE_FRACTION)
+def test_compact_sampling_mask(batch_size, vocab_size, max_num_kept,
+                               inactive_fraction, finite_fraction):
+
+    seed_everything(42)
+
+    max_num_kept = min(max_num_kept, vocab_size)
+
+    logits = _make_logits(batch_size, vocab_size, finite_fraction, DEVICE)
+    num_sampled_tokens = _make_num_sampled_tokens(batch_size,
+                                                  inactive_fraction, DEVICE)
+
+    _check_against_reference(logits, num_sampled_tokens, max_num_kept)
+
+
+@pytest.mark.parametrize("batch_size", [4])
+@pytest.mark.parametrize("vocab_size", [1, 7, 33, 50, 513, 1001])
+@pytest.mark.parametrize("max_num_kept", [1, 8, 32])
+@pytest.mark.parametrize("finite_fraction", [0.3, 1.0])
+def test_compact_sampling_mask_unaligned_vocab_size(batch_size, vocab_size,
+                                                    max_num_kept,
+                                                    finite_fraction):
+    """vocab_size not a multiple of the wave size / byte width exercises the
+    scalar-fallback load/store and tail-byte packing paths."""
+    seed_everything(42)
+
+    max_num_kept = min(max_num_kept, vocab_size)
+
+    logits = _make_logits(batch_size, vocab_size, finite_fraction, DEVICE)
+    num_sampled_tokens = _make_num_sampled_tokens(batch_size, 0.0, DEVICE)
+
+    _check_against_reference(logits, num_sampled_tokens, max_num_kept)
+
+
+@pytest.mark.parametrize("batch_size", [8])
+@pytest.mark.parametrize("vocab_size", [256, 2048])
+def test_compact_sampling_mask_all_inactive(batch_size, vocab_size):
+    """Rows with no sampled token must report count=0 and an all-zero
+    bitmask/token_ids, regardless of the (irrelevant) logits contents."""
+    seed_everything(42)
+
+    logits = torch.randn(batch_size,
+                         vocab_size,
+                         dtype=torch.float32,
+                         device=DEVICE)
+    num_sampled_tokens = torch.zeros(batch_size,
+                                     dtype=torch.int32,
+                                     device=DEVICE)
+
+    token_ids, packed_mask, counts = compact_sampling_mask_xpu(
+        logits, num_sampled_tokens, max_num_kept=32)
+
+    torch.testing.assert_close(counts,
+                               torch.zeros_like(counts),
+                               rtol=0,
+                               atol=0)
+    torch.testing.assert_close(packed_mask,
+                               torch.zeros_like(packed_mask),
+                               rtol=0,
+                               atol=0)
+
+
+@pytest.mark.parametrize("batch_size", [1])
+@pytest.mark.parametrize("vocab_size", [1024])
+@pytest.mark.parametrize("infinite_value", ["inf", "nan"])
+def test_compact_sampling_mask_non_finite_values(batch_size, vocab_size,
+                                                 infinite_value):
+    """+inf/nan logits must never be counted as finite/kept."""
+    seed_everything(42)
+
+    logits = torch.randn(batch_size,
+                         vocab_size,
+                         dtype=torch.float32,
+                         device=DEVICE)
+    logits[:, ::2] = float(infinite_value)
+    num_sampled_tokens = torch.ones(batch_size,
+                                    dtype=torch.int32,
+                                    device=DEVICE)
+
+    _check_against_reference(logits, num_sampled_tokens, max_num_kept=64)


### PR DESCRIPTION
As this PR show, replace triton kernel by torch reference function can fix CI failure.
https://github.com/vllm-project/vllm/pull/55638
The failure root cause is unknown, and the failure is hard to reproduce by running only the UT case.
But torch reference is slow, so will use sycl kernel to replace triton kernel.
As below results show, sycl kernel is faster than triton kernel.
<img width="986" height="179" alt="image" src="https://github.com/user-attachments/assets/4dc9d979-e1b8-4738-8444-13a45f286b3f" />
