### PR TITLE
Support per-row RNG state in XPU sampler

### DIFF
--- a/csrc/xpu/ops.h
+++ b/csrc/xpu/ops.h
@@ -342,7 +342,7 @@ bool is_xe3_arch(int64_t device_index);
 
 void exponential_2d_(
     torch::Tensor& tensor,
-    torch::Tensor& seeds,  // should on CPU
+    torch::Tensor& seeds,  // CPU [2] shared
     const double lambda);
 
 void topk_topp_sampler(
@@ -352,7 +352,7 @@ void topk_topp_sampler(
     const std::optional<torch::Tensor>& k,
     const std::optional<torch::Tensor>& p,
     const std::string& logprobs_mode,
-    torch::Tensor& seeds,  // should on CPU
+    torch::Tensor& seeds,  // CPU [2] shared or XPU [batch_size, 2] per-row
     const double lambda);
 
 #ifdef VLLM_MQA_LOGITS_ENABLED

--- a/csrc/xpu/sampler/topk_topp_sampler.cpp
+++ b/csrc/xpu/sampler/topk_topp_sampler.cpp
@@ -12,19 +12,42 @@ void topk_topp_sampler(
     const std::optional<torch::Tensor>& k,
     const std::optional<torch::Tensor>& p,
     const std::string& logprobs_mode,
-    torch::Tensor& seeds,  // should on CPU
+    torch::Tensor& seeds,
     const double lambda) {
   int batch_size = logits.size(0);
   int vocab_size = logits.size(1);
 
   TORCH_CHECK(
-      seeds.device().is_cpu(),
-      "seeds tensor must be on CPU, but got device: ",
-      seeds.device());
+      seeds.dtype() == torch::kInt64,
+      "seeds tensor must be int64, but got ",
+      seeds.dtype());
+  TORCH_CHECK(seeds.is_contiguous(), "seeds tensor must be contiguous");
   TORCH_CHECK(
-      seeds.numel() == 2,
-      "seeds tensor must have 2 elements (seed and offset), but got numel: ",
-      seeds.numel());
+      seeds.dim() == 1 || seeds.dim() == 2,
+      "seeds tensor must have rank 1 or 2, but got ",
+      seeds.dim());
+  bool has_per_row_rng = seeds.dim() == 2;
+  if (has_per_row_rng) {
+    TORCH_CHECK(
+        seeds.device() == logits.device(),
+        "per-row seeds tensor must be on the same device as logits, but got ",
+        seeds.device(),
+        " and ",
+        logits.device());
+    TORCH_CHECK(
+        seeds.size(0) == batch_size && seeds.size(1) == 2,
+        "per-row seeds tensor must have shape [batch_size, 2], but got ",
+        seeds.sizes());
+  } else {
+    TORCH_CHECK(
+        seeds.device().is_cpu(),
+        "shared seeds tensor must be on CPU, but got device: ",
+        seeds.device());
+    TORCH_CHECK(
+        seeds.dim() == 1 && seeds.numel() == 2,
+        "shared seeds tensor must have shape [2], but got ",
+        seeds.sizes());
+  }
   TORCH_CHECK(
       logits.dtype() == torch::kFloat32,
       "Logits tensor must be float32, but got ",
@@ -49,9 +72,16 @@ void topk_topp_sampler(
 
   auto& queue = vllm::xpu::vllmGetQueue();
 
-  auto seeds_ptr = reinterpret_cast<int64_t*>(seeds.data_ptr());
-  int64_t seed = seeds_ptr[0];
-  int64_t offset = seeds_ptr[1];
+  const int64_t* seed_offsets = nullptr;
+  int64_t seed = 0;
+  int64_t offset = 0;
+  if (has_per_row_rng) {
+    seed_offsets = seeds.data_ptr<int64_t>();
+  } else {
+    auto seeds_ptr = seeds.data_ptr<int64_t>();
+    seed = seeds_ptr[0];
+    offset = seeds_ptr[1];
+  }
 
   torch::Tensor buffer = torch::empty_like(logits);
 
@@ -65,6 +95,7 @@ void topk_topp_sampler(
       buffer.data_ptr<float>(),                                          \
       k.has_value() ? k->data_ptr<int64_t>() : nullptr,                  \
       p.has_value() ? p->data_ptr<float>() : nullptr,                    \
+      seed_offsets,                                                      \
       batch_size,                                                        \
       vocab_size,                                                        \
       seed,                                                              \

--- a/csrc/xpu/sampler/topk_topp_sampler_kernels.hpp
+++ b/csrc/xpu/sampler/topk_topp_sampler_kernels.hpp
@@ -59,6 +59,7 @@ struct random_sampler_only_kernel {
       int64_t* random_sampled,
       float* logits_to_return,
       float* logits,
+      const int64_t* seed_offsets,
       const int batch_size,
       const int vocab_size,
       const int64_t seed,
@@ -67,6 +68,7 @@ struct random_sampler_only_kernel {
       : random_sampled(random_sampled),
         logits_to_return(logits_to_return),
         logits(logits),
+        seed_offsets(seed_offsets),
         batch_size(batch_size),
         vocab_size(vocab_size),
         seed(seed),
@@ -91,11 +93,15 @@ struct random_sampler_only_kernel {
     const int local_id = item.get_local_linear_id();
     const int local_range = item.get_local_range(0);
 
-    const int global_id = item.get_global_linear_id();
-    uint64_t philox_seed = seed;
-    uint64_t philox_offset = offset;
+    const bool has_per_row_rng = seed_offsets != nullptr;
+    const int64_t* row_rng =
+        has_per_row_rng ? seed_offsets + batch_id * 2 : nullptr;
+    uint64_t philox_seed = has_per_row_rng ? row_rng[0] : seed;
+    uint64_t philox_offset = has_per_row_rng ? row_rng[1] : offset;
+    const int philox_subsequence =
+        has_per_row_rng ? local_id : item.get_global_linear_id();
     RAND::randStatePhilox4_32_10_t state;
-    RAND::rand_init(philox_seed, global_id, philox_offset, &state);
+    RAND::rand_init(philox_seed, philox_subsequence, philox_offset, &state);
 
     RAND::Uniform4DistributionFunctor dist_func;
     RAND::ExponentialFunctor<scalar_t, acc_scalar_t> exponential_func(lambda);
@@ -263,6 +269,7 @@ struct random_sampler_only_kernel {
   int64_t* random_sampled;
   float* logits_to_return;
   float* logits;
+  const int64_t* seed_offsets;
   const int batch_size;
   const int vocab_size;
   const int64_t seed;
@@ -286,6 +293,7 @@ struct top_k_only_kernel {
       float* logits,
       float* buffer,
       const int64_t* top_k,
+      const int64_t* seed_offsets,
       const int batch_size,
       const int vocab_size,
       const int64_t seed,
@@ -296,6 +304,7 @@ struct top_k_only_kernel {
         logits(logits),
         buffer(buffer),
         top_k(top_k),
+        seed_offsets(seed_offsets),
         batch_size(batch_size),
         vocab_size(vocab_size),
         seed(seed),
@@ -320,11 +329,15 @@ struct top_k_only_kernel {
     const int local_id = item.get_local_linear_id();
     const int local_range = item.get_local_range(0);
 
-    const int global_id = item.get_global_linear_id();
-    uint64_t philox_seed = seed;
-    uint64_t philox_offset = offset;
+    const bool has_per_row_rng = seed_offsets != nullptr;
+    const int64_t* row_rng =
+        has_per_row_rng ? seed_offsets + batch_id * 2 : nullptr;
+    uint64_t philox_seed = has_per_row_rng ? row_rng[0] : seed;
+    uint64_t philox_offset = has_per_row_rng ? row_rng[1] : offset;
+    const int philox_subsequence =
+        has_per_row_rng ? local_id : item.get_global_linear_id();
     RAND::randStatePhilox4_32_10_t state;
-    RAND::rand_init(philox_seed, global_id, philox_offset, &state);
+    RAND::rand_init(philox_seed, philox_subsequence, philox_offset, &state);
 
     RAND::Uniform4DistributionFunctor dist_func;
     RAND::ExponentialFunctor<scalar_t, acc_scalar_t> exponential_func(lambda);
@@ -717,6 +730,7 @@ struct top_k_only_kernel {
   float* logits;
   float* buffer;
   const int64_t* top_k;
+  const int64_t* seed_offsets;
   const int batch_size;
   const int vocab_size;
   const int64_t seed;
@@ -739,6 +753,7 @@ struct top_p_only_kernel {
       float* logits_to_return,
       float* logits,
       const float* top_p,
+      const int64_t* seed_offsets,
       const int batch_size,
       const int vocab_size,
       const int64_t seed,
@@ -748,6 +763,7 @@ struct top_p_only_kernel {
         logits_to_return(logits_to_return),
         logits(logits),
         top_p(top_p),
+        seed_offsets(seed_offsets),
         batch_size(batch_size),
         vocab_size(vocab_size),
         seed(seed),
@@ -772,11 +788,15 @@ struct top_p_only_kernel {
     const int local_id = item.get_local_linear_id();
     const int local_range = item.get_local_range(0);
 
-    const int global_id = item.get_global_linear_id();
-    uint64_t philox_seed = seed;
-    uint64_t philox_offset = offset;
+    const bool has_per_row_rng = seed_offsets != nullptr;
+    const int64_t* row_rng =
+        has_per_row_rng ? seed_offsets + batch_id * 2 : nullptr;
+    uint64_t philox_seed = has_per_row_rng ? row_rng[0] : seed;
+    uint64_t philox_offset = has_per_row_rng ? row_rng[1] : offset;
+    const int philox_subsequence =
+        has_per_row_rng ? local_id : item.get_global_linear_id();
     RAND::randStatePhilox4_32_10_t state;
-    RAND::rand_init(philox_seed, global_id, philox_offset, &state);
+    RAND::rand_init(philox_seed, philox_subsequence, philox_offset, &state);
 
     RAND::Uniform4DistributionFunctor dist_func;
     RAND::ExponentialFunctor<scalar_t, acc_scalar_t> exponential_func(lambda);
@@ -1076,6 +1096,7 @@ struct top_p_only_kernel {
   float* logits_to_return;
   float* logits;
   const float* top_p;
+  const int64_t* seed_offsets;
   const int batch_size;
   const int vocab_size;
   const int64_t seed;
@@ -1100,6 +1121,7 @@ struct top_k_top_p_kernel {
       float* buffer,
       const int64_t* top_k,
       const float* top_p,
+      const int64_t* seed_offsets,
       const int batch_size,
       const int vocab_size,
       const int64_t seed,
@@ -1111,6 +1133,7 @@ struct top_k_top_p_kernel {
         buffer(buffer),
         top_k(top_k),
         top_p(top_p),
+        seed_offsets(seed_offsets),
         batch_size(batch_size),
         vocab_size(vocab_size),
         seed(seed),
@@ -1135,11 +1158,15 @@ struct top_k_top_p_kernel {
     const int local_id = item.get_local_linear_id();
     const int local_range = item.get_local_range(0);
 
-    const int global_id = item.get_global_linear_id();
-    uint64_t philox_seed = seed;
-    uint64_t philox_offset = offset;
+    const bool has_per_row_rng = seed_offsets != nullptr;
+    const int64_t* row_rng =
+        has_per_row_rng ? seed_offsets + batch_id * 2 : nullptr;
+    uint64_t philox_seed = has_per_row_rng ? row_rng[0] : seed;
+    uint64_t philox_offset = has_per_row_rng ? row_rng[1] : offset;
+    const int philox_subsequence =
+        has_per_row_rng ? local_id : item.get_global_linear_id();
     RAND::randStatePhilox4_32_10_t state;
-    RAND::rand_init(philox_seed, global_id, philox_offset, &state);
+    RAND::rand_init(philox_seed, philox_subsequence, philox_offset, &state);
 
     RAND::Uniform4DistributionFunctor dist_func;
     RAND::ExponentialFunctor<scalar_t, acc_scalar_t> exponential_func(lambda);
@@ -1626,6 +1653,7 @@ struct top_k_top_p_kernel {
   float* buffer;
   const int64_t* top_k;
   const float* top_p;
+  const int64_t* seed_offsets;
   const int batch_size;
   const int vocab_size;
   const int64_t seed;
@@ -1642,6 +1670,7 @@ void topk_topp_sampler_kernel_launcher(
     float* buffer,
     const int64_t* top_k,
     const float* top_p,
+    const int64_t* seed_offsets,
     const int batch_size,
     const int vocab_size,
     const int64_t seed,
@@ -1658,6 +1687,7 @@ void topk_topp_sampler_kernel_launcher(
           logits,
           buffer,
           top_k,
+          seed_offsets,
           batch_size,
           vocab_size,
           seed,
@@ -1675,6 +1705,7 @@ void topk_topp_sampler_kernel_launcher(
           logits_to_return,
           logits,
           top_p,
+          seed_offsets,
           batch_size,
           vocab_size,
           seed,
@@ -1694,6 +1725,7 @@ void topk_topp_sampler_kernel_launcher(
           buffer,
           top_k,
           top_p,
+          seed_offsets,
           batch_size,
           vocab_size,
           seed,
@@ -1710,6 +1742,7 @@ void topk_topp_sampler_kernel_launcher(
           random_sampled,
           logits_to_return,
           logits,
+          seed_offsets,
           batch_size,
           vocab_size,
           seed,

--- a/tests/test_topk_topp_sampler.py
+++ b/tests/test_topk_topp_sampler.py
@@ -25,6 +25,108 @@ MINI_PYTEST_PARAMS = {
 }
 
 
+def _run_xpu_sampler(logits, top_k, top_p, seed_offsets):
+    random_sampled = torch.empty(
+        logits.shape[0], dtype=torch.int64, device=logits.device)
+    torch.ops._xpu_C.topk_topp_sampler(
+        random_sampled,
+        None,
+        logits,
+        top_k,
+        top_p,
+        "raw_logits",
+        seed_offsets,
+        1.0,
+    )
+    return random_sampled
+
+
+@pytest.mark.parametrize(
+    ("top_k_value", "top_p_value"),
+    [(None, None), (32, None), (None, 0.8), (32, 0.8)],
+)
+def test_per_row_seed_offsets_match_individual_calls(
+        top_k_value, top_p_value):
+    batch_size = 8
+    vocab_size = 1024
+    generator = torch.Generator(device="cpu").manual_seed(42)
+    logits = torch.randn(
+        batch_size, vocab_size, generator=generator).to(DEVICE)
+    top_k = (
+        torch.full(
+            (batch_size, ), top_k_value, dtype=torch.int64, device=DEVICE)
+        if top_k_value is not None else None
+    )
+    top_p = (
+        torch.full(
+            (batch_size, ), top_p_value, dtype=torch.float32, device=DEVICE)
+        if top_p_value is not None else None
+    )
+    seed_offsets = torch.tensor(
+        [[100 + row, row * vocab_size] for row in range(batch_size)],
+        dtype=torch.int64,
+        device=DEVICE,
+    )
+
+    batched = _run_xpu_sampler(
+        logits.clone(), top_k, top_p, seed_offsets)
+    individual = torch.stack([
+        _run_xpu_sampler(
+            logits[row:row + 1].clone(),
+            top_k[row:row + 1] if top_k is not None else None,
+            top_p[row:row + 1] if top_p is not None else None,
+            seed_offsets[row].cpu(),
+        )[0]
+        for row in range(batch_size)
+    ])
+    torch.testing.assert_close(batched, individual, rtol=0, atol=0)
+
+    permutation = torch.tensor(
+        [5, 2, 7, 0, 3, 6, 1, 4], dtype=torch.int64, device=DEVICE)
+    permuted = _run_xpu_sampler(
+        logits[permutation].clone(),
+        top_k[permutation] if top_k is not None else None,
+        top_p[permutation] if top_p is not None else None,
+        seed_offsets[permutation],
+    )
+    torch.testing.assert_close(
+        permuted, batched[permutation], rtol=0, atol=0)
+
+
+def test_per_row_seed_offsets_validate_shape_and_device():
+    batch_size = 2
+    logits = torch.randn(
+        batch_size, 128, dtype=torch.float32, device=DEVICE)
+
+    with pytest.raises(
+            RuntimeError, match="same device as logits"):
+        _run_xpu_sampler(
+            logits.clone(),
+            None,
+            None,
+            torch.zeros(batch_size, 2, dtype=torch.int64),
+        )
+
+    with pytest.raises(
+            RuntimeError, match=r"shape \[batch_size, 2\]"):
+        _run_xpu_sampler(
+            logits.clone(),
+            None,
+            None,
+            torch.zeros(
+                batch_size, 3, dtype=torch.int64, device=DEVICE),
+        )
+
+    with pytest.raises(RuntimeError, match="rank 1 or 2"):
+        _run_xpu_sampler(
+            logits.clone(),
+            None,
+            None,
+            torch.zeros(
+                batch_size, 2, 1, dtype=torch.int64, device=DEVICE),
+        )
+
+
 @pytest.mark.parametrize("batch_size", BATCH_SIZE)
 @pytest.mark.parametrize("vocab_size", VOCAB_SIZE)
 @pytest.mark.parametrize("k", K)


### PR DESCRIPTION
# Essential Elements of an Effective PR Description Checklist

- [x] The purpose of the PR.
- [x] The test plan.
- [x] The test results.
- [x] Documentation impact considered.

## Purpose

The XPU top-k/top-p sampler previously accepted one CPU `int64[2]` `[seed, offset]` pair shared by the whole batch. A caller that needs an independent RNG stream for each row therefore has to invoke the operator once per row.

Starting with FlashInfer v0.6.4 ([flashinfer-ai/flashinfer#2432](https://github.com/flashinfer-ai/flashinfer/pull/2432)), its sampling APIs accept 1-D tensor seed and offset inputs with one value per batch row. This feature aligns the XPU sampler with that per-row RNG behavior.

This PR additionally accepts a contiguous XPU `int64[batch_size, 2]` tensor containing one seed/offset pair per row. The
existing CPU `int64[2]` input remains supported and keeps its original behavior.

For per-row input, each workgroup reads its row's seed and offset and uses its local lane ID as the Philox subsequence. This makes a batched call match independent batch-size-one calls and keeps each row's result invariant when the batch is reordered.

## Validation

### Test plan

```bash
cmake --build build/temp --target _xpu_C --parallel 16

ZE_AFFINITY_MASK=0 PYTHONPATH=.   pytest -q tests/test_topk_topp_sampler.py -k per_row_seed_offsets

ZE_AFFINITY_MASK=0 PYTHONPATH=. XPU_KERNEL_TEST_SCOPE=mini   pytest -q tests/test_topk_topp_sampler.py
```

### Test results

- The targeted `_xpu_C` build completed successfully on current `main`.
- Focused per-row tests: `5 passed, 1008 deselected`.
- Sampler mini suite: `99 passed, 2 skipped`.
- A manual A/B check compared the installed pre-change binary with the rebuilt PR binary using a CPU `int64[2]` state, batch size 8, and unfiltered, top-k, top-p, and combined top-k/top-p modes. All sampled token IDs were identical.

## Performance

Local synchronized wall-clock microbenchmark on an Intel Arc Pro B60, using vocabulary size 151,936, top-k 32, and top-p 0.8. The comparison is one batched operator call versus repeated batch-size-one operator calls; benchmark inputs, output tensors, and RNG-state tensors were preallocated.

| Batch size | Batched `[B,2]` | Per-row calls | Speedup |
| ---: | ---: | ---: | ---: |
| 1 | 0.366 ms | 0.371 ms | 1.01x |
| 2 | 0.422 ms | 0.806 ms | 1.91x |
| 4 | 0.479 ms | 1.705 ms | 3.56x |
| 8 | 0.533 ms | 3.530 ms | 6.62x |
| 16 | 0.503 ms | 6.508 ms | 12.95x |
| 32 | 0.770 ms | 14.238 ms | 18.48x |

## Documentation update

No user-facing documentation update is needed. The operator signature is unchanged; the accepted RNG-state shapes are documented in `csrc/xpu/ops.h`.

**BEFORE SUBMITTING, PLEASE READ <https://docs.vllm.ai/en/latest/contributing>**
