### PR TITLE
 add config for TIGER-Lab/VLM2Vec-Full

### DIFF
--- a/csrc/xpu/attn/kernel_configs/paged_decode_default.conf
+++ b/csrc/xpu/attn/kernel_configs/paged_decode_default.conf
@@ -93,6 +93,7 @@
 8,128,16,false,true,false
 # TIGER-Lab/VLM2Vec-Full
 8,96,16,false,true,false
+8,96,64,false,true,false
 # bigcode/starcoder2-3b
 16,128,16,false,true,false
 # spec-decode uniform qlen (qgroup=16, head=128, page=16, non-causal)


### PR DESCRIPTION
For UT of vllm to test TIGER-Lab/VLM2Vec-Full block size 64:
https://github.com/vllm-project/vllm/pull/56038