### PR TITLE
fix: initialize atomic_buffer to 0 to avoid race conditions

### DIFF
--- a/csrc/xpu/grouped_gemm/xe_2/grouped_gemm_xe2.hpp
+++ b/csrc/xpu/grouped_gemm/xe_2/grouped_gemm_xe2.hpp
@@ -102,15 +102,6 @@ CUTE_DEVICE void MoEGEMM(
   int group_range = item.get_group_range(1);
   int local_id = item.get_local_linear_id();
 
-  if (group_id == 0 && local_id == 0) {
-    auto atm = sycl::atomic_ref<
-        int,
-        sycl::memory_order::relaxed,
-        sycl::memory_scope::device,
-        sycl::access::address_space::global_space>(atomic_buffer[0]);
-    atm.store(0);
-  }
-
   int pre_rows = 0;
   int pre_tiles = 0;
 

--- a/csrc/xpu/grouped_gemm/xe_2/grouped_gemm_xe2_interface.hpp
+++ b/csrc/xpu/grouped_gemm/xe_2/grouped_gemm_xe2_interface.hpp
@@ -249,11 +249,11 @@ at::Tensor cutlass_grouped_gemm_xe2_impl(
     TORCH_CHECK(ptr_bias->size(1) == N, "ptr_bias.size(1) must match N");
   }
 
-  // Must be zero-initialized on the host side: the persistent kernel uses this
-  // as a global work counter and reads it via atomicAdd from every workgroup.
-  // Zeroing it inside the kernel from a single workgroup is a data race, and a
-  // garbage (possibly negative) initial value makes workgroups compute negative
-  // tile coordinates and write out of bounds of ptr_D.
+  // Must be initialized to zero before kernel launch: the persistent kernel
+  // uses this as a global work counter and reads it via atomicAdd from every
+  // workgroup. Zeroing it inside the kernel from a single workgroup is a data
+  // race, and a garbage (possibly negative) initial value makes workgroups
+  // compute negative tile coordinates and write out of bounds of ptr_D.
   at::Tensor atomic_buffer =
       at::zeros({static_cast<long>(1)}, ptr_A.options().dtype(at::kInt));
 

--- a/csrc/xpu/grouped_gemm/xe_2/grouped_gemm_xe2_interface.hpp
+++ b/csrc/xpu/grouped_gemm/xe_2/grouped_gemm_xe2_interface.hpp
@@ -249,8 +249,13 @@ at::Tensor cutlass_grouped_gemm_xe2_impl(
     TORCH_CHECK(ptr_bias->size(1) == N, "ptr_bias.size(1) must match N");
   }
 
+  // Must be zero-initialized on the host side: the persistent kernel uses this
+  // as a global work counter and reads it via atomicAdd from every workgroup.
+  // Zeroing it inside the kernel from a single workgroup is a data race, and a
+  // garbage (possibly negative) initial value makes workgroups compute negative
+  // tile coordinates and write out of bounds of ptr_D.
   at::Tensor atomic_buffer =
-      at::empty({static_cast<long>(1)}, ptr_A.options().dtype(at::kInt));
+      at::zeros({static_cast<long>(1)}, ptr_A.options().dtype(at::kInt));
 
 #define MoEGEMMLauncherCallER(                                                 \
     LayoutA,                                                                   \

--- a/csrc/xpu/grouped_gemm/xe_2/grouped_gemm_xe2_interface.hpp
+++ b/csrc/xpu/grouped_gemm/xe_2/grouped_gemm_xe2_interface.hpp
@@ -249,11 +249,9 @@ at::Tensor cutlass_grouped_gemm_xe2_impl(
     TORCH_CHECK(ptr_bias->size(1) == N, "ptr_bias.size(1) must match N");
   }
 
-  // Must be initialized to zero before kernel launch: the persistent kernel
-  // uses this as a global work counter and reads it via atomicAdd from every
-  // workgroup. Zeroing it inside the kernel from a single workgroup is a data
-  // race, and a garbage (possibly negative) initial value makes workgroups
-  // compute negative tile coordinates and write out of bounds of ptr_D.
+  // Must be zeroed before kernel launch. Workgroup execution order
+  // is non-deterministic, so initializing in the definition is the most
+  // safe place to avoid any race condition as well as garbage data
   at::Tensor atomic_buffer =
       at::zeros({static_cast<long>(1)}, ptr_A.options().dtype(at::kInt));
 


### PR DESCRIPTION
Race condition by uninitialized value

We encounted the issue during implementation of DeepEP