### PR TITLE
[ATTN] chunk-prefill: take the wider tile when it divides the page size

### DIFF
--- a/benchmark/src/flash_attn_interface_.py
+++ b/benchmark/src/flash_attn_interface_.py
@@ -27,12 +27,16 @@ def _as_int32_device_tensor(x, device: torch.device) -> torch.Tensor:
 
 
 def _kv_tile_from_block_size(block_size: int) -> int:
-    # Mirror of flash_api.cpp get_num_splits() / TileShapeQK<1>.
-    if block_size == 16:
-        return 16
+    # Mirror of paged_decode_utils.hpp::dispatch_by_page_size /
+    # flash_api.cpp get_num_splits() / TileShapeQK<1>. Keep in step with the
+    # copy in vllm_xpu_kernels/flash_attn_interface.py -- if this returns a
+    # wider tile than the kernel runs, build_decode_split_plan sizes the work
+    # list for too few tiles and part of the KV history is skipped.
+    if block_size > 0 and block_size % 64 == 0:
+        return 64
     if block_size == 32:
         return 32
-    return 64
+    return 16
 
 
 def _min_blocks_for_split(kv_tile: int) -> int:

--- a/csrc/xpu/attn/xe_2/fmha_xe2.cpp
+++ b/csrc/xpu/attn/xe_2/fmha_xe2.cpp
@@ -263,14 +263,20 @@ void cutlass_chunk_prefill_impl(
         " (supported: any positive multiple of 16)");
   }
 
-  // Policy selection preserves the original routing for the previously
-  // supported sizes: block_size == 32 and every positive multiple of 64 use
-  // the default chunk_policy_head* set (TileShapeQK[1] = 32), which divides
-  // those page sizes cleanly. Every other supported multiple of 16 (16, 48,
-  // 80, 96, 112, 160, ...) uses the *_b16 policies (TileShapeQK[1] = 16) so
-  // that tiles_per_page = page_size / TileShapeQK[1] is exact.
-  const bool use_b16_policy =
-      is_paged && (block_size != 32) && (block_size % 64 != 0);
+  // Policy selection takes the wider tile whenever it divides the page size
+  // exactly, so that tiles_per_page = page_size / TileShapeQK[1] is an integer
+  // at the greatest available width. Any multiple of 32 divides the default
+  // chunk_policy_head* set (TileShapeQK[1] = 32); everything else that is a
+  // multiple of 16 (16, 48, 80, 112, 240, ...) needs the *_b16 policies
+  // (TileShapeQK[1] = 16). Routing for every size the pre-relaxation rule
+  // accepted is unchanged: 16 -> b16, 32 and 64*n -> default.
+  //
+  // Note this deliberately differs from paged_decode_utils.hpp, which keeps a
+  // page size that is a multiple of 32 but not 64 on the 16-wide tile. The two
+  // dispatches serve different call shapes and measure differently: on
+  // chunk-prefill the wider tile is 21-35% faster for this class, while on
+  // paged decode the narrower one is ~4% faster.
+  const bool use_b16_policy = is_paged && (block_size % 32) != 0;
 
   if (use_b16_policy) {
     if (args.head_size <= HEAD_SIZE_LIMIT_0) {

--- a/vllm_xpu_kernels/flash_attn_interface.py
+++ b/vllm_xpu_kernels/flash_attn_interface.py
@@ -172,7 +172,10 @@ def _kv_tile_from_block_size(block_size: int) -> int:
     # Supported block sizes: any positive multiple of 16. The previously
     # supported sizes keep their tile (multiples of 64 -> 64, 32 -> 32); every
     # other multiple of 16 (16, 48, 80, 96, 112, 160, ...) uses the _16 tile.
-    if block_size % 64 == 0:
+    # The positivity guard keeps block_size <= 0 out of the 64 branch, since
+    # 0 % 64 == 0 would otherwise size a split plan for a tile the kernel does
+    # not run.
+    if block_size > 0 and block_size % 64 == 0:
         return 64
     if block_size == 32:
         return 32


### PR DESCRIPTION
Follow-up to #574, which allows the paged KV page size to any positive multiple of 16.

On the **chunk-prefill** path, a page size that is a odd multiple of 32 (96, 160, 224, …) can implement 16 and 32 tile size, but the wider one is faster. #574 sends this class to the 16-wide `_b16` policies; this PR sends it to the default 32-wide ones. Routing is unchanged for every size the pre-relaxation rule accepted (`16 -> b16`, `32` and `64*n` -> default).

`paged_decode_utils.hpp` is deliberately **not** changed: the same measurement comes out the other way there.

## Measurement

Intel Arc Pro B70 (Xe2), single card, bf16, head_dim 128, non-causal, ~17.6k KV tokens. Median of 50 timed iterations after 10 warmup, `torch.xpu.synchronize()` inside the timed region. Test plans available at PR 585

**Chunk-prefill** — two wheels from one tree differing only in `use_b16_policy`, 10 heads, one page of query:

| page | this PR | #574 | this PR (ms) | #574 (ms) | #574 slower |
|---|---|---|---|---|---|
| 96 | 32 | 16 | 1.1242 | 1.5163 | **+34.9%** |
| 160 | 32 | 16 | 1.0790 | 1.3983 | **+29.6%** |
| 224 | 32 | 16 | 1.0866 | 1.3206 | **+21.5%** |
| 1440 | 32 | 16 | 1.3475 | 1.7349 | **+28.8%** |
| 48 | 16 | 16 | 1.5836 | 1.5833 | −0.0% *(control)* |
| 64 | 32 | 32 | 1.1541 | 1.1531 | −0.1% *(control)* |
| 128 | 32 | 32 | 1.1030 | 1.1031 | +0.0% *(control)* |
| 880 | 16 | 16 | 1.7624 | 1.7546 | −0.4% *(control)* |


## Correctness

Throughput change only; both routings are equally correct. #585 adds a directed suite comparing against the dense `ref_paged_attn` oracle — 31 cases including the newly-admitted page sizes and mix-batch — and it passes identically on both wheels.

