### PR TITLE
Add XPU SYCL kernels for Kimi-K3 MLA epilogue ops

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -594,6 +594,7 @@ if(BASIC_KERNELS_ENABLED)
       "csrc/activation.cpp"
       "csrc/pos_encoding_kernels.cpp"
       "csrc/fused_qknorm_rope.cpp"
+      "csrc/kimi_k3_mla_epilogue.cpp"
       "csrc/torch_bindings.cpp"
       "csrc/quantization/fp8/fp8_quant.cpp"
       "csrc/quantization/fp4/mxfp4_quant.cpp"

--- a/csrc/kimi_k3_mla_epilogue.cpp
+++ b/csrc/kimi_k3_mla_epilogue.cpp
@@ -312,16 +312,17 @@ bool check_rope_inputs(
   auto const& rope_cache = cos_sin_cache.value();
   CHECK_DEVICE(positions);
   CHECK_DEVICE(rope_cache);
+  CHECK_CONTIGUOUS(positions);
+  CHECK_CONTIGUOUS(rope_cache);
   TORCH_CHECK(
       positions.dim() == 1 && positions.scalar_type() == torch::kInt64 &&
           positions.size(0) == num_tokens,
-      "position_ids must be int64 XPU with shape [num_tokens]");
+      "position_ids must be int64 XPU with shape [num_tokens], contiguous");
   TORCH_CHECK(
       rope_cache.dim() == 2 && rope_cache.size(1) == 64 &&
-          rope_cache.stride(1) == 1 &&
           rope_cache.scalar_type() == torch::kFloat32,
-      "cos_sin_cache must have shape [max_position, 64], unit last-dim "
-      "stride, and be fp32");
+      "cos_sin_cache must have shape [max_position, 64], contiguous, and be "
+      "fp32");
   return true;
 }
 }  // namespace
@@ -344,7 +345,9 @@ void fused_kimi_k3_mla_key_concat_kv_cache_insert(
   CHECK_DEVICE(k_out);
   CHECK_DEVICE(k_cache);
   CHECK_DEVICE(slot_mapping);
+  CHECK_STRIDE_ALIGNMENT(k_nope);
   TORCH_CHECK(k_nope.dim() == 3 && k_nope.size(2) == 128, "k_nope [Tp,H,128]");
+  CHECK_STRIDE_ALIGNMENT(q);
   TORCH_CHECK(q.dim() == 3 && q.size(2) == 192, "q [Tp,H,192]");
   CHECK_STRIDE_ALIGNMENT(k_pe);
   TORCH_CHECK(k_pe.dim() == 2 && k_pe.size(1) == 64, "k_pe [Tp,64]");
@@ -359,8 +362,10 @@ void fused_kimi_k3_mla_key_concat_kv_cache_insert(
       k_cache.dim() == 3 && k_cache.size(1) == cache_block_size &&
           k_cache.size(2) == 576,
       "k_cache [nblk,block_size,576] contiguous");
+  CHECK_CONTIGUOUS(slot_mapping);
   TORCH_CHECK(
-      slot_mapping.scalar_type() == torch::kInt64, "slot_mapping int64");
+      slot_mapping.scalar_type() == torch::kInt64,
+      "slot_mapping int64, contiguous");
   auto const dt = k_nope.scalar_type();
   TORCH_CHECK(
       q.scalar_type() == dt && k_pe.scalar_type() == dt &&
@@ -458,8 +463,10 @@ void fused_kimi_k3_mla_decode_q_concat_kv_cache_insert(
   CHECK_DEVICE(k_cache);
   CHECK_DEVICE(slot_mapping);
   auto const dt = ql_nope.scalar_type();
+  CHECK_STRIDE_ALIGNMENT(ql_nope);
   TORCH_CHECK(
       ql_nope.dim() == 3 && ql_nope.size(2) == 512, "ql_nope [B,H,512]");
+  CHECK_STRIDE_ALIGNMENT(q_pe);
   TORCH_CHECK(
       q_pe.scalar_type() == dt && q_pe.dim() == 3 && q_pe.size(2) == 64,
       "q_pe [B,H,64]");
@@ -481,8 +488,10 @@ void fused_kimi_k3_mla_decode_q_concat_kv_cache_insert(
       k_cache.scalar_type() == dt && k_cache.dim() == 3 &&
           k_cache.size(1) == cache_block_size && k_cache.size(2) == 576,
       "k_cache [nblk,block_size,576] contiguous, matches ql_nope dtype");
+  CHECK_CONTIGUOUS(slot_mapping);
   TORCH_CHECK(
-      slot_mapping.scalar_type() == torch::kInt64, "slot_mapping int64");
+      slot_mapping.scalar_type() == torch::kInt64,
+      "slot_mapping int64, contiguous");
 
   int const num_tokens = static_cast<int>(ql_nope.size(0));
   int const num_heads = static_cast<int>(ql_nope.size(1));

--- a/csrc/kimi_k3_mla_epilogue.cpp
+++ b/csrc/kimi_k3_mla_epilogue.cpp
@@ -1,0 +1,557 @@
+/*
+ * XPU port of the CUDA Kimi-K3 MLA epilogue kernels
+ * (vllm/csrc/libtorch_stable/fused_kimi_k3_mla_key_concat_kv_cache_kernel.cu).
+ * bf16/fp16 only — the fp8 and fp8_ds_mla cache-layout variants, and the
+ * sm_90+ PDL launch overlap, are not ported.
+ */
+#include <sycl/sycl.hpp>
+
+#include <ATen/DeviceGuard.h>
+
+#include "dispatch_utils.h"
+#include "utils.h"
+
+namespace vllm {
+namespace kimi_k3 {
+
+constexpr int kKvLoraRank = 512;
+constexpr int kQkNopeHeadDim = 128;
+constexpr int kQkRopeHeadDim = 64;
+constexpr int kQkHeadDim = kQkNopeHeadDim + kQkRopeHeadDim;  // 192
+constexpr int kCacheEntry = kKvLoraRank + kQkRopeHeadDim;    // 576
+constexpr int kVecElems = 8;  // 8 bf16/fp16 elems == 16B vector
+constexpr int kSubGroupSize = 32;
+
+template <typename scalar_t, bool APPLY_ROPE>
+static inline void copy_chunk8(
+    scalar_t* dst, const scalar_t* src, int elem_base, const float* cos_sin) {
+  using vllm::xpu::from_float;
+  using vllm::xpu::to_float;
+  auto v =
+      *reinterpret_cast<const vllm::xpu::aligned_vec<scalar_t, kVecElems>*>(
+          src);
+  if constexpr (APPLY_ROPE) {
+#pragma unroll
+    for (int i = 0; i < kVecElems / 2; i++) {
+      int const pair = elem_base / 2 + i;
+      float const cos = cos_sin[pair];
+      float const sin = cos_sin[pair + kQkRopeHeadDim / 2];
+      float const x = to_float(v[2 * i]);
+      float const y = to_float(v[2 * i + 1]);
+      from_float(v[2 * i], x * cos - y * sin);
+      from_float(v[2 * i + 1], x * sin + y * cos);
+    }
+  }
+  *reinterpret_cast<vllm::xpu::aligned_vec<scalar_t, kVecElems>*>(dst) = v;
+}
+
+// One sub-group per (token, head) writes q-RoPE + full-key concat; one
+// extra sub-group per token (slot == num_heads) writes the latent cache row.
+template <typename scalar_t, bool APPLY_ROPE>
+class KeyConcatKvCacheKernel {
+ public:
+  KeyConcatKvCacheKernel(
+      scalar_t* q_,
+      int64_t q_tok_stride_,
+      int64_t q_head_stride_,
+      const scalar_t* k_nope_,
+      int64_t kn_tok_stride_,
+      int64_t kn_head_stride_,
+      const scalar_t* k_pe_,
+      int64_t k_pe_tok_stride_,
+      const scalar_t* kv_c_,
+      int64_t kv_c_tok_stride_,
+      scalar_t* k_out_,
+      int64_t ko_tok_stride_,
+      int64_t ko_head_stride_,
+      scalar_t* k_cache_,
+      int64_t cache_block_stride_,
+      int64_t cache_token_stride_,
+      const int64_t* slot_mapping_,
+      const int64_t* position_ids_,
+      const float* cos_sin_cache_,
+      int num_tokens_,
+      int num_heads_,
+      int cache_block_size_)
+      : q(q_),
+        q_tok_stride(q_tok_stride_),
+        q_head_stride(q_head_stride_),
+        k_nope(k_nope_),
+        kn_tok_stride(kn_tok_stride_),
+        kn_head_stride(kn_head_stride_),
+        k_pe(k_pe_),
+        k_pe_tok_stride(k_pe_tok_stride_),
+        kv_c(kv_c_),
+        kv_c_tok_stride(kv_c_tok_stride_),
+        k_out(k_out_),
+        ko_tok_stride(ko_tok_stride_),
+        ko_head_stride(ko_head_stride_),
+        k_cache(k_cache_),
+        cache_block_stride(cache_block_stride_),
+        cache_token_stride(cache_token_stride_),
+        slot_mapping(slot_mapping_),
+        position_ids(position_ids_),
+        cos_sin_cache(cos_sin_cache_),
+        num_tokens(num_tokens_),
+        num_heads(num_heads_),
+        cache_block_size(cache_block_size_) {}
+
+  void operator() [[sycl::reqd_sub_group_size(kSubGroupSize)]] (
+      sycl::nd_item<1> item) const {
+    auto sg = item.get_sub_group();
+    int const lane = sg.get_local_linear_id();
+    int const global_sg = item.get_group(0) * sg.get_group_linear_range() +
+                          sg.get_group_linear_id();
+    int const slots_per_token = num_heads + 1;
+    int const token = global_sg / slots_per_token;
+    int const slot = global_sg % slots_per_token;
+    if (token >= num_tokens) return;
+
+    const float* rope = nullptr;
+    if constexpr (APPLY_ROPE) {
+      rope = cos_sin_cache + position_ids[token] * kQkRopeHeadDim;
+    }
+
+    if (slot < num_heads) {
+      scalar_t* qh = q + token * q_tok_stride + slot * q_head_stride;
+      if constexpr (APPLY_ROPE) {
+        for (int e = lane * kVecElems; e < kQkRopeHeadDim;
+             e += kSubGroupSize * kVecElems) {
+          copy_chunk8<scalar_t, true>(
+              qh + kQkNopeHeadDim + e, qh + kQkNopeHeadDim + e, e, rope);
+        }
+      }
+      scalar_t* ko = k_out + token * ko_tok_stride + slot * ko_head_stride;
+      const scalar_t* kn =
+          k_nope + token * kn_tok_stride + slot * kn_head_stride;
+      const scalar_t* kp = k_pe + token * k_pe_tok_stride;
+      for (int e = lane * kVecElems; e < kQkHeadDim;
+           e += kSubGroupSize * kVecElems) {
+        if (e < kQkNopeHeadDim) {
+          copy_chunk8<scalar_t, false>(ko + e, kn + e, 0, nullptr);
+        } else {
+          int const rope_e = e - kQkNopeHeadDim;
+          copy_chunk8<scalar_t, APPLY_ROPE>(ko + e, kp + rope_e, rope_e, rope);
+        }
+      }
+    } else {
+      int64_t const slot_id = slot_mapping[token];
+      if (slot_id < 0) return;
+      scalar_t* row = k_cache +
+                      (slot_id / cache_block_size) * cache_block_stride +
+                      (slot_id % cache_block_size) * cache_token_stride;
+      const scalar_t* kvc = kv_c + token * kv_c_tok_stride;
+      const scalar_t* kp = k_pe + token * k_pe_tok_stride;
+      for (int e = lane * kVecElems; e < kCacheEntry;
+           e += kSubGroupSize * kVecElems) {
+        if (e < kKvLoraRank) {
+          copy_chunk8<scalar_t, false>(row + e, kvc + e, 0, nullptr);
+        } else {
+          int const rope_e = e - kKvLoraRank;
+          copy_chunk8<scalar_t, APPLY_ROPE>(row + e, kp + rope_e, rope_e, rope);
+        }
+      }
+    }
+  }
+
+ private:
+  scalar_t* q;
+  int64_t q_tok_stride, q_head_stride;
+  const scalar_t* k_nope;
+  int64_t kn_tok_stride, kn_head_stride;
+  const scalar_t* k_pe;
+  int64_t k_pe_tok_stride;
+  const scalar_t* kv_c;
+  int64_t kv_c_tok_stride;
+  scalar_t* k_out;
+  int64_t ko_tok_stride, ko_head_stride;
+  scalar_t* k_cache;
+  int64_t cache_block_stride, cache_token_stride;
+  const int64_t* slot_mapping;
+  const int64_t* position_ids;
+  const float* cos_sin_cache;
+  int num_tokens, num_heads, cache_block_size;
+};
+
+// One sub-group per (token, head) writes mqa_q = [ql_nope | q_pe]; one extra
+// sub-group per token (slot == num_heads) writes the latent cache row.
+template <typename scalar_t, bool APPLY_ROPE>
+class DecodeQConcatKvCacheKernel {
+ public:
+  DecodeQConcatKvCacheKernel(
+      const scalar_t* ql_nope_,
+      int64_t qn_tok_stride_,
+      int64_t qn_head_stride_,
+      const scalar_t* q_pe_,
+      int64_t qpe_tok_stride_,
+      int64_t qpe_head_stride_,
+      const scalar_t* kv_c_,
+      int64_t kv_c_tok_stride_,
+      const scalar_t* k_pe_,
+      int64_t k_pe_tok_stride_,
+      scalar_t* mqa_q_,
+      int64_t mq_tok_stride_,
+      int64_t mq_head_stride_,
+      scalar_t* k_cache_,
+      int64_t cache_block_stride_,
+      int64_t cache_token_stride_,
+      const int64_t* slot_mapping_,
+      const int64_t* position_ids_,
+      const float* cos_sin_cache_,
+      int num_tokens_,
+      int num_heads_,
+      int cache_block_size_)
+      : ql_nope(ql_nope_),
+        qn_tok_stride(qn_tok_stride_),
+        qn_head_stride(qn_head_stride_),
+        q_pe(q_pe_),
+        qpe_tok_stride(qpe_tok_stride_),
+        qpe_head_stride(qpe_head_stride_),
+        kv_c(kv_c_),
+        kv_c_tok_stride(kv_c_tok_stride_),
+        k_pe(k_pe_),
+        k_pe_tok_stride(k_pe_tok_stride_),
+        mqa_q(mqa_q_),
+        mq_tok_stride(mq_tok_stride_),
+        mq_head_stride(mq_head_stride_),
+        k_cache(k_cache_),
+        cache_block_stride(cache_block_stride_),
+        cache_token_stride(cache_token_stride_),
+        slot_mapping(slot_mapping_),
+        position_ids(position_ids_),
+        cos_sin_cache(cos_sin_cache_),
+        num_tokens(num_tokens_),
+        num_heads(num_heads_),
+        cache_block_size(cache_block_size_) {}
+
+  void operator() [[sycl::reqd_sub_group_size(kSubGroupSize)]] (
+      sycl::nd_item<1> item) const {
+    auto sg = item.get_sub_group();
+    int const lane = sg.get_local_linear_id();
+    int const global_sg = item.get_group(0) * sg.get_group_linear_range() +
+                          sg.get_group_linear_id();
+    int const slots_per_token = num_heads + 1;
+    int const token = global_sg / slots_per_token;
+    int const slot = global_sg % slots_per_token;
+    if (token >= num_tokens) return;
+
+    const float* rope = nullptr;
+    if constexpr (APPLY_ROPE) {
+      rope = cos_sin_cache + position_ids[token] * kQkRopeHeadDim;
+    }
+
+    if (slot < num_heads) {
+      scalar_t* dst = mqa_q + token * mq_tok_stride + slot * mq_head_stride;
+      const scalar_t* a =
+          ql_nope + token * qn_tok_stride + slot * qn_head_stride;
+      const scalar_t* b =
+          q_pe + token * qpe_tok_stride + slot * qpe_head_stride;
+      for (int e = lane * kVecElems; e < kCacheEntry;
+           e += kSubGroupSize * kVecElems) {
+        if (e < kKvLoraRank) {
+          copy_chunk8<scalar_t, false>(dst + e, a + e, 0, nullptr);
+        } else {
+          int const rope_e = e - kKvLoraRank;
+          copy_chunk8<scalar_t, APPLY_ROPE>(dst + e, b + rope_e, rope_e, rope);
+        }
+      }
+    } else {
+      int64_t const slot_id = slot_mapping[token];
+      if (slot_id < 0) return;
+      scalar_t* row = k_cache +
+                      (slot_id / cache_block_size) * cache_block_stride +
+                      (slot_id % cache_block_size) * cache_token_stride;
+      const scalar_t* kvc = kv_c + token * kv_c_tok_stride;
+      const scalar_t* kp = k_pe + token * k_pe_tok_stride;
+      for (int e = lane * kVecElems; e < kCacheEntry;
+           e += kSubGroupSize * kVecElems) {
+        if (e < kKvLoraRank) {
+          copy_chunk8<scalar_t, false>(row + e, kvc + e, 0, nullptr);
+        } else {
+          int const rope_e = e - kKvLoraRank;
+          copy_chunk8<scalar_t, APPLY_ROPE>(row + e, kp + rope_e, rope_e, rope);
+        }
+      }
+    }
+  }
+
+ private:
+  const scalar_t* ql_nope;
+  int64_t qn_tok_stride, qn_head_stride;
+  const scalar_t* q_pe;
+  int64_t qpe_tok_stride, qpe_head_stride;
+  const scalar_t* kv_c;
+  int64_t kv_c_tok_stride;
+  const scalar_t* k_pe;
+  int64_t k_pe_tok_stride;
+  scalar_t* mqa_q;
+  int64_t mq_tok_stride, mq_head_stride;
+  scalar_t* k_cache;
+  int64_t cache_block_stride, cache_token_stride;
+  const int64_t* slot_mapping;
+  const int64_t* position_ids;
+  const float* cos_sin_cache;
+  int num_tokens, num_heads, cache_block_size;
+};
+
+}  // namespace kimi_k3
+}  // namespace vllm
+
+namespace {
+// position_ids/cos_sin_cache are provided together or not at all; validated
+// the same way as the CUDA op (int64 [num_tokens], fp32 [max_position, 64]).
+bool check_rope_inputs(
+    std::optional<torch::Tensor> const& position_ids,
+    std::optional<torch::Tensor> const& cos_sin_cache,
+    int64_t num_tokens) {
+  TORCH_CHECK(
+      position_ids.has_value() == cos_sin_cache.has_value(),
+      "position_ids and cos_sin_cache must be provided together");
+  if (!position_ids.has_value()) return false;
+  auto const& positions = position_ids.value();
+  auto const& rope_cache = cos_sin_cache.value();
+  CHECK_DEVICE(positions);
+  CHECK_DEVICE(rope_cache);
+  TORCH_CHECK(
+      positions.dim() == 1 && positions.scalar_type() == torch::kInt64 &&
+          positions.size(0) == num_tokens,
+      "position_ids must be int64 XPU with shape [num_tokens]");
+  TORCH_CHECK(
+      rope_cache.dim() == 2 && rope_cache.size(1) == 64 &&
+          rope_cache.stride(1) == 1 &&
+          rope_cache.scalar_type() == torch::kFloat32,
+      "cos_sin_cache must have shape [max_position, 64], unit last-dim "
+      "stride, and be fp32");
+  return true;
+}
+}  // namespace
+
+void fused_kimi_k3_mla_key_concat_kv_cache_insert(
+    torch::Tensor& q,
+    torch::Tensor const& k_nope,
+    torch::Tensor const& k_pe,
+    torch::Tensor const& kv_c_normed,
+    torch::Tensor& k_out,
+    torch::Tensor& k_cache,
+    torch::Tensor const& slot_mapping,
+    int64_t cache_block_size,
+    std::optional<torch::Tensor> position_ids,
+    std::optional<torch::Tensor> cos_sin_cache) {
+  CHECK_DEVICE(q);
+  CHECK_DEVICE(k_nope);
+  CHECK_DEVICE(k_pe);
+  CHECK_DEVICE(kv_c_normed);
+  CHECK_DEVICE(k_out);
+  CHECK_DEVICE(k_cache);
+  CHECK_DEVICE(slot_mapping);
+  TORCH_CHECK(k_nope.dim() == 3 && k_nope.size(2) == 128, "k_nope [Tp,H,128]");
+  TORCH_CHECK(q.dim() == 3 && q.size(2) == 192, "q [Tp,H,192]");
+  CHECK_STRIDE_ALIGNMENT(k_pe);
+  TORCH_CHECK(k_pe.dim() == 2 && k_pe.size(1) == 64, "k_pe [Tp,64]");
+  CHECK_CONTIGUOUS(kv_c_normed);
+  TORCH_CHECK(
+      kv_c_normed.dim() == 2 && kv_c_normed.size(1) == 512,
+      "kv_c_normed [Tp,512] contiguous");
+  CHECK_CONTIGUOUS(k_out);
+  TORCH_CHECK(k_out.dim() == 3 && k_out.size(2) == 192, "k_out [Tp,H,192]");
+  CHECK_CONTIGUOUS(k_cache);
+  TORCH_CHECK(
+      k_cache.dim() == 3 && k_cache.size(1) == cache_block_size &&
+          k_cache.size(2) == 576,
+      "k_cache [nblk,block_size,576] contiguous");
+  TORCH_CHECK(
+      slot_mapping.scalar_type() == torch::kInt64, "slot_mapping int64");
+  auto const dt = k_nope.scalar_type();
+  TORCH_CHECK(
+      q.scalar_type() == dt && k_pe.scalar_type() == dt &&
+          kv_c_normed.scalar_type() == dt && k_out.scalar_type() == dt &&
+          k_cache.scalar_type() == dt,
+      "all tensors must share k_nope's dtype");
+
+  int const num_tokens = static_cast<int>(k_nope.size(0));
+  int const num_heads = static_cast<int>(k_nope.size(1));
+  bool const apply_rope =
+      check_rope_inputs(position_ids, cos_sin_cache, num_tokens);
+  if (num_tokens == 0) return;
+
+  const at::DeviceGuard device_guard(k_nope.device());
+  auto& queue = vllm::xpu::vllmGetQueue();
+  constexpr int kSgsPerWg = 8;
+  int64_t const total_sgs = static_cast<int64_t>(num_tokens) * (num_heads + 1);
+  int64_t const grid_sgs = (total_sgs + kSgsPerWg - 1) / kSgsPerWg;
+
+  VLLM_DISPATCH_HALF_TYPES(
+      dt, "fused_kimi_k3_mla_key_concat_kv_cache_insert", [&] {
+        using sycl_t = typename vllm::xpu::SyclTypeTrait<scalar_t>::Type;
+        auto q_ptr = reinterpret_cast<sycl_t*>(q.data_ptr<scalar_t>());
+        auto kn_ptr =
+            reinterpret_cast<const sycl_t*>(k_nope.data_ptr<scalar_t>());
+        auto kp_ptr =
+            reinterpret_cast<const sycl_t*>(k_pe.data_ptr<scalar_t>());
+        auto kvc_ptr =
+            reinterpret_cast<const sycl_t*>(kv_c_normed.data_ptr<scalar_t>());
+        auto ko_ptr = reinterpret_cast<sycl_t*>(k_out.data_ptr<scalar_t>());
+        auto kc_ptr = reinterpret_cast<sycl_t*>(k_cache.data_ptr<scalar_t>());
+        auto sm_ptr = slot_mapping.data_ptr<int64_t>();
+        auto pid_ptr =
+            apply_rope ? position_ids.value().data_ptr<int64_t>() : nullptr;
+        auto cs_ptr = apply_rope ? reinterpret_cast<const float*>(
+                                       cos_sin_cache.value().data_ptr<float>())
+                                 : nullptr;
+
+        auto launch = [&](auto apply_rope_tag) {
+          constexpr bool kApplyRope = decltype(apply_rope_tag)::value;
+          queue.submit([&](sycl::handler& cgh) {
+            cgh.parallel_for(
+                sycl::nd_range<1>(
+                    grid_sgs * kSgsPerWg * vllm::kimi_k3::kSubGroupSize,
+                    kSgsPerWg * vllm::kimi_k3::kSubGroupSize),
+                vllm::kimi_k3::KeyConcatKvCacheKernel<sycl_t, kApplyRope>(
+                    q_ptr,
+                    q.stride(0),
+                    q.stride(1),
+                    kn_ptr,
+                    k_nope.stride(0),
+                    k_nope.stride(1),
+                    kp_ptr,
+                    k_pe.stride(0),
+                    kvc_ptr,
+                    kv_c_normed.stride(0),
+                    ko_ptr,
+                    k_out.stride(0),
+                    k_out.stride(1),
+                    kc_ptr,
+                    k_cache.stride(0),
+                    k_cache.stride(1),
+                    sm_ptr,
+                    pid_ptr,
+                    cs_ptr,
+                    num_tokens,
+                    num_heads,
+                    static_cast<int>(cache_block_size)));
+          });
+        };
+        if (apply_rope) {
+          launch(std::bool_constant<true>{});
+        } else {
+          launch(std::bool_constant<false>{});
+        }
+      });
+}
+
+void fused_kimi_k3_mla_decode_q_concat_kv_cache_insert(
+    torch::Tensor const& ql_nope,
+    torch::Tensor const& q_pe,
+    torch::Tensor const& kv_c_normed,
+    torch::Tensor const& k_pe,
+    torch::Tensor& mqa_q,
+    torch::Tensor& k_cache,
+    torch::Tensor const& slot_mapping,
+    int64_t cache_block_size,
+    std::optional<torch::Tensor> position_ids,
+    std::optional<torch::Tensor> cos_sin_cache) {
+  CHECK_DEVICE(ql_nope);
+  CHECK_DEVICE(q_pe);
+  CHECK_DEVICE(kv_c_normed);
+  CHECK_DEVICE(k_pe);
+  CHECK_DEVICE(mqa_q);
+  CHECK_DEVICE(k_cache);
+  CHECK_DEVICE(slot_mapping);
+  auto const dt = ql_nope.scalar_type();
+  TORCH_CHECK(
+      ql_nope.dim() == 3 && ql_nope.size(2) == 512, "ql_nope [B,H,512]");
+  TORCH_CHECK(
+      q_pe.scalar_type() == dt && q_pe.dim() == 3 && q_pe.size(2) == 64,
+      "q_pe [B,H,64]");
+  CHECK_CONTIGUOUS(kv_c_normed);
+  TORCH_CHECK(
+      kv_c_normed.scalar_type() == dt && kv_c_normed.dim() == 2 &&
+          kv_c_normed.size(1) == 512,
+      "kv_c_normed [B,512] contiguous");
+  CHECK_STRIDE_ALIGNMENT(k_pe);
+  TORCH_CHECK(
+      k_pe.scalar_type() == dt && k_pe.dim() == 2 && k_pe.size(1) == 64,
+      "k_pe [B,64]");
+  CHECK_CONTIGUOUS(mqa_q);
+  TORCH_CHECK(
+      mqa_q.scalar_type() == dt && mqa_q.dim() == 3 && mqa_q.size(2) == 576,
+      "mqa_q [B,H,576] contiguous");
+  CHECK_CONTIGUOUS(k_cache);
+  TORCH_CHECK(
+      k_cache.scalar_type() == dt && k_cache.dim() == 3 &&
+          k_cache.size(1) == cache_block_size && k_cache.size(2) == 576,
+      "k_cache [nblk,block_size,576] contiguous, matches ql_nope dtype");
+  TORCH_CHECK(
+      slot_mapping.scalar_type() == torch::kInt64, "slot_mapping int64");
+
+  int const num_tokens = static_cast<int>(ql_nope.size(0));
+  int const num_heads = static_cast<int>(ql_nope.size(1));
+  bool const apply_rope =
+      check_rope_inputs(position_ids, cos_sin_cache, num_tokens);
+  if (num_tokens == 0) return;
+
+  const at::DeviceGuard device_guard(ql_nope.device());
+  auto& queue = vllm::xpu::vllmGetQueue();
+  constexpr int kSgsPerWg = 8;
+  int64_t const total_sgs = static_cast<int64_t>(num_tokens) * (num_heads + 1);
+  int64_t const grid_sgs = (total_sgs + kSgsPerWg - 1) / kSgsPerWg;
+
+  VLLM_DISPATCH_HALF_TYPES(
+      dt, "fused_kimi_k3_mla_decode_q_concat_kv_cache_insert", [&] {
+        using sycl_t = typename vllm::xpu::SyclTypeTrait<scalar_t>::Type;
+        auto qn_ptr =
+            reinterpret_cast<const sycl_t*>(ql_nope.data_ptr<scalar_t>());
+        auto qp_ptr =
+            reinterpret_cast<const sycl_t*>(q_pe.data_ptr<scalar_t>());
+        auto kvc_ptr =
+            reinterpret_cast<const sycl_t*>(kv_c_normed.data_ptr<scalar_t>());
+        auto kp_ptr =
+            reinterpret_cast<const sycl_t*>(k_pe.data_ptr<scalar_t>());
+        auto mq_ptr = reinterpret_cast<sycl_t*>(mqa_q.data_ptr<scalar_t>());
+        auto kc_ptr = reinterpret_cast<sycl_t*>(k_cache.data_ptr<scalar_t>());
+        auto sm_ptr = slot_mapping.data_ptr<int64_t>();
+        auto pid_ptr =
+            apply_rope ? position_ids.value().data_ptr<int64_t>() : nullptr;
+        auto cs_ptr = apply_rope ? reinterpret_cast<const float*>(
+                                       cos_sin_cache.value().data_ptr<float>())
+                                 : nullptr;
+
+        auto launch = [&](auto apply_rope_tag) {
+          constexpr bool kApplyRope = decltype(apply_rope_tag)::value;
+          queue.submit([&](sycl::handler& cgh) {
+            cgh.parallel_for(
+                sycl::nd_range<1>(
+                    grid_sgs * kSgsPerWg * vllm::kimi_k3::kSubGroupSize,
+                    kSgsPerWg * vllm::kimi_k3::kSubGroupSize),
+                vllm::kimi_k3::DecodeQConcatKvCacheKernel<sycl_t, kApplyRope>(
+                    qn_ptr,
+                    ql_nope.stride(0),
+                    ql_nope.stride(1),
+                    qp_ptr,
+                    q_pe.stride(0),
+                    q_pe.stride(1),
+                    kvc_ptr,
+                    kv_c_normed.stride(0),
+                    kp_ptr,
+                    k_pe.stride(0),
+                    mq_ptr,
+                    mqa_q.stride(0),
+                    mqa_q.stride(1),
+                    kc_ptr,
+                    k_cache.stride(0),
+                    k_cache.stride(1),
+                    sm_ptr,
+                    pid_ptr,
+                    cs_ptr,
+                    num_tokens,
+                    num_heads,
+                    static_cast<int>(cache_block_size)));
+          });
+        };
+        if (apply_rope) {
+          launch(std::bool_constant<true>{});
+        } else {
+          launch(std::bool_constant<false>{});
+        }
+      });
+}

--- a/csrc/ops.h
+++ b/csrc/ops.h
@@ -137,6 +137,31 @@ void fused_qk_norm_rope(
     torch::Tensor& position_ids,
     int64_t forced_token_heads_per_warp);
 
+// Kimi-K3 MLA epilogues (bf16/fp16 only; no fp8 / fp8_ds_mla variants).
+void fused_kimi_k3_mla_key_concat_kv_cache_insert(
+    torch::Tensor& q,
+    torch::Tensor const& k_nope,
+    torch::Tensor const& k_pe,
+    torch::Tensor const& kv_c_normed,
+    torch::Tensor& k_out,
+    torch::Tensor& k_cache,
+    torch::Tensor const& slot_mapping,
+    int64_t cache_block_size,
+    std::optional<torch::Tensor> position_ids,
+    std::optional<torch::Tensor> cos_sin_cache);
+
+void fused_kimi_k3_mla_decode_q_concat_kv_cache_insert(
+    torch::Tensor const& ql_nope,
+    torch::Tensor const& q_pe,
+    torch::Tensor const& kv_c_normed,
+    torch::Tensor const& k_pe,
+    torch::Tensor& mqa_q,
+    torch::Tensor& k_cache,
+    torch::Tensor const& slot_mapping,
+    int64_t cache_block_size,
+    std::optional<torch::Tensor> position_ids,
+    std::optional<torch::Tensor> cos_sin_cache);
+
 void reshape_and_cache(
     torch::Tensor& key,
     torch::Tensor& value,

--- a/csrc/torch_bindings.cpp
+++ b/csrc/torch_bindings.cpp
@@ -161,6 +161,27 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
       "int forced_token_heads_per_warp=-1) -> ()");
   ops.impl("fused_qk_norm_rope", torch::kXPU, &fused_qk_norm_rope);
 
+  // Kimi-K3 MLA epilogues (bf16/fp16 only)
+  ops.def(
+      "fused_kimi_k3_mla_key_concat_kv_cache_insert(Tensor! q, "
+      "Tensor k_nope, Tensor k_pe, Tensor kv_c_normed, Tensor! k_out, "
+      "Tensor! k_cache, Tensor slot_mapping, int cache_block_size, "
+      "Tensor? position_ids, Tensor? cos_sin_cache) -> ()");
+  ops.impl(
+      "fused_kimi_k3_mla_key_concat_kv_cache_insert",
+      torch::kXPU,
+      &fused_kimi_k3_mla_key_concat_kv_cache_insert);
+
+  ops.def(
+      "fused_kimi_k3_mla_decode_q_concat_kv_cache_insert(Tensor ql_nope, "
+      "Tensor q_pe, Tensor kv_c_normed, Tensor k_pe, Tensor! mqa_q, "
+      "Tensor! k_cache, Tensor slot_mapping, int cache_block_size, "
+      "Tensor? position_ids, Tensor? cos_sin_cache) -> ()");
+  ops.impl(
+      "fused_kimi_k3_mla_decode_q_concat_kv_cache_insert",
+      torch::kXPU,
+      &fused_kimi_k3_mla_decode_q_concat_kv_cache_insert);
+
   // Compute FP8 quantized tensor for given scaling factor.
   ops.def(
       "static_scaled_fp8_quant(Tensor! result, Tensor input, Tensor scale, "

--- a/tests/test_kimi_k3_mla_epilogue.py
+++ b/tests/test_kimi_k3_mla_epilogue.py
@@ -1,0 +1,232 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Correctness tests for the Kimi-K3 MLA epilogue SYCL kernels.
+
+Tests the fused prefill (q-RoPE + K concat + latent cache insert) and decode
+(Q concat + latent cache insert) kernels against a pure-PyTorch reference.
+bf16 only -- fp8 / fp8_ds_mla cache-layout variants are not implemented.
+
+Run:
+    pytest tests/test_kimi_k3_mla_epilogue.py -v
+"""
+import pytest
+import torch
+
+import vllm_xpu_kernels._C  # noqa: F401
+
+DEVICE = torch.device("xpu")
+
+QK_NOPE_DIM = 128
+QK_ROPE_DIM = 64
+QK_HEAD_DIM = QK_NOPE_DIM + QK_ROPE_DIM  # 192
+KV_LORA_RANK = 512
+CACHE_ENTRY = KV_LORA_RANK + QK_ROPE_DIM  # 576
+HALF_ROPE = QK_ROPE_DIM // 2
+
+
+def _rope_pair(x: torch.Tensor, cos_sin: torch.Tensor) -> torch.Tensor:
+    """GPT-J-style interleaved-pair RoPE. x: [..., 64], cos_sin: [64]."""
+    cos = cos_sin[:HALF_ROPE].float()
+    sin = cos_sin[HALF_ROPE:].float()
+    xf = x.float()
+    x_even, x_odd = xf[0::2], xf[1::2]
+    new_even = x_even * cos - x_odd * sin
+    new_odd = x_even * sin + x_odd * cos
+    return torch.stack([new_even, new_odd], dim=-1).flatten().to(x.dtype)
+
+
+def reference_prefill(q, k_nope, k_pe, kv_c, k_out, k_cache, slot_mapping,
+                      position_ids, cos_sin_cache, block_size):
+    num_tokens, num_heads = k_nope.shape[0], k_nope.shape[1]
+    for t in range(num_tokens):
+        rope = None
+        if position_ids is not None:
+            rope = cos_sin_cache[position_ids[t].item()]
+        for h in range(num_heads):
+            k_pe_h = k_pe[t]
+            if rope is not None:
+                q[t, h, QK_NOPE_DIM:] = _rope_pair(q[t, h, QK_NOPE_DIM:], rope)
+                k_pe_h = _rope_pair(k_pe_h, rope)
+            k_out[t, h] = torch.cat([k_nope[t, h], k_pe_h])
+        slot_id = slot_mapping[t].item()
+        if slot_id < 0:
+            continue
+        k_pe_latent = k_pe[t]
+        if rope is not None:
+            k_pe_latent = _rope_pair(k_pe_latent, rope)
+        blk, off = slot_id // block_size, slot_id % block_size
+        k_cache[blk, off] = torch.cat([kv_c[t], k_pe_latent])
+
+
+def reference_decode(ql_nope, q_pe, kv_c, k_pe, mqa_q, k_cache, slot_mapping,
+                     position_ids, cos_sin_cache, block_size):
+    num_tokens, num_heads = ql_nope.shape[0], ql_nope.shape[1]
+    for t in range(num_tokens):
+        rope = None
+        if position_ids is not None:
+            rope = cos_sin_cache[position_ids[t].item()]
+        for h in range(num_heads):
+            q_pe_h = q_pe[t, h]
+            if rope is not None:
+                q_pe_h = _rope_pair(q_pe_h, rope)
+            mqa_q[t, h] = torch.cat([ql_nope[t, h], q_pe_h])
+        slot_id = slot_mapping[t].item()
+        if slot_id < 0:
+            continue
+        k_pe_latent = k_pe[t]
+        if rope is not None:
+            k_pe_latent = _rope_pair(k_pe_latent, rope)
+        blk, off = slot_id // block_size, slot_id % block_size
+        k_cache[blk, off] = torch.cat([kv_c[t], k_pe_latent])
+
+
+def _make_rope(num_tokens, max_pos, apply_rope, device):
+    if not apply_rope:
+        return None, None
+    positions = torch.randint(0, max_pos, (num_tokens,), dtype=torch.int64,
+                              device=device)
+    cos_sin = torch.randn(max_pos, QK_ROPE_DIM, dtype=torch.float32,
+                          device=device)
+    return positions, cos_sin
+
+
+@pytest.mark.parametrize("num_tokens", [1, 5, 37])
+@pytest.mark.parametrize("num_heads", [1, 8])
+@pytest.mark.parametrize("apply_rope", [False, True])
+def test_prefill_correctness(num_tokens, num_heads, apply_rope):
+    torch.manual_seed(0)
+    block_size, num_blocks = 16, num_tokens + 1
+    max_pos = 4096
+
+    q = torch.randn(num_tokens, num_heads, QK_HEAD_DIM, dtype=torch.bfloat16,
+                    device=DEVICE)
+    k_nope = torch.randn(num_tokens, num_heads, QK_NOPE_DIM,
+                         dtype=torch.bfloat16, device=DEVICE)
+    k_pe = torch.randn(num_tokens, QK_ROPE_DIM, dtype=torch.bfloat16,
+                       device=DEVICE)
+    kv_c = torch.randn(num_tokens, KV_LORA_RANK, dtype=torch.bfloat16,
+                       device=DEVICE)
+    slot_mapping = torch.randperm(num_blocks * block_size,
+                                  device=DEVICE)[:num_tokens].to(torch.int64)
+    positions, cos_sin = _make_rope(num_tokens, max_pos, apply_rope, DEVICE)
+
+    q_ref = q.clone()
+    k_out = torch.empty(num_tokens, num_heads, QK_HEAD_DIM,
+                        dtype=torch.bfloat16, device=DEVICE)
+    k_out_ref = k_out.clone()
+    k_cache = torch.zeros(num_blocks, block_size, CACHE_ENTRY,
+                          dtype=torch.bfloat16, device=DEVICE)
+    k_cache_ref = k_cache.clone()
+
+    reference_prefill(q_ref, k_nope, k_pe, kv_c, k_out_ref, k_cache_ref,
+                      slot_mapping, positions, cos_sin, block_size)
+    torch.ops._C.fused_kimi_k3_mla_key_concat_kv_cache_insert(
+        q, k_nope, k_pe, kv_c, k_out, k_cache, slot_mapping, block_size,
+        positions, cos_sin)
+
+    torch.testing.assert_close(q.float(), q_ref.float(), atol=2e-2, rtol=2e-2)
+    torch.testing.assert_close(k_out.float(), k_out_ref.float(), atol=2e-2,
+                               rtol=2e-2)
+    torch.testing.assert_close(k_cache.float(), k_cache_ref.float(),
+                               atol=2e-2, rtol=2e-2)
+
+
+@pytest.mark.parametrize("num_tokens", [1, 5, 37])
+@pytest.mark.parametrize("num_heads", [1, 8])
+@pytest.mark.parametrize("apply_rope", [False, True])
+def test_decode_correctness(num_tokens, num_heads, apply_rope):
+    torch.manual_seed(0)
+    block_size, num_blocks = 16, num_tokens + 1
+    max_pos = 4096
+
+    ql_nope = torch.randn(num_tokens, num_heads, KV_LORA_RANK,
+                          dtype=torch.bfloat16, device=DEVICE)
+    q_pe = torch.randn(num_tokens, num_heads, QK_ROPE_DIM,
+                       dtype=torch.bfloat16, device=DEVICE)
+    kv_c = torch.randn(num_tokens, KV_LORA_RANK, dtype=torch.bfloat16,
+                       device=DEVICE)
+    k_pe = torch.randn(num_tokens, QK_ROPE_DIM, dtype=torch.bfloat16,
+                       device=DEVICE)
+    slot_mapping = torch.randperm(num_blocks * block_size,
+                                  device=DEVICE)[:num_tokens].to(torch.int64)
+    positions, cos_sin = _make_rope(num_tokens, max_pos, apply_rope, DEVICE)
+
+    mqa_q = torch.empty(num_tokens, num_heads, CACHE_ENTRY,
+                        dtype=torch.bfloat16, device=DEVICE)
+    mqa_q_ref = mqa_q.clone()
+    k_cache = torch.zeros(num_blocks, block_size, CACHE_ENTRY,
+                          dtype=torch.bfloat16, device=DEVICE)
+    k_cache_ref = k_cache.clone()
+
+    reference_decode(ql_nope, q_pe, kv_c, k_pe, mqa_q_ref, k_cache_ref,
+                     slot_mapping, positions, cos_sin, block_size)
+    torch.ops._C.fused_kimi_k3_mla_decode_q_concat_kv_cache_insert(
+        ql_nope, q_pe, kv_c, k_pe, mqa_q, k_cache, slot_mapping, block_size,
+        positions, cos_sin)
+
+    torch.testing.assert_close(mqa_q.float(), mqa_q_ref.float(), atol=2e-2,
+                               rtol=2e-2)
+    torch.testing.assert_close(k_cache.float(), k_cache_ref.float(),
+                               atol=2e-2, rtol=2e-2)
+
+
+def test_negative_slot_skipped():
+    """Tokens with slot_mapping=-1 should not write to the cache."""
+    torch.manual_seed(0)
+    num_tokens, num_heads, block_size, num_blocks = 8, 4, 16, 2
+
+    ql_nope = torch.randn(num_tokens, num_heads, KV_LORA_RANK,
+                          dtype=torch.bfloat16, device=DEVICE)
+    q_pe = torch.randn(num_tokens, num_heads, QK_ROPE_DIM,
+                       dtype=torch.bfloat16, device=DEVICE)
+    kv_c = torch.randn(num_tokens, KV_LORA_RANK, dtype=torch.bfloat16,
+                       device=DEVICE)
+    k_pe = torch.randn(num_tokens, QK_ROPE_DIM, dtype=torch.bfloat16,
+                       device=DEVICE)
+    slot_mapping = torch.full((num_tokens,), -1, dtype=torch.int64,
+                              device=DEVICE)
+    mqa_q = torch.empty(num_tokens, num_heads, CACHE_ENTRY,
+                        dtype=torch.bfloat16, device=DEVICE)
+    k_cache = torch.zeros(num_blocks, block_size, CACHE_ENTRY,
+                          dtype=torch.bfloat16, device=DEVICE)
+
+    torch.ops._C.fused_kimi_k3_mla_decode_q_concat_kv_cache_insert(
+        ql_nope, q_pe, kv_c, k_pe, mqa_q, k_cache, slot_mapping, block_size,
+        None, None)
+
+    assert k_cache.abs().max().item() == 0.0
+
+
+def test_nonsequential_slots():
+    """Non-contiguous slot_mapping crossing block boundaries."""
+    torch.manual_seed(7)
+    num_tokens, num_heads, block_size, num_blocks = 6, 4, 16, 3
+    slots = torch.tensor([0, 5, 15, 16, 17, -1], dtype=torch.int64,
+                         device=DEVICE)
+
+    ql_nope = torch.randn(num_tokens, num_heads, KV_LORA_RANK,
+                          dtype=torch.bfloat16, device=DEVICE)
+    q_pe = torch.randn(num_tokens, num_heads, QK_ROPE_DIM,
+                       dtype=torch.bfloat16, device=DEVICE)
+    kv_c = torch.randn(num_tokens, KV_LORA_RANK, dtype=torch.bfloat16,
+                       device=DEVICE)
+    k_pe = torch.randn(num_tokens, QK_ROPE_DIM, dtype=torch.bfloat16,
+                       device=DEVICE)
+    mqa_q = torch.empty(num_tokens, num_heads, CACHE_ENTRY,
+                        dtype=torch.bfloat16, device=DEVICE)
+    mqa_q_ref = mqa_q.clone()
+    k_cache = torch.zeros(num_blocks, block_size, CACHE_ENTRY,
+                          dtype=torch.bfloat16, device=DEVICE)
+    k_cache_ref = k_cache.clone()
+
+    reference_decode(ql_nope, q_pe, kv_c, k_pe, mqa_q_ref, k_cache_ref,
+                     slots, None, None, block_size)
+    torch.ops._C.fused_kimi_k3_mla_decode_q_concat_kv_cache_insert(
+        ql_nope, q_pe, kv_c, k_pe, mqa_q, k_cache, slots, block_size,
+        None, None)
+
+    torch.testing.assert_close(mqa_q.float(), mqa_q_ref.float(), atol=2e-2,
+                               rtol=2e-2)
+    torch.testing.assert_close(k_cache.float(), k_cache_ref.float(),
+                               atol=2e-2, rtol=2e-2)
+    # untouched block/offset stays zero
+    assert k_cache[2, 1].abs().max().item() == 0.0

--- a/tests/test_kimi_k3_mla_epilogue.py
+++ b/tests/test_kimi_k3_mla_epilogue.py
@@ -3,7 +3,7 @@
 
 Tests the fused prefill (q-RoPE + K concat + latent cache insert) and decode
 (Q concat + latent cache insert) kernels against a pure-PyTorch reference.
-bf16 only -- fp8 / fp8_ds_mla cache-layout variants are not implemented.
+bf16/fp16 only -- fp8 / fp8_ds_mla cache-layout variants are not implemented.
 
 Run:
     pytest tests/test_kimi_k3_mla_epilogue.py -v
@@ -28,10 +28,10 @@ def _rope_pair(x: torch.Tensor, cos_sin: torch.Tensor) -> torch.Tensor:
     cos = cos_sin[:HALF_ROPE].float()
     sin = cos_sin[HALF_ROPE:].float()
     xf = x.float()
-    x_even, x_odd = xf[0::2], xf[1::2]
+    x_even, x_odd = xf[..., 0::2], xf[..., 1::2]
     new_even = x_even * cos - x_odd * sin
     new_odd = x_even * sin + x_odd * cos
-    return torch.stack([new_even, new_odd], dim=-1).flatten().to(x.dtype)
+    return torch.stack([new_even, new_odd], dim=-1).flatten(-2).to(x.dtype)
 
 
 def reference_prefill(q, k_nope, k_pe, kv_c, k_out, k_cache, slot_mapping,
@@ -92,18 +92,19 @@ def _make_rope(num_tokens, max_pos, apply_rope, device):
 @pytest.mark.parametrize("num_tokens", [1, 5, 37])
 @pytest.mark.parametrize("num_heads", [1, 8])
 @pytest.mark.parametrize("apply_rope", [False, True])
-def test_prefill_correctness(num_tokens, num_heads, apply_rope):
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+def test_prefill_correctness(num_tokens, num_heads, apply_rope, dtype):
     torch.manual_seed(0)
     block_size, num_blocks = 16, num_tokens + 1
     max_pos = 4096
 
-    q = torch.randn(num_tokens, num_heads, QK_HEAD_DIM, dtype=torch.bfloat16,
+    q = torch.randn(num_tokens, num_heads, QK_HEAD_DIM, dtype=dtype,
                     device=DEVICE)
     k_nope = torch.randn(num_tokens, num_heads, QK_NOPE_DIM,
-                         dtype=torch.bfloat16, device=DEVICE)
-    k_pe = torch.randn(num_tokens, QK_ROPE_DIM, dtype=torch.bfloat16,
+                         dtype=dtype, device=DEVICE)
+    k_pe = torch.randn(num_tokens, QK_ROPE_DIM, dtype=dtype,
                        device=DEVICE)
-    kv_c = torch.randn(num_tokens, KV_LORA_RANK, dtype=torch.bfloat16,
+    kv_c = torch.randn(num_tokens, KV_LORA_RANK, dtype=dtype,
                        device=DEVICE)
     slot_mapping = torch.randperm(num_blocks * block_size,
                                   device=DEVICE)[:num_tokens].to(torch.int64)
@@ -111,10 +112,10 @@ def test_prefill_correctness(num_tokens, num_heads, apply_rope):
 
     q_ref = q.clone()
     k_out = torch.empty(num_tokens, num_heads, QK_HEAD_DIM,
-                        dtype=torch.bfloat16, device=DEVICE)
+                        dtype=dtype, device=DEVICE)
     k_out_ref = k_out.clone()
     k_cache = torch.zeros(num_blocks, block_size, CACHE_ENTRY,
-                          dtype=torch.bfloat16, device=DEVICE)
+                          dtype=dtype, device=DEVICE)
     k_cache_ref = k_cache.clone()
 
     reference_prefill(q_ref, k_nope, k_pe, kv_c, k_out_ref, k_cache_ref,
@@ -133,28 +134,29 @@ def test_prefill_correctness(num_tokens, num_heads, apply_rope):
 @pytest.mark.parametrize("num_tokens", [1, 5, 37])
 @pytest.mark.parametrize("num_heads", [1, 8])
 @pytest.mark.parametrize("apply_rope", [False, True])
-def test_decode_correctness(num_tokens, num_heads, apply_rope):
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+def test_decode_correctness(num_tokens, num_heads, apply_rope, dtype):
     torch.manual_seed(0)
     block_size, num_blocks = 16, num_tokens + 1
     max_pos = 4096
 
     ql_nope = torch.randn(num_tokens, num_heads, KV_LORA_RANK,
-                          dtype=torch.bfloat16, device=DEVICE)
+                          dtype=dtype, device=DEVICE)
     q_pe = torch.randn(num_tokens, num_heads, QK_ROPE_DIM,
-                       dtype=torch.bfloat16, device=DEVICE)
-    kv_c = torch.randn(num_tokens, KV_LORA_RANK, dtype=torch.bfloat16,
+                       dtype=dtype, device=DEVICE)
+    kv_c = torch.randn(num_tokens, KV_LORA_RANK, dtype=dtype,
                        device=DEVICE)
-    k_pe = torch.randn(num_tokens, QK_ROPE_DIM, dtype=torch.bfloat16,
+    k_pe = torch.randn(num_tokens, QK_ROPE_DIM, dtype=dtype,
                        device=DEVICE)
     slot_mapping = torch.randperm(num_blocks * block_size,
                                   device=DEVICE)[:num_tokens].to(torch.int64)
     positions, cos_sin = _make_rope(num_tokens, max_pos, apply_rope, DEVICE)
 
     mqa_q = torch.empty(num_tokens, num_heads, CACHE_ENTRY,
-                        dtype=torch.bfloat16, device=DEVICE)
+                        dtype=dtype, device=DEVICE)
     mqa_q_ref = mqa_q.clone()
     k_cache = torch.zeros(num_blocks, block_size, CACHE_ENTRY,
-                          dtype=torch.bfloat16, device=DEVICE)
+                          dtype=dtype, device=DEVICE)
     k_cache_ref = k_cache.clone()
 
     reference_decode(ql_nope, q_pe, kv_c, k_pe, mqa_q_ref, k_cache_ref,


### PR DESCRIPTION
Description:
  ## Purpose
  Kimi-K3's shared MLA (Multi-head Latent Attention) implementation calls two CUDA-only fused custom ops for its epilogue (the RoPE + K/Q concat + paged-cache-insert plumbing that follows the QKV projection GEMMs):
  - `fused_kimi_k3_mla_key_concat_kv_cache_insert` (prefill)
  - `fused_kimi_k3_mla_decode_q_concat_kv_cache_insert` (decode)

  Neither has an XPU registration, so `torch.ops._C.<name>` doesn't resolve on XPU tensors and the model crashes with `AttributeError: '_OpNamespace' '_C' object has no attribute '...'` on first attention forward. Decode is hit first under real serving traffic.

  This adds SYCL implementations registered under the same op names/schema (`torch::kXPU`), so the existing vllm call sites dispatch correctly with no changes needed on the Python side. bf16/fp16 only for now — fp8 and `fp8_ds_mla` cache-layout variants, and the CUDA sm_90+ PDL launch
  overlap, are not ported.

  **Not a duplicate of #480:** that PR adds Kimi Delta Attention (KDA) kernels for the *other* attention mechanism Kimi-Linear mixes in (linear/gated-delta-rule attention). Checked its op names (`kda_attention`, `kda_gated_delta_rule`, `kda_causal_conv1d`) against vllm's call sites
  directly — none are currently called anywhere in vllm, so that PR doesn't affect this code path either way. Independent, non-overlapping fix.

  Related to vllm-project/vllm#56422 (tracking issue combining this PR and the companion vllm PR).

  ## Test Plan
  Correctness: new `tests/test_kimi_k3_mla_epilogue.py` — both ops (prefill key-concat, decode q-concat) × RoPE on/off × several token/head counts, verified against a pure-PyTorch reference, plus dedicated negative-slot and non-sequential-slot edge cases.

  Performance: op-level microbenchmark comparing the fused kernel against the equivalent 3-launch generic composition (`rotary_embedding` custom op + `cat` + `concat_and_cache_mla`), at decode batch sizes 1/8/32 and prefill chunk sizes 128/512/2048, on a single B70.

  ## Test Result
  Correctness: 26/26 pass on B70.

  Performance: 2.9-4.9x speedup over the composed path, largest at small batch (launch-overhead-bound regime), narrowing at larger prefill chunks as compute time starts to dominate launch overhead. Not yet measured at full e2e serving — expect this to compress substantially there,
  consistent with this repo's LayerNorm kernel (2.1-4.8x isolated, 5-9% e2e).
